### PR TITLE
Use a better strategy to generate unique entity names

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -466,8 +466,9 @@ class EasyAdminExtension extends Extension
     {
         $uniqueName = $entityName;
 
+        $i = 2;
         while (in_array($uniqueName, $existingEntityNames)) {
-            $uniqueName .= '_';
+            $uniqueName = $entityName.($i++);
         }
 
         return $uniqueName;

--- a/Tests/DependencyInjection/fixtures/configurations/input/admin_003.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/input/admin_003.yml
@@ -5,4 +5,5 @@
 easy_admin:
     entities:
         - AppBundle\Entity\TestEntity
-        - AppBundle\OtherNamespace\Entity\TestEntity
+        - AppBundle\AnotherNamespace\Entity\TestEntity
+        - AnotherBundle\Entity\TestEntity

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
@@ -114,10 +114,124 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
-            class: AppBundle\OtherNamespace\Entity\TestEntity
+        TestEntity2:
+            class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: TestEntity
-            name: TestEntity_
+            name: TestEntity2
+            edit:
+                fields: {  }
+                actions:
+                    delete:
+                        name: delete
+                        type: method
+                        label: action.delete
+                        class: ''
+                        icon: trash
+                    list:
+                        name: list
+                        type: method
+                        label: action.list
+                        class: ''
+                        icon: null
+            list:
+                fields: {  }
+                actions:
+                    show:
+                        name: show
+                        type: method
+                        label: action.show
+                        class: ''
+                        icon: null
+                    edit:
+                        name: edit
+                        type: method
+                        label: action.edit
+                        class: ''
+                        icon: null
+                    search:
+                        name: search
+                        type: method
+                        label: action.search
+                        class: ''
+                        icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        class: ''
+                        icon: null
+                    list:
+                        name: list
+                        type: method
+                        label: action.list
+                        class: ''
+                        icon: null
+            new:
+                fields: {  }
+                actions:
+                    list:
+                        name: list
+                        type: method
+                        label: action.list
+                        class: ''
+                        icon: null
+            search:
+                fields: {  }
+            show:
+                fields: {  }
+                actions:
+                    delete:
+                        name: delete
+                        type: method
+                        label: action.delete
+                        class: ''
+                        icon: trash
+                    list:
+                        name: list
+                        type: method
+                        label: action.list
+                        class: ''
+                        icon: null
+                    edit:
+                        name: edit
+                        type: method
+                        label: action.edit
+                        class: ''
+                        icon: edit
+            templates:
+                layout: '@EasyAdmin/default/layout.html.twig'
+                edit: '@EasyAdmin/default/edit.html.twig'
+                list: '@EasyAdmin/default/list.html.twig'
+                new: '@EasyAdmin/default/new.html.twig'
+                show: '@EasyAdmin/default/show.html.twig'
+                form: '@EasyAdmin/default/form.html.twig'
+                paginator: '@EasyAdmin/default/paginator.html.twig'
+                field_array: '@EasyAdmin/default/field_array.html.twig'
+                field_association: '@EasyAdmin/default/field_association.html.twig'
+                field_bigint: '@EasyAdmin/default/field_bigint.html.twig'
+                field_boolean: '@EasyAdmin/default/field_boolean.html.twig'
+                field_date: '@EasyAdmin/default/field_date.html.twig'
+                field_datetime: '@EasyAdmin/default/field_datetime.html.twig'
+                field_datetimetz: '@EasyAdmin/default/field_datetimetz.html.twig'
+                field_decimal: '@EasyAdmin/default/field_decimal.html.twig'
+                field_float: '@EasyAdmin/default/field_float.html.twig'
+                field_id: '@EasyAdmin/default/field_id.html.twig'
+                field_image: '@EasyAdmin/default/field_image.html.twig'
+                field_integer: '@EasyAdmin/default/field_integer.html.twig'
+                field_simple_array: '@EasyAdmin/default/field_simple_array.html.twig'
+                field_smallint: '@EasyAdmin/default/field_smallint.html.twig'
+                field_string: '@EasyAdmin/default/field_string.html.twig'
+                field_text: '@EasyAdmin/default/field_text.html.twig'
+                field_time: '@EasyAdmin/default/field_time.html.twig'
+                field_toggle: '@EasyAdmin/default/field_toggle.html.twig'
+                label_empty: '@EasyAdmin/default/label_empty.html.twig'
+                label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
+                label_null: '@EasyAdmin/default/label_null.html.twig'
+                label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+        TestEntity3:
+            class: AnotherBundle\Entity\TestEntity
+            label: TestEntity
+            name: TestEntity3
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: AnotherTestEntity
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: AnotherTestEntity
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: TestEntity
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: EntityCustomLabel
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: 'Custom #Entity ~ Label'
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: TestEntity
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: AnotherTestEntity
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_029.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_029.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: 'Another Custom #Entity ~ Label'
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
@@ -114,10 +114,10 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
-        TestEntity_:
+        TestEntity2:
             class: AppBundle\AnotherNamespace\Entity\TestEntity
             label: AnotherTestEntity
-            name: TestEntity_
+            name: TestEntity2
             edit:
                 fields: {  }
                 actions:


### PR DESCRIPTION
In the backend we use the entity name in the URL and as the key of the array that stores entities configuration. So it must be unique. The problem happens when you have different entities with the same name:

``` yaml
easy_admin:
    entities:
        - AppBundle\Entity\TestEntity
        - AppBundle\AnotherNamespace\Entity\TestEntity
        - AnotherBundle\Entity\TestEntity
```

Until now we appended an underscore to the repeated names to make them unique:

```
TestEntity
TestEntity_
TestEntity__
...
```

I don't know what I was thinking when I made such a stupid decision. This PR changes the strategy to append an autoincremental numeric suffix:

```
TestEntity
TestEntity2
TestEntity3
...
```
