### PR TITLE
Improve field configuration parsing

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -357,11 +357,9 @@ class Configurator
             // for the field, use it as 'fieldType'. Otherwise, infer the best field
             // type using the property data type.
             if (in_array($view, array('edit', 'new'))) {
-                if (isset($originalFieldConfiguration['type'])) {
-                    $normalizedConfiguration['fieldType'] = $originalFieldConfiguration['type'];
-                } else {
-                    $normalizedConfiguration['fieldType'] = $this->getFormTypeFromDoctrineType($normalizedConfiguration['type']);
-                }
+                $normalizedConfiguration['fieldType'] = isset($originalFieldConfiguration['type'])
+                    ? $originalFieldConfiguration['type']
+                    : $this->getFormTypeFromDoctrineType($normalizedConfiguration['type']);
             }
 
             // special case for the 'list' view: 'boolean' properties are displayed

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -162,12 +162,11 @@ class Configurator
      */
     private function getFieldsForListView(array $entityConfiguration)
     {
-        // there is a custom configuration for 'list' fields
-        if (count($entityConfiguration['list']['fields']) > 0) {
-            return $this->normalizeFieldsConfiguration('list', $entityConfiguration);
+        if (0 === count($entityConfiguration['list']['fields'])) {
+            $entityConfiguration['list']['fields'] = $this->filterListFieldsBasedOnSmartGuesses($this->defaultEntityFields);
         }
 
-        return $this->filterListFieldsBasedOnSmartGuesses($this->defaultEntityFields);
+        return $this->normalizeFieldsConfiguration('list', $entityConfiguration);
     }
 
     /**
@@ -371,9 +370,16 @@ class Configurator
             // special case for the 'list' view: 'boolean' properties are displayed
             // as toggleable flip switches when certain conditions are met
             if ('list' === $view && 'boolean' === $normalizedConfiguration['dataType']) {
-                // conditions: 1) the end-user hasn't configured the field type explicitly
-                // 2) the 'edit' action is allowed for the 'list' view of this entity
-                if (!isset($fieldConfiguration['type']) && array_key_exists('edit', $entityConfiguration['list']['actions'])) {
+                // conditions:
+                //   1) the end-user hasn't configured the field type explicitly
+                //   2) the 'edit' action is enabled for the 'list' view of this entity
+                $originalEntityListConfiguration = $this->backendConfig['entities'][$entityConfiguration['name']]['list'];
+                $originalFieldConfiguration = isset($originalEntityListConfiguration['fields'][$fieldName])
+                    ? $originalEntityListConfiguration['fields'][$fieldName] : null;
+
+                $isEditActionEnabled = array_key_exists('edit', $entityConfiguration['list']['actions']);
+
+                if (!isset($originalFieldConfiguration['type']) && $isEditActionEnabled) {
                     $normalizedConfiguration['dataType'] = 'toggle';
                 }
             }

--- a/Resources/doc/4-customizing-list-view.md
+++ b/Resources/doc/4-customizing-list-view.md
@@ -481,34 +481,8 @@ easy_admin:
 These are the supported types:
 
   * All the [Symfony Form types](http://symfony.com/doc/current/reference/forms/types.html)
-  * All the [Doctrine data types](http://doctrine-dbal.readthedocs.org/en/latest/reference/types.html)
   * Custom EasyAdmin types:
     * `image`, displays images inlined in the entity listings. Read the
       previous sections for more details.
     * `toggle`, displays a boolean value as a flip switch. Read the previous
       sections for more details.
-
-If you use any of the types defined by Doctrine, the backend automatically
-transforms into the appropriate Symfony Form type using the following
-conversion table:
-
-| Doctrine Type  | Symfony form type
-| -------------- | -----------------
-| `array`        | `collection`
-| `bigint`       | `text`
-| `blob`         | `textarea`
-| `boolean`      | `checkbox`
-| `date`         | `date`
-| `datetime`     | `datetime`
-| `datetimetz`   | `datetime`
-| `decimal`      | `number`
-| `float`        | `number`
-| `guid`         | `text`
-| `integer`      | `integer`
-| `json_array`   | `textarea`
-| `object`       | `textarea`
-| `simple_array` | `collection`
-| `smallint`     | `integer`
-| `string`       | `text`
-| `text`         | `textarea`
-| `time`         | `time`

--- a/Resources/doc/5-customizing-show-view.md
+++ b/Resources/doc/5-customizing-show-view.md
@@ -148,11 +148,7 @@ easy_admin:
 
 These are the supported types:
 
-  * All the Doctrine data types:
-    * Dates: `date`, `datetime`, `datetimetz`, `time`
-    * Logical: `boolean`
-    * Arrays: `array`, `simple_array`
-    * Text: `string`, `text`
-    * Numeric: `bigint`, `integer`, `smallint`, `decimal`, `float`
-  * `image`, custom type defined by EasyAdmin which displays images inlined in
-    the entity show page. Read the previous sections for more details.
+  * All the [Symfony Form types](http://symfony.com/doc/current/reference/forms/types.html)
+  * Custom EasyAdmin types:
+    * `image`, displays images inlined in the entity listings. Read the
+      previous sections for more details.


### PR DESCRIPTION
This fixes #220.

The main two changes introduced:
- Previously, the nice field configuration options were only applied when you configured the view fields explicitly. Now we apply those defaults also when you don't configure anything. An example of the issues that this change solves: if you don't configure the boolean fields, they are displayed as dull badges; if you configure them, they are displayed as cool flip switches. Now the behavior is the same in both cases: flip switches (unless you configure them as booleans).
- Previously the documentation said that you could use Doctrine types as the value of the `type` field option. This is wrong. The `type` option only admits Symfony Form types (and the two custom `toggle` and `image` types defined by EasyAdmin).
