### PR TITLE
Improved the way we inspect the getters/setters of properties

### DIFF
--- a/Reflection/ClassPropertyReflector.php
+++ b/Reflection/ClassPropertyReflector.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Reflection;
+
+/**
+ * Introspects information about the properties of the given class.
+ */
+class ClassPropertyReflector
+{
+    /**
+     * Returns the name of the getter for the class property or null if there is none.
+     *
+     * @param  string      $classNamespace
+     * @param  string      $propertyName
+     * @return string|null
+     */
+    public function getGetter($classNamespace, $propertyName)
+    {
+        $getterMethods = array(
+            'get'.ucfirst($propertyName),
+            'is'.ucfirst($propertyName),
+            $propertyName,
+            'has'.ucfirst($propertyName),
+        );
+
+        foreach ($getterMethods as $method) {
+            if (method_exists($classNamespace, $method)) {
+                return $method;
+            }
+        }
+    }
+
+    /**
+     * Returns the name of the setter for the class property or null if there is none.
+     *
+     * @param  string      $classNamespace
+     * @param  string      $propertyName
+     * @return string|null
+     */
+    public function getSetter($classNamespace, $propertyName)
+    {
+        $setterMethods = array(
+            'set'.ucfirst($propertyName),
+            'setIs'.ucfirst($propertyName),
+            $propertyName,
+        );
+
+        foreach ($setterMethods as $method) {
+            if (method_exists($classNamespace, $method)) {
+                return $method;
+            }
+        }
+    }
+
+    /**
+     * Returns 'true' if the class property is public (it exists and its scope is 'public').
+     *
+     * @param  string $classNamespace
+     * @param  string $propertyName
+     * @return bool
+     */
+    public function isPublic($classNamespace, $propertyName)
+    {
+        if (!property_exists($classNamespace, $propertyName)) {
+            return false;
+        }
+
+        $propertyMetadata = new \ReflectionProperty($classNamespace, $propertyName);
+        if ($propertyMetadata->isPublic()) {
+            return true;
+        }
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -14,7 +14,10 @@
         <service id="easyadmin.configurator" class="JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator">
             <argument>%easyadmin.config%</argument>
             <argument type="service" id="doctrine"></argument>
+            <argument type="service" id="easyadmin.property_reflector"></argument>
         </service>
+
+        <service id="easyadmin.property_reflector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\ClassPropertyReflector" public="false"></service>
 
     </services>
 </container>

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -34,7 +34,7 @@
             {% for field in form.children if field.vars.name != '_token' %}
                 <div class="form-group {% if not field.vars.valid %}has-error{% endif %}">
                     {% if entity_fields[field.vars.name]['type'] == 'association' %}
-                        {{ entity_field(item, entity_fields[field.vars.name]['name'], entity_fields[field.vars.name]) }}
+                        {{ entity_field(item, entity_fields[field.vars.name]) }}
                     {% else %}
                         {% set field_label = entity_fields[field.vars.name]['label']|default(null) %}
                         {{ form_label(field, field_label, { label_attr: { class: 'col-sm-2 control-label' } }) }}

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -102,9 +102,9 @@
 
                                 <td class="{{ isSortingField ? 'sorted' : '' }} {{ metadata.type|lower }}">
                                     {% if metadata.type in ['array', 'json_array', 'simple_array', 'text'] %}
-                                        {{ entity_field(item, field, metadata)|truncate_entity_field }}
+                                        {{ entity_field(item, metadata)|truncate_entity_field }}
                                     {% else %}
-                                        {{ entity_field(item, field, metadata) }}
+                                        {{ entity_field(item, metadata) }}
                                     {% endif %}
                                 </td>
                             {% endfor %}

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -25,7 +25,7 @@
             {% for field in form.children if field.vars.name != '_token' %}
                 <div class="form-group field_{{ entity_fields[field.vars.name]['type']|lower|default('default') }} {% if not field.vars.valid %}has-error{% endif %}">
                     {% if entity_fields[field.vars.name]['type'] == 'association' %}
-                        {{ entity_field(item, entity_fields[field.vars.name]['name'], entity_fields[field.vars.name]) }}
+                        {{ entity_field(item, entity_fields[field.vars.name]) }}
                     {% else %}
                         {% set field_label = entity_fields[field.vars.name]['label']|default(null) %}
                         {{ form_label(field, field_label, { label_attr: { class: 'col-sm-2 control-label' } }) }}

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -40,9 +40,9 @@
                 <div class="col-sm-10">
                     <div class="form-control {{ metadata.type|lower }}">
                         {% if metadata.type in ['text'] %}
-                            {{ entity_field(item, field, metadata)|nl2br }}
+                            {{ entity_field(item, metadata)|nl2br }}
                         {% else %}
-                            {{ entity_field(item, field, metadata) }}
+                            {{ entity_field(item, metadata) }}
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
In several places of the application we need to inspect which is the getter/setter for the property. This is non-trivial because the getters can be `getXXX()`, `isXXX()`, `xxx()`, `hasXXX()`, etc. Sometimes, the getter even doesn't exist, but the entity property is public, so it's possible to access the property. The same goes for the setter.

This PR centralizes all this logic in a new simple class called `ClassPropertyReflector`. This way we can simplify a lot the Twig extension and the controller. In addition, this introspection is done only once during the application execution and previously we did this each time we displayed the value of a property in the application. Using Blackfire profiler, I got a small performance bump (around 2%) and hundreds of less function calls (between 200 and 300 depending on the entity).
