### PR TITLE
Fix search with no result is failing (no transchoice)

### DIFF
--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -15,7 +15,11 @@
         <div class="row">
             <div class="col-xs-12 col-sm-5">
                 {% if 'search' == app.request.get('action') %}
-                    <h1 class="title">{{ 'list.results_found' | transchoice(paginator.nbResults) | raw }}</h1>
+                    {% if paginator.nbResults > 0 %}
+                        <h1 class="title">{{ 'list.results_found' | transchoice(paginator.nbResults) | raw }}</h1>
+                    {% else %}
+                        <h1 class="title">{{ 'list.no_results' | trans | raw }}</h1>
+                    {% endif %}
                 {% else %}
                     <h1 class="title">{{ config['entities'][entity.name]['label'] }}</h1>
                 {% endif %}


### PR DESCRIPTION
A search with no result is failing, because the `list.results_found` does not provide any choice when nbResults is 0.
If there is no result, print `list.no_results` instead.

Previously, when no result : 

> An exception has been thrown during the rendering of a template ("Unable to choose a translation for "{1} <strong>1</strong> résultat trouvé|]1,Inf] <strong>%count%</strong> résultats trouvés" with locale "fr" for value "0". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %count% apples").") in @EasyAdmin/list.html.twig at line 18.
