### PR TITLE
[Menu] Footer does not need to be positioned absolute

### DIFF
--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -1108,7 +1108,7 @@ body.error .error-solution pre {
         margin: 0;
         overflow: hidden;
         overflow-y: auto !important;
-        padding: 0 0 1em;
+        padding: 0;
         width: 222px;
     }
     #header #header-menu {
@@ -1161,10 +1161,7 @@ body.error .error-solution pre {
         padding-bottom: 1em;
         padding-top: 1em;
         padding-left: 10px;
-        position: absolute;
-        bottom: 0;
         width: 100%;
-        z-index: 999;
         -moz-transition: box-shadow 0.3s ease-out;
         -webkit-transition: box-shadow 0.3s ease-out;
         transition: box-shadow 0.3s ease-out;


### PR DESCRIPTION
See and forget about #310 .

Menu footer does not need to be positioned absolute at all.
