### PR TITLE
Removed the hack that controlled the label of the special 'id' field

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -349,6 +349,13 @@ class Configurator
                 $normalizedConfiguration['sortable'] = false;
             }
 
+            // special case: if the field is called 'id' and doesn't define a custom
+            // label, use 'ID' as label. This improves the readability of the label
+            // of this important field, which is usually related to the primary key
+            if ('id' === $normalizedConfiguration['fieldName'] && !isset($normalizedConfiguration['label'])) {
+                $normalizedConfiguration['label'] = 'ID';
+            }
+
             // 'list', 'search' and 'show' views: use the value of the 'type' option
             // as the 'dataType' option because the previous code has already
             // prioritized end-user preferences over Doctrine and default values

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -87,7 +87,7 @@
                                         {% set _request_parameters = _request_parameters|merge({ sortField: metadata.property }) %}
                                     {% endif %}
 
-                                    {% set _column_label =  metadata.label ? ( metadata.label|trans(_trans_parameters) ) : ( ('id' == metadata.property) ? 'ID' : field|humanize ) %}
+                                    {% set _column_label =  metadata.label ? metadata.label|trans(_trans_parameters) : field|humanize %}
 
                                     {% if metadata.sortable %}
                                         <a href="{{ path('admin', _request_parameters|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
@@ -123,7 +123,7 @@
                             <tr data-id="{{ _item_id }}">
                                 {% for field, metadata in fields %}
                                     {% set isSortingField = metadata.property == app.request.get('sortField') %}
-                                    {% set _column_label =  metadata.label ? ( metadata.label|trans(_trans_parameters) ) : ( ('id' == metadata.property) ? 'ID' : field|humanize ) %}
+                                    {% set _column_label =  metadata.label ? metadata.label|trans(_trans_parameters) : field|humanize %}
 
                                     <td data-label="{{ _column_label }}" class="{{ isSortingField ? 'sorted' : '' }} {{ metadata.dataType|lower }}">
                                         {{ easyadmin_render_field_for_list_view(_entity.name, item, metadata) }}

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -18,8 +18,6 @@
                 <label class="col-sm-2 control-label">
                     {% if metadata.label %}
                         {{ metadata.label|trans }}
-                    {% elseif 'id' == metadata.property %}
-                        ID
                     {% else %}
                         {{ field|humanize }}
                     {% endif %}

--- a/Tests/AppBundleTest/CategoryEntityTest.php
+++ b/Tests/AppBundleTest/CategoryEntityTest.php
@@ -26,6 +26,16 @@ class CategoryEntityTest extends AbstractTestCase
         return $client->request('GET', '/admin/?entity=Category&action=list&view=list');
     }
 
+    /**
+     * @return Crawler
+     */
+    private function requestShowView()
+    {
+        $client = static::createClient();
+
+        return $client->request('GET', '/admin/?action=show&view=list&entity=Category&id=200');
+    }
+
     public function testListViewPageTitle()
     {
         $crawler = $this->requestListView();
@@ -131,5 +141,22 @@ class CategoryEntityTest extends AbstractTestCase
 
         $this->assertEquals('/admin/?view=list&action=list&entity=Category&sortField=id&sortDirection=DESC&page=2', $crawler->filter('.list-pagination li a:contains("Next")')->attr('href'));
         $this->assertEquals('/admin/?view=list&action=list&entity=Category&sortField=id&sortDirection=DESC&page=14', $crawler->filter('.list-pagination li a:contains("Last")')->attr('href'));
+    }
+
+    public function testShowViewPageTitle()
+    {
+        $crawler = $this->requestShowView();
+
+        $this->assertEquals('Details for Categories number 200', trim($crawler->filter('h1.title')->text()));
+    }
+
+    public function testShowViewFieldLabels()
+    {
+        $crawler = $this->requestShowView();
+        $fieldLabels = array('Id', 'Label', 'Parent category');
+
+        foreach ($fieldLabels as $i => $label) {
+            $this->assertEquals($label, trim($crawler->filter('#main .form-group label')->eq($i)->text()));
+        }
     }
 }

--- a/Tests/AppBundleTest/CategoryEntityTest.php
+++ b/Tests/AppBundleTest/CategoryEntityTest.php
@@ -153,7 +153,7 @@ class CategoryEntityTest extends AbstractTestCase
     public function testShowViewFieldLabels()
     {
         $crawler = $this->requestShowView();
-        $fieldLabels = array('Id', 'Label', 'Parent category');
+        $fieldLabels = array('#', 'Label', 'Parent category');
 
         foreach ($fieldLabels as $i => $label) {
             $this->assertEquals($label, trim($crawler->filter('#main .form-group label')->eq($i)->text()));

--- a/Tests/Fixtures/App/config/config_test.yml
+++ b/Tests/Fixtures/App/config/config_test.yml
@@ -26,7 +26,7 @@ easy_admin:
             show:
                 title: 'Details for %%entity_name%% number %%entity_id%%'
                 fields:
-                    - { property: 'id', label: 'Id' }
+                    - { property: 'id', label: '#' }
                     - { property: 'name', label: 'Label' }
                     - { property: 'parent', label: 'Parent category' }
         Image:

--- a/Tests/Fixtures/App/config/config_test.yml
+++ b/Tests/Fixtures/App/config/config_test.yml
@@ -23,6 +23,12 @@ easy_admin:
                     - 'id'
                     - { property: 'name', label: 'Label' }
                     - { property: 'parent', label: 'Parent category' }
+            show:
+                title: 'Details for %%entity_name%% number %%entity_id%%'
+                fields:
+                    - { property: 'id', label: 'Id' }
+                    - { property: 'name', label: 'Label' }
+                    - { property: 'parent', label: 'Parent category' }
         Image:
             class: JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Entity\Image
             label: 'Images'


### PR DESCRIPTION
I absolutely hated this hack that polluted the templates. Now we tweak the label of the `id` field in the Configurator class (if needed).
