### PR TITLE
[Test] Simplify input / output dataprovider & ignore build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 phpunit.xml
 vendor/*
+build/

--- a/Tests/CommonPhpUnitTestCase.php
+++ b/Tests/CommonPhpUnitTestCase.php
@@ -15,16 +15,6 @@ abstract class CommonPhpUnitTestCase extends \PHPUnit_Framework_TestCase
 {
     protected function provideConfigurationFiles($fixturesDir)
     {
-        $fixtures = array();
-
-        $inputs = glob($fixturesDir.'/input/admin_*.yml');
-        $outputs = glob($fixturesDir.'/output/config_*.yml');
-
-        $numFixtures = count($inputs);
-        for ($i = 0; $i < $numFixtures; $i++) {
-            $fixtures[] = array($inputs[$i], $outputs[$i]);
-        }
-
-        return $fixtures;
+        return array_map(null, glob($fixturesDir.'/input/admin_*.yml'), glob($fixturesDir.'/output/config_*.yml'));
     }
 }


### PR DESCRIPTION
I found how behaves php `array_map` function in particular cases while asking myself stupid questions late in the night. 
Guess what ? One of those [particular usages](http://php.net/manual/en/function.array-map.php#example-5417) matches perfectly our case in the `CommonPhpUnitTestCase::provideConfigurationFiles()` and allow to _drastically_ simplify it (though it was not complex at all) ^^.

Also, I add the build directory to the `.gitignore` file.
