### PR TITLE
Fix a bug when toggleing boolean values from list

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -288,7 +288,7 @@ class AdminController extends Controller
             throw new \Exception(sprintf('It\'s not possible to toggle the value of the "%s" boolean property of the "%s" entity.', $propertyName, $this->entity['name']));
         }
 
-        $newValue = (bool) $this->request->query->get('newValue');
+        $newValue = $this->request->query->get('newValue') === 'true';
         if (null !== $setter = $propertyMetadata['setter']) {
             $entity->{$setter}($newValue);
         } else {


### PR DESCRIPTION
As of [this](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/Resources/views/list.html.twig#L163), the `newValue` will only be equal to either `"true"` or `"false"`, so they're both strings evaluated as "true" when typecasted to boolean , so the value will always be `true` in the database.

This PR fixes this behavior in checking effectively the string is equal to `"true"` or not.
