### PR TITLE
Allow to configure the actions for each entity

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -130,11 +130,6 @@ class Configurator
             $actions[] = 'list';
         }
 
-        // 'easyadminAjaxEdit' is a private action used for boolean flip switches
-        if (!in_array('easyadminAjaxEdit', $actions)) {
-            $actions[] = 'easyadminAjaxEdit';
-        }
-
         return $actions;
     }
 
@@ -392,7 +387,7 @@ class Configurator
             // special case for the 'list' action: 'boolean' properties are displayed
             // as toggleable flip switches when certain conditions are met
             if ('list' === $action && 'boolean' === $normalizedConfiguration['dataType']) {
-                // conditions: 1) the end-user hasn't configures the field type explicitly
+                // conditions: 1) the end-user hasn't configured the field type explicitly
                 // 2) the 'edit' action is allowed for this entity
                 if(!isset($fieldConfiguration['type']) && in_array('edit', $entityConfiguration['actions'])) {
                     $normalizedConfiguration['dataType'] = 'toggle';

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -385,9 +385,13 @@ class Configurator
             }
 
             // special case for the 'list' action: 'boolean' properties are displayed
-            // as toggleable flip switches unless end-user configures their type explicitly
-            if ('list' === $action && 'boolean' === $normalizedConfiguration['dataType'] && !isset($fieldConfiguration['type'])) {
-                $normalizedConfiguration['dataType'] = 'toggle';
+            // as toggleable flip switches when certain conditions are met
+            if ('list' === $action && 'boolean' === $normalizedConfiguration['dataType']) {
+                // conditions: 1) the end-user hasn't configures the field type explicitly
+                // 2) the 'edit' action is allowed for this entity
+                if(!isset($fieldConfiguration['type']) && in_array('edit', $entityConfiguration['actions'])) {
+                    $normalizedConfiguration['dataType'] = 'toggle';
+                }
             }
 
             if (null === $normalizedConfiguration['format']) {

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -84,8 +84,10 @@ class Configurator
         }
 
         $entityConfiguration = $this->backendConfig['entities'][$entityName];
-        $entityMetadata = $this->inspector->getEntityMetadata($entityConfiguration['class']);
 
+        $entityConfiguration['actions'] = $this->getEntityActions($entityName);
+
+        $entityMetadata = $this->inspector->getEntityMetadata($entityConfiguration['class']);
         $entityConfiguration['primary_key_field_name'] = $entityMetadata->getSingleIdentifierFieldName();
 
         $entityProperties = $this->processEntityPropertiesMetadata($entityMetadata);
@@ -105,6 +107,30 @@ class Configurator
         $this->entitiesConfig[$entityName] = $entityConfiguration;
 
         return $entityConfiguration;
+    }
+
+    /**
+     * Returns the enabled actions for the given entity.
+     *
+     * @param  string $entityName
+     * @return array
+     */
+    public function getEntityActions($entityName)
+    {
+        $actions = isset($this->backendConfig['entities'][$entityName]['actions'])
+            ? $this->backendConfig['entities'][$entityName]['actions']
+            : null;
+
+        if (null === $actions) {
+            $actions = array('delete', 'edit', 'new', 'search', 'show');
+        }
+
+        // 'list' action is mandatory for all entities
+        if (!in_array('list', $actions)) {
+            $actions[] = 'list';
+        }
+
+        return $actions;
     }
 
     /**

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -130,6 +130,11 @@ class Configurator
             $actions[] = 'list';
         }
 
+        // 'easyadminAjaxEdit' is a private action used for boolean flip switches
+        if (!in_array('easyadminAjaxEdit', $actions)) {
+            $actions[] = 'easyadminAjaxEdit';
+        }
+
         return $actions;
     }
 

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -113,9 +113,9 @@ class Configurator
      * Returns the enabled actions for the given entity.
      *
      * @param  string $entityName
-     * @return array
+     * @return string[]
      */
-    public function getEntityActions($entityName)
+    private function getEntityActions($entityName)
     {
         $actions = isset($this->backendConfig['entities'][$entityName]['actions'])
             ? $this->backendConfig['entities'][$entityName]['actions']

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -33,7 +33,6 @@ use Pagerfanta\Adapter\DoctrineORMAdapter;
  */
 class AdminController extends Controller
 {
-    protected $allowedActions = array('list', 'edit', 'new', 'show', 'search', 'delete', 'toggle');
     protected $config;
     protected $entity = array();
 
@@ -87,19 +86,19 @@ class AdminController extends Controller
             return $this->render404error('@EasyAdmin/error/no_entities.html.twig');
         }
 
-        if (!in_array($action = $request->query->get('action', 'list'), $this->allowedActions)) {
-            return $this->render404error('@EasyAdmin/error/forbidden_action.html.twig', array(
-                'action' => $action,
-                'allowed_actions' => $this->allowedActions,
-            ));
-        }
-
         if (null !== $entityName = $request->query->get('entity')) {
             if (!array_key_exists($entityName, $this->config['entities'])) {
                 return $this->render404error('@EasyAdmin/error/undefined_entity.html.twig', array('entity_name' => $entityName));
             }
 
             $this->entity = $this->get('easyadmin.configurator')->getEntityConfiguration($entityName);
+        }
+
+        if (!in_array($action = $request->query->get('action', 'list'), $this->entity['actions'])) {
+            return $this->render404error('@EasyAdmin/error/forbidden_action.html.twig', array(
+                'action' => $action,
+                'enabled_actions' => $this->entity['actions'],
+            ));
         }
 
         if (null !== $entityName) {
@@ -258,10 +257,11 @@ class AdminController extends Controller
     }
 
     /**
-     * Changes the value of a boolean entity property. This method is used for
-     * the boolean toggle switches displayed in the backend.
+     * Modifies the entity properties via an Ajax call. Currently it's used for
+     * changing the value of boolean properties when the user clicks on the
+     * flip switched displayed for boolean values in the 'list' action.
      */
-    protected function toggleAction()
+    protected function easyadminAjaxEditAction()
     {
         if (!in_array('edit', $this->entity['actions'])) {
             throw new \Exception('This entity doesn\'t allow to edit its fields.');

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -139,6 +139,10 @@ class AdminController extends Controller
      */
     protected function editAction()
     {
+        if ($this->request->isXmlHttpRequest()) {
+            return $this->ajaxEdit();
+        }
+
         if (!$item = $this->em->getRepository($this->entity['class'])->find($this->request->query->get('id'))) {
             throw $this->createNotFoundException(sprintf('Unable to find entity (%s #%d).', $this->entity['name'], $this->request->query->get('id')));
         }
@@ -261,7 +265,7 @@ class AdminController extends Controller
      * changing the value of boolean properties when the user clicks on the
      * flip switched displayed for boolean values in the 'list' action.
      */
-    protected function easyadminAjaxEditAction()
+    protected function ajaxEdit()
     {
         if (!in_array('edit', $this->entity['actions'])) {
             throw new \Exception('This entity doesn\'t allow to edit its fields.');

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -263,6 +263,10 @@ class AdminController extends Controller
      */
     protected function toggleAction()
     {
+        if (!in_array('edit', $this->entity['actions'])) {
+            throw new \Exception('This entity doesn\'t allow to edit its fields.');
+        }
+
         if (!$entity = $this->em->getRepository($this->entity['class'])->find($this->request->query->get('id'))) {
             throw new \Exception('The entity does not exist.');
         }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -59,10 +59,6 @@ class Configuration implements ConfigurationInterface
 
                 ->arrayNode('actions')
                     ->prototype('scalar')->end()
-                    ->validate()
-                        ->ifTrue(function ($v) { return !is_array($v); })
-                        ->thenInvalid('Entity actions must be defined in a YAML array.')
-                    ->end()
                     ->info('The list of actions enabled by default for all entities.')
                 ->end()
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,7 +23,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             // 'list_actions' and 'max_results' global options are deprecated since 1.0.8
-            // and they are replaced by 'actions' and 'max_results' options under the 'list' key
+            // and they are replaced by 'actions' and 'list -> max_results' options
             ->validate()
                 ->ifTrue(function ($v) { return isset($v['list_max_results']); })
                 ->then(function ($v) {
@@ -40,11 +40,7 @@ class Configuration implements ConfigurationInterface
             ->validate()
                 ->ifTrue(function ($v) { return isset($v['list_actions']); })
                 ->then(function ($v) {
-                    if (!isset($v['list'])) {
-                        $v['list'] = array();
-                    }
-
-                    $v['list']['actions'] = $v['list_actions'];
+                    $v['actions'] = $v['list_actions'];
                     unset($v['list_actions']);
 
                     return $v;
@@ -56,14 +52,23 @@ class Configuration implements ConfigurationInterface
                     ->info('The name displayed as the title of the administration zone (e.g. company name, project name).')
                 ->end()
 
-                ->integerNode('list_max_results')
-                    ->defaultNull()
-                    ->info('DEPRECATED: use "max_results" option under the "list" key.')
-                ->end()
-
                 ->variableNode('list_actions')
                     ->defaultNull()
-                    ->info('DEPRECATED: use "actions" option under the "list" key.')
+                    ->info('DEPRECATED: use the global "actions" option.')
+                ->end()
+
+                ->arrayNode('actions')
+                    ->prototype('scalar')->end()
+                    ->validate()
+                        ->ifTrue(function ($v) { return !is_array($v); })
+                        ->thenInvalid('Entity actions must be defined in a YAML array.')
+                    ->end()
+                    ->info('The list of actions enabled by default for all entities.')
+                ->end()
+
+                ->integerNode('list_max_results')
+                    ->defaultNull()
+                    ->info('DEPRECATED: use "max_results" option under the "list" global key.')
                 ->end()
 
                 ->arrayNode('list')
@@ -72,11 +77,6 @@ class Configuration implements ConfigurationInterface
                         ->integerNode('max_results')
                             ->defaultValue(15)
                             ->info('The maximum number of items to show on listing and search pages.')
-                        ->end()
-                        ->variableNode('actions')
-                            ->defaultValue(array('edit', 'new'))
-                            ->info('The actions to show for each item of listing and search pages. Possible values: "edit", "show" and "new".')
-                            ->example(array('edit', 'show'))
                         ->end()
                     ->end()
                 ->end()

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -45,6 +45,7 @@ class EasyAdminExtension extends Extension
             $actions = array('delete', 'edit', 'new', 'search', 'show');
         }
 
+        // 'list' action is mandatory for all entities
         if (!in_array('list', $actions)) {
             $actions[] = 'list';
         }

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -22,7 +22,6 @@ class EasyAdminExtension extends Extension
     {
         // process bundle's configuration parameters
         $backendConfiguration = $this->processConfiguration(new Configuration(), $configs);
-        $backendConfiguration['actions'] =  $this->getBackendActions($backendConfiguration['actions']);
         $backendConfiguration['entities'] = $this->getEntitiesConfiguration($backendConfiguration['entities']);
 
         $container->setParameter('easyadmin.config', $backendConfiguration);
@@ -30,27 +29,6 @@ class EasyAdminExtension extends Extension
         // load bundle's services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
-    }
-
-    /**
-     * Processes backend actions configuration to ensure that its value is correct.
-     * @param  array $configuredActions
-     * @return array
-     */
-    public function getBackendActions($configuredActions)
-    {
-        $actions = $configuredActions;
-
-        if (null === $actions) {
-            $actions = array('delete', 'edit', 'new', 'search', 'show');
-        }
-
-        // 'list' action is mandatory for all entities
-        if (!in_array('list', $actions)) {
-            $actions[] = 'list';
-        }
-
-        return $actions;
     }
 
     /**

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -22,6 +22,7 @@ class EasyAdminExtension extends Extension
     {
         // process bundle's configuration parameters
         $backendConfiguration = $this->processConfiguration(new Configuration(), $configs);
+        $backendConfiguration['actions'] =  $this->getBackendActions($backendConfiguration['actions']);
         $backendConfiguration['entities'] = $this->getEntitiesConfiguration($backendConfiguration['entities']);
 
         $container->setParameter('easyadmin.config', $backendConfiguration);
@@ -29,6 +30,26 @@ class EasyAdminExtension extends Extension
         // load bundle's services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+    }
+
+    /**
+     * Processes backend actions configuration to ensure that its value is correct.
+     * @param  array $configuredActions
+     * @return array
+     */
+    public function getBackendActions($configuredActions)
+    {
+        $actions = $configuredActions;
+
+        if (null === $actions) {
+            $actions = array('delete', 'edit', 'new', 'search', 'show');
+        }
+
+        if (!in_array('list', $actions)) {
+            $actions[] = 'list';
+        }
+
+        return $actions;
     }
 
     /**

--- a/Resources/doc/3-customizing-first-backend.md
+++ b/Resources/doc/3-customizing-first-backend.md
@@ -115,6 +115,25 @@ easy_admin:
             class: AppBundle\Entity\Order
 ```
 
+Customize the Actions Displayed for Each Entity
+-----------------------------------------------
+
+The backend provides six different actions for each entity: ``delete``,
+``edit``, ``list``, ``new``, ``search`` and ``show``. The ``list`` action is
+mandatory for all entities, but the rest of actions can be disabled. Use the
+global ``actions`` option to set the actions available in your backend:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    # this option makes the backend a read-only application: you cannot
+    # create, delete or modify entities
+    actions: ['show', 'search']
+    # ...
+```
+
+In the current version of EasyAdmin you cannot define custom actions.
+
 Customize the Translation of the Backend Interface
 --------------------------------------------------
 

--- a/Resources/doc/3-customizing-first-backend.md
+++ b/Resources/doc/3-customizing-first-backend.md
@@ -132,6 +132,22 @@ easy_admin:
     # ...
 ```
 
+The global `actions` option is applied to all entities. However, you can also
+define the `actions` option for each entity to override that global option:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    actions: ['show', 'search']
+    entities:
+        Customers:
+            actions: ['delete', 'edit', 'show']
+            class: AppBundle\Entity\Customer
+        Orders:
+            actions: ['edit', 'show', 'search', 'new']
+            class: AppBundle\Entity\Order
+```
+
 In the current version of EasyAdmin you cannot define custom actions.
 
 Customize the Translation of the Backend Interface

--- a/Resources/doc/3-customizing-first-backend.md
+++ b/Resources/doc/3-customizing-first-backend.md
@@ -115,13 +115,13 @@ easy_admin:
             class: AppBundle\Entity\Order
 ```
 
-Customize the Actions Displayed for Each Entity
+Customize the Actions Displayed for each Entity
 -----------------------------------------------
 
 The backend provides six different actions for each entity: ``delete``,
 ``edit``, ``list``, ``new``, ``search`` and ``show``. The ``list`` action is
-mandatory for all entities, but the rest of actions can be disabled. Use the
-global ``actions`` option to set the actions available in your backend:
+mandatory for all entities, but the rest of the actions can be disabled. Use
+the global ``actions`` option to set the available actions in your backend:
 
 ```yaml
 # app/config/config.yml

--- a/Resources/doc/3-customizing-first-backend.md
+++ b/Resources/doc/3-customizing-first-backend.md
@@ -126,14 +126,14 @@ global ``actions`` option to set the actions available in your backend:
 ```yaml
 # app/config/config.yml
 easy_admin:
-    # this option makes the backend a read-only application: you cannot
-    # create, delete or modify entities
+    # this option turns the backend into a read-only application:
+    # you cannot create, delete or modify entities
     actions: ['show', 'search']
     # ...
 ```
 
-The global `actions` option is applied to all entities. However, you can also
-define the `actions` option for each entity to override that global option:
+The global `actions` option is applied to all entities. However, entities can
+also define their own `actions` option to override the global option:
 
 ```yaml
 # app/config/config.yml

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -391,7 +391,8 @@ easy_admin:
 Customize Boolean Values
 ------------------------
 
-By default, boolean values are displayed in listings as flip switches:
+By default, when the `edit` action is enabled for the entity, its boolean
+values are displayed in listings as flip switches:
 
 ![Advanced boolean fields](images/easyadmin-boolean-field-toggle.gif)
 
@@ -420,6 +421,10 @@ Now the boolean value will be rendered as a simple label and its value cannot
 be modified:
 
 ![Boolean field displayed as a label](images/easyadmin-boolean-field-label.png)
+
+These non-editable labels are also displayed when the `edit` action is not
+enabled for the entity (see the `actions` option in the
+[Chapter 3](3-customizing-first-backend.md)).
 
 Display Image Field Types
 -------------------------

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -423,8 +423,7 @@ be modified:
 ![Boolean field displayed as a label](images/easyadmin-boolean-field-label.png)
 
 These non-editable labels are also displayed when the `edit` action is not
-enabled for the entity (see the `actions` option in the
-[Chapter 3](3-customizing-first-backend.md)).
+enabled for the entity (see the `actions` option in [Chapter 3](3-customizing-first-backend.md)).
 
 Display Image Field Types
 -------------------------

--- a/Resources/doc/4-customizing-list-action.md
+++ b/Resources/doc/4-customizing-list-action.md
@@ -128,23 +128,6 @@ easy_admin:
     # ...
 ```
 
-Customize the Actions Displayed for Listings
---------------------------------------------
-
-By default, listings display the `edit` action for each item and the global
-`new` button to create a new item. If you also want to add the popular `show`
-action, define the `actions` option under the `list` key:
-
-```yaml
-# app/config/config.yml
-easy_admin:
-    list:
-        actions: ['edit', 'show', 'new']
-    # ...
-```
-
-In the current version of EasyAdmin you cannot define custom actions.
-
 Customize the Columns Displayed
 -------------------------------
 

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -61,9 +61,11 @@
                         <i class="fa fa-save"></i> {{ 'action.save_changes'|trans }}
                     </button>
 
-                    <button type="button" id="button-delete" class="btn btn-danger">
-                        <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
-                    </button>
+                    {% if 'delete' in easyadmin_config('actions') %}
+                        <button type="button" id="button-delete" class="btn btn-danger">
+                            <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
+                        </button>
+                    {% endif %}
 
                     <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
                         {{- 'action.back_to_listing'|trans -}}

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -61,7 +61,7 @@
                         <i class="fa fa-save"></i> {{ 'action.save_changes'|trans }}
                     </button>
 
-                    {% if 'delete' in easyadmin_config('actions') %}
+                    {% if easyadmin_action_is_enabled('delete', entity.name) %}
                         <button type="button" id="button-delete" class="btn btn-danger">
                             <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
                         </button>

--- a/Resources/views/error/forbidden_action.html.twig
+++ b/Resources/views/error/forbidden_action.html.twig
@@ -38,11 +38,11 @@
                     <ul>
                         <li>
                             Change this action for one of the following allowed actions:
-                            <code>{{ allowed_actions|join('</code>, <code>')|raw }}</code>
+                            <code>{{ enabled_actions|join('</code>, <code>')|raw }}</code>
                         </li>
                         <li>
                             If the action name is correct, make sure it's included in
-                            the <code>$allowedActions</code> property of your backend.
+                            the <code>actions</code> option of your entity configuration.
                         </li>
                     </ul>
                 </div>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -157,7 +157,7 @@
                 var columnIndex = $(this).closest('td').index() + 1;
                 var propertyName = $('table th.toggle:nth-child(' + columnIndex + ')').data('property-name');
 
-                var toggleUrl = "{{ path('admin', { action: 'easyadminAjaxEdit', entity: entity.name })|raw }}"
+                var toggleUrl = "{{ path('admin', { action: 'edit', entity: entity.name })|raw }}"
                               + "&id=" + $(this).closest('tr').data('id')
                               + "&property=" + propertyName
                               + "&newValue=" + newValue.toString();

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -157,7 +157,7 @@
                 var columnIndex = $(this).closest('td').index() + 1;
                 var propertyName = $('table th.toggle:nth-child(' + columnIndex + ')').data('property-name');
 
-                var toggleUrl = "{{ path('admin', { action: 'toggle', entity: entity.name })|raw }}"
+                var toggleUrl = "{{ path('admin', { action: 'easyadminAjaxEdit', entity: entity.name })|raw }}"
                               + "&id=" + $(this).closest('tr').data('id')
                               + "&property=" + propertyName
                               + "&newValue=" + newValue.toString();

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -53,7 +53,7 @@
 
     <div id="main" class="col-sm-12">
         <div>
-            {% set _entity_list_actions = easyadmin_list_item_actions(entity.name) %}
+            {% set _list_item_actions = easyadmin_list_item_actions(entity.name) %}
 
             <table class="table">
                 <thead>
@@ -94,7 +94,7 @@
                                 {% endif %}
                             </th>
                         {% endfor %}
-                        {% if _entity_list_actions|length > 0 %}
+                        {% if _list_item_actions|length > 0 %}
                             <th>
                                 <span>{{ 'list.row_actions'|trans }}</span>
                             </th>
@@ -116,9 +116,9 @@
                                     {% endif %}
                                 </td>
                             {% endfor %}
-                            {% if _entity_list_actions|length > 0 %}
+                            {% if _list_item_actions|length > 0 %}
                                 <td class="actions">
-                                    {% for action in _entity_list_actions %}
+                                    {% for action in _list_item_actions %}
                                         <a href="{{ path('admin', { action: action, entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
                                             {{- ('action.' ~ action)|trans -}}
                                         </a>
@@ -128,7 +128,7 @@
                         </tr>
                     {% else %}
                         <tr>
-                            <td colspan="{{ _entity_list_actions|length > 0 ? fields|length + 1 : fields|length }}">
+                            <td colspan="{{ _list_item_actions|length > 0 ? fields|length + 1 : fields|length }}">
                                 {{ 'search.no_results'|trans }}
                             </td>
                         </tr>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -30,7 +30,7 @@
                 <h1 class="title">{{ block('content_title') }}</h1>
             </div>
             <div class="col-xs-12 col-sm-7">
-                {% if 'new' in easyadmin_config('actions') %}
+                {% if easyadmin_action_is_enabled('new', entity.name) %}
                     <div id="content-actions">
                             <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
                                 {{ entity.new.action_label|default('action.new')|trans({'%entity_name%': entity.label|trans}) }}
@@ -38,7 +38,7 @@
                     </div>
                 {% endif %}
 
-                {% if 'search' in easyadmin_config('actions') %}
+                {% if easyadmin_action_is_enabled('search', entity.name) %}
                     <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
                         <div class="input-group">
                             <input type="hidden" name="action" value="search">
@@ -113,7 +113,7 @@
                                 </td>
                             {% endfor %}
                                 <td class="actions">
-                                    {% for action in easyadmin_config('actions') if not (action in ['delete', 'list', 'new', 'search']) %}
+                                    {% for action in easyadmin_list_item_actions(entity.name) %}
                                         <a href="{{ path('admin', { action: action, entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
                                             {{- ('action.' ~ action)|trans -}}
                                         </a>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -53,6 +53,8 @@
 
     <div id="main" class="col-sm-12">
         <div>
+            {% set _entity_list_actions = easyadmin_list_item_actions(entity.name) %}
+
             <table class="table">
                 <thead>
                     <tr>
@@ -92,9 +94,11 @@
                                 {% endif %}
                             </th>
                         {% endfor %}
+                        {% if _entity_list_actions|length > 0 %}
                             <th>
                                 <span>{{ 'list.row_actions'|trans }}</span>
                             </th>
+                        {% endif %}
                     </tr>
                 </thead>
 
@@ -112,17 +116,21 @@
                                     {% endif %}
                                 </td>
                             {% endfor %}
+                            {% if _entity_list_actions|length > 0 %}
                                 <td class="actions">
-                                    {% for action in easyadmin_list_item_actions(entity.name) %}
+                                    {% for action in _entity_list_actions %}
                                         <a href="{{ path('admin', { action: action, entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
                                             {{- ('action.' ~ action)|trans -}}
                                         </a>
                                     {% endfor %}
                                 </td>
+                            {% endif %}
                         </tr>
                     {% else %}
                         <tr>
-                            <td colspan="{{ fields|length + 1 }}">{{ 'search.no_results'|trans }}</td>
+                            <td colspan="{{ _entity_list_actions|length > 0 ? fields|length + 1 : fields|length }}">
+                                {{ 'search.no_results'|trans }}
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -30,20 +30,23 @@
                 <h1 class="title">{{ block('content_title') }}</h1>
             </div>
             <div class="col-xs-12 col-sm-7">
-                <div id="content-actions">
-                    {% if 'new' in easyadmin_config('list.actions') %}
-                        <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
-                            {{ entity.new.action_label|default('action.new')|trans({'%entity_name%': entity.label|trans}) }}
-                        </a>
-                    {% endif %}
-                </div>
-                <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
-                    <div class="input-group">
-                        <input type="hidden" name="action" value="search">
-                        <input type="hidden" name="entity" value="{{ entity.name }}">
-                        <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ 'list.search_placeholder'|trans }}" value="{{ app.request.get('query')|default('') }}">
+                {% if 'new' in easyadmin_config('actions') %}
+                    <div id="content-actions">
+                            <a class="btn" href="{{ path('admin', { entity: entity.name, action: 'new' }) }}">
+                                {{ entity.new.action_label|default('action.new')|trans({'%entity_name%': entity.label|trans}) }}
+                            </a>
                     </div>
-                </form>
+                {% endif %}
+
+                {% if 'search' in easyadmin_config('actions') %}
+                    <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
+                        <div class="input-group">
+                            <input type="hidden" name="action" value="search">
+                            <input type="hidden" name="entity" value="{{ entity.name }}">
+                            <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ 'list.search_placeholder'|trans }}" value="{{ app.request.get('query')|default('') }}">
+                        </div>
+                    </form>
+                {% endif %}
             </div>
         </div>
     </div>
@@ -110,7 +113,7 @@
                                 </td>
                             {% endfor %}
                                 <td class="actions">
-                                    {% for action in easyadmin_config('list.actions') if action != 'new' %}
+                                    {% for action in easyadmin_config('actions') if not (action in ['delete', 'list', 'new', 'search']) %}
                                         <a href="{{ path('admin', { action: action, entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
                                             {{- ('action.' ~ action)|trans -}}
                                         </a>

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -34,13 +34,13 @@
 
         <div class="form-group form-actions">
             <div class="col-sm-10 col-sm-offset-2">
-                {% if 'edit' in easyadmin_config('actions') %}
+                {% if easyadmin_action_is_enabled('edit', entity.name) %}
                     <a class="btn btn-edit" href="{{ path('admin', { action: 'edit', entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
                         <i class="fa fa-edit"></i> {{ 'action.edit'|trans }}
                     </a>
                 {% endif %}
 
-                {% if 'delete' in easyadmin_config('actions') %}
+                {% if easyadmin_action_is_enabled('delete', entity.name) %}
                     <button type="button" id="button-delete" class="btn btn-danger">
                         <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
                     </button>

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -34,13 +34,17 @@
 
         <div class="form-group form-actions">
             <div class="col-sm-10 col-sm-offset-2">
-                <a class="btn btn-edit" href="{{ path('admin', { action: 'edit', entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
-                    <i class="fa fa-edit"></i> {{ 'action.edit'|trans }}
-                </a>
+                {% if 'edit' in easyadmin_config('actions') %}
+                    <a class="btn btn-edit" href="{{ path('admin', { action: 'edit', entity: entity.name, id: attribute(item, entity.primary_key_field_name) }) }}">
+                        <i class="fa fa-edit"></i> {{ 'action.edit'|trans }}
+                    </a>
+                {% endif %}
 
-                <button type="button" id="button-delete" class="btn btn-danger">
-                    <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
-                </button>
+                {% if 'delete' in easyadmin_config('actions') %}
+                    <button type="button" id="button-delete" class="btn btn-danger">
+                        <i class="fa fa-trash"></i> {{ 'action.delete'|trans }}
+                    </button>
+                {% endif %}
 
                 <a class="btn btn-list btn-secondary" href="{{ path('admin', ({ entity: entity.name, action: 'list' }) ) }}">
                     {{- 'action.back_to_listing'|trans -}}

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -33,7 +33,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('easyadmin_config', array($this, 'getBackendConfiguration')),
             new \Twig_SimpleFunction('easyadmin_entity', array($this, 'getEntityConfiguration')),
             new \Twig_SimpleFunction('easyadmin_action_is_enabled', array($this, 'isActionEnabled')),
-            new \Twig_SimpleFunction('easyadmin_list_item_actions', array($this, 'getActionsForListingItems')),
+            new \Twig_SimpleFunction('easyadmin_list_item_actions', array($this, 'getActionsForListItem')),
         );
     }
 
@@ -228,7 +228,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
      * @param  string $entityName
      * @return array
      */
-    public function getActionsForListingItems($entityName)
+    public function getActionsForListItem($entityName)
     {
         $entityConfiguration = $this->configurator->getEntityConfiguration($entityName);
         $excludedActions = array('delete', 'list', 'new', 'search');

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -32,6 +32,8 @@ class EasyAdminTwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('easyadmin_render_field', array($this, 'renderEntityField')),
             new \Twig_SimpleFunction('easyadmin_config', array($this, 'getBackendConfiguration')),
             new \Twig_SimpleFunction('easyadmin_entity', array($this, 'getEntityConfiguration')),
+            new \Twig_SimpleFunction('easyadmin_action_is_enabled', array($this, 'isActionEnabled')),
+            new \Twig_SimpleFunction('easyadmin_list_item_actions', array($this, 'getActionsForListingItems')),
         );
     }
 
@@ -204,6 +206,34 @@ class EasyAdminTwigExtension extends \Twig_Extension
         }
 
         return '';
+    }
+
+    /**
+     * Checks whether the given 'action' is enabled for the given 'entity'.
+     *
+     * @param  string  $action
+     * @param  string  $entityName
+     * @return boolean
+     */
+    public function isActionEnabled($action, $entityName)
+    {
+        $entityConfiguration = $this->configurator->getEntityConfiguration($entityName);
+
+        return in_array($action, $entityConfiguration['actions']);
+    }
+
+    /**
+     * Returns the actions configured for each item displayed in the 'list' action.
+     *
+     * @param  string $entityName
+     * @return array
+     */
+    public function getActionsForListingItems($entityName)
+    {
+        $entityConfiguration = $this->configurator->getEntityConfiguration($entityName);
+        $excludedActions = array('delete', 'list', 'new', 'search');
+
+        return array_diff($entityConfiguration['actions'], $excludedActions);
     }
 
     /*

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -231,7 +231,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
     public function getActionsForListingItems($entityName)
     {
         $entityConfiguration = $this->configurator->getEntityConfiguration($entityName);
-        $excludedActions = array('easyadminAjaxEdit', 'delete', 'list', 'new', 'search');
+        $excludedActions = array('delete', 'list', 'new', 'search');
 
         return array_diff($entityConfiguration['actions'], $excludedActions);
     }

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -231,7 +231,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
     public function getActionsForListingItems($entityName)
     {
         $entityConfiguration = $this->configurator->getEntityConfiguration($entityName);
-        $excludedActions = array('delete', 'list', 'new', 'search');
+        $excludedActions = array('easyadminAjaxEdit', 'delete', 'list', 'new', 'search');
 
         return array_diff($entityConfiguration['actions'], $excludedActions);
     }


### PR DESCRIPTION
This is the required PR previous to allowing to define custom actions. We want to allow the user to configure the actions for each entity. This is a WIP pull request, so for now, you can only configure actions for all the backend. This is the updated documentation:

```
Customize the Actions Displayed for Each Entity
-----------------------------------------------

The backend provides six different actions for each entity: ``delete``,
``edit``, ``list``, ``new``, ``search`` and ``show``. The ``list`` action is
mandatory for all entities, but the rest of actions can be disabled. Use the
global ``actions`` option to set the actions available in your backend:

# app/config/config.yml
easy_admin:
    # this option makes the backend a read-only application: you cannot
    # create, delete or modify entities
    actions: ['show', 'search']
    # ...

In the current version of EasyAdmin you cannot define custom actions.
```

There are a lot of details pending to complete this PR, but I wanted to share it publicly to get early feedback. Things to do:
- Allow to configure actions per entity.
- When there are no actions except `list`, don't show the `Actions` column in the listings.
- The special `toggle` action for boolean values should only be enabled when the `edit` action is enabled for that entity.
- The controller should check the actual enabled actions before executing the controller.
- ...

This PR is based on the original work of @jesusdiez in #168.
