### PR TITLE
Allow to have different entities with the same exact name

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -62,6 +62,11 @@ class EasyAdminExtension extends Extension
             $parts = explode('\\', $entityClass);
             $entityName = array_pop($parts);
 
+            // to avoid entity name collision, make sure that its name is unique
+            while (array_key_exists($entityName, $entities)) {
+                $entityName .= '_';
+            }
+
             $entities[$entityName] = array(
                 'label' => !is_numeric($key) ? $key : $entityName,
                 'name'  => $entityName,
@@ -78,6 +83,11 @@ class EasyAdminExtension extends Extension
         foreach ($config as $customEntityName => $entityConfiguration) {
             $parts = explode('\\', $entityConfiguration['class']);
             $realEntityName = array_pop($parts);
+
+            // to avoid entity name collision, make sure that its name is unique
+            while (array_key_exists($realEntityName, $entities)) {
+                $realEntityName .= '_';
+            }
 
             // copy the original entity to not loose any of its configuration
             $entities[$realEntityName] = $config[$customEntityName];


### PR DESCRIPTION
This is very rare, except for entities like "Category" which can
be defined in different bundles for different purposes. The proposed
solution is very simple, but it should do the trick.
