### PR TITLE
Table header is rawable

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -99,10 +99,10 @@
                                                 <i class="fa fa-sort"></i>
                                             {% endif %}
 
-                                            {{ _column_label }}
+                                            {{ _column_label|raw }}
                                         </a>
                                     {% else %}
-                                        <span>{{ _column_label }}</span>
+                                        <span>{{ _column_label|raw }}</span>
                                     {% endif %}
                                 </th>
                             {% endfor %}


### PR DESCRIPTION
It's the same concept of #254 but for table headers. It allows to use a simple icon tag if needed.
