### PR TITLE
Extend Forms with service

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -376,6 +376,13 @@ class AdminController extends Controller
      */
     protected function createEditForm($entity, array $entityProperties)
     {
+        $servicename = sprintf('form.type.%s', strtolower($this->entity['name']));
+
+		if($this->get('service_container')->has($servicename))
+		{
+			return $this->createForm( $this->get($servicename), $entity	);
+		}
+        
         $form = $this->createFormBuilder($entity, array(
             'data_class' => $this->entity['class'],
         ));


### PR DESCRIPTION
With this simple change, it's possible generate form with standard EasyAdmin or with service. Example:

``` yaml
...
    form.type.<entityname>:
        class: <class>
        arguments: [null]
        tags:
          - { name: form.type, alias: <entityname> }
```
