### PR TITLE
Allow the user to use a string key in config

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -40,8 +40,8 @@ class EasyAdminExtension extends Extension
             return $entitiesConfiguration;
         }
 
-        $entitiesConfigurationKeys = array_keys($entitiesConfiguration);
-        if (is_integer($entitiesConfigurationKeys[0])) {
+        $entitiesConfigurationValues = array_values($entitiesConfiguration);
+        if (is_string($entitiesConfigurationValues[0])) {
             return $this->processEntityConfigurationFromSimpleParameters($entitiesConfiguration);
         }
 
@@ -51,12 +51,12 @@ class EasyAdminExtension extends Extension
     private function processEntityConfigurationFromSimpleParameters($config)
     {
         $entities = array();
-        foreach ($config as $entityClass) {
+        foreach ($config as $key => $entityClass) {
             $parts = explode('\\', $entityClass);
             $entityName = array_pop($parts);
 
             $entities[$entityName] = array(
-                'label' => $entityName,
+                'label' => !is_numeric($key) ? $key : $entityName,
                 'name'  => $entityName,
                 'class' => $entityClass,
             );


### PR DESCRIPTION
To be able to retrieve only the "label" and "class" attributes.

I think it could be great because it will allow you to have such config:

``` yml
#config.yml
easy_admin:
    entities:
        Posts: AppBundle\Entity\Post
        Users: AppBundle\Entity\User
```
