### PR TITLE
don't use deprecated Yaml component features

### DIFF
--- a/Tests/Configuration/ConfiguratorTest.php
+++ b/Tests/Configuration/ConfiguratorTest.php
@@ -37,7 +37,7 @@ class ConfiguratorTest extends \PHPUnit_Framework_TestCase
     {
         $this->markTestSkipped('Skip test until we can find the solution for the following error: "Argument 1 passed to EasyAdminBundle\Configuration\Configurator::processEntityPropertiesMetadata() must be an instance of Doctrine\ORM\Mapping\ClassMetadata, instance of Mock_ClassMetadataInfo_2057af3e given');
 
-        $backendConfig = Yaml::parse($inputFixtureFilepath);
+        $backendConfig = Yaml::parse(file_get_contents($inputFixtureFilepath));
         $backendConfig['easy_admin']['entities'] = $this->extension->getEntitiesConfiguration($backendConfig['easy_admin']['entities']);
         $configurator = new Configurator($backendConfig['easy_admin'], $this->inspector, $this->reflector);
         $configuration = $configurator->getEntityConfiguration('TestEntity');

--- a/Tests/DependencyInjection/EasyAdminExtensionTest.php
+++ b/Tests/DependencyInjection/EasyAdminExtensionTest.php
@@ -19,7 +19,7 @@ class EasyAdminExtensionTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetEntitiesConfiguration($inputFixtureFilepath, $outputFixtureFilepath)
     {
-        $backendConfig = Yaml::parse($inputFixtureFilepath);
+        $backendConfig = Yaml::parse(file_get_contents($inputFixtureFilepath));
         $configuration = $this->extension->getEntitiesConfiguration($backendConfig['easy_admin']['entities']);
         // Yaml component dumps empty arrays as hashes, fix it to increase configuration readability
         $yamlConfiguration = str_replace('{  }', '[]', Yaml::dump($configuration));


### PR DESCRIPTION
Since Symfony 2.2, the ability to pass file names to the `Yaml::parse()`
method is deprecated.
