### PR TITLE
Allow to configure the titles and labels of the pages and UI elements

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -117,13 +117,11 @@ class EasyAdminExtension extends Extension
             // copy the original entity configuration to not lose any of its options
             $config = $entityConfiguration;
 
-            // if the common 'form' config is defined, and 'new' or 'edit' config are
-            // undefined, just copy the 'form' config into them to simplify the rest of the code
-            if (isset($config['form']['fields']) && !isset($config['edit']['fields'])) {
-                $config['edit']['fields'] = $config['form']['fields'];
-            }
-            if (isset($config['form']['fields']) && !isset($config['new']['fields'])) {
-                $config['new']['fields'] = $config['form']['fields'];
+            // if the common 'form' config is defined, use its options to complete
+            // the configuration for the 'new' and 'edit' actions
+            if (isset($config['form'])) {
+                $config['new'] = isset($config['new']) ? array_replace($config['form'], $config['new']) : $config['form'];
+                $config['edit'] = isset($config['edit']) ? array_replace($config['form'], $config['edit']) : $config['form'];
             }
 
             // configuration for the actions related to the entity ('list', 'edit', etc.)

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -45,6 +45,42 @@ easy_admin:
 Refer to the [EasyAdmin Configuration Reference](10-configuration-reference.md)
 chapter to check out all the available configuration formats.
 
+Customize the Title of the Page
+-------------------------------
+
+By default, the title of the listing page just displays the name of the entity.
+Define the `title` option to set a custom page title:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            list:
+                title: "Most recent customers"
+        # ...
+```
+
+Customize the Label of the Button to Create new Items
+-----------------------------------------------------
+
+Listing page includes a button in the top right part of the page to create new
+items of the same entity. By default, this button displays a generic label that
+includes the name of the entity. Define the `label` option of the `new` action
+to change this value:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            new:  # <-- change it in the 'new' action, not in the 'list' action
+                label: "Add Customer"
+        # ...
+```
+
 Customize the Number of Item Rows Displayed
 -------------------------------------------
 

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -99,6 +99,21 @@ easy_admin:
         # ...
 ```
 
+Similarly to the page title, this label can also include the `%entity_name%`
+variable to display the class name of the current entity:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            new:
+                # use double %% to escape special YAML characters
+                button_label: "Add %%entity_name%%"
+        # ...
+```
+
 Customize the Number of Item Rows Displayed
 -------------------------------------------
 

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -85,8 +85,8 @@ Customize the Label of the Button to Create new Items
 
 Listing page includes a button in the top right part of the page to create new
 items of the same entity. By default, this button displays a generic label that
-includes the name of the entity. Define the `label` option of the `new` action
-to change this value:
+includes the name of the entity. Define the `action_label` option of the `new`
+action to change this value:
 
 ```yaml
 # app/config/config.yml
@@ -95,7 +95,7 @@ easy_admin:
         Customer:
             class: AppBundle\Entity\Customer
             new:  # <-- define it in the 'new' action, not in the 'list' action
-                button_label: "Add Customer"
+                action_label: "Add Customer"
         # ...
 ```
 
@@ -110,7 +110,7 @@ easy_admin:
             class: AppBundle\Entity\Customer
             new:
                 # use double %% to escape special YAML characters
-                button_label: "Add %%entity_name%%"
+                action_label: "Add %%entity_name%%"
         # ...
 ```
 

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -62,6 +62,24 @@ easy_admin:
         # ...
 ```
 
+The `title` option can include the following variable:
+
+  * `%entity_name%`, resolves to the class name of the current entity (e.g.
+    `Customer`, `Product`, `User`, etc.)
+
+Beware that, in Symfony applications, YAML values enclosed with `%` and `%`
+have a special meaning. Use two consecutive `%` characters to avoid any issue:
+
+```yaml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            list:
+                title: '%%entity_name%% listing'
+        # ...
+```
+
 Customize the Label of the Button to Create new Items
 -----------------------------------------------------
 

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -76,8 +76,8 @@ easy_admin:
     entities:
         Customer:
             class: AppBundle\Entity\Customer
-            new:  # <-- change it in the 'new' action, not in the 'list' action
-                label: "Add Customer"
+            new:  # <-- define it in the 'new' action, not in the 'list' action
+                button_label: "Add Customer"
         # ...
 ```
 

--- a/Resources/doc/5-customizing-show-action.md
+++ b/Resources/doc/5-customizing-show-action.md
@@ -36,6 +36,27 @@ easy_admin:
         # ...
 ```
 
+The `title` option can include any of the following two variables:
+
+  * `%entity_name%`, resolves to the class name of the current entity (e.g.
+    `Customer`, `Product`, `User`, etc.)
+  * `%entity_id%`, resolves to the value of the primary key of the entity being
+    displayed. Even if the option is called `entity_id`, it also works for
+    primary keys with names different from `id`.
+
+Beware that, in Symfony applications, YAML values enclosed with `%` and `%`
+have a special meaning. Use two consecutive `%` characters to avoid any issue:
+
+```yaml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            show:
+                title: 'Customer %%entity_id%% details'
+        # ...
+```
+
 Customize the Order of the Fields
 ---------------------------------
 

--- a/Resources/doc/5-customizing-show-action.md
+++ b/Resources/doc/5-customizing-show-action.md
@@ -18,6 +18,24 @@ easy_admin:
     # ...
 ```
 
+Customize the Title of the Page
+-------------------------------
+
+By default, the title of the `show` page displays the name of the entity and
+the value of the primary key field. Define the `title` option to set a custom
+page title:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            show:
+                title: 'Customer details'
+        # ...
+```
+
 Customize the Order of the Fields
 ---------------------------------
 

--- a/Resources/doc/6-customizing-new-edit-actions.md
+++ b/Resources/doc/6-customizing-new-edit-actions.md
@@ -1,6 +1,23 @@
 Chapter 6. Customizing the New and Edit Actions
 ===============================================
 
+Customize the Title of the Page
+-------------------------------
+
+By default, the title of the `edit` page displays a very generic title (just
+the `Edit` word). Define the `title` option to set a custom page title:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            show:
+                title: 'Modify customer information'
+        # ...
+```
+
 Customize which Fields are Displayed
 ------------------------------------
 

--- a/Resources/doc/6-customizing-new-edit-actions.md
+++ b/Resources/doc/6-customizing-new-edit-actions.md
@@ -1,11 +1,69 @@
 Chapter 6. Customizing the New and Edit Actions
 ===============================================
 
+The `new` action is displayed when creating a new item of the given entity,
+whereas the `edit` action is displayed when editing any entity instance. Both
+actions are pretty similar, so most of the times you apply them the same
+customization.
+
+Instead of duplicating the configuration for both actions, you can define a new
+*virtual* `form` action with the common configuration:
+
+```yaml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            form:  # <-- 'form' is applied to both 'new' and 'edit' actions
+                fields:
+                    - 'id'
+                    - { property: 'email', type: 'email', label: 'Contact' }
+                    # ...
+    # ...
+```
+
+Any option defined in the `form` action will be copied into the `new` and
+`edit` actions. However, any option defined in the `edit` and `new` action
+overrides the corresponding `form` option. In other words, always use the
+`form` action to define the common configuration, and then define in the `new`
+and `edit` actions just the specific options you want to override:
+
+```yaml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            form:
+                fields: ['id', 'name', 'email']
+                title:  'Add customer'
+            new:
+                fields: ['name', 'email']
+            edit:
+                title:  'Edit customer'
+    # ...
+```
+
+The above configuration is equivalent to the following:
+
+```yaml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            new:
+                fields: ['name', 'email']
+                title:  'Add customer'
+            edit:
+                fields: ['id', 'name', 'email']
+                title:  'Edit customer'
+    # ...
+```
+
 Customize the Title of the Page
 -------------------------------
 
-By default, the title of the `edit` page displays a very generic title (just
-the `Edit` word). Define the `title` option to set a custom page title:
+By default, the title of the `edit`/`new` pages displays a very generic title.
+Define the `title` option to set a custom page title:
 
 ```yaml
 # app/config/config.yml
@@ -13,8 +71,30 @@ easy_admin:
     entities:
         Customer:
             class: AppBundle\Entity\Customer
-            show:
+            form:
                 title: 'Modify customer information'
+        # ...
+```
+
+The `title` option can include any of the following two variables:
+
+  * `%entity_name%`, resolves to the class name of the current entity (e.g.
+    `Customer`, `Product`, `User`, etc.)
+  * `%entity_id%`, resolves to the value of the primary key of the entity being
+    edited. Obviously, this variable is not available for the title of the
+    `new` action. Even if the option is called `entity_id`, it also works for
+    primary keys with names different from `id`.
+
+Beware that, in Symfony applications, YAML values enclosed with `%` and `%`
+have a special meaning. Use two consecutive `%` characters to avoid any issue:
+
+```yaml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            form:
+                title: 'Modify customer %%entity_id%% information'
         # ...
 ```
 
@@ -23,17 +103,15 @@ Customize which Fields are Displayed
 
 By default, the forms used to create and edit entities display all their
 properties. Customize any of these forms for any of your entities using the
-`new` and `edit` options:
+`fields` option:
 
 ```yaml
 easy_admin:
     entities:
         Customer:
             class: AppBundle\Entity\Customer
-            edit:
+            form:
                 fields: ['firstName', 'secondName', 'phone', 'email']
-            new:
-                fields: ['firstName', 'secondName', 'phone', 'email', 'creditLimit']
     # ...
 ```
 
@@ -49,16 +127,14 @@ Customize the Order of the Fields Displayed
 By default, forms show their fields in the same order as they were defined in
 the associated entities. You could customize the fields order just by
 reordering the entity properties, but it's more convenient to just define the
-order using the `fields` option of the `new` and `edit` options:
+order using the `fields` option:
 
 ```yaml
 easy_admin:
     entities:
         Customer:
             class: AppBundle\Entity\Customer
-            edit:
-                fields: ['firstName', 'secondName', 'phone', 'email']
-            new:
+            form:
                 fields: ['firstName', 'secondName', 'phone', 'email']
     # ...
 ```
@@ -78,7 +154,7 @@ easy_admin:
     entities:
         Customer:
             class: AppBundle\Entity\Customer
-            edit:
+            form:
                 fields:
                     - 'id'
                     - { property: 'email', type: 'email', label: 'Contact' }
@@ -102,31 +178,6 @@ These are the options that you can define for form fields:
   * `class`: it's the CSS class that will be applied to the form field widget.
     For example, to display a big input field, use the Bootstrap 3 class called
     `input-lg`.
-
-Apply the Same Customization to the New and Edit Forms
-------------------------------------------------------
-
-Even if you can define different options for the fields used in the `new` and
-`edit` action, most of the times they will be exactly the same. If that's your
-case, define the options in the special `form` action instead of duplicating
-the `new` and `edit` configuration:
-
-```yaml
-easy_admin:
-    entities:
-        Customer:
-            class: AppBundle\Entity\Customer
-            form:  # <-- 'form' is applied to both 'new' and 'edit' actions
-                fields:
-                    - 'id'
-                    - { property: 'email', type: 'email', label: 'Contact' }
-                    # ...
-    # ...
-```
-
-If `new` or `edit` options are defined, they will always be used, regardless
-of the `form` option. In other words, `form` and `new`/`edit` are mutually
-exclusive options.
 
 Add Custom Doctrine Types to Forms
 ----------------------------------

--- a/Resources/translations/EasyAdminBundle.cs.xliff
+++ b/Resources/translations/EasyAdminBundle.cs.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="cs" datatype="plaintext">
+    <file source-language="en" target-language="cs" datatype="plaintext" original="file.ext">
         <body>
             <!-- generic actions displayed on buttons and links -->
             <trans-unit id="action.new">
@@ -39,7 +39,7 @@
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>
-                <target>Create new %entity_name%</target>
+                <target>Vytvořit %entity_name%</target>
             </trans-unit>
             <trans-unit id="show.page_title">
                 <source>show.page_title</source>

--- a/Resources/translations/EasyAdminBundle.cs.xliff
+++ b/Resources/translations/EasyAdminBundle.cs.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="cs" target-language="cs" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="cs" datatype="plaintext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Zavřít</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Vytvořit %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Přihlášen jako</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Zobrazit</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Vytvořit %entity%</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Akce</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Žádné položky.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Editace</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Hledat</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Smazat</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Zpět na výpis</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Uložit změny</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Zrušit</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Zpět na výpis</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Create new %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>Edit %entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Žádné položky nebyly nalezeny|{1} <strong>1</strong> položka nalezena|]1,Inf] <strong>%count%</strong> položek nalezeno]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Žádné položky.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Akce</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Hledat</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>První</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> z <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Zrušit</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Zavřít</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Výpis</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Editovat</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Nový</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Zobrazit</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Hledat</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Smazat</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Žádné položky nebyly nalezeny|{1} <strong>1</strong> položka nalezena|]1,Inf] <strong>%count%</strong> položek nalezeno]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Hledat</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Přihlášen jako</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.de.xliff
+++ b/Resources/translations/EasyAdminBundle.de.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="de" datatype="plaintext">
+    <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
         <body>
             <!-- generic actions displayed on buttons and links -->
             <trans-unit id="action.new">
@@ -39,7 +39,7 @@
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>
-                <target>Create new %entity_name%</target>
+                <target>%entity_name% erstellen</target>
             </trans-unit>
             <trans-unit id="show.page_title">
                 <source>show.page_title</source>

--- a/Resources/translations/EasyAdminBundle.de.xliff
+++ b/Resources/translations/EasyAdminBundle.de.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="de" target-language="de" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="de" datatype="plaintext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Schließen</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>%entity_name% erstellen</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Angemeldet als</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Anzeigen</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>%entity% erstellen</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Aktionen</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Keine Ergebnisse gefunden.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Ändern</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Suchen</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Löschen</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Zurück zur Übersicht</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Änderungen speichern</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Abbrechen</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Zurück zur Übersicht</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Create new %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Keine Ergebnisse vorhanden|{1} <strong>1</strong> Ergebnis gefunden|]1,Inf] <strong>%count%</strong> Ergebnisse gefunden]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Keine Ergebnisse gefunden.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Aktionen</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Suchen</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Erste</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> von <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Abbrechen</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Schließen</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Liste</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Ändern</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Neu</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Anzeigen</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Suchen</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Löschen</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Keine Ergebnisse vorhanden|{1} <strong>1</strong> Ergebnis gefunden|]1,Inf] <strong>%count%</strong> Ergebnisse gefunden]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Suche</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Angemeldet als</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.en.xliff
+++ b/Resources/translations/EasyAdminBundle.en.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="en" datatype="plaintext">
+    <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
         <body>
             <!-- generic actions displayed on buttons and links -->
             <trans-unit id="action.new">
@@ -39,7 +39,7 @@
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>
-                <target>Create new %entity_name%</target>
+                <target>Create %entity_name%</target>
             </trans-unit>
             <trans-unit id="show.page_title">
                 <source>show.page_title</source>

--- a/Resources/translations/EasyAdminBundle.en.xliff
+++ b/Resources/translations/EasyAdminBundle.en.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="en" datatype="plaintext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Close</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>New %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Logged in as</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Show</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Create new %entity%</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Actions</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>No results found.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Edit</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Search</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Delete</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Back to listing</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Save changes</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Cancel</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Back to listing</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Create new %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>Edit %entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} No results found|{1} <strong>1</strong> result found|]1,Inf] <strong>%count%</strong> results found]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>No results found.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Actions</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Search</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>First</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> of <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Cancel</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Close</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>List</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Edit</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>New</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Show</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Search</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Delete</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} No results found|{1} <strong>1</strong> result found|]1,Inf] <strong>%count%</strong> results found]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Search</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Logged in as</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.es.xliff
+++ b/Resources/translations/EasyAdminBundle.es.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="es" datatype="plaintext">
+    <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
         <body>
             <!-- generic actions displayed on buttons and links -->
             <trans-unit id="action.new">

--- a/Resources/translations/EasyAdminBundle.es.xliff
+++ b/Resources/translations/EasyAdminBundle.es.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="es" datatype="plaintext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Cerrar</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Crear %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Conectado como</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Show</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Crear %entity%</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Acciones</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>No se han encontrado resultados.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Modificar</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Buscar</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Borrar</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Volver al listado</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Guardar cambios</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Cancelar</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Volver al listado</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Crear %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>Modificar %entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} No se han encontrado resultados|{1} <strong>1</strong> resultado|]1,Inf] <strong>%count%</strong> resultados]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>No se han encontrado resultados.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Acciones</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Buscar</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Primera</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> de <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Cancelar</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Cerrar</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Listado</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Modificar</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Crear</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Ver</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Buscar</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Borrar</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} No se han encontrado resultados|{1} <strong>1</strong> resultado|]1,Inf] <strong>%count%</strong> resultados]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Buscar</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Conectado como</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.eu.xliff
+++ b/Resources/translations/EasyAdminBundle.eu.xliff
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="eu" datatype="plaintext">
+    <file source-language="en" target-language="eu" datatype="plaintext" original="file.ext">
         <body>
             <!-- generic actions displayed on buttons and links -->
             <trans-unit id="action.new">

--- a/Resources/translations/EasyAdminBundle.eu.xliff
+++ b/Resources/translations/EasyAdminBundle.eu.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" target-language="eu" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="eu" datatype="plaintext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Itxi</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>%entity_name%-a sortu</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Konektatutako erabiltzailea</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Ikusi</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>%entity%-a sortu</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Akzioak</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Ez da emaitzarik topatu.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Aldatu</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Bilatu</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Ezabatu</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Zerrendara itzuli</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Aldaketak gorde</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Ezeztatu</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Zerrendara itzuli</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>%entity_name%-a sortu</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%) aldatu</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Ez da emaitzarik topatu|{1} Emaitza <strong>1</strong> |]1,Inf] <strong>%count%</strong> emaitza]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Ez da emaitzarik topatu.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Akzioak</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Bilatu</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Lehena</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong>tik - <strong>%end%</strong>era <strong>%results%</strong>tik]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Ezeztatu</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Itxi</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Zerrenda</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Aldatu</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Sortu</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Ikusi</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Bilatu</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Ezabatu</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Ez da emaitzarik topatu|{1} Emaitza <strong>1</strong> |]1,Inf] <strong>%count%</strong> emaitza]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Bilatu</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Konektatutako erabiltzailea</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.fr.xliff
+++ b/Resources/translations/EasyAdminBundle.fr.xliff
@@ -2,26 +2,79 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Fermer</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Créer %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Connecté en tant que</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Voir</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Créer "%entity%"</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Actions</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Éditer</target>
             </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Rechercher</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Supprimer</target>
+            </trans-unit>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
+                <target>Sauvegarder les modifications</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Annuler</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Retour à la liste</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Créer "%entity_name%"</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Aucun résultat trouvé|{1} <strong>1</strong> résultat trouvé|]1,Inf] <strong>%count%</strong> résultats trouvés]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Aucun résultat trouvé</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Actions</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Rechercher</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Premier</target>
@@ -42,57 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> sur <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
-                <target>Éditer</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Fermer</target>
             </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
-                <target>Sauvegarder les modifications</target>
-            </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
-                <target>Supprimer</target>
-            </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Retour à la liste</target>
-            </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Annuler</target>
-            </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Lister</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Créer</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Voir</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Rechercher</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Supprimer</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Aucun résultat trouvé|{1} <strong>1</strong> résultat trouvé|]1,Inf] <strong>%count%</strong> résultats trouvés]]></target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Aucun résultat trouvé</target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Rechercher</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Connecté en tant que</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.it.xliff
+++ b/Resources/translations/EasyAdminBundle.it.xliff
@@ -2,26 +2,79 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Chiudi</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Crea %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Connesso come</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Vedi</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Crea "%entity%"</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Azioni</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Modifica</target>
             </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Cerca</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Elimina</target>
+            </trans-unit>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
+                <target>Salva modifiche</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Annulla</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Torna alla lista</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Crea new %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Nessun risultato|{1} <strong>1</strong> risultato|]1,Inf] <strong>%count%</strong> risultati]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Nessun risultato</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Azioni</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Cerca</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Prima</target>
@@ -42,57 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> di <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
-                <target>Modifica</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Chiudi</target>
             </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
-                <target>Salva modifiche</target>
-            </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
-                <target>Elimina</target>
-            </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Torna alla lista</target>
-            </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Annulla</target>
-            </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Crea</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Vedi</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Cerca</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Elimina</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Nessun risultato|{1} <strong>1</strong> risultato|]1,Inf] <strong>%count%</strong> risultati]]></target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Nessun risultato</target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Cerca</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Connesso come</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.nl.xliff
+++ b/Resources/translations/EasyAdminBundle.nl.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="nl" target-language="nl" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Sluiten</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Nieuw %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Aangemeld als</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Tonen</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Maak nieuw %entity%</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Acties</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Geen resultaten gevonden.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Bewerken</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Zoeken</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Verwijderen</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Terugkeren naar overzicht</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Opslaan</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Afkeuren</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Terugkeren naar overzicht</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Maak nieuw %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Geen resultaten gevonden|{1} <strong>1</strong> resultaat gevonden|]1,Inf] <strong>%count%</strong> resultaten gevonden]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Geen resultaten gevonden.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Acties</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Zoeken</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Eerst</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> van <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Afkeuren</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Sluiten</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Overzicht</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Bewerken</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Nieuw</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Tonen</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Zoeken</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Verwijderen</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Geen resultaten gevonden|{1} <strong>1</strong> resultaat gevonden|]1,Inf] <strong>%count%</strong> resultaten gevonden]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Zoeken</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Aangemeld als</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.pl.xliff
+++ b/Resources/translations/EasyAdminBundle.pl.xliff
@@ -2,42 +2,79 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="pl" datatype="plaintext" original="file.ext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Zamknij</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Dodaj %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Zalogowany jako</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Pokaż</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Dodaj nowy %entity%</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Akcje</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Brak wyników.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Edytuj</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Szukaj</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Usuń</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Wróć do listy</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Zapisz zmiany</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Anuluj</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Wróć do listy</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Dodaj nowy %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Brak wyników|{1} Znaleziono <strong>1</strong> wynik|{2,3,4} Znaleziono <strong>%count%</strong> wyniki|[5,Inf] Znaleziono <strong>%count%</strong> wyników]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Brak wyników.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Akcje</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Szukaj</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Pierwsza</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> z <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Anuluj</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Zamknij</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Edytuj</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Dodaj nowy</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Pokaż</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Szukaj</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Usuń</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Brak wyników|{1} Znaleziono <strong>1</strong> wynik|{2,3,4} Znaleziono <strong>%count%</strong> wyniki|[5,Inf] Znaleziono <strong>%count%</strong> wyników]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Szukaj</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Zalogowany jako</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.ru.xliff
+++ b/Resources/translations/EasyAdminBundle.ru.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="ru" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="ru" datatype="plaintext" original="file.ext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Закрыть</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Создать %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Вы вошли как</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Показать</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Создать новый %entity%</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Действия</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Ничего не найдено.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Редактировать</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Поиск</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Удалить</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Вернуться к списку</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Сохранить изменения</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Отклонить</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Вернуться к списку</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Создать новый %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Ничего не найдено|{1} <strong>1</strong> запись найдена |{2,3,4} Всего <strong>%count%</strong> записи |[5,Inf] Всего <strong>%count%</strong> записей]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Ничего не найдено.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Действия</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Поиск</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Первая</target>
@@ -58,37 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> из <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Отклонить</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Закрыть</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Список</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Редактировать</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Новый</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Показать</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Поиск</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Удалить</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Ничего не найдено|{1} <strong>1</strong> запись найдена |{2,3,4} Всего <strong>%count%</strong> записи |[5,Inf] Всего <strong>%count%</strong> записей]]></target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Вы вошли как</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.sl.xliff
+++ b/Resources/translations/EasyAdminBundle.sl.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="sl" datatype="plaintext" original="file.ext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Zaprite</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Novo %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Prijavljeni kot</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Prikažite</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Ustvarite novo %entity%</target>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Urejanje</target>
             </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Akcije</target>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Iskanje</target>
             </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Nobenih rezultatov ni najdenih.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
-                <target>Uredite</target>
-            </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Izbrišite</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Nazaj na poslušanje</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Shranite spremembe</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Prekličite</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Nazaj na poslušanje</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Ustvarite novo %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Rezultati niso bili najdeni|{1} <strong>1</strong> rezultat najden|{2} <strong>%count%</strong> rezultata najdena|{3} <strong>%count%</strong> rezultati najdeni|[5,Inf] <strong>%count%</strong>rezultatov najdenih]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Nobenih rezultatov ni najdenih.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Akcije</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Iskanje</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Prva</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> od <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Prekličite</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Zaprite</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Seznam</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Urejanje</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Novo</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Prikažite</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Iskanje</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Izbrišite</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Rezultati niso bili najdeni|{1} <strong>1</strong> rezultat najden|{2} <strong>%count%</strong> rezultata najdena|{3} <strong>%count%</strong> rezultati najdeni|[5,Inf] <strong>%count%</strong>rezultatov najdenih]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Iskanje</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Prijavljeni kot</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/translations/EasyAdminBundle.sv.xliff
+++ b/Resources/translations/EasyAdminBundle.sv.xliff
@@ -1,43 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+    <file source-language="en" target-language="sv" datatype="plaintext" original="file.ext">
         <body>
-            <trans-unit id="header.close">
-                <source>header.close</source>
-                <target>Stäng</target>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Skapa %entity_name%</target>
             </trans-unit>
-            <trans-unit id="header.logged_in_as">
-                <source>header.logged_in_as</source>
-                <target>Inloggad som</target>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Visa</target>
             </trans-unit>
-            <trans-unit id="entity.create">
-                <source>entity.create</source>
-                <target>Skapa ny %entity%</target>
-            </trans-unit>
-            <trans-unit id="list.actions">
-                <source>list.actions</source>
-                <target>Actions</target>
-            </trans-unit>
-            <trans-unit id="list.no_results">
-                <source>list.no_results</source>
-                <target>Inga resultat.</target>
-            </trans-unit>
-            <trans-unit id="entity.edit">
-                <source>entity.edit</source>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
                 <target>Redigera</target>
             </trans-unit>
-            <trans-unit id="entity.delete">
-                <source>entity.delete</source>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Sök</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
                 <target>Ta bort</target>
             </trans-unit>
-            <trans-unit id="link.back_to_listing">
-                <source>link.back_to_listing</source>
-                <target>Åter till lista</target>
-            </trans-unit>
-            <trans-unit id="entity.save_changes">
-                <source>entity.save_changes</source>
+            <trans-unit id="action.save_changes">
+                <source>action.save_changes</source>
                 <target>Spara ändringar</target>
             </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Avbryt</target>
+            </trans-unit>
+            <trans-unit id="action.back_to_listing">
+                <source>action.back_to_listing</source>
+                <target>Åter till lista</target>
+            </trans-unit>
+
+            <!-- page titles -->
+            <trans-unit id="new.page_title">
+                <source>new.page_title</source>
+                <target>Create new %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="show.page_title">
+                <source>show.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="edit.page_title">
+                <source>edit.page_title</source>
+                <target>%entity_name% (#%entity_id%)</target>
+            </trans-unit>
+            <trans-unit id="list.page_title">
+                <source>list.page_title</source>
+                <target>%entity_name%</target>
+            </trans-unit>
+            <trans-unit id="search.page_title">
+                <source>search.page_title</source>
+                <target><![CDATA[{0} Inga resultat|{1} <strong>1</strong> result|]1,Inf] <strong>%count%</strong> resultat]]></target>
+            </trans-unit>
+
+            <!-- 'search' action -->
+            <trans-unit id="search.no_results">
+                <source>search.no_results</source>
+                <target>Inga resultat.</target>
+            </trans-unit>
+
+            <!-- 'list' action -->
+            <trans-unit id="list.row_actions">
+                <source>list.row_actions</source>
+                <target>Actions</target>
+            </trans-unit>
+            <trans-unit id="list.search_placeholder">
+                <source>list.search_placeholder</source>
+                <target>Sök</target>
+            </trans-unit>
+
+            <!-- paginator -->
             <trans-unit id="paginator.first">
                 <source>paginator.first</source>
                 <target>Första</target>
@@ -58,41 +95,15 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> av <strong>%results%</strong>]]></target>
             </trans-unit>
-            <trans-unit id="actions.cancel">
-                <source>actions.cancel</source>
-                <target>Avbryt</target>
+
+            <!-- misc. elements -->
+            <trans-unit id="header.close">
+                <source>header.close</source>
+                <target>Stäng</target>
             </trans-unit>
-            <trans-unit id="actions.list">
-                <source>actions.list</source>
-                <target>Lista</target>
-            </trans-unit>
-            <trans-unit id="actions.edit">
-                <source>actions.edit</source>
-                <target>Redigera</target>
-            </trans-unit>
-            <trans-unit id="actions.new">
-                <source>actions.new</source>
-                <target>Ny</target>
-            </trans-unit>
-            <trans-unit id="actions.show">
-                <source>actions.show</source>
-                <target>Visa</target>
-            </trans-unit>
-            <trans-unit id="actions.search">
-                <source>actions.search</source>
-                <target>Sök</target>
-            </trans-unit>
-            <trans-unit id="actions.delete">
-                <source>actions.delete</source>
-                <target>Ta bort</target>
-            </trans-unit>
-            <trans-unit id="list.results_found">
-                <source>list.results_found</source>
-                <target><![CDATA[{0} Inga resultat|{1} <strong>1</strong> result|]1,Inf] <strong>%count%</strong> resultat]]></target>
-            </trans-unit>
-            <trans-unit id="list.search">
-                <source>list.search</source>
-                <target>Sök</target>
+            <trans-unit id="header.logged_in_as">
+                <source>header.logged_in_as</source>
+                <target>Inloggad som</target>
             </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>

--- a/Resources/views/_list_paginator.html.twig
+++ b/Resources/views/_list_paginator.html.twig
@@ -3,7 +3,7 @@
     <div class="list-pagination">
         <div class="row">
             <div class="col-sm-2 hidden-xs" class="list-pagination-counter">
-                {{ 'paginator.counter' | trans({"%start%": paginator.currentPageOffsetStart, "%end%": paginator.currentPageOffsetEnd, "%results%": paginator.nbResults}) | raw }}
+                {{ 'paginator.counter'|trans({"%start%": paginator.currentPageOffsetStart, "%end%": paginator.currentPageOffsetEnd, "%results%": paginator.nbResults})|raw }}
             </div>
 
             <div class="col-xs-12 col-sm-10">
@@ -11,13 +11,13 @@
                     {% if 1 == paginator.currentPage %}
                         <li class="disabled">
                             <span>
-                                <i class="fa fa-angle-double-left"></i> {{ 'paginator.first' | trans }}
+                                <i class="fa fa-angle-double-left"></i> {{ 'paginator.first'|trans }}
                             </span>
                         </li>
                     {% else %}
                         <li>
                             <a href="{{ path('admin', request_attributes|merge({ page: 1 }) ) }}">
-                                <i class="fa fa-angle-double-left"></i> {{ 'paginator.first' | trans }}
+                                <i class="fa fa-angle-double-left"></i> {{ 'paginator.first'|trans }}
                             </a>
                         </li>
                     {% endif %}
@@ -25,13 +25,13 @@
                     {% if paginator.hasPreviousPage %}
                         <li>
                             <a href="{{ path('admin', request_attributes|merge({ page: paginator.previousPage }) ) }}">
-                                <i class="fa fa-angle-left"></i> {{ 'paginator.previous' | trans }}
+                                <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
                             </a>
                         </li>
                     {% else %}
                         <li class="disabled">
                             <span>
-                                <i class="fa fa-angle-left"></i> {{ 'paginator.previous' | trans }}
+                                <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
                             </span>
                         </li>
                     {% endif %}
@@ -39,13 +39,13 @@
                     {% if paginator.hasNextPage %}
                         <li>
                             <a href="{{ path('admin', request_attributes|merge({ page: paginator.nextPage }) ) }}">
-                                {{ 'paginator.next' | trans }} <i class="fa fa-angle-right"></i>
+                                {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
                             </a>
                         </li>
                     {% else %}
                         <li class="disabled">
                             <span>
-                                {{ 'paginator.next' | trans }} <i class="fa fa-angle-right"></i>
+                                {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
                             </span>
                         </li>
                     {% endif %}
@@ -53,13 +53,13 @@
                     {% if paginator.currentPage < paginator.nbPages %}
                         <li>
                             <a href="{{ path('admin', request_attributes|merge({ page: paginator.nbPages }) ) }}">
-                                {{ 'paginator.last' | trans }} <i class="fa fa-angle-double-right"></i>
+                                {{ 'paginator.last'|trans }} <i class="fa fa-angle-double-right"></i>
                             </a>
                         </li>
                     {% else %}
                         <li class="disabled">
                             <span>
-                                {{ 'paginator.last' | trans }} <i class="fa fa-angle-double-right"></i>
+                                {{ 'paginator.last'|trans }} <i class="fa fa-angle-double-right"></i>
                             </span>
                         </li>
                     {% endif %}

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ 'entity.edit' | trans({'%label%': entity.name ~ ' ' ~ attribute(item, entity.primary_key_field_name)}) }}
+    {{ entity.edit.title|default('entity.edit') | trans({'%label%': entity.name ~ ' ' ~ attribute(item, entity.primary_key_field_name)}) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.edit.title|default('entity.edit') | trans({'%label%': entity.name ~ ' ' ~ attribute(item, entity.primary_key_field_name)}) }}
+    {{ entity.edit.title|default('entity.edit')|trans({'%entity_name%': entity.name, '%entity_id%': attribute(item, entity.primary_key_field_name)}) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -25,7 +25,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.edit.title|default('entity.edit')|trans({'%entity_name%': entity.name, '%entity_id%': attribute(item, entity.primary_key_field_name)}) }}
+    {{ entity.edit.title|default('edit.page_title')|trans({'%entity_name%': entity.name, '%entity_id%': attribute(item, entity.primary_key_field_name)}) }}
 {% endblock %}
 
 {% block main %}
@@ -78,15 +78,15 @@
             <div class="form-group">
                 <div class="col-sm-10 col-sm-offset-2">
                     <button type="submit" class="btn">
-                        <i class="fa fa-save"></i> {{ 'entity.save_changes' | trans }}
+                        <i class="fa fa-save"></i> {{ 'action.save_changes'|trans }}
                     </button>
 
                     <button type="button" id="button-delete" class="btn btn-danger">
-                        <i class="fa fa-trash"></i> {{ 'entity.delete' | trans }}
+                        <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
                     </button>
 
                     <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
-                        {{- 'link.back_to_listing' | trans -}}
+                        {{- 'link.back_to_listing'|trans -}}
                     </a>
                 </div>
             </div>
@@ -100,15 +100,15 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-body">
-                <h4>{{ 'delete_modal.title' | trans }}</h4>
-                <p>{{ 'delete_modal.content' | trans }}</p>
+                <h4>{{ 'delete_modal.title'|trans }}</h4>
+                <p>{{ 'delete_modal.content'|trans }}</p>
             </div>
             <div class="modal-footer">
                 <button type="button" data-dismiss="modal" class="btn">
-                    {{ 'actions.cancel' | trans }}
+                    {{ 'action.cancel'|trans }}
                 </button>
                 <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
-                    <i class="fa fa-trash"></i> {{ 'entity.delete' | trans }}
+                    <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
                 </button>
             </div>
         </div>

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -49,7 +49,7 @@
                             </li>
                         {% endfor %}
                             <li class="visible-xs visible-sm header-nav-close">
-                                <a href="#header">{{ 'header.close' | trans }}</a>
+                                <a href="#header">{{ 'header.close'|trans }}</a>
                             </li>
                     </ul>
                 </div>
@@ -58,7 +58,7 @@
                     {% if app.user %}
                         <div id="header-security" class="col-xs-12 col-md-2 col-lg-12">
                             <p>
-                                <small><i class="fa fa-lock"></i> <span>{{ 'header.logged_in_as' | trans }}</span></small>
+                                <small><i class="fa fa-lock"></i> <span>{{ 'header.logged_in_as'|trans }}</span></small>
                                 {{ app.user.username|default('Unnamed User') }}
                             </p>
                         </div>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -19,7 +19,7 @@
                         {% if 'search' == app.request.get('action') %}
                             {{ 'list.results_found' | transchoice(paginator.nbResults) | raw }}
                         {% else %}
-                            {{ entity.label }}
+                            {{ entity.list.title|default(entity.label)|trans }}
                         {% endif %}
                     {% endblock %}
                 </h1>
@@ -27,7 +27,7 @@
             <div class="col-xs-12 col-sm-7">
                 <div id="content-actions">
                     <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
-                        {{ 'entity.create' | trans({"%entity%": entity.name}) }}
+                        {{ entity.new.label|default('entity.create')|trans({"%entity%": entity.name}) }}
                     </a>
                 </div>
                 <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -5,9 +5,9 @@
 
 {% block content_title %}
     {% if 'search' == app.request.get('action') %}
-        {{ 'list.results_found'|transchoice(paginator.nbResults)|raw }}
+        {{ 'search.page_title'|transchoice(paginator.nbResults)|raw }}
     {% else %}
-        {{ entity.list.title|default(entity.label)|trans({'%entity_name%': entity.name}) }}
+        {{ entity.list.title|default('list.page_title')|trans({'%entity_name%': entity.name}) }}
     {% endif %}
 {% endblock %}
 
@@ -27,14 +27,14 @@
             <div class="col-xs-12 col-sm-7">
                 <div id="content-actions">
                     <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
-                        {{ entity.new.button_label|default('entity.create')|trans({"%entity%": entity.name}) }}
+                        {{ entity.new.button_label|default('action.new')|trans({'%entity_name%': entity.name}) }}
                     </a>
                 </div>
                 <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
                     <div class="input-group">
                         <input type="hidden" name="action" value="search">
                         <input type="hidden" name="entity" value="{{ entity.name }}">
-                        <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ 'list.search' | trans }}" value="{{ app.request.get('query')|default('') }}">
+                        <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ 'list.search_placeholder'|trans }}" value="{{ app.request.get('query')|default('') }}">
                     </div>
                 </form>
             </div>
@@ -84,7 +84,7 @@
                             </th>
                         {% endfor %}
                             <th>
-                                <span>{{ 'list.actions' | trans }}</span>
+                                <span>{{ 'list.row_actions'|trans }}</span>
                             </th>
                     </tr>
                 </thead>
@@ -106,14 +106,14 @@
                                 <td class="actions">
                                     {% for action in config['list_actions'] %}
                                         <a href="{{ path('admin', { action: action, entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
-                                            {{- ('actions.' ~ action)|trans -}}
+                                            {{- ('action.' ~ action)|trans -}}
                                         </a>
                                     {% endfor %}
                                 </td>
                         </tr>
                     {% else %}
                         <tr>
-                            <td colspan="{{ fields|length + 1 }}">{{ 'list.no_results' | trans }}</td>
+                            <td colspan="{{ fields|length + 1 }}">{{ 'search.no_results'|trans }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -27,7 +27,7 @@
             <div class="col-xs-12 col-sm-7">
                 <div id="content-actions">
                     <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
-                        {{ entity.new.label|default('entity.create')|trans({"%entity%": entity.name}) }}
+                        {{ entity.new.button_label|default('entity.create')|trans({"%entity%": entity.name}) }}
                     </a>
                 </div>
                 <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -27,7 +27,7 @@
             <div class="col-xs-12 col-sm-7">
                 <div id="content-actions">
                     <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
-                        {{ entity.new.button_label|default('action.new')|trans({'%entity_name%': entity.name}) }}
+                        {{ entity.new.action_label|default('action.new')|trans({'%entity_name%': entity.name}) }}
                     </a>
                 </div>
                 <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -3,6 +3,14 @@
 {% trans_default_domain "EasyAdminBundle" %}
 {% block body_class 'admin list ' ~ entity.name|lower %}
 
+{% block content_title %}
+    {% if 'search' == app.request.get('action') %}
+        {{ 'list.results_found'|transchoice(paginator.nbResults)|raw }}
+    {% else %}
+        {{ entity.list.title|default(entity.label)|trans({'%entity_name%': entity.name}) }}
+    {% endif %}
+{% endblock %}
+
 {% block content %}
 {% if 'search' == app.request.get('action') %}
     {% set request_attributes = { action: 'search', entity: entity.name, query: app.request.get('query')|default('') } %}
@@ -14,15 +22,7 @@
     <div id="content-header" class="col-sm-12">
         <div class="row">
             <div class="col-xs-12 col-sm-5">
-                <h1 class="title">
-                    {% block content_title %}
-                        {% if 'search' == app.request.get('action') %}
-                            {{ 'list.results_found' | transchoice(paginator.nbResults) | raw }}
-                        {% else %}
-                            {{ entity.list.title|default(entity.label)|trans }}
-                        {% endif %}
-                    {% endblock %}
-                </h1>
+                <h1 class="title">{{ block('content_title') }}</h1>
             </div>
             <div class="col-xs-12 col-sm-7">
                 <div id="content-actions">

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.new.title|default('entity.create')|trans({"%entity%": entity.name}) }}
+    {{ entity.new.title|default('entity.create')|trans({'%entity_name%': entity.name}) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.new.title|default('entity.create')|trans({'%entity_name%': entity.name}) }}
+    {{ entity.new.title|default('new.page_title')|trans({'%entity_name%': entity.name}) }}
 {% endblock %}
 
 {% block main %}
@@ -69,11 +69,11 @@
             <div class="form-group">
                 <div class="col-sm-10 col-sm-offset-2">
                     <button type="submit" class="btn">
-                        <i class="fa fa-save"></i> {{ 'entity.save_changes' | trans }}
+                        <i class="fa fa-save"></i> {{ 'action.save_changes'|trans }}
                     </button>
 
                     <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
-                        {{- 'link.back_to_listing' | trans -}}
+                        {{- 'action.back_to_listing'|trans -}}
                     </a>
                 </div>
             </div>

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ 'entity.create' | trans({"%entity%": entity.name}) }}
+    {{ entity.new.title|default('entity.create')|trans({"%entity%": entity.name}) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.label ~ ' ' ~ attribute(item, entity.primary_key_field_name) }}
+    {{ entity.show.title|default(entity.label ~ ' ' ~ attribute(item, entity.primary_key_field_name))|trans }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.show.title|default('actions.show')|trans({'%entity_name%': entity.name, '%entity_id%': attribute(item, entity.primary_key_field_name)}) }}
+    {{ entity.show.title|default('show.page_title')|trans({'%entity_name%': entity.name, '%entity_id%': attribute(item, entity.primary_key_field_name)}) }}
 {% endblock %}
 
 {% block main %}
@@ -52,15 +52,15 @@
         <div class="form-group form-actions">
             <div class="col-sm-10 col-sm-offset-2">
                 <a class="btn btn-edit" href="{{ path('admin', { action: 'edit', entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
-                    <i class="fa fa-edit"></i> {{ 'entity.edit' | trans({"%entity%": entity.name}) }}
+                    <i class="fa fa-edit"></i> {{ 'action.edit'|trans }}
                 </a>
 
                 <button type="button" id="button-delete" class="btn btn-danger">
-                    <i class="fa fa-trash"></i> {{ 'entity.delete' | trans() }}
+                    <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
                 </button>
 
                 <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
-                    {{- 'link.back_to_listing' | trans -}}
+                    {{- 'action.back_to_listing'|trans -}}
                 </a>
             </div>
         </div>
@@ -72,15 +72,15 @@
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-body">
-                    <h4>{{ 'delete_modal.title' | trans }}</h4>
-                    <p>{{ 'delete_modal.content' | trans }}</p>
+                    <h4>{{ 'delete_modal.title'|trans }}</h4>
+                    <p>{{ 'delete_modal.content'|trans }}</p>
                 </div>
                 <div class="modal-footer">
                     <button type="button" data-dismiss="modal" class="btn">
-                        {{ 'actions.cancel' | trans }}
+                        {{ 'action.cancel'|trans }}
                     </button>
                     <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
-                        <i class="fa fa-trash"></i> {{ 'entity.delete' | trans }}
+                        <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
                     </button>
                 </div>
             </div>

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -21,7 +21,7 @@
 {% endblock %}
 
 {% block content_title %}
-    {{ entity.show.title|default(entity.label ~ ' ' ~ attribute(item, entity.primary_key_field_name))|trans }}
+    {{ entity.show.title|default('actions.show')|trans({'%entity_name%': entity.name, '%entity_id%': attribute(item, entity.primary_key_field_name)}) }}
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
This PR adds support for some of the basic customizations that aren't still available in EasyAdmin. Read the new documentation to see how it works.

I have 3 questions regarding this PR:
- How can we add support to include variables as part of the `title`/`label`? What if the title wants to display the `id` or the `title` of the associated entity?
- The `trans` filter is applied to all titles. Is this enough to provide full translation support? (this question is specially directed to @ogizanagi who raised this question in another issue).
- The label to create new entities is customized via the `label` option of the `new` action. I don't like the `label` name because it's too generic and it can be confused with `title`. I thought about `button_label` in `new` action or `new_button_label` in `list` action. Thoughts or comments?
