### PR TITLE
Fixed the sorting of search results

### DIFF
--- a/Resources/views/_list_paginator.html.twig
+++ b/Resources/views/_list_paginator.html.twig
@@ -16,7 +16,7 @@
                         </li>
                     {% else %}
                         <li>
-                            <a href="{{ path('admin', request_attributes|merge({ page: 1 }) ) }}">
+                            <a href="{{ path('admin', _request_parameters|merge({ page: 1 }) ) }}">
                                 <i class="fa fa-angle-double-left"></i> {{ 'paginator.first'|trans }}
                             </a>
                         </li>
@@ -24,7 +24,7 @@
 
                     {% if paginator.hasPreviousPage %}
                         <li>
-                            <a href="{{ path('admin', request_attributes|merge({ page: paginator.previousPage }) ) }}">
+                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.previousPage }) ) }}">
                                 <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
                             </a>
                         </li>
@@ -38,7 +38,7 @@
 
                     {% if paginator.hasNextPage %}
                         <li>
-                            <a href="{{ path('admin', request_attributes|merge({ page: paginator.nextPage }) ) }}">
+                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.nextPage }) ) }}">
                                 {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
                             </a>
                         </li>
@@ -52,7 +52,7 @@
 
                     {% if paginator.currentPage < paginator.nbPages %}
                         <li>
-                            <a href="{{ path('admin', request_attributes|merge({ page: paginator.nbPages }) ) }}">
+                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.nbPages }) ) }}">
                                 {{ 'paginator.last'|trans }} <i class="fa fa-angle-double-right"></i>
                             </a>
                         </li>

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -21,10 +21,11 @@
 {% endblock %}
 
 {% block content %}
-{% if 'search' == app.request.get('action') %}
-    {% set request_attributes = { view: 'list', action: 'search', entity: _entity.name, query: app.request.get('query')|default('') } %}
-{% else %}
-    {% set request_attributes = { view: 'list', action: 'list', entity: _entity.name, sortDirection: app.request.get('sortDirection', 'DESC') } %}
+    {% set _request_parameters = { view: 'list', action: app.request.get('action'), entity: _entity.name, sortField: app.request.get('sortField', ''), sortDirection: app.request.get('sortDirection', 'DESC') } %}
+
+    {% if 'search' == app.request.get('action') %}
+        {% set _request_parameters = _request_parameters|merge({ query: app.request.get('query')|default('') }) %}
+    {% else %}
 {% endif %}
 
 <div class="row">
@@ -50,6 +51,8 @@
                         <input type="hidden" name="view" value="list">
                         <input type="hidden" name="action" value="search">
                         <input type="hidden" name="entity" value="{{ _entity.name }}">
+                        <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
+                        <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
                         <div class="input-group">
                             <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
                         </div>
@@ -73,14 +76,14 @@
                             <th data-property-name="{{ metadata.property }}" class="{{ isSortingField ? 'sorted' : '' }} {{ metadata.virtual|default(false) ? 'virtual' : '' }} {{ metadata.dataType|lower }}">
                                 {% if isSortingField %}
                                     {% set sortDirection = ('DESC' == app.request.get('sortDirection')) ? 'ASC' : 'DESC' %}
-                                    {% set request_attributes = request_attributes|merge({ sortField: metadata.property }) %}
+                                    {% set _request_parameters = _request_parameters|merge({ sortField: metadata.property }) %}
                                 {% endif %}
 
                                 {% set _column_label =  metadata.label ? ( metadata.label|trans(_trans_parameters) ) : ( ('id' == metadata.property) ? 'ID' : field|humanize ) %}
                                 {% set _table_column_labels = _table_column_labels|merge([_column_label]) %}
 
                                 {% if metadata.sortable %}
-                                    <a href="{{ path('admin', request_attributes|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
+                                    <a href="{{ path('admin', _request_parameters|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
                                         {% if isSortingField and sortDirection == 'DESC' %}
                                             <i class="fa fa-caret-up"></i>
                                         {% elseif isSortingField and sortDirection == 'ASC' %}

--- a/Resources/views/list.html.twig
+++ b/Resources/views/list.html.twig
@@ -46,7 +46,10 @@
 
                 {% if easyadmin_action_is_enabled_for_list_view('search', _entity.name) %}
                     {% set _action = easyadmin_get_action_for_list_view('search', _entity.name) %}
-                    <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin', { view: 'list', action: 'search', entity: _entity.name }) }}">
+                    <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
+                        <input type="hidden" name="view" value="list">
+                        <input type="hidden" name="action" value="search">
+                        <input type="hidden" name="entity" value="{{ _entity.name }}">
                         <div class="input-group">
                             <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
                         </div>


### PR DESCRIPTION
@Pierstoval I've taken your #243 pull request and I've tweaked a bit in this pull request. The two changes are:
- The `request_attributes` variable has been renamed to `_request_parameters` (I wanted to do this since long time ago).
- The following issue has been fixed: if you do a search, sort the results by any column and then do another search, the sorting of the results is reset. The solution was to add as `hidden` form properties the request parameters `sortField` and `sortDirection`
