### PR TITLE
Fix layout issue when too many items.

### DIFF
--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -860,11 +860,13 @@ body.error code {
         padding-top: 0;
         margin-bottom: 0;
         overflow: visible;
-        min-height: 100%;
+        height: 100%;
         top: 0;
         bottom: 0;
         position: fixed;
         width: 202px;
+        overflow-y: scroll;
+        overflow-x: hidden;
     }
     #header-contents {
         margin-right: -25px;


### PR DESCRIPTION
This fixes #73

Now, for media >1200px wide, the left menu is no longer "simply fixed" to the left.
This allows many list items to be normally put under each other, and the scroll bar
appears to be able to view the others. The security panel "Logged as ..." is also
changed, as it's no longer fixed and is just wrapped to the bottom, right after all
other params. This PR also fixes the problems with layout between 1200 and 1024px,
as all the menu links wrap themselves with the inline-block normal wrapping.
No change is made for smaller devices.

I know that with this fix, we won't be able to have the old fashioned fixed left sidebar, but as long as we have not set up the "tree" structure (as it may break configuration) , we certainly need this for bigger back-ends, or simply for smaller screens that are between 1024 and 1200px wide.

I wish this could be implemented, because my new back-end will probably have to manage 20 or 25 different entities, and as said, with no "tree" structure, I definitely need this feature to use my back-office.
