### PR TITLE
Header menu links: reduce line-height

### DIFF
--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -915,8 +915,8 @@ body.error code {
         display: block;
         font-size: 16px;
         font-weight: 500;
-        line-height: 2.5;
-        padding: 0;
+        line-height: 1.8;
+        padding: 0.35em 0;
         text-align: left;
         -moz-transition: padding-left .1s ease-out 0s;
         -webkit-transition: padding-left .1s ease-out;


### PR DESCRIPTION
Maybe only me, but when having a menu item wrapped (too long text), I feel like the there is two items instead of one, because of the line-height.
As it is my personal opinion and easily overridable with a custom stylesheet, but is a very simple change, I made a PR to replace the overage line-height with a padding.
I feel like those values are more natural:

| Before | After |
| --- | :-: |
| ![screenshot 2015-01-29 a 15 50 40](https://cloud.githubusercontent.com/assets/2211145/5959847/afdd37d6-a7d1-11e4-851a-8c440daaf150.jpg) | ![screenshot 2015-01-29 a 15 50 45](https://cloud.githubusercontent.com/assets/2211145/5959846/afdba1be-a7d1-11e4-8857-23627fb27521.jpg) |
