### PR TITLE
Configurable route linked in header logo

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -161,6 +161,11 @@ class Configuration implements ConfigurationInterface
                     ->info('The name displayed as the title of the administration zone (e.g. company name, project name).')
                 ->end()
 
+                ->scalarNode('logo_route')
+                    ->defaultValue('admin')
+                    ->info('The route linked in header logo of the administration zone.')
+                ->end()
+
                 ->arrayNode('formats')
                     ->performNoDeepMerging()
                     ->addDefaultsIfNotSet()

--- a/Resources/doc/3-customizing-first-backend.md
+++ b/Resources/doc/3-customizing-first-backend.md
@@ -64,6 +64,16 @@ easy_admin:
     # ...
 ```
 
+Also you can set the route to be linked in the logo. By default, the logo links 
+to admin home page (route 'admin').
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    logo_route: my_home_page
+    # ...
+```
+
 Customize the Order of the Main Menu Items
 ------------------------------------------
 

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -33,7 +33,7 @@
                     {% set _site_name_length = easyadmin_config('site_name')|length <= 10 ? 'short'
                         : easyadmin_config('site_name')|length <= 12 ? 'medium' : 'long;'
                     %}
-                    <a href="{{ path('admin') }}" class="{{ _site_name_length }}">{{ easyadmin_config('site_name')|raw }}</a>
+                    <a href="{{ path(easyadmin_config('logo_route')) }}" class="{{ _site_name_length }}">{{ easyadmin_config('site_name')|raw }}</a>
                 </div>
 
                 <div id="header-nav" class="col-xs-12 col-md-8 col-lg-12">


### PR DESCRIPTION
I propose to add a new configuration entry to allow change the route linked in logo.
By default it's set to "admin" route.
