### PR TITLE
Force the locale used to translate the interface for easy admin routes.

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,11 @@ class Configuration implements ConfigurationInterface
                     ->info('The name displayed as the title of the administration zone (e.g. company name, project name).')
                 ->end()
 
+                ->scalarNode('locale')
+                    ->defaultValue('%kernel.default_locale%')
+                    ->info('The locale to use for the admin interface.')
+                ->end()
+
                 ->integerNode('list_max_results')
                     ->defaultValue(15)
                     ->info('The maximum number of items to show on listing and search pages.')

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -25,6 +25,7 @@ class EasyAdminExtension extends Extension
         $backendConfiguration['entities'] = $this->getEntitiesConfiguration($backendConfiguration['entities']);
 
         $container->setParameter('easyadmin.config', $backendConfiguration);
+        $container->setParameter('easyadmin.locale', $backendConfiguration['locale']);
 
         // load bundle's services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/Listener/ForceLocaleListener.php
+++ b/Listener/ForceLocaleListener.php
@@ -1,0 +1,40 @@
+<?php
+
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Listener;
+
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Forces the locale used to translate the EasyAdmin interface on EasyAdmin routes.
+ *
+ * @package JavierEguiluz\Bundle\EasyAdminBundle\Listener
+ */
+class ForceLocaleListener implements EventSubscriberInterface
+{
+    private $forcedLocale;
+
+    public function __construct($forcedLocale = 'en')
+    {
+        $this->forcedLocale = $forcedLocale;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if('admin' === $request->get('_route')) {
+            $request->setLocale($this->forcedLocale);
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array(array('onKernelRequest', 14)),
+        );
+    }
+}

--- a/README.md
+++ b/README.md
@@ -215,6 +215,31 @@ easy_admin:
     # ...
 ```
 
+### Configure the Backend Language
+
+The EasyAdmin bundle and its interface are only intended to be used as a single-language backend. However, many translations are available.
+By default, the backend will translate its interface using the `kernel.default_locale` parameter which is generally set in your config.yml under the `framework` configuration:
+
+```yaml
+# app/config/config.yml
+framework:
+    #esi:             ~
+    translator:      { fallback: "%locale%" }
+    default_locale:   en # kernel.default_locale` is set here
+```
+
+Use the `locale` option to change this value only for EasyAdmin interface:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    locale: 'fr'
+    # ...
+```
+
+In case you have a LocaleListener setting the locale according to the user's browser language, or a `_locale` parameter, the EasyAdmin bundle registers a `kernel.request` listener, overriding the locale with the default or the EasyAdmin configured one.  
+If you want to use your own *LocaleListener* anyway, use a priority lower than **14**.
+
 ### Customize the Number of Items Displayed in Listings
 
 By default, listings display a maximum of `15` items. Define the
@@ -1274,6 +1299,7 @@ the future. However, it's safe to consider that they'll never be implemented:
   * CMS-like features.
   * Assetic or frontend-tools-based (gulp, grunt, bower) asset processing.
   * Support for AngularJS or any other JavaScript-based client-side technology.
+  * Multi-language backends.
 
 ### How to Collaborate in this Project
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,5 +16,10 @@
             <argument type="service" id="doctrine"></argument>
         </service>
 
+        <service id="easyadmin.listener.force_locale" class="JavierEguiluz\Bundle\EasyAdminBundle\Listener\ForceLocaleListener">
+            <argument>%easyadmin.locale%</argument>
+            <tag name="kernel.event_subscriber" />
+        </service>
+
     </services>
 </container>


### PR DESCRIPTION
As @javiereguiluz  stated, **our target is to create single-language backends. We'll "_never_" support multi-language backends**.
According to this, the locale must be forced in order to translate the easy admin interface only in one language, for better consistency, even if a custom `LocaleListener` tries to get the locale from session, browser or a query parameter...

Related: #122
