### PR TITLE
Allow easier override of the "new" action.

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -219,8 +219,7 @@ class AdminController extends Controller
      */
     protected function newAction()
     {
-        $entityFullyQualifiedClassName = $this->entity['class'];
-        $item = new $entityFullyQualifiedClassName();
+        $item = $this->instanciateNewEntity();
 
         $fields = $fields = $this->entity['new']['fields'];
         $newForm = $this->createNewForm($item, $fields);
@@ -320,6 +319,18 @@ class AdminController extends Controller
         $this->em->flush();
 
         return new Response((string) $newValue);
+    }
+    
+    /**
+     * Creates a new object of the current managed entity.
+     * This method is mostly here for override convenience, because it allows
+     * the user to use his own method to customize the entity instanciation.
+     * 
+     * @return object
+     */
+    protected function instanciateNewEntity() {
+        $entityFullyQualifiedClassName = $this->entity['class'];
+        return new $entityFullyQualifiedClassName();
     }
 
     /**


### PR DESCRIPTION
With this commit, we can easily customize the instanciation of our entities.

I'm proposing this modification because we have a specific case in which we only want to add default contents in a brand new instanciated object, but the content is retrieved via webservice, so I'm doing it in the controller.

Also, this simple workaround allows the users to override the method and create new `User` entity in the FOSUserBundle by returning a new User object using the
`$this->container->get('fos_user.user_manager')->createUser()` instruction.

I think this is useful :smiley: 
