### PR TITLE
Fix some design issues when header title is multiline

### DIFF
--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -1062,6 +1062,7 @@ body.error .error-solution pre {
     #header-logo {
         float: none;
         margin: 0;
+        height: auto;
         overflow: visible;
         text-overflow: inherit;
         padding: 0;
@@ -1185,5 +1186,23 @@ body.error .error-solution pre {
 
     body.error #content h1 {
         margin-top: .25em;
+    }
+}
+
+
+/* -------------------------------------------------------------------------
+ALL BUT LARGE DESKTOP
+------------------------------------------------------------------------- */
+@media (max-width: 1200px) {
+    #header-logo {
+        display: table;
+        height: 50px;
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+    #header-logo a {
+        display: table-cell;
+        vertical-align: middle;
+        float: none;
     }
 }

--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -938,8 +938,6 @@ body.error .error-solution pre {
         width: 100%;
     }
 
-    #header-logo a {
-    }
     #header-logo a img {
         max-height: 40px;
     }
@@ -1070,11 +1068,10 @@ body.error .error-solution pre {
     }
     #header-logo a {
         display: block;
-        height: 65px;
+        float: none;
+        min-height: 65px;
         font-size: 18px;
-        line-height: 65px;
-        padding-left: 10px;
-        width: 100%;
+        padding: 20px 10px;
     }
     #header-logo a.medium {
         font-size: 24px;

--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -405,6 +405,7 @@ button.btn-danger {
     float: left;
     font-size: 16px;
     font-weight: 500;
+    height: auto;
     margin: 0;
     overflow: hidden;
     position: relative;

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -41,7 +41,7 @@
                     <div id="header-logo" class="navbar-brand">
                         {% block header_logo %}
                         {% set _site_name_length = easyadmin_config('site_name')|length <= 10 ? 'short'
-                            : easyadmin_config('site_name')|length <= 12 ? 'medium' : 'long;'
+                            : easyadmin_config('site_name')|length <= 12 ? 'medium' : 'long'
                         %}
                         <a href="{{ path('admin') }}" class="{{ _site_name_length }}">{{ easyadmin_config('site_name')|raw }}</a>
                         {% endblock header_logo %}


### PR DESCRIPTION
Before:
(the multiline text is invisible)
![capture d ecran 2015-04-15 a 10 29 14](https://cloud.githubusercontent.com/assets/3369266/7154882/99fd4806-e35a-11e4-9ee4-2a11c71fccde.png)

After:
(the header logo's height adapts automatically)
![capture d ecran 2015-04-15 a 10 31 54](https://cloud.githubusercontent.com/assets/3369266/7154889/aa21e7a0-e35a-11e4-881f-88ca3333a6e0.png)

Does it sound right ?
