### PR TITLE
Added nav blocks to layout to allow override when extending the layout

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -40,7 +40,9 @@
                         </a>
                     </div>
 
+                    {% block navigation %}
                     <ul id="header-menu">
+                        {% block navigation_items %}
                         {% for item in config.entities %}
                             <li class="{{ item.name|lower == app.request.get('entity')|lower ? 'active' : '' }}">
                                 <a href="{{ path('admin', { entity: item.name, action: 'list' }) }}">
@@ -51,10 +53,13 @@
                             <li class="visible-xs visible-sm header-nav-close">
                                 <a href="#header">{{ 'header.close'|trans }}</a>
                             </li>
+                        {% endblock %}
                     </ul>
+                    {% endblock %}
                 </div>
 
                 <div id="header-footer">
+                {% block header_footer %}
                     {% if app.user %}
                         <div id="header-security" class="col-xs-12 col-md-2 col-lg-12">
                             <p>
@@ -63,6 +68,7 @@
                             </p>
                         </div>
                     {% endif %}
+                {% endblock %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This has no BC breaks, and it's used especially allow overriding the menu in a much more custom way, when you extend the controller and/or the layout in your own back-end.

It's a specific demand from one of my colleagues at work and I think it's really interesting to add them. Plus, I'm gonna need this kind of feature to add a user logout/profile page directly in the menu tab instead of the footer
