### PR TITLE
Tweaked the titles of some pages

### DIFF
--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ 'entity.edit' | trans({'%label%': entity.name ~ ' #' ~ attribute(item, entity.primary_key_field_name)}) }}
+    {{ 'entity.edit' | trans({'%label%': entity.name ~ ' ' ~ attribute(item, entity.primary_key_field_name)}) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -8,7 +8,7 @@
         <meta http-equiv="content-type" content="text/html; charset=utf-8">
         <meta name="generator" content="EasyAdmin" />
 
-        <title>{% block page_title %}{{ block('content_title')|striptags }}{% endblock %}</title>
+        <title>{% block page_title %}{{ block('content_title') }}{% endblock %}</title>
 
         {% block head_stylesheets %}
             <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/bootstrap.min.css') }}">

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.label ~ ' #' ~ attribute(item, entity.primary_key_field_name) }}
+    {{ entity.label ~ ' ' ~ attribute(item, entity.primary_key_field_name) }}
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
This fixes #131

Changes:
- `|striptags` filter is no longer applied to avoid issues (see #131)
- The `#` is not prefixed to the entity's primary key value because not all primary keys are numeric
