### PR TITLE
Entities names & properties translation

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -93,8 +93,10 @@ class EasyAdminExtension extends Extension
             $entityClassParts = explode('\\', $entityConfiguration['class']);
             $entityName = end($entityClassParts);
 
+            //Check if translation key exists and use it as label
+            $entityConfiguration['label'] = isset($entityConfiguration['translation_key']) ? $entityConfiguration['translation_key'] : null;
             // config format #1 doesn't define custom labels: use the entity name as label
-            $entityConfiguration['label'] = is_integer($entityLabel) ? $entityName : $entityLabel;
+            if(null === $entityConfiguration['label']) $entityConfiguration['label'] = is_integer($entityLabel) ? $entityName : $entityLabel;
 
             $normalizedConfiguration[$entityName] = $entityConfiguration;
         }

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ 'entity.edit' | trans({'%label%': entity.name ~ ' #' ~ attribute(item, entity.primary_key_field_name)}) }}
+    {{ 'entity.edit' | trans({'%label%': entity.label|trans ~ ' #' ~ attribute(item, entity.primary_key_field_name)}) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -44,7 +44,7 @@
                         {% for item in config.entities %}
                             <li class="{{ item.name|lower == app.request.get('entity')|lower ? 'active' : '' }}">
                                 <a href="{{ path('admin', { entity: item.name, action: 'list' }) }}">
-                                    {{ item.label }}
+                                    {{ item.label | trans }}
                                 </a>
                             </li>
                         {% endfor %}

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -19,7 +19,7 @@
                         {% if 'search' == app.request.get('action') %}
                             {{ 'list.results_found' | transchoice(paginator.nbResults) | raw }}
                         {% else %}
-                            {{ entity.label }}
+                            {{ entity.label | trans }}
                         {% endif %}
                     {% endblock %}
                 </h1>

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ 'entity.create' | trans({"%entity%": entity.name}) }}
+    {{ 'entity.create' | trans({"%entity%": entity.label|trans}) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.label ~ ' #' ~ attribute(item, entity.primary_key_field_name) }}
+    {{ entity.label|trans ~ ' #' ~ attribute(item, entity.primary_key_field_name) }}
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
Related to #117 discussion.

This PR will add full support for translations in complementary with the #153 one.
This one is about entities names & properties (only their name, not value) translation.

Every single `label` key in the easy_admin config will now support translation keys:

``` yaml
easy_admin:
    entities:
        Post:
            class: AppBundle\Entity\Post
            label: app.post #explicit label
        app.category: AppBundle\Entity\Post #implicit label
```

Translate entity fields (show, list, edit/new actions) : 

``` yaml
# app/config/config.yml
easy_admin:
    entities:
        Customer:
            class: AppBundle\Entity\Customer
            list:
                fields:
                    - 'id'
                    - { property: 'firstname', label: app.orders.firstname }
                    - { property: 'lastname', label: app.orders.firstname  }
            form:
                fields:
                    - 'id'
                    - { property: 'firstname', label: app.orders.firstname }
                    - { property: 'lastname', label: app.orders.firstname  }                    
        # ...
```
