### PR TITLE
DateTime format for display

### DIFF
--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -60,11 +60,11 @@ class EasyAdminTwigExtension extends \Twig_Extension
             }
 
             if (in_array($fieldType, array('date', 'datetime', 'datetimetz'))) {
-                return $value->format(self::DATE_FORMAT);
+                return $value->format(isset($fieldMetadata['format']) ? $fieldMetadata['format'] : self::DATE_FORMAT);
             }
 
             if (in_array($fieldType, array('time'))) {
-                return $value->format(self::TIME_FORMAT);
+                return $value->format(isset($fieldMetadata['format']) ? $fieldMetadata['format'] : self::TIME_FORMAT);
             }
 
             if (in_array($fieldType, array('boolean'))) {


### PR DESCRIPTION
Allow to configure a format for display, at entity field level in configuration, for `date`, `datetime`, `datetimez`, and `time` types.

**_e.g:**_

``` yaml
# app/config/config.yml
easy_admin:
    entities:
        Customer:
            class: AppBundle\Entity\Customer
            list:
                fields: 
                   - id
                   - name
                   - { property: 'email', label: 'Email' }
                   - { property: 'createdAt', type: datetime, format: 'd/m/Y H:i' }
    # ...
```

Where should this feature be included in the existing documentation ? (As the types are not really documented currently)
