### PR TITLE
Set title on truncated text fields

### DIFF
--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -73,7 +73,10 @@ class EasyAdminTwigExtension extends \Twig_Extension
             }
 
             if (in_array($fieldType, array('string', 'text'))) {
-                return strlen($value) > 64 ? substr($value, 0, 64).'...' : $value;
+                return strlen($value) > 64 ? new \Twig_Markup(sprintf('<span title="%s">%s</span>',
+                    strlen($value) > 512 ? substr($value, 0, 512).'...' : $value,
+                    substr($value, 0, 64).'...'
+                ), 'UTF-8') : $value;
             }
 
             if (in_array($fieldType, array('bigint', 'integer', 'smallint', 'decimal', 'float'))) {


### PR DESCRIPTION
Set HTML `title` attribute in order to get a tooltip text, giving a better visibility on content:

``` html
<span title="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque mauris lorem, volutpat a varius ut, venenatis auctor lorem. Nunc non maximus quam.">
    Lorem ipsum dolor sit amet, consectetur adipiscing eli...
</span>
```

As the markup isn't the same if the string has less than 64chars (no span), you might prefer having a span anyway for every text fields in order to keep consistency ?

BTW, some remarks:
- Other field types, as array or association might have more than 64chars, and there is no limit.
- Number of chars already lead to display issues (with a mobile device for instance, on the show view), and not limiting other types might be worse.
- The 512 chars for title limit, as the 64 limit is arbitrary. Should this be configurable (per field, general, ...) ?
- Why are the fields truncated inside the Twig_Function, instead of using a truncate filter on views ?
