### PR TITLE
allow Travis to report results as fast as possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - nightly
 
 matrix:
+  fast_finish: true
   allow_failures:
     - php: hhvm
     - php: nightly


### PR DESCRIPTION
Allowing fast finishes lets Travis report a successful build as soon as
all running builds are allowed to fail.
