### PR TITLE
install dependencies only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ matrix:
     - php: nightly
 
 before_install:
-  - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev symfony/symfony:$SYMFONY_VERSION; fi
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:$SYMFONY_VERSION; fi
 
-install: composer install
+install:
+  - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
+  - if [ "$deps" != "low" ]; then composer install; fi


### PR DESCRIPTION
- don't run `composer install` when `composer update` was used before
  (when the lowest allowed dependency versions were installed)
- don't install dependencies when `composer require` is executed (they
  will be installed later anyway when `composer install` is run)
