### PR TITLE
Allow to override any action easily

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -193,7 +193,13 @@ class AdminController extends Controller
         }
 
         $fields = $this->entity['edit']['fields'];
-        $editForm = $this->createEditForm($entity, $fields);
+
+        if (method_exists($this, $customMethodName = 'create'.$this->entity['name'].'EditForm')) {
+            $editForm = $this->{$customMethodName}($entity, $fields);
+        } else {
+            $editForm = $this->createEditForm($entity, $fields);
+        }
+
         $deleteForm = $this->createDeleteForm($this->entity['name'], $id);
 
         $editForm->handleRequest($this->request);
@@ -283,7 +289,12 @@ class AdminController extends Controller
         }
 
         $fields = $this->entity['new']['fields'];
-        $newForm = $this->createNewForm($entity, $fields);
+
+        if (method_exists($this, $customMethodName = 'create'.$this->entity['name'].'NewForm')) {
+            $newForm = $this->{$customMethodName}($entity, $fields);
+        } else {
+            $newForm = $this->createNewForm($entity, $fields);
+        }
 
         $newForm->handleRequest($this->request);
         if ($newForm->isValid()) {
@@ -588,7 +599,7 @@ class AdminController extends Controller
             return sprintf('theme_%s %s', strtolower(str_replace('.html.twig', '', basename($formTheme))), $previousClass);
         });
 
-        $form = $this->createFormBuilder($entity, array(
+        $formBuilder = $this->createFormBuilder($entity, array(
             'data_class' => $this->entity['class'],
             'attr' => array('class' => $formCssClass, 'id' => $view.'-form'),
         ));
@@ -612,10 +623,10 @@ class AdminController extends Controller
             $formFieldOptions['attr']['field_css_class'] = $metadata['class'];
             $formFieldOptions['attr']['field_help'] = $metadata['help'];
 
-            $form->add($name, $metadata['fieldType'], $formFieldOptions);
+            $formBuilder->add($name, $metadata['fieldType'], $formFieldOptions);
         }
 
-        return $form->getForm();
+        return $formBuilder->getForm();
     }
 
     /**

--- a/Event/EasyAdminEvents.php
+++ b/Event/EasyAdminEvents.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Event;
+
+final class EasyAdminEvents
+{
+    const PRE_DELETE = 'easy_admin.pre_delete';
+    const POST_DELETE = 'easy_admin.post_delete';
+    const PRE_EDIT = 'easy_admin.pre_edit';
+    const POST_EDIT = 'easy_admin.post_edit';
+    const PRE_LIST = 'easy_admin.pre_list';
+    const POST_LIST = 'easy_admin.post_list';
+    const PRE_NEW = 'easy_admin.pre_new';
+    const POST_NEW = 'easy_admin.post_new';
+    const PRE_SEARCH = 'easy_admin.pre_search';
+    const POST_SEARCH = 'easy_admin.post_search';
+    const PRE_SHOW = 'easy_admin.pre_show';
+    const POST_SHOW = 'easy_admin.post_show';
+}

--- a/Event/EasyAdminEvents.php
+++ b/Event/EasyAdminEvents.php
@@ -13,11 +13,11 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Event;
 
 final class EasyAdminEvents
 {
-    // Initialization related events
+    // Events related to initialization
     const PRE_INITIALIZE = 'easy_admin.pre_initialize';
     const POST_INITIALIZE = 'easy_admin.post_initialize';
 
-    // Backend views related events
+    // Events related to backend views
     const PRE_DELETE = 'easy_admin.pre_delete';
     const POST_DELETE = 'easy_admin.post_delete';
     const PRE_EDIT = 'easy_admin.pre_edit';
@@ -31,7 +31,7 @@ final class EasyAdminEvents
     const PRE_SHOW = 'easy_admin.pre_show';
     const POST_SHOW = 'easy_admin.post_show';
 
-    // Doctrine related events
+    // Events related to Doctrine entities
     const PRE_PERSIST = 'easy_admin.pre_persist';
     const POST_PERSIST = 'easy_admin.post_persist';
     const PRE_UPDATE = 'easy_admin.pre_update';

--- a/Event/EasyAdminEvents.php
+++ b/Event/EasyAdminEvents.php
@@ -13,6 +13,11 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Event;
 
 final class EasyAdminEvents
 {
+    // Initialization related events
+    const PRE_INITIALIZE = 'easy_admin.pre_initialize';
+    const POST_INITIALIZE = 'easy_admin.post_initialize';
+
+    // Backend views related events
     const PRE_DELETE = 'easy_admin.pre_delete';
     const POST_DELETE = 'easy_admin.post_delete';
     const PRE_EDIT = 'easy_admin.pre_edit';
@@ -25,4 +30,12 @@ final class EasyAdminEvents
     const POST_SEARCH = 'easy_admin.post_search';
     const PRE_SHOW = 'easy_admin.pre_show';
     const POST_SHOW = 'easy_admin.post_show';
+
+    // Doctrine related events
+    const PRE_PERSIST = 'easy_admin.pre_persist';
+    const POST_PERSIST = 'easy_admin.post_persist';
+    const PRE_UPDATE = 'easy_admin.pre_update';
+    const POST_UPDATE = 'easy_admin.post_update';
+    const PRE_REMOVE = 'easy_admin.pre_remove';
+    const POST_REMOVE = 'easy_admin.post_remove';
 }

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -1,20 +1,20 @@
 {% trans_default_domain "EasyAdminBundle" %}
 {% form_theme form with easyadmin_config('design.form_theme') %}
 
-{% set _entity = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity.label|trans, '%entity_id%': attribute(item, _entity.primary_key_field_name) } %}
+{% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans, '%entity_id%': attribute(entity, _entity_config.primary_key_field_name) } %}
 
-{% extends _entity.templates.layout %}
+{% extends _entity_config.templates.layout %}
 
-{% block body_class 'admin edit ' ~ _entity.name|lower %}
+{% block body_class 'admin edit ' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity.edit.title|default('edit.page_title')|trans(_trans_parameters) }}
+    {{ _entity_config.edit.title|default('edit.page_title')|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
     {% block entity_form %}
-        {{ include(_entity.templates.form, { view: 'edit' }) }}
+        {{ include(_entity_config.templates.form, { view: 'edit' }) }}
     {% endblock entity_form %}
 
     {% block delete_form %}
@@ -38,8 +38,8 @@
                             {{ 'action.cancel'|trans(_trans_parameters) }}
                         </button>
 
-                        {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity.name) %}
-                            {% set _delete_action = easyadmin_get_action_for_edit_view('delete', _entity.name) %}
+                        {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity_config.name) %}
+                            {% set _delete_action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
                                 {{ _delete_action.label|default('action.delete')|trans(_trans_parameters) }}

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -8,7 +8,7 @@
             {% set _field_metadata = entity_fields[field.vars.name] %}
 
             {% if _field_metadata['fieldType'] == 'association' %}
-                {{ easyadmin_render_field_for_edit_view(item, _field_metadata) }}
+                {{ easyadmin_render_field_for_edit_view(entity, _field_metadata) }}
             {% else %}
                 {% set _field_label = _field_metadata['label']|default(null) %}
                 {{ form_row(field, { label: _field_label|trans(_trans_parameters) }) }}
@@ -49,14 +49,14 @@
                 </button>
 
                 {% set _entity_actions = (view == 'new')
-                    ? easyadmin_get_actions_for_new_item(_entity.name)
-                    : easyadmin_get_actions_for_edit_item(_entity.name) %}
+                    ? easyadmin_get_actions_for_new_item(_entity_config.name)
+                    : easyadmin_get_actions_for_edit_item(_entity_config.name) %}
 
                 {% for _action in _entity_actions %}
                     {% if 'method' == _action.type %}
-                        {% set _action_href = path('admin', { action: _action.name, view: view, entity: _entity.name, id: attribute(item, _entity.primary_key_field_name) }) %}
+                        {% set _action_href = path('admin', { action: _action.name, view: view, entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name) }) %}
                     {% elseif 'route' == _action.type %}
-                        {% set _action_href = path(_action.name, { entity: _entity.name, id: attribute(item, _entity.primary_key_field_name) }) %}
+                        {% set _action_href = path(_action.name, { entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name) }) %}
                     {% endif %}
 
                     <a class="btn {{ _action.class|default('') }}" href="{{ _action_href }}">
@@ -66,8 +66,8 @@
                 {% endfor %}
 
                 {% if view == 'edit' %}
-                    {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity.name) %}
-                        {% set _action = easyadmin_get_action_for_edit_view('delete', _entity.name) %}
+                    {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity_config.name) %}
+                        {% set _action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                         <button type="button" id="button-delete" class="btn {{ _action.class|default('btn-danger') }}">
                             {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                             {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
@@ -76,14 +76,14 @@
                 {% endif %}
 
                 {# for aesthetic reasons, the 'list' action is always displayed as a link instead of a button #}
-                {% if view == 'new' and easyadmin_action_is_enabled_for_new_view('list', _entity.name) %}
-                    {% set _list_action = easyadmin_get_action_for_new_view('list', _entity.name) %}
-                {% elseif view == 'edit' and easyadmin_action_is_enabled_for_edit_view('list', _entity.name) %}
-                    {% set _list_action = easyadmin_get_action_for_edit_view('list', _entity.name) %}
+                {% if view == 'new' and easyadmin_action_is_enabled_for_new_view('list', _entity_config.name) %}
+                    {% set _list_action = easyadmin_get_action_for_new_view('list', _entity_config.name) %}
+                {% elseif view == 'edit' and easyadmin_action_is_enabled_for_edit_view('list', _entity_config.name) %}
+                    {% set _list_action = easyadmin_get_action_for_edit_view('list', _entity_config.name) %}
                 {% endif %}
 
                 {% if _list_action is defined %}
-                    <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer') : path('admin', ({ entity: _entity.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
+                    <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer') : path('admin', ({ entity: _entity_config.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
                         {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
                         {{ _list_action.label|default('action.list')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -1,11 +1,11 @@
 {% trans_default_domain "EasyAdminBundle" %}
 
-{% set _entity = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity.label|trans } %}
+{% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans } %}
 
-{% extends _entity.templates.layout %}
+{% extends _entity_config.templates.layout %}
 
-{% block body_class 'admin list ' ~ _entity.name|lower %}
+{% block body_class 'admin list ' ~ _entity_config.name|lower %}
 
 {% block head_stylesheets %}
     {{ parent() }}
@@ -16,12 +16,12 @@
     {% if 'search' == app.request.get('action') %}
         {{ 'search.page_title'|transchoice(paginator.nbResults)|raw }}
     {% else %}
-        {{ _entity.list.title|default('list.page_title')|trans(_trans_parameters) }}
+        {{ _entity_config.list.title|default('list.page_title')|trans(_trans_parameters) }}
     {% endif %}
 {% endblock %}
 
 {% block content %}
-    {% set _request_parameters = { view: 'list', action: app.request.get('action'), entity: _entity.name, sortField: app.request.get('sortField', ''), sortDirection: app.request.get('sortDirection', 'DESC'), page: app.request.get('page', 1) } %}
+    {% set _request_parameters = { view: 'list', action: app.request.get('action'), entity: _entity_config.name, sortField: app.request.get('sortField', ''), sortDirection: app.request.get('sortDirection', 'DESC'), page: app.request.get('page', 1) } %}
 
     {% if 'search' == app.request.get('action') %}
         {% set _request_parameters = _request_parameters|merge({ query: app.request.get('query')|default('') }) %}
@@ -38,11 +38,11 @@
                 </div>
                 <div class="col-xs-12 col-sm-7">
                 {% block view_actions %}
-                    {% if easyadmin_action_is_enabled_for_list_view('new', _entity.name) %}
+                    {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
                         {% block new_action %}
-                            {% set _action = easyadmin_get_action_for_list_view('new', _entity.name) %}
+                            {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
                             <div id="content-actions">
-                                <a class="btn {{ _action.class|default('') }}" href="{{ path('admin', { entity: _entity.name, action: _action.name, view: 'list' }) }}">
+                                <a class="btn {{ _action.class|default('') }}" href="{{ path('admin', { entity: _entity_config.name, action: _action.name, view: 'list' }) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                     {{ _action.label|default('action.new')|trans(_trans_parameters) }}
                                 </a>
@@ -50,9 +50,9 @@
                         {% endblock new_action %}
                     {% endif %}
 
-                    {% if easyadmin_action_is_enabled_for_list_view('search', _entity.name) %}
+                    {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
                         {% block search_action %}
-                            {% set _action = easyadmin_get_action_for_list_view('search', _entity.name) %}
+                            {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
                             <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
                                 <input type="hidden" name="view" value="list">
                                 <input type="hidden" name="action" value="search">
@@ -74,7 +74,7 @@
         <div id="main" class="col-sm-12">
         {% block main %}
             <div>
-                {% set _list_item_actions = easyadmin_get_actions_for_list_item(_entity.name) %}
+                {% set _list_item_actions = easyadmin_get_actions_for_list_item(_entity_config.name) %}
 
                 <table class="table">
                     <thead>
@@ -121,14 +121,14 @@
                     <tbody>
                     {% block table_body %}
                         {% for item in paginator.currentPageResults %}
-                            {% set _item_id = attribute(item, _entity.primary_key_field_name) %}
+                            {% set _item_id = attribute(item, _entity_config.primary_key_field_name) %}
                             <tr data-id="{{ _item_id }}">
                                 {% for field, metadata in fields %}
                                     {% set isSortingField = metadata.property == app.request.get('sortField') %}
                                     {% set _column_label =  metadata.label ? metadata.label|trans(_trans_parameters) : field|humanize %}
 
                                     <td data-label="{{ _column_label }}" class="{{ isSortingField ? 'sorted' : '' }} {{ metadata.dataType|lower }}">
-                                        {{ easyadmin_render_field_for_list_view(_entity.name, item, metadata) }}
+                                        {{ easyadmin_render_field_for_list_view(_entity_config.name, item, metadata) }}
                                     </td>
                                 {% endfor %}
 
@@ -145,7 +145,7 @@
 
                                             <a class="{{ _action.class|default('') }}" href="{{ _action_href }}">{% spaceless %}
                                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                                {{ _action.label|trans({'%entity_name%': _entity.label|trans, '%entity_id%': _item_id}) }}
+                                                {{ _action.label|trans({'%entity_name%': _entity_config.label|trans, '%entity_id%': _item_id}) }}
                                             {% endspaceless %}</a>
                                         {% endfor %}
                                     {% endblock item_actions %}
@@ -164,7 +164,7 @@
                 </table>
 
                 {% block paginator %}
-                    {{ include(_entity.templates.paginator) }}
+                    {{ include(_entity_config.templates.paginator) }}
                 {% endblock paginator %}
             </div>
         {% endblock main %}
@@ -187,7 +187,7 @@
                 var columnIndex = $(this).closest('td').index() + 1;
                 var propertyName = $('table th.toggle:nth-child(' + columnIndex + ')').data('property-name');
 
-                var toggleUrl = "{{ path('admin', { action: 'edit', entity: _entity.name, view: 'list' })|raw }}"
+                var toggleUrl = "{{ path('admin', { action: 'edit', entity: _entity_config.name, view: 'list' })|raw }}"
                               + "&id=" + $(this).closest('tr').data('id')
                               + "&property=" + propertyName
                               + "&newValue=" + newValue.toString();

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -1,20 +1,20 @@
 {% trans_default_domain "EasyAdminBundle" %}
 {% form_theme form with easyadmin_config('design.form_theme') %}
 
-{% set _entity = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity.label|trans } %}
+{% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans } %}
 
-{% extends _entity.templates.layout %}
+{% extends _entity_config.templates.layout %}
 
-{% block body_class 'admin new ' ~ _entity.name|lower %}
+{% block body_class 'admin new ' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity.new.title|default('new.page_title')|trans(_trans_parameters) }}
+    {{ _entity_config.new.title|default('new.page_title')|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
     {% block entity_form %}
-        {{ include(_entity.templates.form, { view: 'new' }) }}
+        {{ include(_entity_config.templates.form, { view: 'new' }) }}
     {% endblock entity_form %}
 {% endblock %}
 

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -1,14 +1,14 @@
 {% trans_default_domain "EasyAdminBundle" %}
 
-{% set _entity = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity.label|trans, '%entity_id%': attribute(item, _entity.primary_key_field_name) } %}
+{% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans, '%entity_id%': attribute(entity, _entity_config.primary_key_field_name) } %}
 
-{% extends _entity.templates.layout %}
+{% extends _entity_config.templates.layout %}
 
-{% block body_class 'admin show ' ~ _entity.name|lower %}
+{% block body_class 'admin show ' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity.show.title|default('show.page_title')|trans(_trans_parameters) }}
+    {{ _entity_config.show.title|default('show.page_title')|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
@@ -24,7 +24,7 @@
                 </label>
                 <div class="col-sm-10">
                     <div class="form-control">
-                        {{ easyadmin_render_field_for_show_view(_entity.name, item, metadata) }}
+                        {{ easyadmin_render_field_for_show_view(_entity_config.name, entity, metadata) }}
                     </div>
 
                     {% if metadata.help|default('') != '' %}
@@ -37,12 +37,12 @@
         <div class="form-group form-actions">
             <div class="col-sm-10 col-sm-offset-2">
             {% block item_actions %}
-                {% set _show_actions = easyadmin_get_actions_for_show_item(_entity.name) %}
+                {% set _show_actions = easyadmin_get_actions_for_show_item(_entity_config.name) %}
                 {% for _action in _show_actions %}
                     {% if 'method' == _action.type %}
-                        {% set _action_href = path('admin', { action: _action.name, view: 'show', entity: _entity.name, id: attribute(item, _entity.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
+                        {% set _action_href = path('admin', { action: _action.name, view: 'show', entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
                     {% elseif 'route' == _action.type %}
-                        {% set _action_href = path(_action.name, { entity: _entity.name, id: attribute(item, _entity.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
+                        {% set _action_href = path(_action.name, { entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
                     {% endif %}
 
                     <a class="btn {{ _action.class|default('') }}" href="{{ _action_href }}">
@@ -51,8 +51,8 @@
                     </a>
                 {% endfor %}
 
-                {% if easyadmin_action_is_enabled_for_show_view('delete', _entity.name) %}
-                    {% set _action = easyadmin_get_action_for_show_view('delete', _entity.name) %}
+                {% if easyadmin_action_is_enabled_for_show_view('delete', _entity_config.name) %}
+                    {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                     <button type="button" id="button-delete" class="btn {{ _action.class|default('btn-danger') }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
@@ -60,9 +60,9 @@
                 {% endif %}
 
                 {# for aesthetic reasons, the 'list' action is always displayed as a link instead of a button #}
-                {% if easyadmin_action_is_enabled_for_show_view('list', _entity.name) %}
-                    {% set _action = easyadmin_get_action_for_show_view('list', _entity.name) %}
-                    <a class="btn btn-list btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer') : path('admin', ({ entity: _entity.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
+                {% if easyadmin_action_is_enabled_for_show_view('list', _entity_config.name) %}
+                    {% set _action = easyadmin_get_action_for_show_view('list', _entity_config.name) %}
+                    <a class="btn btn-list btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer') : path('admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {{ _action.label|default('action.list')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>
@@ -93,8 +93,8 @@
                             {{ 'action.cancel'|trans(_trans_parameters) }}
                         </button>
 
-                        {% if easyadmin_action_is_enabled_for_show_view('delete', _entity.name) %}
-                            {% set _action = easyadmin_get_action_for_show_view('delete', _entity.name) %}
+                        {% if easyadmin_action_is_enabled_for_show_view('delete', _entity_config.name) %}
+                            {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                 {{ _action.label|default('action.delete')|trans(_trans_parameters) }}


### PR DESCRIPTION
This PR introduces a simple overriding mechanism for actions and controller methods. Examples:
### Customize the instantiation of a single entity

Create a new AdminController extending from the default one and add this method:

``` php
public function createNew<EntityName>Entity()
{
    ...
}
```
### Customize the instantiation of all entities

Create a new AdminController extending from the default one and add this method:

``` php
public function createNewEntity()
{
    ...
}
```
### Tweak a specific entity before persisting/updating/removing it

Create a new AdminController extending from the default one and add this method:

``` php
public function prePersist<EntityName>Entity()
public function preUpdate<EntityName>Entity()
public function preRemove<EntityName>Entity()
{
    ...
}
```
### Tweak all entities before persisting/updating/removing them

Create a new AdminController extending from the default one and add this method:

``` php
public function prePersistEntity()
public function preUpdateEntity()
public function preRemoveEntity()
{
    ...
}
```
### Tweak the list/new/edit/show/delete method for a specific entity

Create a new AdminController extending from the default one and add this method:

``` php
public function list<EntityName>Action()
public function new<EntityName>Action()
public function edit<EntityName>Action()
public function show<EntityName>Action()
public function delete<EntityName>Action()
{
    ...
}
```
### Tweak the list/new/edit/show/delete method for all entities

Create a new AdminController extending from the default one and add this method:

``` php
public function listAction()
public function newAction()
public function editAction()
public function showAction()
public function deleteAction()
{
    ...
}
```
### Modify the backend using events

Hook into any of the new events defined by the bundle:

``` php
// Initialization related events
const PRE_INITIALIZE = 'easy_admin.pre_initialize';
const POST_INITIALIZE = 'easy_admin.post_initialize';

// Backend views related events
const PRE_DELETE = 'easy_admin.pre_delete';
const POST_DELETE = 'easy_admin.post_delete';
const PRE_EDIT = 'easy_admin.pre_edit';
const POST_EDIT = 'easy_admin.post_edit';
const PRE_LIST = 'easy_admin.pre_list';
const POST_LIST = 'easy_admin.post_list';
const PRE_NEW = 'easy_admin.pre_new';
const POST_NEW = 'easy_admin.post_new';
const PRE_SEARCH = 'easy_admin.pre_search';
const POST_SEARCH = 'easy_admin.post_search';
const PRE_SHOW = 'easy_admin.pre_show';
const POST_SHOW = 'easy_admin.post_show';

// Doctrine related events
const PRE_PERSIST = 'easy_admin.pre_persist';
const POST_PERSIST = 'easy_admin.post_persist';
const PRE_UPDATE = 'easy_admin.pre_update';
const POST_UPDATE = 'easy_admin.post_update';
const PRE_REMOVE = 'easy_admin.pre_remove';
const POST_REMOVE = 'easy_admin.post_remove';
```

Single entity actions (edit, new, delete, etc.) receive the `$entity` as the event subject. The actions related to multiple entities (list, search) receive the `$paginator` object as the subject of the event. In addition, the event receives all the controller variables as arguments. You can access them via `getArgument()` or via the array access provided by Symfony for the GenericEvent:

``` php
<?php

namespace AppBundle\EventListener;

use Symfony\Component\EventDispatcher\EventSubscriberInterface;
use Symfony\Component\EventDispatcher\GenericEvent;

class EasyAdminSubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents()
    {
        return array(
            'easy_admin.pre_update' => array('preUpdate'),
        );
    }

    public function preUpdate(GenericEvent $event)
    {
        $entity = $event->getSubject();
        $view = $event['view'];
        $entity = $event['entity'];

        // ...
    }
}
```
