### PR TITLE
Form helper becomes 'rawable' to allow html inside

### DIFF
--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -33,7 +33,7 @@ col-sm-2
             {{ form_errors(form) }}
 
             {% if form.vars.attr.field_help|default('') != '' %}
-                <span class="help-block"><i class="fa fa-info-circle"></i> {{ form.vars.attr.field_help }}</span>
+                <span class="help-block"><i class="fa fa-info-circle"></i> {{ form.vars.attr.field_help | raw }}</span>
             {% endif %}
         </div>
     </div>

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -184,7 +184,7 @@
         {{- form_errors(form) -}}
 
         {% if form.vars.attr.field_help|default('') != '' %}
-            <span class="help-block"><i class="fa fa-info-circle"></i> {{ form.vars.attr.field_help }}</span>
+            <span class="help-block"><i class="fa fa-info-circle"></i> {{ form.vars.attr.field_help | raw }}</span>
         {% endif %}
     </div>
 {%- endblock form_row %}


### PR DESCRIPTION
Actually, if I want this it's impossible:

``` yaml
easy_admin:
    entities:
        Post:
            class: AppBundle\Entity\Post
            form:
                fields:
                    - { property: "complexProperty", help: '<span class="badge">Alert!</span> This field is complex, please be careful!' }
```

This PR directly allows using HTML inside help messages, which is important in some complex backends, or when the end users may not understand some logical behaviors.
