### PR TITLE
Allowed grouping entities for a 2-level tree in nav

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -117,6 +117,7 @@ class AdminController extends Controller
 
         $this->em = $this->getDoctrine()->getManagerForClass($this->entity['class']);
 
+
         $this->request = $request;
     }
 

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -32,6 +32,7 @@ class EasyAdminExtension extends Extension
         $backendConfiguration = $this->processConfiguration(new Configuration(), $configs);
         $backendConfiguration['entities'] = $this->getEntitiesConfiguration($backendConfiguration['entities']);
         $backendConfiguration = $this->processEntityActions($backendConfiguration);
+        $backendConfiguration['grouped_entities'] = $this->getGroupedEntities($backendConfiguration);
 
         $container->setParameter('easyadmin.config', $backendConfiguration);
 
@@ -342,6 +343,8 @@ class EasyAdminExtension extends Extension
                 }
             }
 
+            $config['group'] = isset($config['group']) ? $config['group'] : '_';
+
             $entities[$entityName] = $config;
         }
 
@@ -430,5 +433,28 @@ class EasyAdminExtension extends Extension
         }
 
         return $fields;
+    }
+
+    private function getGroupedEntities(array $config)
+    {
+        // Manage grouped entities to create 2-level tree
+        $groupedEntities = array();
+
+        $entities = $config['entities'];
+        foreach ($entities as $key => $entity) {
+            if (!isset($groupedEntities[$entity['group']])) {
+                $groupedEntities[$entity['group']] = array();
+            }
+            $groupedEntities[$entity['group']][] = $key;
+        }
+        // Sort by key
+        ksort($groupedEntities);
+
+        if (isset($groupedEntities['_'])) {
+            // Non-grouped entities will have the group "_", so we force these values to be prepended to the list
+            $groupedEntities = array('_' => $groupedEntities['_']) + $groupedEntities;
+        }
+
+        return array_merge($groupedEntities, isset($config['grouped_entities']) ? $config['grouped_entities'] : array());
     }
 }

--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -516,6 +516,9 @@ body:not(:target) #header-menu:target .header-nav-close a {
 #header #header-footer {
     display: none;
 }
+#header #header-menu li h3 {
+    color: #D5D2CA;
+}
 
 /* Footer
    ------------------------------------------------------------------------- */
@@ -748,6 +751,11 @@ body.error code {
 /* =========================================================================
    RESPONSIVE
    ========================================================================= */
+
+#header #header-menu li h3 {
+    padding-left: 10px;
+    margin-top: 0.5em;
+}
 
 /* -------------------------------------------------------------------------
    VERTICAL TABLETS and LANDSCAPE SMARTPHONES
@@ -990,6 +998,16 @@ body.error code {
     }
     #header #header-menu li:last-child {
         border: none;
+    }
+    #header #header-menu li.grouped {
+        padding-left: 20px;
+    }
+    #header #header-menu li ul.entities_group {
+        margin-left: -20px;
+        padding-left: 10px;
+    }
+    #header #header-menu li h3 {
+        padding-left: 0;
     }
     #header #header-menu li a {
         color: #D5D2CA;

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -43,12 +43,24 @@
                     {% block navigation %}
                     <ul id="header-menu">
                         {% block navigation_items %}
-                        {% for item in easyadmin_config('entities') %}
-                            <li class="{{ item.name|lower == app.request.get('entity')|lower ? 'active' : '' }}">
-                                <a href="{{ path('admin', { entity: item.name, action: 'list' }) }}">
-                                    {{- item.label|trans -}}
-                                </a>
-                            </li>
+                        {% for group, entities in easyadmin_config('grouped_entities') if entities is not empty %}
+                            {% if group != '_' %}
+                                <li class="entities_group">
+                                <h3>{{ group|trans }}</h3>
+                                <ul class="entities_group">
+                            {% endif %}
+                            {% for class in entities %}
+                                {% set item = easyadmin_entity(class) %}
+                                <li class="{{ item.name|lower == app.request.get('entity')|lower ? 'active' : '' }}{{ group != '_' ? ' grouped' : '' }}">
+                                    <a href="{{ path('admin', { entity: item.name, action: 'list' }) }}">
+                                        {{ item.label|trans }}
+                                    </a>
+                                </li>
+                            {% endfor %}
+                            {% if group != '_' %}
+                                </ul>
+                                </li>
+                            {% endif %}
                         {% endfor %}
                             <li class="visible-xs visible-sm header-nav-close">
                                 <a href="#header">{{ 'header.close'|trans }}</a>


### PR DESCRIPTION
If you don't specify anything, entities are listed normally.

If you add a `group` parameter to your entity configuration in EasyAdmin, then all `grouped` entities will be sorted in a tree-like structure.

Like this:

``` yml
# app/config/config.yml
easy_admin:
    entities:
        Posts:
            groups: Blog
            class: AppBundle\Entity\Post
        Pages:
            groups: Cms
            class: AppBundle\Entity\Page
        "Config":
            class: AppBundle\Entity\Config
```

Like this:
![capture d ecran 2015-03-02 a 13 03 53](https://cloud.githubusercontent.com/assets/3369266/6440384/ab1fdcfc-c0dc-11e4-9f54-78acda773c6e.png)

For now there is no show/hide feature, but I think it should be necessary if there are more than 10 entities in the whole back-end, what you think?
