### PR TITLE
Field contents now are only truncated for 'list' action

### DIFF
--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -653,6 +653,7 @@ body.show .form-control {
     border: 0;
     border-radius: 0;
     box-shadow: none;
+    height: auto;
 }
 body.show .form-control.text {
     height: auto;

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -92,7 +92,11 @@
                                 {% set isSortingField = metadata.property == app.request.get('sortField') %}
 
                                 <td class="{{ isSortingField ? 'sorted' : '' }} {{ metadata.type|lower }}">
-                                    {{ entity_field(item, field, metadata) }}
+                                    {% if metadata.type in ['array', 'json_array', 'simple_array', 'text'] %}
+                                        {{ entity_field(item, field, metadata)|entity_field_truncate }}
+                                    {% else %}
+                                        {{ entity_field(item, field, metadata) }}
+                                    {% endif %}
                                 </td>
                             {% endfor %}
                                 <td class="actions">

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -39,7 +39,11 @@
                 </label>
                 <div class="col-sm-10">
                     <div class="form-control {{ metadata.type|lower }}">
-                        {{ entity_field(item, field, metadata) }}
+                        {% if metadata.type in ['text'] %}
+                            {{ entity_field(item, field, metadata)|nl2br }}
+                        {% else %}
+                            {{ entity_field(item, field, metadata) }}
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -29,7 +29,14 @@ class EasyAdminTwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'entity_field' => new \Twig_Function_Method($this, 'displayEntityField'),
+            new \Twig_SimpleFunction('entity_field', array($this, 'displayEntityField')),
+        );
+    }
+
+    public function getFilters()
+    {
+        return array(
+            new \Twig_SimpleFilter('entity_field_truncate', array($this, 'entity_field_truncate_filter'), array('needs_environment' => true)),
         );
     }
 
@@ -51,7 +58,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
             // when a virtual field doesn't define it's type, consider it a string
             // and limit its length to avoid visual issues with very long values
             if (true === $fieldMetadata['virtual'] && null === $fieldType) {
-                return substr(strval($value), 0, 64);
+                return strval($value);
             }
 
             if ('id' === $fieldName) {
@@ -79,7 +86,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
             }
 
             if (in_array($fieldType, array('string', 'text'))) {
-                return strlen($value) > 64 ? substr($value, 0, 64).'...' : $value;
+                return $value;
             }
 
             if (in_array($fieldType, array('bigint', 'integer', 'smallint', 'decimal', 'float'))) {
@@ -139,6 +146,45 @@ class EasyAdminTwigExtension extends \Twig_Extension
         }
 
         return $entity->{$property};
+    }
+
+    /*
+     * Copied from the official Text Twig extension.
+     *
+     * code: https://github.com/twigphp/Twig-extensions/blob/master/lib/Twig/Extensions/Extension/Text.php
+     * author: Henrik Bjornskov <hb@peytz.dk>
+     * copyright holder: (c) 2009 Fabien Potencier
+     */
+    public function entity_field_truncate_filter(\Twig_Environment $env, $value, $length = 64, $preserve = false, $separator = '...')
+    {
+        if (function_exists('mb_get_info')) {
+            if (mb_strlen($value, $env->getCharset()) > $length) {
+                if ($preserve) {
+                    // If breakpoint is on the last word, return the value without separator.
+                    if (false === ($breakpoint = mb_strpos($value, ' ', $length, $env->getCharset()))) {
+                        return $value;
+                    }
+
+                    $length = $breakpoint;
+                }
+
+                return rtrim(mb_substr($value, 0, $length, $env->getCharset())) . $separator;
+            }
+
+            return $value;
+        }
+
+        if (strlen($value) > $length) {
+            if ($preserve) {
+                if (false !== ($breakpoint = strpos($value, ' ', $length))) {
+                    $length = $breakpoint;
+                }
+            }
+
+            return rtrim(substr($value, 0, $length)) . $separator;
+        }
+
+        return $value;
     }
 
     public function getName()

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -56,7 +56,6 @@ class EasyAdminTwigExtension extends \Twig_Extension
             }
 
             // when a virtual field doesn't define it's type, consider it a string
-            // and limit its length to avoid visual issues with very long values
             if (true === $fieldMetadata['virtual'] && null === $fieldType) {
                 return strval($value);
             }

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -101,7 +101,11 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 }
 
                 if (method_exists($value, 'getId')) {
-                    return new \Twig_Markup(sprintf('<a href="%s">%s</a>', $this->urlGenerator->generate('admin', array('entity' => $associatedEntityClassName, 'action' => 'show', 'id' => $value->getId())), $value), 'UTF-8');
+                    $associatedEntityUrl = $this->urlGenerator->generate('admin', array('entity' => $associatedEntityClassName, 'action' => 'show', 'id' => $value->getId()));
+                    $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+                    $associatedEntityValue = strlen($value) > 64 ? substr($value, 0, 64).'...' : $value;
+
+                    return new \Twig_Markup(sprintf('<a href="%s">%s</a>', $associatedEntityUrl, $associatedEntityValue), 'UTF-8');
                 }
 
                 return $value;

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -102,7 +102,9 @@ class EasyAdminTwigExtension extends \Twig_Extension
 
                 if (method_exists($value, 'getId')) {
                     $associatedEntityUrl = $this->urlGenerator->generate('admin', array('entity' => $associatedEntityClassName, 'action' => 'show', 'id' => $value->getId()));
+                    // escaping is done manually in order to include this content in a Twig_Markup object
                     $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+                    // ideally we'd use the 'entity_field_truncate_filter' method, but it's cumbersome to invoke it from here
                     $associatedEntityValue = strlen($value) > 64 ? substr($value, 0, 64).'...' : $value;
 
                     return new \Twig_Markup(sprintf('<a href="%s">%s</a>', $associatedEntityUrl, $associatedEntityValue), 'UTF-8');


### PR DESCRIPTION
- Contents displayed in the `list` action are truncated to prevent visual issues with long contents.
- Same contents displayed in the `show` action are not truncated, but we apply some CSS tricks to avoid visual problems with very long contents.
- The Twig function no longer truncates contents. A new filter based on the `truncate` filter of the official Twig Text extension does the work of truncating contents.

This fixes #86
