### PR TITLE
EntityManagers different than the default one are now supported

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -12,6 +12,7 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
 
 use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
@@ -19,7 +20,7 @@ class Configurator
 {
     private $backendConfig = array();
     private $entitiesConfig = array();
-    private $em;
+    private $doctrineManager;
 
     private $doctrineTypeToFormTypeMap = array(
         'association' => null,
@@ -43,10 +44,10 @@ class Configurator
         'time' => 'time',
     );
 
-    public function __construct(array $backendConfig, ObjectManager $em)
+    public function __construct(array $backendConfig, ManagerRegistry $manager)
     {
         $this->backendConfig = $backendConfig;
-        $this->em = $em;
+        $this->doctrineManager = $manager;
     }
 
     /**
@@ -71,7 +72,8 @@ class Configurator
         $entityClass = $this->backendConfig['entities'][$entityName]['class'];
         $entityConfiguration['class'] = $entityClass;
 
-        $doctrineEntityMetadata = $this->em->getMetadataFactory()->getMetadataFor($entityClass);
+        $em = $this->doctrineManager->getManagerForClass($entityClass);
+        $doctrineEntityMetadata = $em->getMetadataFactory()->getMetadataFor($entityClass);
 
         $entityProperties = $this->getEntityPropertiesMetadata($doctrineEntityMetadata);
         $entityConfiguration['properties'] = $entityProperties;

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -94,8 +94,6 @@ class AdminController extends Controller
             ));
         }
 
-        $this->em = $this->getDoctrine()->getManager();
-
         if (null !== $entityName = $request->query->get('entity')) {
             if (!array_key_exists($entityName, $this->config['entities'])) {
                 return $this->render404error('@EasyAdmin/error/undefined_entity.html.twig', array('entity_name' => $entityName));
@@ -113,6 +111,7 @@ class AdminController extends Controller
             }
         }
 
+        $this->em = $this->getDoctrine()->getManagerForClass($this->entity['class']);
         $this->request = $request;
     }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,7 +12,7 @@
 
         <service id="easyadmin.configurator" class="JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator">
             <argument>%easyadmin.config%</argument>
-            <argument type="service" id="doctrine.orm.entity_manager"></argument>
+            <argument type="service" id="doctrine"></argument>
         </service>
 
     </services>

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "sensio/framework-extra-bundle" : "~2.3|~3.0",
         "symfony/dependency-injection"  : "~2.3",
         "symfony/config"                : "~2.3",
+        "symfony/doctrine-bridge"       : "~2.3",
         "symfony/form"                  : "~2.3",
         "symfony/framework-bundle"      : "~2.3",
         "symfony/http-foundation"       : "~2.3",


### PR DESCRIPTION
EasyAdmin no longer uses the default entity manager. Now we look for the entity manager associated with the given entity. This means that you can use EasyAdmin in applications that define several entity managers. Everything should work out-of-the-box without having to do anything.

This fixes #50.
