### PR TITLE
Improved the boolean flip switches

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -268,6 +268,10 @@ class AdminController extends Controller
         ));
     }
 
+    /**
+     * Changes the value of a boolean entity property. This method is used for
+     * the boolean toggle switches displayed in the backend.
+     */
     protected function toggleAction()
     {
         if (!$entity = $this->em->getRepository($this->entity['class'])->find($this->request->query->get('id'))) {
@@ -281,17 +285,11 @@ class AdminController extends Controller
             throw new \Exception(sprintf('The "%s" property is not boolean.', $propertyName));
         }
 
-        if (!$propertyMetadata['canBeGet']) {
-            throw new \Exception(sprintf('It\'s not possible to get the current value of the "%s" boolean property of the "%s" entity.', $propertyName, $this->entity['name']));
-        }
-
-        $oldValue = (null !== $getter = $propertyMetadata['getter']) ? $entity->{$getter}() : $entity->{$propertyName};
-        $newValue = !$oldValue;
-
         if (!$propertyMetadata['canBeSet']) {
             throw new \Exception(sprintf('It\'s not possible to toggle the value of the "%s" boolean property of the "%s" entity.', $propertyName, $this->entity['name']));
         }
 
+        $newValue = $this->request->query->getBoolean('newValue');
         if (null !== $setter = $propertyMetadata['setter']) {
             $entity->{$setter}($newValue);
         } else {
@@ -300,7 +298,7 @@ class AdminController extends Controller
 
         $this->em->flush();
 
-        return new Response(true === $newValue ? 'on' : 'off');
+        return new Response((string) $newValue);
     }
 
     /**

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -146,19 +146,13 @@
                 var propertyName = $('table th.boolean:nth-child(' + columnIndex + ')').data('property-name');
 
                 var toggleUrl = "{{ path('admin', { action: 'toggle', entity: entity.name })|raw }}"
+                              + "&id=" + $(this).closest('tr').data('id')
                               + "&property=" + propertyName
-                              + "&id=" + $(this).closest('tr').data('id');
+                              + "&newValue=" + newValue.toString();
 
                 var toggleRequest = $.ajax({ type: "GET", url: toggleUrl, data: {} });
 
-                toggleRequest.done(function(result) {
-                    // protection against race conditions: if the persisted value
-                    // doesn't match the new value, change it to avoid confusions
-                    var persistedValue = ('on' == result) ? true : false;
-                    if (persistedValue != newValue) {
-                        toggle.bootstrapToggle(persistedValue == true ? 'on' : 'off');
-                    }
-                });
+                toggleRequest.done(function(result) {});
 
                 toggleRequest.fail(function(result) {
                     // in case of error, restore the original value and disable the toggle


### PR DESCRIPTION
This PR improves the recently introduced "boolean flip switches" in two ways:
- We no longer prevent "race conditions". This is the classic feature that can only be done perfect or not done at all. I implemented something basic that doesn't work well in all situations. Doing it right will require the use of locks or any similar mechanism and it's totally out of the scope of this bundle.
- The controller is much simpler because now it simply sets the value passed from the template, instead of retrieving the original value and flipping it.
