### PR TITLE
Improved the way errors are displayed in forms

### DIFF
--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -287,11 +287,8 @@ button.btn-danger {
     transition: none;
 }
 
-.form-group.field_checkbox label.control-label {
-    visibility: hidden;
-}
-
-.help-block {
+.help-block,
+.has-error .help-block {
     color: #797470;
 }
 
@@ -303,15 +300,19 @@ button.btn-danger {
     border-color: #D44542;
     box-shadow: none;
 }
-.has-error .help-block {
+.has-error .error-block {
     color: #D44542;
     font-weight: bold;
+    padding-top: 5px;
 }
-.has-error .help-block ul {
-    margin: 0;
+.has-error .error-block .label-danger {
+    margin-right: 3px;
 }
-.has-error  .help-block .glyphicon {
-    display: none;
+.has-error .error-block ul {
+    margin: .5em 0 .5em 1.5em;
+}
+.has-error .error-block ul li {
+    margin-bottom: .5em;
 }
 
 /* Modal windows

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -32,16 +32,17 @@
     {{ form_start(form, { attr: { id: 'edit-form', novalidate: 'novalidate' } }) }}
         <div id="form">
             {% for field in form.children if field.vars.name != '_token' %}
-                <div class="form-group">
+                <div class="form-group {% if not field.vars.valid %}has-error{% endif %}">
                     {% if entity_fields[field.vars.name]['type'] == 'association' %}
                         {{ entity_field(item, entity_fields[field.vars.name]['name'], entity_fields[field.vars.name]) }}
                     {% else %}
                         {% set field_label = entity_fields[field.vars.name]['label']|default(null) %}
                         {{ form_label(field, field_label, { label_attr: { class: 'col-sm-2 control-label' } }) }}
 
-                        <div class="col-sm-10">
+                        <div class="col-sm-10 {% if entity_fields[field.vars.name]['type'] == 'checkbox' %}col-sm-offset-2{% endif %}">
                             {% set widget_attributes = { attr: { class: entity_fields[field.vars.name]['class']|default(null) } } %}
                             {{ form_widget(field, widget_attributes) }}
+                            {{ form_errors(field) }}
 
                             {% if entity_fields[field.vars.name]['help'] is defined %}
                                 <span class="help-block">{{ entity_fields[field.vars.name]['help'] }}</span>

--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -26,7 +26,7 @@ col-sm-2
 
 {% block form_row -%}
 {% spaceless %}
-    <div class="form-group{% if (not compound or force_error|default(false)) and not valid %} has-error{% endif %}">
+    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %}">
         {{ form_label(form) }}
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}
@@ -46,7 +46,7 @@ col-sm-2
 
 {% block checkbox_radio_row -%}
 {% spaceless %}
-    <div class="form-group{% if not valid %} has-error{% endif %}">
+    <div class="form-group {% if not valid %}has-error{% endif %}">
         <div class="{{ block('form_label_class') }}"></div>
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -163,13 +163,23 @@
     {% if parent_label_class is defined %}
         {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
     {% endif %}
-    {% if label is empty %}
-        {% set label = name|humanize %}
+
+    {# Do no display the label if widget is not defined in order to prevent double label rendering #}
+    {% if widget is defined %}
+        {% if required %}
+            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' required')|trim}) %}
+        {% endif %}
+        {% if parent_label_class is defined %}
+            {% set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' ' ~ parent_label_class)|trim}) %}
+        {% endif %}
+        {% if label is empty %}
+            {% set label = name|humanize %}
+        {% endif %}
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+                {{ widget|raw }}
+                {{ label|trans({}, translation_domain) }}
+        </label>
     {% endif %}
-    <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-        {{ widget|default('')|raw }}
-        {{ label|trans({}, translation_domain) }}
-    </label>
 {% endblock checkbox_radio_label %}
 
 {# Rows #}
@@ -224,14 +234,19 @@
 
 {# Errors #}
 
-{% block form_errors -%}
-    {% if errors|length > 0 -%}
-    {% if form.parent %}<span class="help-block">{% else %}<div class="alert alert-danger">{% endif %}
-    <ul class="list-unstyled">
-        {%- for error in errors -%}
-            <li><span class="glyphicon glyphicon-exclamation-sign"></span> {{ error.message }}</li>
-        {%- endfor -%}
-    </ul>
-    {% if form.parent %}</span>{% else %}</div>{% endif %}
-    {%- endif %}
-{%- endblock form_errors %}
+{% block form_errors %}
+    {% if errors|length > 1 %}
+        <div class="error-block">
+            <span class="label label-danger">{{ errors|length }} ERRORS</span>
+            <ul>
+                {% for error in errors %}
+                    <li>{{ error.message }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% elseif errors|length == 1 %}
+        <div class="error-block">
+            <span class="label label-danger">ERROR</span> {{ errors|first.message }}
+        </div>
+    {% endif %}
+{% endblock form_errors %}

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -23,16 +23,17 @@
     {{ form_start(form, { attr: { id: 'new-form', novalidate: 'novalidate' } }) }}
         <div id="form">
             {% for field in form.children if field.vars.name != '_token' %}
-                <div class="form-group field_{{ entity_fields[field.vars.name]['type']|lower|default('default') }}">
+                <div class="form-group field_{{ entity_fields[field.vars.name]['type']|lower|default('default') }} {% if not field.vars.valid %}has-error{% endif %}">
                     {% if entity_fields[field.vars.name]['type'] == 'association' %}
                         {{ entity_field(item, entity_fields[field.vars.name]['name'], entity_fields[field.vars.name]) }}
                     {% else %}
                         {% set field_label = entity_fields[field.vars.name]['label']|default(null) %}
                         {{ form_label(field, field_label, { label_attr: { class: 'col-sm-2 control-label' } }) }}
 
-                        <div class="col-sm-10">
+                        <div class="col-sm-10 {% if entity_fields[field.vars.name]['type'] == 'checkbox' %}col-sm-offset-2{% endif %}">
                             {% set widget_attributes = { attr: { class: entity_fields[field.vars.name]['class']|default(null) } } %}
                             {{ form_widget(field, widget_attributes) }}
+                            {{ form_errors(field) }}
 
                             {% if entity_fields[field.vars.name]['help'] is defined %}
                                 <span class="help-block">{{ entity_fields[field.vars.name]['help'] }}</span>


### PR DESCRIPTION
I wasn't happy with the default styles of the form errors provided by the Symfony's built-in bootstrap from theme, so I decided to tweak them.

This is the result, showing the differences when there is only one error and when there are more than one error for a field:

![form_errors](https://cloud.githubusercontent.com/assets/73419/5966831/ef367452-a807-11e4-8958-e9e6b1875862.png)
