### PR TITLE
Fixed the management of allowed and forbidden actions

### DIFF
--- a/Resources/views/error/forbidden_action.html.twig
+++ b/Resources/views/error/forbidden_action.html.twig
@@ -10,7 +10,7 @@
     <ul>
         <li>
             Change this action for one of the following allowed actions:
-            <code>{{ enabled_actions|join('</code>, <code>')|raw }}</code>.
+            <code>{{ allowed_actions|join('</code>, <code>')|raw }}</code>.
         </li>
         <li>
             If the action name is correct, make sure it's included in

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -48,7 +48,7 @@
                         {% block navigation_items %}
                         {% for item in easyadmin_config('entities') %}
                             <li class="{{ item.name|lower == app.request.get('entity')|lower ? 'active' : '' }}">
-                                <a href="{{ path('admin', { entity: item.name, action: 'list' }) }}">
+                                <a href="{{ path('admin', { entity: item.name, action: 'list', view: 'list' }) }}">
                                     {{- item.label|trans -}}
                                 </a>
                             </li>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -37,7 +37,7 @@
                 {% if easyadmin_action_is_enabled_for_list_view('new', _entity.name) %}
                     {% set _action = easyadmin_get_action_for_list_view('new', _entity.name) %}
                     <div id="content-actions">
-                        <a class="btn {{ _action.class|default('') }}" href="{{ path('admin', { entity: _entity.name, action: _action.name }) }}">
+                        <a class="btn {{ _action.class|default('') }}" href="{{ path('admin', { entity: _entity.name, action: _action.name, view: 'list' }) }}">
                             {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                             {{ _action.label|default('action.new')|trans(_trans_parameters) }}
                         </a>
@@ -46,11 +46,8 @@
 
                 {% if easyadmin_action_is_enabled_for_list_view('search', _entity.name) %}
                     {% set _action = easyadmin_get_action_for_list_view('search', _entity.name) %}
-                    <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
+                    <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin', { view: 'list', action: 'search', entity: _entity.name }) }}">
                         <div class="input-group">
-                            <input type="hidden" name="action" value="search">
-                            <input type="hidden" name="view" value="list">
-                            <input type="hidden" name="entity" value="{{ _entity.name }}">
                             <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
                         </div>
                     </form>

--- a/Resources/views/show.html.twig
+++ b/Resources/views/show.html.twig
@@ -45,7 +45,7 @@
                 {% set _show_actions = easyadmin_get_actions_for_show_item(_entity.name) %}
                 {% for _action in _show_actions %}
                     {% if 'method' == _action.type %}
-                        {% set _action_href = path('admin', { action: _action.name, view: 'edit', entity: _entity.name, id: attribute(item, _entity.primary_key_field_name) }) %}
+                        {% set _action_href = path('admin', { action: _action.name, view: 'show', entity: _entity.name, id: attribute(item, _entity.primary_key_field_name) }) %}
                     {% elseif 'route' == _action.type %}
                         {% set _action_href = path(_action.name, { entity: _entity.name, id: attribute(item, _entity.primary_key_field_name) }) %}
                     {% endif %}


### PR DESCRIPTION
This fixes #221.

In short, to determine if an action is allowed you must have into account two things: where you are (the view) and what do you want to do (the action).

We didn't detect where we are correctly and therefore, some actions were wrongly forbidden. This pull request hopefully fixes all these problems.
