### PR TITLE
Improved the way 'virtual' fields are displayed and added more documentation about these fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ your virtual field is a *boolean* value or a date, define its time using the
 `type` option:
 
 ```yaml
-# in this example, the virtual fields ' is_eligible' and 'last_contact' will
+# in this example, the virtual fields 'is_eligible' and 'last_contact' will
 # be considered strings, even if they return boolean and DateTime values
 # respectively
 easy_admin:
@@ -365,7 +365,7 @@ easy_admin:
                 fields: ['id', 'is_eligible', 'last_contact']
     # ...
 
-# in this example, the virtual fields ' is_eligible' and 'last_contact' will
+# in this example, the virtual fields 'is_eligible' and 'last_contact' will
 # be displayed as a boolean and a DateTime value respectively
 easy_admin:
     entities:

--- a/README.md
+++ b/README.md
@@ -304,10 +304,10 @@ easy_admin:
 
 #### Virtual Entity Fields
 
-Sometimes it's useful to modify the original entity properties before
-displaying them in the listings. For example, if your `Customer` entity
-defines `firstName` and `lastName` properties, you may want to just display
-a column called `Name` with both information. These are called `virtual fields`
+Sometimes, it's useful to include in listings values which are not entity
+properties. For example, if your `Customer` entity defines `firstName` and
+`lastName` properties, you may want to just display a column called `Name`
+with both information merged. These columns are called `virtual fields`
 because they don't really exist as real Doctrine entity fields.
 
 First, add this new virtual field to the entity configuration:
@@ -322,10 +322,12 @@ easy_admin:
     # ...
 ```
 
-If you reload your backend, you'll get an error because the `name` field does
-not match any of the entity's properties. To fix this issue, add a new public
+If you reload the backend, you'll see that the virtual field only displays
+`Inaccessible` as its value. The reason is that virtual field `name` does not
+match any of the entity's properties. To fix this issue, add a new public
 method in your entity called `getXxx()` or `xxx()`, where `xxx` is the name of
-the virtual field (in this case, `name`):
+the virtual field (in this case the field is called `name`, so the method must
+be called `getName()` or `name()`):
 
 ```php
 namespace AppBundle\Entity;
@@ -346,9 +348,40 @@ class Customer
 }
 ```
 
-That's it. Reload your backend and you'll see the new virtual field displayed
-in the entity listing. The only current limitation of virtual fields is that
-you cannot reorder listings using these fields.
+That's it. Reload your backend and now you'll see the real values of this
+virtual field. By default, virtual fields are displayed as text contents. If
+your virtual field is a *boolean* value or a date, define its time using the
+`type` option:
+
+```yaml
+# in this example, the virtual fields ' is_eligible' and 'last_contact' will
+# be considered strings, even if they return boolean and DateTime values
+# respectively
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            list:
+                fields: ['id', 'is_eligible', 'last_contact']
+    # ...
+
+# in this example, the virtual fields ' is_eligible' and 'last_contact' will
+# be displayed as a boolean and a DateTime value respectively
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            list:
+                fields: [
+                    'id',
+                    { property: 'is_eligible', type: 'boolean' },
+                    { property: 'last_contact', type: 'datetime' }
+                ]
+    # ...
+```
+
+The only current limitation of virtual fields is that you cannot reorder
+listings using these fields.
 
 ### Customize which Fields are Displayed in the Show Action
 

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -48,6 +48,12 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 return new \Twig_Markup('<span class="label">NULL</span>', 'UTF-8');
             }
 
+            // when a virtual field doesn't define it's type, consider it a string
+            // and limit its length to avoid visual issues with very long values
+            if (true === $fieldMetadata['virtual'] && null === $fieldType) {
+                return substr(strval($value), 0, 64);
+            }
+
             if ('id' === $fieldName) {
                 // return the ID value as is to avoid number formatting
                 return $value;
@@ -98,7 +104,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
             return '';
         }
 
-        return strval($value);
+        return '';
     }
 
     /**


### PR DESCRIPTION
This is the continuation of the PR #84 made by @nlemahieu.

@nlemahieu as you can see in the new documentation, virtual fields can indeed define their types, which makes sense for fields of type `boolean` and `datetime`. In addition, I've tweaked your PR to limit the length of the content to display in the virtual field (this prevents that the listing looks awful when the contents are very long).
