### PR TITLE
Implementing Beautify admin routes

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -15,5 +15,10 @@
             <argument type="service" id="doctrine.orm.entity_manager"></argument>
         </service>
 
+        <service id="easyadmin.routing.easy_admin_loader" class="JavierEguiluz\Bundle\EasyAdminBundle\Routing\EasyAdminLoader">
+            <argument>%easyadmin.config%</argument>
+            <tag name="routing.loader" />
+        </service>
+
     </services>
 </container>

--- a/Resources/views/_list_paginator.html.twig
+++ b/Resources/views/_list_paginator.html.twig
@@ -16,7 +16,7 @@
                         </li>
                     {% else %}
                         <li>
-                            <a href="{{ path('admin', request_attributes|merge({ page: 1 }) ) }}">
+                            <a href="{{ entity_path(entity, 'list', request_attributes|merge({ page: 1 }) ) }}">
                                 <i class="fa fa-angle-double-left"></i> {{ 'paginator.first' | trans }}
                             </a>
                         </li>
@@ -24,7 +24,7 @@
 
                     {% if paginator.hasPreviousPage %}
                         <li>
-                            <a href="{{ path('admin', request_attributes|merge({ page: paginator.previousPage }) ) }}">
+                            <a href="{{ entity_path(entity, 'list', request_attributes|merge({ page: paginator.previousPage }) ) }}">
                                 <i class="fa fa-angle-left"></i> {{ 'paginator.previous' | trans }}
                             </a>
                         </li>
@@ -38,7 +38,7 @@
 
                     {% if paginator.hasNextPage %}
                         <li>
-                            <a href="{{ path('admin', request_attributes|merge({ page: paginator.nextPage }) ) }}">
+                            <a href="{{ entity_path(entity, 'list', request_attributes|merge({ page: paginator.nextPage }) ) }}">
                                 {{ 'paginator.next' | trans }} <i class="fa fa-angle-right"></i>
                             </a>
                         </li>
@@ -52,7 +52,7 @@
 
                     {% if paginator.currentPage < paginator.nbPages %}
                         <li>
-                            <a href="{{ path('admin', request_attributes|merge({ page: paginator.nbPages }) ) }}">
+                            <a href="{{ entity_path(entity, 'list', request_attributes|merge({ page: paginator.nbPages }) ) }}">
                                 {{ 'paginator.last' | trans }} <i class="fa fa-angle-double-right"></i>
                             </a>
                         </li>

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -84,7 +84,7 @@
                         <i class="fa fa-trash"></i> {{ 'entity.delete' | trans }}
                     </button>
 
-                    <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
+                    <a class="btn btn-list btn-secondary" href="{{ entity_path(entity, 'list') }}">
                         {{ 'link.back_to_listing' | trans }}
                     </a>
                 </div>

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -30,7 +30,7 @@
         <div id="header" class="col-lg-2">
             <div id="header-contents" class="row">
                 <div id="header-logo" class="col-xs-6 col-md-2 col-lg-12">
-                    <a href="{{ path('admin') }}">{{ config.site_name|raw }}</a>
+                    <a href="{{ path('easy_admin_homepage') }}">{{ config.site_name|raw }}</a>
                 </div>
 
                 <div id="header-nav" class="col-xs-12 col-md-8 col-lg-12">
@@ -43,7 +43,7 @@
                     <ul id="header-menu">
                         {% for item in config.entities %}
                             <li class="{{ item.name|lower == app.request.get('entity')|lower ? 'active' : '' }}">
-                                <a href="{{ path('admin', { entity: item.name, action: 'list' }) }}">
+                                <a href="{{ entity_path(item, 'list') }}">
                                     {{ item.label }}
                                 </a>
                             </li>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -4,17 +4,17 @@
 {% block body_class 'admin list ' ~ entity.name|lower %}
 
 {% block content %}
-{% if 'search' == app.request.get('action') %}
-    {% set request_attributes = { action: 'search', entity: entity.name, query: app.request.get('query')|default('') } %}
+{% if 'search' == app.request.attributes.get('action') %}
+    {% set request_attributes = { query: app.request.get('query')|default('') } %}
 {% else %}
-    {% set request_attributes = { action: 'list', entity: entity.name, sortDirection: app.request.get('sortDirection', 'DESC') } %}
+    {% set request_attributes = { sortDirection: app.request.get('sortDirection', 'DESC') } %}
 {% endif %}
 
 <div class="row">
     <div id="content-header" class="col-sm-12">
         <div class="row">
             <div class="col-xs-12 col-sm-5">
-                {% if 'search' == app.request.get('action') %}
+                {% if 'search' == app.request.attributes.get('action') %}
                     <h1 class="title">{{ 'list.results_found' | transchoice(paginator.nbResults) | raw }}</h1>
                 {% else %}
                     <h1 class="title">{{ config['entities'][entity.name]['label'] }}</h1>
@@ -22,14 +22,12 @@
             </div>
             <div class="col-xs-12 col-sm-7">
                 <div id="content-actions">
-                    <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
+                    <a class="btn" href="{{ entity_path(entity, 'new') }}">
                         {{ 'entity.create' | trans({"%entity%": entity.name}) }}
                     </a>
                 </div>
-                <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
+                <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ entity_path(entity, 'search') }}">
                     <div class="input-group">
-                        <input type="hidden" name="action" value="search">
-                        <input type="hidden" name="entity" value="{{ entity.name }}">
                         <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ 'list.search' | trans }}" value="{{ app.request.get('query')|default('') }}">
                     </div>
                 </form>
@@ -53,7 +51,7 @@
 
                                 {# for now you cannot sort by virtual fields not directly mapped to entity attributes #}
                                 {% if not metadata.virtual|default(false) %}
-                                    <a href="{{ path('admin', request_attributes|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
+                                    <a href="{{ entity_path(entity, app.request.attributes.get('action'), request_attributes|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
                                         {% if isSortingField and sortDirection == 'DESC' %}
                                             <i class="fa fa-caret-up"></i>
                                         {% elseif isSortingField and sortDirection == 'ASC' %}
@@ -97,7 +95,7 @@
                             {% endfor %}
                                 <td class="actions">
                                     {% for action in config['list_actions'] %}
-                                        <a href="{{ path('admin', { action: action, entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
+                                        <a href="{{ entity_path(entity, action, { id: attribute(item, entity.primary_key_field_name) }) }}">
                                             {{ ('actions.' ~ action)|trans }}
                                         </a>
                                     {% endfor %}

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -71,7 +71,7 @@
                         <i class="fa fa-save"></i> {{ 'entity.save_changes' | trans }}
                     </button>
 
-                    <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
+                    <a class="btn btn-list btn-secondary" href="{{ entity_path(entity, 'list') }}">
                         {{ 'link.back_to_listing' | trans }}
                     </a>
                 </div>

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -47,7 +47,7 @@
 
         <div class="form-group form-actions">
             <div class="col-sm-10 col-sm-offset-2">
-                <a class="btn btn-edit" href="{{ path('admin', { action: 'edit', entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
+                <a class="btn btn-edit" href="{{ entity_path(entity, 'edit',{ id: attribute(item, entity.primary_key_field_name) }) }}">
                     <i class="fa fa-edit"></i> {{ 'entity.edit' | trans({"%entity%": entity.name}) }}
                 </a>
 
@@ -55,7 +55,7 @@
                     <i class="fa fa-trash"></i> {{ 'entity.delete' | trans() }}
                 </button>
 
-                <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
+                <a class="btn btn-list btn-secondary" href="{{ entity_path(entity, 'list') }}">
                     {{ 'link.back_to_listing' | trans }}
                 </a>
             </div>

--- a/Routing/EasyAdminLoader.php
+++ b/Routing/EasyAdminLoader.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Routing;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\Config\Loader\LoaderResolverInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+
+class EasyAdminLoader implements LoaderInterface
+{
+    private $config;
+
+    function __construct($config)
+    {
+        $this->config = $config;
+    }
+
+    public function load($resource, $type = null)
+    {
+        $collection = new RouteCollection();
+
+        $this->createHomepageRoute($collection);
+
+        foreach ($this->config['entities'] as $name => $config) {
+            $this->createEntityRoutes($collection, $name, $config);
+        }
+
+        return $collection;
+    }
+
+    public function supports($resource, $type = null)
+    {
+        return 'easy_admin' === $type;
+    }
+
+    public function getResolver()
+    {
+
+    }
+
+    public function setResolver(LoaderResolverInterface $resolver)
+    {
+
+    }
+
+    protected function createHomepageRoute(RouteCollection $collection)
+    {
+        if (count($this->config['entities'])) {
+            $entity = current($this->config['entities']);
+
+            $collection->add('easy_admin_homepage', new Route('/', array(
+                '_controller' => 'FrameworkBundle:Redirect:redirect',
+                'route' => 'easy_admin_' . strtolower($entity['name']) . '_list',
+            )));
+        }
+    }
+
+    protected function createEntityRoutes(RouteCollection $collection, $name, $config)
+    {
+        $routeEntityPart = strtolower($name);
+        $routeNameTemplate = 'easy_admin_' . $routeEntityPart . '_%s';
+
+        if (isset($config['list'])) {
+            $route = new Route(sprintf('/%s/%s/{page}', $routeEntityPart, 'list'), array(
+                '_controller' => 'EasyAdminBundle:Admin:list',
+                'entity' => $name,
+                'action' => 'list',
+                'page' => 1,
+            ));
+            $collection->add(sprintf($routeNameTemplate, 'list'), $route);
+        }
+
+        if (isset($config['show'])) {
+            $route = new Route(sprintf('/%s/%s/{id}', $routeEntityPart, 'show'), array(
+                '_controller' => 'EasyAdminBundle:Admin:show',
+                'entity' => $name,
+                'action' => 'show',
+            ));
+            $collection->add(sprintf($routeNameTemplate, 'show'), $route);
+        }
+
+        if (true) {
+            $route = new Route(sprintf('/%s/%s', $routeEntityPart, 'search'), array(
+                '_controller' => 'EasyAdminBundle:Admin:search',
+                'entity' => $name,
+                'action' => 'search',
+            ));
+            $collection->add(sprintf($routeNameTemplate, 'search'), $route);
+        }
+
+        if (isset($config['new'])) {
+            $route = new Route(sprintf('/%s/%s', $routeEntityPart, 'new'), array(
+                '_controller' => 'EasyAdminBundle:Admin:new',
+                'entity' => $name,
+                'action' => 'new',
+            ));
+            $collection->add(sprintf($routeNameTemplate, 'new'), $route);
+        }
+
+        if (isset($config['edit'])) {
+            $route = new Route(sprintf('/%s/%s/{id}', $routeEntityPart, 'edit'), array(
+                '_controller' => 'EasyAdminBundle:Admin:edit',
+                'entity' => $name,
+                'action' => 'edit',
+            ));
+            $collection->add(sprintf($routeNameTemplate, 'edit'), $route);
+        }
+
+        if (true) {
+            $route = new Route(sprintf('/%s/%s/{id}', $routeEntityPart, 'delete'), array(
+                '_controller' => 'EasyAdminBundle:Admin:delete',
+                'entity' => $name,
+                'action' => 'delete',
+            ));
+            $collection->add(sprintf($routeNameTemplate, 'delete'), $route);
+        }
+    }
+}

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -30,6 +30,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
     {
         return array(
             'entity_field' => new \Twig_Function_Method($this, 'displayEntityField'),
+            'entity_path' => new \Twig_Function_Method($this, 'createPath'),
         );
     }
 
@@ -105,6 +106,13 @@ class EasyAdminTwigExtension extends \Twig_Extension
         }
 
         return '';
+    }
+
+    public function createPath($entity, $action, array $parameters = array())
+    {
+        $route = 'easy_admin_' . strtolower($entity['name']) . '_' . $action;
+
+        return $this->urlGenerator->generate($route, $parameters);
     }
 
     /**


### PR DESCRIPTION
This change allow to use real routes for Entity Admins

See https://github.com/javiereguiluz/EasyAdminBundle/issues/56

For each entity defined in **easy_admin.entities** the following routes are created:

``` yml
easy_admin:
    entities:
        'Users': AppBundle\Entity\User
        'Taks': AppBundle\Entity\Task
```

| Route | Path |
| --- | --- |
| easy_admin_homepage | /admin |
| easy_admin_user_list | /admin/user/list |
| easy_admin_user_show | /admin/user/show/{id} |
| easy_admin_user_search | /admin/user/search |
| easy_admin_user_new | /admin/user/new |
| easy_admin_user_edit | /admin/user/edit/{id} |
| easy_admin_user_delete | /admin/user/delete/{id} |
| easy_admin_task_list | /admin/task/list |
| easy_admin_task_show | /admin/task/show/{id} |
| easy_admin_task_search | /admin/task/search |
| easy_admin_task_new | /admin/task/new |
| easy_admin_task_edit | /admin/task/edit/{id} |
| easy_admin_task_delete | /admin/task/delete/{id} |

The route **easy_admin_homepage** is a redirection to the first entity route list.

For create a path in the AdminController use the **generateEntityUrl** Method, thid method expected:
- The entity array config
- The action name
- The parameters array (optional)

In twig exists the **entity_path** function and uses the same arguments.

The code in de routing.yml has changed for:

``` yml
easy_admin_bundle:
    resource: .
    type:     easy_admin
    prefix:   /admin
```
