### PR TITLE
Display virtual columns

### DIFF
--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -96,7 +96,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
             return '';
         }
 
-        return '';
+        return strval($value);
     }
 
     /**


### PR DESCRIPTION
There was a problem during the display of the virtual columns.
In the twig extension we try to match the field type to know in what format we need to display the value.
By definition a virtual columns does not have any type, so we always send a empty string. So to be sure, if at the end we didn't find the good type we return a string cast of the value.
