### PR TITLE
Added support for form_widget attributes

### DIFF
--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -10,8 +10,10 @@
             {% if _field_metadata['fieldType'] == 'association' %}
                 {{ easyadmin_render_field_for_edit_view(entity, _field_metadata) }}
             {% else %}
-                {% set _field_label = _field_metadata['label']|default(null) %}
-                {{ form_row(field, { label: _field_label|trans(_trans_parameters) }) }}
+                {% set _field_label = _field_metadata['label'] | default(null) | trans(_trans_parameters) %}
+                {% set widget_attr = _field_metadata['widget_attr'] is defined ? _field_metadata['widget_attr'] : {} %}
+                {% set widget_attr = ( widget_attr | merge({label: _field_label})) %}
+                {{ form_row(field, widget_attr) }}
             {% endif %}
 
             {% if _field_metadata['fieldType'] == 'collection' %}


### PR DESCRIPTION
With this very simple modification, you can customize the widget for each field directly in the configuration.

The official documentation about widget parameters is here:
http://symfony.com/doc/current/reference/forms/twig_reference.html#form-variables-reference

Example:
Configuration:

``` yaml
easy_admin:
    entities:
        Translation:
            class: Orbitale\Bundle\TranslationBundle\Entity\Translation
            form:
                fields: [ { property: source }, translation, locale, domain, notes ]
```

Form render:
![capture d ecran 2015-04-09 a 18 31 07](https://cloud.githubusercontent.com/assets/3369266/7071613/af7fe0e4-dee6-11e4-9d78-1eeb9189a3c1.png)

This PR allows this:

``` yaml
easy_admin:
    entities:
        Translation:
            class: Orbitale\Bundle\TranslationBundle\Entity\Translation
            form:
                fields: [ { property: source, widget_attr: { "disabled": true } }, translation, locale, domain, notes ]
```

![capture d ecran 2015-04-09 a 18 32 40](https://cloud.githubusercontent.com/assets/3369266/7071647/d68d516c-dee6-11e4-889e-cbf26f678a49.png)

What do you think about this?
