### PR TITLE
[Menu] Fix bottom padding.

### DIFF
--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -1108,7 +1108,7 @@ body.error .error-solution pre {
         margin: 0;
         overflow: hidden;
         overflow-y: auto !important;
-        padding: 0 0 1em;
+        padding: 0 0 70px;
         width: 222px;
     }
     #header #header-menu {


### PR DESCRIPTION
With the default easyadmin css provided by the bundle, the menu padding is not sufficient in order to scroll to the last item (or partially):

![capture d ecran 2015-05-18 a 11 20 14](https://cloud.githubusercontent.com/assets/2211145/7677972/d8c6e38e-fd50-11e4-9139-c3d6327a1384.PNG)

This is due to the fact that the menu footer is positioned with absolute and over the menu, so the padding-bottom should be at least equal to the footer height.
With default css and an authenticated user with a long username for instance, the footer height is 66px.
