### PR TITLE
Enhance date & time choice widget by allowing null with one click

### DIFF
--- a/Resources/public/javascript/admin.js
+++ b/Resources/public/javascript/admin.js
@@ -20,3 +20,17 @@ function mainMenuDropShadow() {
     var scrollPercent = 100 * this.scrollTop / this.scrollHeight / (1 - this.clientHeight / this.scrollHeight);
     isNaN(scrollPercent) || scrollPercent >= 100 ? headerFooter.removeClass('drop-shadow') : headerFooter.addClass('drop-shadow');
 }
+
+function enhanceNullableDatetimeFields() {
+    var fnNullDates = function() {
+        var checkbox = $(this);
+        checkbox.parents('.null-control').siblings('select').each(function() {
+            $(this).prop('disabled', checkbox.is(':checked'))
+        });
+    };
+    $('.field_datetime .null-control')
+        .each(function () {
+            $(this).appendTo($(this).siblings('.form-inline'));
+        })
+        .find(':checkbox').bind('change', fnNullDates).each(fnNullDates);
+}

--- a/Resources/public/stylesheet/admin.css
+++ b/Resources/public/stylesheet/admin.css
@@ -706,6 +706,10 @@ body.new form textarea {
 body.new form .form-inline select + select {
     margin-left: .5em;
 }
+body.new form .field_datetime .form-inline .null-control {
+    display: inline-block;
+    margin-left: 5px;
+}
 
 /* -------------------------------------------------------------------------
    EDIT PAGE
@@ -715,6 +719,10 @@ body.edit form textarea {
 }
 body.edit form .form-inline select + select {
     margin-left: .5em;
+}
+body.edit form .field_datetime .form-inline .null-control {
+    display: inline-block;
+    margin-left: 5px;
 }
 
 /* -------------------------------------------------------------------------

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -17,24 +17,25 @@
     {{ form_start(form, { attr: { id: 'edit-form', novalidate: 'novalidate' } }) }}
         <div id="form">
             {% for field in form.children if field.vars.name != '_token' %}
-                {% set _field_metadata = entity_fields[field.vars.name] %}
-                <div class="form-group {% if not field.vars.valid %}has-error{% endif %}">
-                    {% if _field_metadata['fieldType'] == 'association' %}
-                        {{ easyadmin_render_field_for_edit_view(item, _field_metadata) }}
+                {% set _field_configuration = entity_fields[field.vars.name] %}
+                {% set _field_type = _field_configuration['fieldType'] %}
+                <div class="form-group field_{{ _field_type|lower|default('default') }} {% if not field.vars.valid %}has-error{% endif %}">
+                    {% if _field_type == 'association' %}
+                        {{ easyadmin_render_field_for_edit_view(item, _field_configuration) }}
                     {% else %}
-                        {% set field_label = _field_metadata['label']|default(null) %}
+                        {% set field_label = _field_configuration['label']|default(null) %}
                         {{ form_label(field, field_label|trans(_trans_parameters), { label_attr: { class: 'col-sm-2 control-label' } }) }}
 
-                        <div class="col-sm-10 {% if _field_metadata['fieldType'] == 'checkbox' %}col-sm-offset-2{% endif %}">
-                            {% set widget_attributes = { attr: { class: _field_metadata['class']|default(null) }, label: _field_metadata['label']|trans } %}
+                        <div class="col-sm-10 {% if _field_type == 'checkbox' %}col-sm-offset-2{% endif %}">
+                            {% set widget_attributes = { attr: { class: _field_configuration['class']|default(null) }, label: _field_configuration['label']|trans } %}
                             {{ form_widget(field, widget_attributes) }}
                             {{ form_errors(field) }}
 
-                            {% if _field_metadata['help'] is defined %}
-                                <span class="help-block">{{ _field_metadata['help'] }}</span>
+                            {% if _field_configuration['help'] is defined %}
+                                <span class="help-block">{{ _field_configuration['help'] }}</span>
                             {% endif %}
 
-                            {% if _field_metadata['fieldType'] == 'collection' %}
+                            {% if _field_type == 'collection' %}
                                 {% set add_item_javascript %}
                                     $(function() {
                                         if(event.preventDefault) event.preventDefault(); else event.returnValue = false;

--- a/Resources/views/edit.html.twig
+++ b/Resources/views/edit.html.twig
@@ -29,6 +29,14 @@
                         <div class="col-sm-10 {% if _field_type == 'checkbox' %}col-sm-offset-2{% endif %}">
                             {% set widget_attributes = { attr: { class: _field_configuration['class']|default(null) }, label: _field_configuration['label']|trans } %}
                             {{ form_widget(field, widget_attributes) }}
+                            {% if _field_type in ['datetime', 'datetimetz', 'date', 'time'] and _field_configuration['nullable'] %}
+                                <div class="null-control">
+                                    <label>
+                                        <input type="checkbox" {% if field.vars.data is null %}checked="checked" {% endif %}>
+                                        Null
+                                    </label>
+                                </div>
+                            {% endif %}
                             {{ form_errors(field) }}
 
                             {% if _field_configuration['help'] is defined %}
@@ -148,6 +156,8 @@
                         $('#delete-form').trigger('submit');
                     });
             });
+
+            enhanceNullableDatetimeFields();
         });
     </script>
 {% endblock %}

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -29,6 +29,14 @@
                         <div class="col-sm-10 {% if _field_type == 'checkbox' %}col-sm-offset-2{% endif %}">
                             {% set widget_attributes = { attr: { class: _field_configuration['class']|default(null) }, label: entity_fields[field.vars.name]['label']|trans } %}
                             {{ form_widget(field, widget_attributes) }}
+                            {% if _field_type in ['datetime', 'datetimetz', 'date', 'time'] and _field_configuration['nullable'] %}
+                                <div class="null-control">
+                                    <label>
+                                        <input type="checkbox" {% if field.vars.data is null %}checked="checked" {% endif %}>
+                                        Null
+                                    </label>
+                                </div>
+                            {% endif %}
                             {{ form_errors(field) }}
 
                             {% if _field_configuration['help'] is defined %}
@@ -104,6 +112,8 @@
     <script type="text/javascript">
         $(function() {
             $('#new-form').areYouSure({ 'message': 'You haven\'t saved the changes made on this form.' });
+
+            enhanceNullableDatetimeFields();
         });
     </script>
 {% endblock %}

--- a/Resources/views/new.html.twig
+++ b/Resources/views/new.html.twig
@@ -18,14 +18,15 @@
         <div id="form">
             {% for field in form.children if field.vars.name != '_token' %}
                 {% set _field_configuration = entity_fields[field.vars.name] %}
-                <div class="form-group field_{{ _field_configuration['fieldType']|lower|default('default') }} {% if not field.vars.valid %}has-error{% endif %}">
-                    {% if _field_configuration['fieldType'] == 'association' %}
+                {% set _field_type = _field_configuration['fieldType'] %}
+                <div class="form-group field_{{ _field_type|lower|default('default') }} {% if not field.vars.valid %}has-error{% endif %}">
+                    {% if _field_type == 'association' %}
                         {{ easyadmin_render_field_for_new_view(item, _field_configuration) }}
                     {% else %}
                         {% set field_label = _field_configuration['label']|default(null) %}
                         {{ form_label(field, field_label|trans, { label_attr: { class: 'col-sm-2 control-label' } }) }}
 
-                        <div class="col-sm-10 {% if _field_configuration['fieldType'] == 'checkbox' %}col-sm-offset-2{% endif %}">
+                        <div class="col-sm-10 {% if _field_type == 'checkbox' %}col-sm-offset-2{% endif %}">
                             {% set widget_attributes = { attr: { class: _field_configuration['class']|default(null) }, label: entity_fields[field.vars.name]['label']|trans } %}
                             {{ form_widget(field, widget_attributes) }}
                             {{ form_errors(field) }}
@@ -34,7 +35,7 @@
                                 <span class="help-block">{{ _field_configuration['help'] }}</span>
                             {% endif %}
 
-                            {% if _field_configuration['fieldType'] == 'collection' %}
+                            {% if _field_type == 'collection' %}
                                 {% set add_item_javascript %}
                                     $(function() {
                                         if(event.preventDefault) event.preventDefault(); else event.returnValue = false;


### PR DESCRIPTION
Enhance the date & time basic choice widget by allowing to set `null` with one click.
Whenever a datetime field is nullable, a simple checkbox next to the controls is displayed, in order to disable all the select inputs at once, and submit `null`:

![screenshot 2015-03-28 a 12 59 12](https://cloud.githubusercontent.com/assets/2211145/6881011/5b5d6692-d54c-11e4-86b0-35b6ab43ffb8.PNG)

Until we choose a proper date & time picker, I think we should make the basic form handier when we can.

First commit is only about making the `edit` template more consistent with the `new` one.
# 

Related to #206 
