### PR TITLE
Deprecated "list_max_results" and "list_actions" global options

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -125,7 +125,7 @@ class AdminController extends Controller
     protected function listAction()
     {
         $fields = $this->entity['list']['fields'];
-        $paginator = $this->findAll($this->entity['class'], $this->request->query->get('page', 1), $this->config['list_max_results'], $this->request->query->get('sortField'), $this->request->query->get('sortDirection'));
+        $paginator = $this->findAll($this->entity['class'], $this->request->query->get('page', 1), $this->config['list']['max_results'], $this->request->query->get('sortField'), $this->request->query->get('sortDirection'));
 
         return $this->render('@EasyAdmin/list.html.twig', array(
             'paginator' => $paginator,
@@ -248,7 +248,7 @@ class AdminController extends Controller
     protected function searchAction()
     {
         $searchableFields = $this->entity['search']['fields'];
-        $paginator = $this->findBy($this->entity['class'], $this->request->query->get('query'), $searchableFields, $this->request->query->get('page', 1), $this->config['list_max_results']);
+        $paginator = $this->findBy($this->entity['class'], $this->request->query->get('query'), $searchableFields, $this->request->query->get('page', 1), $this->config['list']['max_results']);
         $fields = $this->entity['list']['fields'];
 
         return $this->render('@EasyAdmin/list.html.twig', array(

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,34 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('easy_admin');
 
         $rootNode
+            // 'list_actions' and 'max_results' global options are deprecated since 1.0.8
+            // and they are replaced by 'actions' and 'max_results' options under the 'list' key
+            ->validate()
+                ->ifTrue(function ($v) { return isset($v['list_max_results']); })
+                ->then(function ($v) {
+                    if (!isset($v['list'])) {
+                        $v['list'] = array();
+                    }
+
+                    $v['list']['max_results'] = $v['list_max_results'];
+                    unset($v['list_max_results']);
+
+                    return $v;
+                })
+            ->end()
+            ->validate()
+                ->ifTrue(function ($v) { return isset($v['list_actions']); })
+                ->then(function ($v) {
+                    if (!isset($v['list'])) {
+                        $v['list'] = array();
+                    }
+
+                    $v['list']['actions'] = $v['list_actions'];
+                    unset($v['list_actions']);
+
+                    return $v;
+                })
+            ->end()
             ->children()
                 ->scalarNode('site_name')
                     ->defaultValue('Easy Admin')
@@ -29,14 +57,28 @@ class Configuration implements ConfigurationInterface
                 ->end()
 
                 ->integerNode('list_max_results')
-                    ->defaultValue(15)
-                    ->info('The maximum number of items to show on listing and search pages.')
+                    ->defaultNull()
+                    ->info('DEPRECATED: use "max_results" option under the "list" key.')
                 ->end()
 
                 ->variableNode('list_actions')
-                    ->defaultValue(array('edit'))
-                    ->info('The actions to show for each item of listing and search pages. Only "edit" and "show" options are available.')
-                    ->example(array('edit', 'show'))
+                    ->defaultNull()
+                    ->info('DEPRECATED: use "actions" option under the "list" key.')
+                ->end()
+
+                ->arrayNode('list')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->integerNode('max_results')
+                            ->defaultValue(15)
+                            ->info('The maximum number of items to show on listing and search pages.')
+                        ->end()
+                        ->variableNode('actions')
+                            ->defaultValue(array('edit', 'new'))
+                            ->info('The actions to show for each item of listing and search pages. Possible values: "edit", "show" and "new".')
+                            ->example(array('edit', 'show'))
+                        ->end()
+                    ->end()
                 ->end()
 
                 ->arrayNode('assets')

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -118,25 +118,28 @@ Customize the Number of Item Rows Displayed
 -------------------------------------------
 
 By default, listings display a maximum of `15` rows. Define the
-`list_max_results` option to change this value:
+`max_results` option under the `list` key to change this value:
 
 ```yaml
 # app/config/config.yml
 easy_admin:
-    list_max_results: 30
+    list:
+        max_results: 30
     # ...
 ```
 
-Customize the Actions Displayed for Each Item
----------------------------------------------
+Customize the Actions Displayed for Listings
+--------------------------------------------
 
-By default, listings just display the `Edit` action for each item. If you also
-want to add the popular `Show` action, define the `list_actions` option:
+By default, listings display the `edit` action for each item and the global
+`new` button to create a new item. If you also want to add the popular `show`
+action, define the `actions` option under the `list` key:
 
 ```yaml
 # app/config/config.yml
 easy_admin:
-    list_actions: ['edit', 'show']
+    list:
+        actions: ['edit', 'show', 'new']
     # ...
 ```
 

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -31,9 +31,11 @@
             </div>
             <div class="col-xs-12 col-sm-7">
                 <div id="content-actions">
-                    <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
-                        {{ entity.new.action_label|default('action.new')|trans({'%entity_name%': entity.label|trans}) }}
-                    </a>
+                    {% if 'new' in easyadmin_config('list.actions') %}
+                        <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
+                            {{ entity.new.action_label|default('action.new')|trans({'%entity_name%': entity.label|trans}) }}
+                        </a>
+                    {% endif %}
                 </div>
                 <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
                     <div class="input-group">
@@ -109,7 +111,7 @@
                                 </td>
                             {% endfor %}
                                 <td class="actions">
-                                    {% for action in easyadmin_config('list_actions') %}
+                                    {% for action in easyadmin_config('list.actions') if action != 'new' %}
                                         <a href="{{ path('admin', { action: action, entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
                                             {{- ('action.' ~ action)|trans -}}
                                         </a>


### PR DESCRIPTION
They have been replaced by the same options under the "list" key:

``` yaml
# BEFORE
easy_admin:
    list_max_results: 10
    list_actions: ['show', 'edit']

# AFTER
easy_admin:
    list:
        max_results: 10
        actions: ['show', 'edit']
```

This is the first change related to adding custom actions. The second change will be to do something like the PR #168. And then, we'll add support for custom actions.
