### PR TITLE
Added: Field options configuration

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -605,7 +605,7 @@ class AdminController extends Controller
         ));
 
         foreach ($entityProperties as $name => $metadata) {
-            $formFieldOptions = array();
+            $formFieldOptions = isset($metadata['options']) ? $metadata['options'] : array();
 
             if ('association' === $metadata['fieldType'] && in_array($metadata['associationType'], array(ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY))) {
                 continue;


### PR DESCRIPTION
Really useful option for me.

For example, if you want to integrate https://github.com/jbouzekri/FileUploaderBundle, you need to specify `endpoint` for `jb_image_ajax` type:

```
easy_admin:
    design:
        form_theme:
            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
            - '@JbFileUploader/Form/fields.html.twig'

        assets:
            css:
                - bundles/jbfileuploader/lib/jquery-file-upload/css/jquery.fileupload.css
                - bundles/jbfileuploader/css/jbfileupload.css
                - bundles/jbfileuploader/lib/jcrop/css/jquery.Jcrop.min.css
            js:
                # - //code.jquery.com/jquery-1.11.0.min.js
                - bundles/jbfileuploader/lib/jquery-file-upload/js/vendor/jquery.ui.widget.js
                - bundles/jbfileuploader/lib/jquery-file-upload/js/jquery.iframe-transport.js
                - bundles/jbfileuploader/lib/jquery-file-upload/js/jquery.fileupload.js
                - bundles/jbfileuploader/js/jbfileupload.js
                - bundles/jbfileuploader/lib/jcrop/js/jquery.Jcrop.js

    entities:
        Category:
            class: AppBundle\Entity\Category
            form:
                fields:
                    - { property: 'image', type: 'jb_image_ajax', options: { endpoint: 'categories' } } # <---- Magic goes here
                    - { property: 'name' }
```

Looks like this related to https://github.com/javiereguiluz/EasyAdminBundle/issues/267
