### PR TITLE
Made the main menu scroll on smaller devices

### DIFF
--- a/Resources/public/javascript/admin.js
+++ b/Resources/public/javascript/admin.js
@@ -1,0 +1,16 @@
+$(function() {
+    $(window).bind('load', updateSidebar);
+    $(window).bind('resize', updateSidebar);
+});
+
+function updateSidebar() {
+    // the sticky sidebar is only displayed in large desktops
+    if ($(window).width() < 1200) {
+        return;
+    }
+
+    // the '#header-nav' element needs to define its 'height' explicitly
+    // otherwise, the 'overflow-y: scroll' property will be ignored
+    var menuHeight = $(window).height() - $('#header-logo').outerHeight() - $('#header-security').outerHeight();
+    $('#header-nav').css('height', menuHeight);
+}

--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -860,11 +860,13 @@ body.error code {
         padding-top: 0;
         margin-bottom: 0;
         overflow: visible;
-        min-height: 100%;
+        height: 100%;
         top: 0;
         bottom: 0;
         position: fixed;
         width: 202px;
+        overflow-y: scroll;
+        overflow-x: hidden;
     }
     #header-contents {
         margin-right: -25px;

--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -859,14 +859,12 @@ body.error code {
         padding-right: 25px;
         padding-top: 0;
         margin-bottom: 0;
-        overflow: visible;
+        overflow: hidden;
         height: 100%;
         top: 0;
         bottom: 0;
         position: fixed;
         width: 202px;
-        overflow-y: scroll;
-        overflow-x: hidden;
     }
     #header-contents {
         margin-right: -25px;
@@ -897,6 +895,8 @@ body.error code {
         padding-right: 0;
         padding: 0;
         margin: 0;
+        overflow-y: scroll;
+        overflow-x: hidden;
         width: 100%;
     }
     #header #header-menu {
@@ -905,7 +905,6 @@ body.error code {
         margin-left: 0;
         margin-right: 0;
         margin-top: 0;
-        max-height: 100%;
         padding: 0;
         list-style: none;
         width: 100%;
@@ -941,15 +940,17 @@ body.error code {
         text-decoration: none;
     }
     #header #header-security {
+        background: #302A2F;
         border-top: 1px solid #483D43;
         bottom: 0;
         color: #D5D2CA;
         font-size: 14px;
+        left: 0;
         margin-top: 1em;
         padding-bottom: 1em;
         padding-top: 1em;
-        position: absolute;
-        width: 100%;
+        position: fixed;
+        width: 202px;
     }
     #header #header-security p {
         line-height: 1.5;

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -93,6 +93,7 @@
     {% block body_javascript %}
         <script src="{{ asset('bundles/easyadmin/javascript/jquery.min.js') }}"></script>
         <script src="{{ asset('bundles/easyadmin/javascript/bootstrap.min.js') }}"></script>
+        <script src="{{ asset('bundles/easyadmin/javascript/admin.js') }}"></script>
     {% endblock %}
     {% for js_asset in config.assets.js %}
         <script src="{{ asset(js_asset) }}"></script>


### PR DESCRIPTION
This PR finishes the work started by @Pierstoval:

![sidebar-menu-resize](https://cloud.githubusercontent.com/assets/73419/6357179/ac4a7606-bc62-11e4-8306-84170a9e6571.gif)

The trick was to use JavaScript to update in real time the height of the main menu. Otherwise, the `overflow-y` property has no effect.
