### PR TITLE
Delete action now displays a modal window to confirm entity removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,16 @@ easy_admin:
     # ...
 ```
 
+#### Unloading the Default JavaScript and Stylesheets
+
+Backend templates use Bootstrap CSS and jQuery frameworks to display their
+contents. In case you want to unload these files in addition to loading your
+own assets, override the value of the `head_stylesheets` and `body_javascripts`
+template blocks.
+
+To do so, you'll have to create your own templates and override default ones,
+as explained in the next section.
+
 ### Customize the Templates of the Backend
 
 In addition to loading your own stylesheets and scripts, you can also override

--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -314,6 +314,20 @@ button.btn-danger {
     display: none;
 }
 
+/* Modal windows
+   ------------------------------------------------------------------------- */
+.modal-dialog .modal-content {
+    border-radius: 0;
+}
+.modal-dialog .modal-content .modal-body h4 {
+    font-size: 21px;
+    margin: .5em 0;
+}
+.modal-dialog .modal-footer {
+    background: #F3EFEB;
+    margin-top: 1.5em;
+}
+
 /* -------------------------------------------------------------------------
    LAYOUT
    ------------------------------------------------------------------------- */

--- a/Resources/translations/EasyAdminBundle.en.xliff
+++ b/Resources/translations/EasyAdminBundle.en.xliff
@@ -58,6 +58,10 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> of <strong>%results%</strong>]]></target>
             </trans-unit>
+            <trans-unit id="actions.cancel">
+                <source>actions.cancel</source>
+                <target>Cancel</target>
+            </trans-unit>
             <trans-unit id="actions.list">
                 <source>actions.list</source>
                 <target>List</target>
@@ -89,6 +93,14 @@
             <trans-unit id="list.search">
                 <source>list.search</source>
                 <target>Search</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.title">
+                <source>delete_modal.title</source>
+                <target>Do you really want to delete this item?</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.content">
+                <source>delete_modal.content</source>
+                <target>There is no undo for this operation.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/EasyAdminBundle.es.xliff
+++ b/Resources/translations/EasyAdminBundle.es.xliff
@@ -58,6 +58,10 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> de <strong>%results%</strong>]]></target>
             </trans-unit>
+            <trans-unit id="actions.cancel">
+                <source>actions.cancel</source>
+                <target>Cancelar</target>
+            </trans-unit>
             <trans-unit id="actions.list">
                 <source>actions.list</source>
                 <target>Listado</target>
@@ -89,6 +93,14 @@
             <trans-unit id="list.search">
                 <source>list.search</source>
                 <target>Buscar</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.title">
+                <source>delete_modal.title</source>
+                <target>¿Realmente quieres borrar este elemento?</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.content">
+                <source>delete_modal.content</source>
+                <target>Esta acción no se puede deshacer.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/EasyAdminBundle.eu.xliff
+++ b/Resources/translations/EasyAdminBundle.eu.xliff
@@ -58,6 +58,10 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong>tik - <strong>%end%</strong>era <strong>%results%</strong>tik]]></target>
             </trans-unit>
+            <trans-unit id="actions.cancel">
+                <source>actions.cancel</source>
+                <target>Ezeztatu</target>
+            </trans-unit>
             <trans-unit id="actions.list">
                 <source>actions.list</source>
                 <target>Zerrenda</target>
@@ -89,6 +93,14 @@
             <trans-unit id="list.search">
                 <source>list.search</source>
                 <target>Bilatu</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.title">
+                <source>delete_modal.title</source>
+                <target>Do you really want to delete this item?</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.content">
+                <source>delete_modal.content</source>
+                <target>There is no undo for this operation.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/EasyAdminBundle.fr.xliff
+++ b/Resources/translations/EasyAdminBundle.fr.xliff
@@ -58,6 +58,10 @@
                 <source>link.back_to_listing</source>
                 <target>Retour à la liste</target>
             </trans-unit>
+            <trans-unit id="actions.cancel">
+                <source>actions.cancel</source>
+                <target>Refuser</target>
+            </trans-unit>
             <trans-unit id="actions.list">
                 <source>actions.list</source>
                 <target>Lister</target>
@@ -89,6 +93,14 @@
             <trans-unit id="list.search">
                 <source>list.search</source>
                 <target>Rechercher</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.title">
+                <source>delete_modal.title</source>
+                <target>Do you really want to delete this item?</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.content">
+                <source>delete_modal.content</source>
+                <target>There is no undo for this operation.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/EasyAdminBundle.nl.xliff
+++ b/Resources/translations/EasyAdminBundle.nl.xliff
@@ -58,6 +58,10 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> van <strong>%results%</strong>]]></target>
             </trans-unit>
+            <trans-unit id="actions.cancel">
+                <source>actions.cancel</source>
+                <target>Afkeuren</target>
+            </trans-unit>
             <trans-unit id="actions.list">
                 <source>actions.list</source>
                 <target>Overzicht</target>
@@ -89,6 +93,14 @@
             <trans-unit id="list.search">
                 <source>list.search</source>
                 <target>Zoeken</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.title">
+                <source>delete_modal.title</source>
+                <target>Do you really want to delete this item?</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.content">
+                <source>delete_modal.content</source>
+                <target>There is no undo for this operation.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/EasyAdminBundle.ru.xliff
+++ b/Resources/translations/EasyAdminBundle.ru.xliff
@@ -58,6 +58,10 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> из <strong>%results%</strong>]]></target>
             </trans-unit>
+            <trans-unit id="actions.cancel">
+                <source>actions.cancel</source>
+                <target>Отклонить</target>
+            </trans-unit>
             <trans-unit id="actions.list">
                 <source>actions.list</source>
                 <target>Список</target>
@@ -85,6 +89,14 @@
             <trans-unit id="list.results_found">
                 <source>list.results_found</source>
                 <target><![CDATA[{1} <strong>1</strong> запись найдена |{2,3,4} Всего <strong>%count%</strong> записи |[5,Inf] Всего <strong>%count%</strong> записей]]></target>
+            </trans-unit>
+            <trans-unit id="delete_modal.title">
+                <source>delete_modal.title</source>
+                <target>Do you really want to delete this item?</target>
+            </trans-unit>
+            <trans-unit id="delete_modal.content">
+                <source>delete_modal.content</source>
+                <target>There is no undo for this operation.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -6,10 +6,20 @@
 
 {% block body_javascript %}
     {{ parent() }}
+
     <script src="{{ asset('bundles/easyadmin/javascript/jquery.are-you-sure.min.js') }}"></script>
     <script type="text/javascript">
         $(function() {
             $('#edit-form').areYouSure({ 'message': 'You haven\'t saved the changes made on this form.' });
+
+            $('#button-delete').on('click', function(e) {
+                e.preventDefault();
+
+                $('#modal-delete').modal({ backdrop: true, keyboard: true })
+                    .one('click', '#modal-delete-button', function (e) {
+                        $('#delete-form').trigger('submit');
+                    });
+            });
         });
     </script>
 {% endblock %}
@@ -70,8 +80,8 @@
                         <i class="fa fa-save"></i> {{ 'entity.save_changes' | trans }}
                     </button>
 
-                    <button type="button" onclick="document.getElementById('delete-form').submit()" class="btn btn-danger">
-                        <i class="fa fa-trash"></i> {{ 'entity.delete' | trans() }}
+                    <button type="button" id="button-delete" class="btn btn-danger">
+                        <i class="fa fa-trash"></i> {{ 'entity.delete' | trans }}
                     </button>
 
                     <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
@@ -83,4 +93,24 @@
     {{ form_end(form) }}
 
     {{ form(delete_form, { attr: { id: 'delete-form', style: 'display: none' }}) }}
+
+
+<div id="modal-delete" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-body">
+                <h4>{{ 'delete_modal.title' | trans }}</h4>
+                <p>{{ 'delete_modal.content' | trans }}</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" data-dismiss="modal" class="btn">
+                    {{ 'actions.cancel' | trans }}
+                </button>
+                <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
+                    <i class="fa fa-trash"></i> {{ 'entity.delete' | trans }}
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -10,13 +10,15 @@
 
         <title>{% block page_title %}{{ block('content_title') }}{% endblock %}</title>
 
-        <link href="{{ asset('bundles/easyadmin/stylesheet/bootstrap.min.css') }}" rel="stylesheet">
-        <link href="{{ asset('bundles/easyadmin/stylesheet/font-awesome.min.css') }}" rel="stylesheet">
-        <link href="{{ asset('bundles/easyadmin/stylesheet/admin.css') }}" rel="stylesheet">
+        {% block head_stylesheets %}
+            <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/bootstrap.min.css') }}">
+            <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/font-awesome.min.css') }}">
+            <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/admin.css') }}">
+        {% endblock %}
+
         {% for css_asset in config.assets.css %}
             <link rel="stylesheet" href="{{ asset(css_asset) }}">
         {% endfor %}
-        {% block head_stylesheets %}{% endblock %}
 
         <link rel="shortcut icon" type="image/png" href="/favicon.png">
 
@@ -90,6 +92,7 @@
 
     {% block body_javascript %}
         <script src="{{ asset('bundles/easyadmin/javascript/jquery.min.js') }}"></script>
+        <script src="{{ asset('bundles/easyadmin/javascript/bootstrap.min.js') }}"></script>
     {% endblock %}
     {% for js_asset in config.assets.js %}
         <script src="{{ asset(js_asset) }}"></script>

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -6,6 +6,7 @@
 
 {% block body_javascript %}
     {{ parent() }}
+
     <script src="{{ asset('bundles/easyadmin/javascript/jquery.are-you-sure.min.js') }}"></script>
     <script type="text/javascript">
         $(function() {
@@ -68,10 +69,6 @@
                 <div class="col-sm-10 col-sm-offset-2">
                     <button type="submit" class="btn">
                         <i class="fa fa-save"></i> {{ 'entity.save_changes' | trans }}
-                    </button>
-
-                    <button type="button" onclick="document.getElementById('delete-form').submit()" class="btn btn-danger">
-                        <i class="fa fa-trash"></i> {{ 'entity.delete' | trans() }}
                     </button>
 
                     <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -3,6 +3,23 @@
 {% trans_default_domain "EasyAdminBundle" %}
 {% block body_class 'admin show ' ~ entity.name|lower %}
 
+{% block body_javascript %}
+    {{ parent() }}
+
+    <script type="text/javascript">
+        $(function() {
+            $('#button-delete').on('click', function(e) {
+                e.preventDefault();
+
+                $('#modal-delete').modal({ backdrop: true, keyboard: true })
+                    .one('click', '#modal-delete-button', function (e) {
+                        $('#delete-form').trigger('submit');
+                    });
+            });
+        });
+    </script>
+{% endblock %}
+
 {% block content_title %}
     {{ entity.name ~ ' #' ~ item.id }}
 {% endblock %}
@@ -28,7 +45,7 @@
                     <i class="fa fa-edit"></i> {{ 'entity.edit' | trans({"%entity%": entity.name}) }}
                 </a>
 
-                <button type="button" onclick="document.getElementById('delete-form').submit()" class="btn btn-danger">
+                <button type="button" id="button-delete" class="btn btn-danger">
                     <i class="fa fa-trash"></i> {{ 'entity.delete' | trans() }}
                 </button>
 
@@ -40,4 +57,23 @@
     </div>
 
     {{ form(delete_form, { attr: { id: 'delete-form', style: 'display: none' }}) }}
+
+    <div id="modal-delete" class="modal fade">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-body">
+                    <h4>{{ 'delete_modal.title' | trans }}</h4>
+                    <p>{{ 'delete_modal.content' | trans }}</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" data-dismiss="modal" class="btn">
+                        {{ 'actions.cancel' | trans }}
+                    </button>
+                    <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
+                        <i class="fa fa-trash"></i> {{ 'entity.delete' | trans }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}


### PR DESCRIPTION
This fixes #65 

And here it is the modal window in action:

![confirm_delete](https://cloud.githubusercontent.com/assets/73419/5906752/6a1d896e-a59a-11e4-9e71-1cf738a1479f.gif)
