### PR TITLE
Allow to use entity.label and entity.name in any page title or button label

### DIFF
--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -2,7 +2,7 @@
 {% form_theme form with easyadmin_config('design.form_theme') %}
 
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans, '%entity_id%': attribute(entity, _entity_config.primary_key_field_name) } %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans, '%entity_id%': attribute(entity, _entity_config.primary_key_field_name) } %}
 
 {% extends _entity_config.templates.layout %}
 

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain "EasyAdminBundle" %}
 
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans } %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans } %}
 
 {% extends _entity_config.templates.layout %}
 
@@ -145,7 +145,7 @@
 
                                             <a class="{{ _action.class|default('') }}" href="{{ _action_href }}">{% spaceless %}
                                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                                {{ _action.label|trans({'%entity_name%': _entity_config.label|trans, '%entity_id%': _item_id}) }}
+                                                {{ _action.label|trans({'%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans, '%entity_id%': _item_id}) }}
                                             {% endspaceless %}</a>
                                         {% endfor %}
                                     {% endblock item_actions %}

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -2,7 +2,7 @@
 {% form_theme form with easyadmin_config('design.form_theme') %}
 
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans } %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans } %}
 
 {% extends _entity_config.templates.layout %}
 

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -1,7 +1,7 @@
 {% trans_default_domain "EasyAdminBundle" %}
 
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans, '%entity_id%': attribute(entity, _entity_config.primary_key_field_name) } %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans, '%entity_id%': attribute(entity, _entity_config.primary_key_field_name) } %}
 
 {% extends _entity_config.templates.layout %}
 

--- a/Tests/AppBundleTest/CategoryEntityTest.php
+++ b/Tests/AppBundleTest/CategoryEntityTest.php
@@ -70,7 +70,7 @@ class CategoryEntityTest extends AbstractTestCase
     {
         $crawler = $this->requestListView();
 
-        $this->assertEquals('New Categories', trim($crawler->filter('#content-actions a.btn')->text()));
+        $this->assertEquals('New Category', trim($crawler->filter('#content-actions a.btn')->text()));
         $this->assertEquals('fa fa-plus-circle', $crawler->filter('#content-actions a.btn i')->attr('class'));
         $this->assertEquals('/admin/?entity=Category&action=new&view=list', $crawler->filter('#content-actions a.btn')->attr('href'));
     }
@@ -147,7 +147,7 @@ class CategoryEntityTest extends AbstractTestCase
     {
         $crawler = $this->requestShowView();
 
-        $this->assertEquals('Details for Categories number 200', trim($crawler->filter('h1.title')->text()));
+        $this->assertEquals('Details for Category number 200', trim($crawler->filter('h1.title')->text()));
     }
 
     public function testShowViewFieldLabels()

--- a/Tests/Fixtures/App/config/config_test.yml
+++ b/Tests/Fixtures/App/config/config_test.yml
@@ -17,8 +17,8 @@ easy_admin:
             list:
                 actions:
                     - { name: 'new', label: 'New %%entity_name%%', icon: 'plus-circle' }
-                    - { name: 'search', label: 'Look for %%entity_name%%' }
-                title: 'Product %%entity_name%%'
+                    - { name: 'search', label: 'Look for %%entity_label%%' }
+                title: 'Product %%entity_label%%'
                 fields:
                     - 'id'
                     - { property: 'name', label: 'Label' }


### PR DESCRIPTION
Right now you can only use `entity_name` option, which wrongly equals to the entity label. After the latest changes where the name and the label are treated as they should, you can now use both `entiy_name` and `entiy_label` options and their values are what you expect.
