### PR TITLE
Fixed the way we handle the form field type

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -200,14 +200,18 @@ class Configurator
             $entityFields = $this->filterFieldsByNameAndType($this->defaultEntityFields, $excludedFieldNames, $excludedFieldTypes);
         }
 
-        // to avoid errors when rendering the form, transform Doctrine types to Form component types
+        // if the user has defined the 'type' for the field, use it. otherwise,
+        // guess the best form type for the Doctrine type associated with the field
         foreach ($entityFields as $fieldName => $fieldConfiguration) {
-            $fieldType = $fieldConfiguration['type'];
+            if (!isset($entityConfiguration[$action]['fields'][$fieldName]['type'])) {
+                $fieldType = $fieldConfiguration['type'];
 
-            // don't change this array_key_exists() by isset() because the resulting type can be null
-            $entityFields[$fieldName]['type'] = array_key_exists($fieldType, $this->doctrineTypeToFormTypeMap)
-                ? $this->doctrineTypeToFormTypeMap[$fieldType]
-                : $fieldType;
+                // don't change this array_key_exists() by isset() because the Doctrine
+                // type map can return 'null' values that shouldn't be ignored
+                $entityFields[$fieldName]['type'] = array_key_exists($fieldType, $this->doctrineTypeToFormTypeMap)
+                    ? $this->doctrineTypeToFormTypeMap[$fieldType]
+                    : 'text';
+            }
         }
 
         return $entityFields;

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -200,8 +200,8 @@ class Configurator
             $entityFields = $this->filterFieldsByNameAndType($this->defaultEntityFields, $excludedFieldNames, $excludedFieldTypes);
         }
 
-        // if the user has defined the 'type' for the field, use it. otherwise,
-        // guess the best form type for the Doctrine type associated with the field
+        // if the user has defined the 'type' for the field, use it. Otherwise,
+        // guess the best form type using the Doctrine type associated with the field
         foreach ($entityFields as $fieldName => $fieldConfiguration) {
             if (!isset($entityConfiguration[$action]['fields'][$fieldName]['type'])) {
                 $fieldType = $fieldConfiguration['type'];

--- a/Resources/doc/6-customizing-new-edit-actions.md
+++ b/Resources/doc/6-customizing-new-edit-actions.md
@@ -166,19 +166,19 @@ easy_admin:
 
 These are the options that you can define for form fields:
 
-  * `property`: it's the name of the associated Doctrine entity property. It
-    can be a real property or a "virtual property" based on an entity method.
-    This is the only mandatory option.
-  * `type`: it's the doctrine type of the field that will be displayed.
-    It will be converted internally into the [corresponding form type](../../Configuration/Configurator.php#L34) 
-    (from available [Symfony Form Types](http://symfony.com/doc/current/reference/forms/types.html)). 
-    If you don't specify a type, EasyAdmin will guess the best type for it. 
-  * `label`: it's the title that will be displayed for the form field. The
-    default title is the "humanized" version of the property name.
-  * `help`: it's the help message that will be displayed below the form field.
-  * `class`: it's the CSS class that will be applied to the form field widget.
-    For example, to display a big input field, use the Bootstrap 3 class called
-    `input-lg`.
+  * `property` (mandatory): it's the name of the associated Doctrine entity
+    property. It can be a real property or a "virtual property" based on an
+    entity method. This is the only mandatory option.
+  * `type` (optional): it's the [Symfony Form Type](http://symfony.com/doc/current/reference/forms/types.html)
+    which will be used to display the field. If you don't specify a type,
+    EasyAdmin will guess the best type for it.
+  * `label` (optional): it's the title that will be displayed for the form
+    field. The default title is the "humanized" version of the property name.
+  * `help` (optional): it's the help message that will be displayed below the
+    form field.
+  * `class` (optional): it's the CSS class that will be applied to the form
+    field widget. For example, to display a big input field, use the Bootstrap
+    3 class called `input-lg`.
 
 Add Custom Doctrine Types to Forms
 ----------------------------------

--- a/Resources/doc/6-customizing-new-edit-actions.md
+++ b/Resources/doc/6-customizing-new-edit-actions.md
@@ -166,19 +166,19 @@ easy_admin:
 
 These are the options that you can define for form fields:
 
-  * `property` (mandatory): it's the name of the associated Doctrine entity
-    property. It can be a real property or a "virtual property" based on an
-    entity method. This is the only mandatory option.
-  * `type` (optional): it's the [Symfony Form Type](http://symfony.com/doc/current/reference/forms/types.html)
-    which will be used to display the field. If you don't specify a type,
-    EasyAdmin will guess the best type for it.
-  * `label` (optional): it's the title that will be displayed for the form
-    field. The default title is the "humanized" version of the property name.
-  * `help` (optional): it's the help message that will be displayed below the
+  * `property` (mandatory): the name of the related Doctrine entity property.
+    It can be a real property or a "virtual property" based on an entity
+    method. This is the only mandatory option.
+  * `type` (optional): the [Symfony Form Type](http://symfony.com/doc/current/reference/forms/types.html)
+    used to render the field. If you don't specify a type, EasyAdmin will
+    guess the best type for it.
+  * `label` (optional): the title that will be displayed for the form field.
+    The default title is the "humanized" version of the property name.
+  * `help` (optional): the help message that will be displayed below the
     form field.
-  * `class` (optional): it's the CSS class that will be applied to the form
-    field widget. For example, to display a big input field, use the Bootstrap
-    3 class called `input-lg`.
+  * `class` (optional): the CSS class that will be applied to the form field
+    widget. For example, to display a big input field, use the Bootstrap 3
+    class called `input-lg`.
 
 Add Custom Doctrine Types to Forms
 ----------------------------------


### PR DESCRIPTION
The new behavior is as follows:
- If the user defines a value for the `type` option of a field, that value is considered as the Symfony Form Type to use. We don't change that value and we don't transform it using a weird "Doctrine to Form mapper". If the type doesn't exist, the application will display an error. If the field doesn't match (e.g. you use `number` or `money` for a text field) the application will also display an error.
- If the user doesn't specify the `type` option, we infer its type using the "Doctrine to Form" mapper. If we can't find the right type, we just use `text` type.
