### PR TITLE
Fix image type with absolute urls

### DIFF
--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -97,9 +97,14 @@ class EasyAdminTwigExtension extends \Twig_Extension
             }
 
             if (in_array($fieldType, array('image'))) {
-                $imageUrl = isset($fieldMetadata['base_path'])
-                    ? rtrim($fieldMetadata['base_path'], '/').'/'.ltrim($value, '/')
-                    : '/'.ltrim($value, '/');
+
+	            if(1 === preg_match('#^(http[s]?|\/\/).*#i', $value)) {
+		            $imageUrl = $value;
+	            } else  {
+		            $imageUrl = isset($fieldMetadata['base_path'])
+			            ? rtrim($fieldMetadata['base_path'], '/').'/'.ltrim($value, '/')
+			            : '/'.ltrim($value, '/');
+	            }
 
                 return new \Twig_Markup(sprintf('<img src="%s">', $imageUrl), 'UTF-8');
             }


### PR DESCRIPTION
Absolute URLs in entity properties were rendered with a heading '/' with the `image` type:

``` yaml
fields:
- { property: 'thumbnail', format: 'image'}
```

If an entity contains a `thumbnail` property with the following absolute URLs: `http://example.com/img/my_image.png`
it previously rendered:

``` html
<img src="/http://example.com/img/my_image.png">
```

This behavior is fixed for the following absolute URLs "patterns":
- http://example.com
- https://example.com
- //example.com

---

related to #165 
