### PR TITLE
Setup coveralls for code coverage

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,4 @@
+service_name: travis-ci
+src_dir: .
+coverage_clover: build/logs/clover.xml
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,8 @@ install:
   - if [ "$deps" = "low" ]; then composer update --prefer-lowest; fi
   - if [ "$deps" != "low" ]; then composer install; fi
 
-script: phpunit --coverage-text
+script: phpunit --coverage-text --coverage-clover build/logs/clover.xml
+
+after_success: |
+    sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" -a "$TRAVIS_PHP_VERSION" != "hhvm-nightly" ]; then php vendor/bin/coveralls -v --config .coveralls.yml; fi;'
+

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,11 @@
     },
     "require-dev": {
         "phpunit/phpunit"                   : "~4.4",
-        "doctrine/doctrine-fixtures-bundle" : "~2.2"
+        "doctrine/doctrine-fixtures-bundle" : "~2.2",
+        "satooshi/php-coveralls": "~0.6"
     },
     "autoload": {
         "psr-4": { "JavierEguiluz\\Bundle\\EasyAdminBundle\\": "" }
     }
 }
+


### PR DESCRIPTION
Coverage helps, but using stats from all builds might be better with [Coveralls](https://coveralls.io/).

@javiereguiluz , just setup Coveralls for this repo, then, merge this PR , and you'll have a great tool to view the proper code coverage depending on the different Travis builds :wink: 

Edit: Now that the PR is submitted, the coverage build is visible [here](https://coveralls.io/r/javiereguiluz/EasyAdminBundle) :wink: 
