### PR TITLE
Remove unnecessary fixed positioning of #header-security & only show scrollbar on hover

### DIFF
--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -895,9 +895,11 @@ body.error code {
         flex: 1;
         height: 0;
         margin: 0;
-        overflow-y: auto;
-        overflow-x: hidden;
+        overflow: hidden;
         padding: 0 0 1em;
+    }
+    #header #header-nav:hover {
+        overflow-y: auto;
     }
     #header #header-menu {
         display: block;

--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -894,15 +894,10 @@ body.error code {
     #header #header-nav {
         flex: 1;
         height: 0;
-        margin-left: 0;
-        margin-right: 0;
-        padding-right: 0;
-        padding: 0;
         margin: 0;
         overflow-y: auto;
         overflow-x: hidden;
-        width: 100%;
-        margin-bottom: 66px;
+        padding: 0 0 1em;
     }
     #header #header-menu {
         display: block;
@@ -945,17 +940,11 @@ body.error code {
         text-decoration: none;
     }
     #header #header-security {
-        background: #302A2F;
         border-top: 1px solid #483D43;
-        bottom: 0;
         color: #D5D2CA;
         font-size: 14px;
-        left: 0;
-        margin-top: 1em;
         padding-bottom: 1em;
         padding-top: 1em;
-        position: fixed;
-        width: 202px;
     }
     #header #header-security p {
         line-height: 1.5;


### PR DESCRIPTION
I just realized that I forgot to remove the now useless fixed positioning of `#header-security` in my previous PR (#142).
In order to simplify the stylesheet, I suggest the following.
