### PR TITLE
Display a custom error page when the requested entity doesn't exist.

### DIFF
--- a/Resources/views/error/undefined_entity.html.twig
+++ b/Resources/views/error/undefined_entity.html.twig
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta http-equiv="content-type" content="text/html; charset=utf-8">
+        <meta name="generator" content="EasyAdmin" />
+
+        <title>EasyAdmin Error</title>
+
+        <link href="{{ asset('bundles/easyadmin/stylesheet/bootstrap.min.css') }}" rel="stylesheet">
+        <link href="{{ asset('bundles/easyadmin/stylesheet/font-awesome.min.css') }}" rel="stylesheet">
+        <link href="{{ asset('bundles/easyadmin/stylesheet/admin.css') }}" rel="stylesheet">
+        <link rel="shortcut icon" type="image/png" href="/favicon.png">
+    </head>
+
+    <body class="error">
+    <div id="wrapper" class="container">
+        <div id="header" class="col-lg-2">
+            <div id="header-contents" class="row">
+                <div id="header-logo" class="col-xs-6 col-md-2 col-lg-12">
+                    <a href="{{ path('admin') }}">EasyAdmin</a>
+                </div>
+            </div>
+        </div>
+
+        <div id="content" class="col-lg-10 col-lg-offset-2">
+            <div class="row">
+                <div class="col-sm-9" id="main">
+                    <h1>Runtime error</h1>
+                    <p class="lead">
+                        The <code>{{ entity_name }}</code> entity is not defined in
+                        the configuration of your backend.
+                    </p>
+
+                    <h2>How to fix this problem</h2>
+
+                    <p>
+                        Open your <code>app/config/config.yml</code> file and add the
+                        class of the <code>{{ entity_name }}</code> entity to the list
+                        of entities managed by EasyAdmin.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This PR also introduces a render404error() shortcut to avoid the
ugly code required to render a template and returning a 404 Response.

This fixes #8
