### PR TITLE
don't fetch associated collections in pagination

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -370,7 +370,7 @@ class AdminController extends Controller
             $query->orderBy('entity.'.$sortField, $sortDirection);
         }
 
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($query));
+        $paginator = new Pagerfanta(new DoctrineORMAdapter($query, false));
         $paginator->setMaxPerPage($maxPerPage);
         $paginator->setCurrentPage($page);
 


### PR DESCRIPTION
This was suggested by @stof in https://github.com/javiereguiluz/EasyAdminBundle/commit/f08250a85b35e5f71603e04ff614e8a79040fe1d#commitcomment-9312611 to allow faster pagination.
