### PR TITLE
Allow to customize the way the "NULL" label is shown

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -208,6 +208,11 @@ class Configuration implements ConfigurationInterface
                             ->end()
                         ->end()
 
+                        ->scalarNode('null_label')
+                            ->defaultValue('<span class="label">NULL</span>')
+                            ->info('The html/text used to render the label used to display NULL values in both "list" and "view" actions.')
+                        ->end()
+
                         ->enumNode('color_scheme')
                             ->values(array('dark', 'light'))
                             ->info('The color scheme applied to the backend design (values: "dark" or "light").')

--- a/Tests/DependencyInjection/fixtures/configurations/input/admin_104.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/input/admin_104.yml
@@ -1,0 +1,7 @@
+# TEST
+# configuration format #104: Simple "null_label" override to check that it works
+
+# CONFIGURATION
+easy_admin:
+    design:
+        null_label: '<div class="text-center">~</div>'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_006.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_006.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_011.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_011.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_015.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_015.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_029.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_029.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
@@ -169,6 +169,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
@@ -91,6 +91,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
@@ -91,6 +91,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
@@ -91,6 +91,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
@@ -95,6 +95,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
@@ -99,6 +99,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
@@ -102,6 +102,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
@@ -102,6 +102,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
@@ -102,6 +102,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
@@ -103,6 +103,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
@@ -91,6 +91,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
@@ -92,6 +92,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
@@ -92,6 +92,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_044.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_044.yml
@@ -4,6 +4,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
@@ -85,6 +85,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
@@ -84,6 +84,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
@@ -84,6 +84,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
@@ -90,6 +90,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
@@ -71,6 +71,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
@@ -85,6 +85,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
@@ -80,6 +80,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
@@ -90,6 +90,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
@@ -86,6 +86,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
@@ -85,6 +85,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
@@ -85,6 +85,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
@@ -91,6 +91,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
@@ -82,6 +82,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
@@ -65,6 +65,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
@@ -86,6 +86,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
@@ -76,6 +76,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
@@ -120,6 +120,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
@@ -124,6 +124,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
@@ -100,6 +100,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
@@ -144,6 +144,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
@@ -127,6 +127,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
@@ -95,6 +95,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_067.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_067.yml
@@ -9,6 +9,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
@@ -81,6 +81,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
@@ -81,6 +81,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
@@ -81,6 +81,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
@@ -82,6 +82,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
@@ -100,6 +100,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
@@ -84,6 +84,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
@@ -102,6 +102,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
@@ -101,6 +101,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
@@ -124,6 +124,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
@@ -103,6 +103,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
@@ -126,6 +126,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
@@ -116,6 +116,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
@@ -264,6 +264,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
@@ -231,6 +231,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
@@ -1,6 +1,7 @@
 easy_admin:
     design:
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
@@ -3,6 +3,7 @@ easy_admin:
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         assets:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
@@ -3,6 +3,7 @@ easy_admin:
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         assets:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
@@ -3,6 +3,7 @@ easy_admin:
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_layout.html.twig'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         assets:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
@@ -3,6 +3,7 @@ easy_admin:
         form_theme:
             - '@AppBundle/form/custom_layout.html.twig'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         assets:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
@@ -3,6 +3,7 @@ easy_admin:
         form_theme:
             - '@AppBundle/form/custom_layout.html.twig'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         assets:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
@@ -4,6 +4,7 @@ easy_admin:
             - '@AppBundle/form/custom_layout.html.twig'
             - form_div_layout.html.twig
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         assets:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         brand_color: '#CC0000'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         brand_color: 'rgb(255, 0, 0)'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         brand_color: 'rgba(255, 0, 0, 0.7)'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         brand_color: 'hsl(0, 100%, 50%)'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         brand_color: 'hsla(0, 100%, 50%, 0.7)'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         brand_color: red
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         brand_color: '#CC0000'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         brand_color: '#CC0000'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         color_scheme: dark
         theme: default
+        null_label: '<span class="label">NULL</span>'
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         color_scheme: dark
         theme: default
+        null_label: '<span class="label">NULL</span>'
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
@@ -2,6 +2,7 @@ easy_admin:
     design:
         color_scheme: light
         theme: default
+        null_label: '<span class="label">NULL</span>'
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
@@ -94,6 +94,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
@@ -87,6 +87,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_103.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_103.yml
@@ -94,6 +94,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
@@ -1,22 +1,22 @@
 easy_admin:
-    list:
-        max_results: 50
-        actions: {  }
     design:
-        assets:
-            css: {  }
-            js: {  }
+        null_label: '<div class="text-center">~</div>'
         theme: default
-        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+        assets:
+            css: {  }
+            js: {  }
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d
         time: 'H:i:s'
         datetime: 'F j, Y H:i'
+    list:
+        actions: {  }
+        max_results: 15
     edit:
         actions: {  }
     new:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_001.yml
@@ -4,6 +4,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_002.yml
@@ -4,6 +4,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_004.yml
@@ -12,6 +12,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_005.yml
@@ -7,6 +7,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_006.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_006.yml
@@ -12,6 +12,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_007.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_007.yml
@@ -12,6 +12,7 @@ easy_admin:
             css: {  }
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_008.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_008.yml
@@ -8,6 +8,7 @@ easy_admin:
                 - 'http://exmaple.com/path/to/asset4.css'
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_009.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_009.yml
@@ -8,6 +8,7 @@ easy_admin:
                 - 'http://exmaple.com/path/to/asset4.js'
             css: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_010.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_010.yml
@@ -12,6 +12,7 @@ easy_admin:
                 - //path/to/asset3.js
                 - 'http://exmaple.com/path/to/asset4.js'
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_011.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_011.yml
@@ -8,6 +8,7 @@ easy_admin:
                 - 'http://exmaple.com/path/to/asset4.css'
             js: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_012.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_012.yml
@@ -8,6 +8,7 @@ easy_admin:
                 - 'http://exmaple.com/path/to/asset4.js'
             css: {  }
         theme: default
+        null_label: '<span class="label">NULL</span>'
         color_scheme: dark
         brand_color: '#E67E22'
         form_theme:

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -111,7 +111,8 @@ class EasyAdminTwigExtension extends \Twig_Extension
             $fieldType = $fieldMetadata['dataType'];
 
             if (null === $value) {
-                return new \Twig_Markup('<span class="label">NULL</span>', 'UTF-8');
+                $config = $this->configurator->getBackendConfig();
+                return new \Twig_Markup($config['design']['null_label'], 'UTF-8');
             }
 
             // when a virtual field doesn't define it's type, consider it a string


### PR DESCRIPTION
I'd like to propose this enhancement in order to propose the users to customize the "null" label in list and view actions.

Before, with default config:
![capture d ecran 2015-04-20 a 14 56 53](https://cloud.githubusercontent.com/assets/3369266/7230531/130c7524-e76f-11e4-9e08-ad73105fe0fd.png)

If I set the option to `design: { null_label: '<div class="text-center">~</div>' }`
![capture d ecran 2015-04-20 a 14 56 29](https://cloud.githubusercontent.com/assets/3369266/7230541/273efb34-e76f-11e4-9c86-f2227e7709de.png)

This allows the back-end to look less "developer-ish", and more "customer-friendly". A customer does not know what `null` means, in computer terms, so a simple "-" or "~" is more verbose I think.
