### PR TITLE
Fix search title (and other titles with html tags)

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -8,7 +8,7 @@
         <meta http-equiv="content-type" content="text/html; charset=utf-8">
         <meta name="generator" content="EasyAdmin" />
 
-        <title>{% block page_title %}{{ block('content_title') }}{% endblock %}</title>
+        <title>{% block page_title %}{{ block('content_title')|striptags|raw }}{% endblock %}</title>
 
         {% block head_stylesheets %}
             <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/bootstrap.min.css') }}">


### PR DESCRIPTION
Obviously the `striptags` controversed in #131 was useful, and should not have been removed in  706e3f9:

![screenshot 2015-03-04 a 10 28 42](https://cloud.githubusercontent.com/assets/2211145/6480934/419a5c3e-c259-11e4-942a-eec67f270a47.PNG)

This PR introduces another way to solve the issue.
