### PR TITLE
Label for fields in edit and new views (checkbox for example)

### DIFF
--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -20,7 +20,7 @@
                         {{ form_label(field, field_label|trans, { label_attr: { class: 'col-sm-2 control-label' } }) }}
 
                         <div class="col-sm-10 {% if entity_fields[field.vars.name]['fieldType'] == 'checkbox' %}col-sm-offset-2{% endif %}">
-                            {% set widget_attributes = { attr: { class: entity_fields[field.vars.name]['class']|default(null) } } %}
+                            {% set widget_attributes = { attr: { class: entity_fields[field.vars.name]['class']|default(null) }, label: entity_fields[field.vars.name]['label']|trans } %}
                             {{ form_widget(field, widget_attributes) }}
                             {{ form_errors(field) }}
 

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -21,7 +21,7 @@
                         {{ form_label(field, field_label|trans, { label_attr: { class: 'col-sm-2 control-label' } }) }}
 
                         <div class="col-sm-10 {% if _field_configuration['fieldType'] == 'checkbox' %}col-sm-offset-2{% endif %}">
-                            {% set widget_attributes = { attr: { class: _field_configuration['class']|default(null) } } %}
+                            {% set widget_attributes = { attr: { class: _field_configuration['class']|default(null) }, label: entity_fields[field.vars.name]['label']|trans } %}
                             {{ form_widget(field, widget_attributes) }}
                             {{ form_errors(field) }}
 


### PR DESCRIPTION
I discovered this issue while trying to internationalize the admin interface.
I wasn't able to set the label for a boolean field using a checkbox.
