### PR TITLE
Show better exception messages when occurring in admin

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -483,4 +483,32 @@ class Configurator
     {
         return $this->backendConfig;
     }
+
+    /**
+     * Returns the entire backend configuration or the value corresponding to
+     * the provided key. The dots of the key are automatically transformed into
+     * nested keys. Example: 'assets.css' => $config['assets']['css']
+     *
+     * @param string|null $key
+     *
+     * @return mixed
+     */
+    public function get($key)
+    {
+        $config = $this->getBackendConfig();
+
+        if (!empty($key)) {
+            $parts = explode('.', $key);
+
+            foreach ($parts as $part) {
+                if (!isset($config[$part])) {
+                    $config = null;
+                    break;
+                }
+                $config = $config[$part];
+            }
+        }
+
+        return $config;
+    }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -148,6 +148,13 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                 ->end()
+
+                ->arrayNode('exception_listener')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')->defaultNull()->end()
+                    ->end()
+                ->end()
             ->end()
         ;
     }

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -70,6 +70,10 @@ class EasyAdminExtension extends Extension
         $backendConfiguration = $this->processEntityActions($backendConfiguration);
         $backendConfiguration = $this->processEntityTemplates($backendConfiguration);
 
+        if (null === $backendConfiguration['exception_listener']['enabled']) {
+            $backendConfiguration['exception_listener']['enabled'] = $container->getParameter('kernel.debug');
+        }
+
         $container->setParameter('easyadmin.config', $backendConfiguration);
 
         // load bundle's services

--- a/Event/ExceptionListener.php
+++ b/Event/ExceptionListener.php
@@ -45,7 +45,7 @@ class ExceptionListener
         $route = $event->getRequest()->attributes->get('_route');
 
         if ('admin' === $route) {
-            $extendsAdminController = true;
+            $isInAdminScope = true;
         } else {
             $controller = $event->getRequest()->attributes->get('_controller');
 
@@ -54,12 +54,12 @@ class ExceptionListener
             $reflection = new \ReflectionClass($class);
 
             do {
-                $extendsAdminController = $reflection->getName() === 'JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController';
+                $isInAdminScope = $reflection->getName() === 'JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController';
                 $reflection = $reflection->getParentClass();
-            } while ($reflection && !$extendsAdminController);
+            } while ($reflection && !$isInAdminScope);
         }
 
-        if ($extendsAdminController) {
+        if ($isInAdminScope) {
             $e = $event->getException();
             $response = new Response('', 500);
 

--- a/Event/ExceptionListener.php
+++ b/Event/ExceptionListener.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Event;
+
+use Symfony\Bundle\TwigBundle\TwigEngine;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+
+class ExceptionListener
+{
+
+    /**
+     * @var TwigEngine
+     */
+    protected $templating;
+
+    public function __construct(TwigEngine $templating)
+    {
+        $this->templating = $templating;
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $controller = $event->getRequest()->attributes->get('_controller');
+
+        if (strpos($controller, 'JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController') !== false) {
+            $e = $event->getException();
+            $response = new Response('', 500);
+
+            $exceptions = array();
+
+            do {
+                $exceptions[] = array(
+                    'class'         => get_class($e),
+                    'file'          => $e->getFile(),
+                    'line'          => $e->getLine(),
+                    'code'          => $e->getCode(),
+                    'message'       => $e->getMessage(),
+                    'trace'         => $e->getTrace(),
+                    'traceAsString' => $e->getTraceAsString(),
+                );
+            } while ($e = $e->getPrevious());
+
+            $response->setContent($this->templating->render('@EasyAdmin/error/exception.html.twig', array('exceptions' => $exceptions)));
+
+            $event->setResponse($response);
+        }
+    }
+
+}

--- a/Event/ExceptionListener.php
+++ b/Event/ExceptionListener.php
@@ -32,7 +32,16 @@ class ExceptionListener
     {
         $controller = $event->getRequest()->attributes->get('_controller');
 
-        if (strpos($controller, 'JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController') !== false) {
+        $class = preg_replace('~\:.*$~', '', $controller);
+
+        $reflection = new \ReflectionClass($class);
+
+        do {
+            $extendsAdminController = $reflection->getName() === 'JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController';
+            $reflection = $reflection->getParentClass();
+        } while ($reflection && !$extendsAdminController);
+
+        if ($extendsAdminController) {
             $e = $event->getException();
             $response = new Response('', 500);
 

--- a/Event/ExceptionListener.php
+++ b/Event/ExceptionListener.php
@@ -27,17 +27,17 @@ class ExceptionListener
     /**
      * @var boolean
      */
-    protected $debug;
+    protected $enabled;
 
     public function __construct(Configurator $configurator, TwigEngine $templating)
     {
-        $this->debug = $configurator->get('exception_listener.active');
+        $this->enabled = $configurator->get('exception_listener.enabled');
         $this->templating = $templating;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        if (!$this->debug) {
+        if (!$this->enabled) {
             return;
         }
 

--- a/Event/ExceptionListener.php
+++ b/Event/ExceptionListener.php
@@ -11,6 +11,7 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Event;
 
+use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
 use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -23,13 +24,23 @@ class ExceptionListener
      */
     protected $templating;
 
-    public function __construct(TwigEngine $templating)
+    /**
+     * @var boolean
+     */
+    protected $debug;
+
+    public function __construct(Configurator $configurator, TwigEngine $templating)
     {
+        $this->debug = $configurator->get('exception_listener.active');
         $this->templating = $templating;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
+        if (!$this->debug) {
+            return;
+        }
+
         $controller = $event->getRequest()->attributes->get('_controller');
 
         $class = preg_replace('~\:.*$~', '', $controller);

--- a/Event/ExceptionListener.php
+++ b/Event/ExceptionListener.php
@@ -42,16 +42,22 @@ class ExceptionListener
             return;
         }
 
-        $controller = $event->getRequest()->attributes->get('_controller');
+        $route = $event->getRequest()->attributes->get('_route');
 
-        $class = preg_replace('~\:.*$~', '', $controller);
+        if ('admin' === $route) {
+            $extendsAdminController = true;
+        } else {
+            $controller = $event->getRequest()->attributes->get('_controller');
 
-        $reflection = new \ReflectionClass($class);
+            $class = preg_replace('~\:.*$~', '', $controller);
 
-        do {
-            $extendsAdminController = $reflection->getName() === 'JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController';
-            $reflection = $reflection->getParentClass();
-        } while ($reflection && !$extendsAdminController);
+            $reflection = new \ReflectionClass($class);
+
+            do {
+                $extendsAdminController = $reflection->getName() === 'JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController';
+                $reflection = $reflection->getParentClass();
+            } while ($reflection && !$extendsAdminController);
+        }
 
         if ($extendsAdminController) {
             $e = $event->getException();

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -23,6 +23,7 @@
         <service id="easyadmin.property_reflector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\ClassPropertyReflector" public="false" />
 
         <service id="easyadmin.listener.exception" class="JavierEguiluz\Bundle\EasyAdminBundle\Event\ExceptionListener">
+            <argument type="service" id="easyadmin.configurator" />
             <argument type="service" id="templating.engine.twig" />
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="250" />
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,21 +6,26 @@
     <services>
 
         <service id="easyadmin.twig.extension" class="JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension" public="false">
-            <argument type="service" id="easyadmin.configurator"></argument>
+            <argument type="service" id="easyadmin.configurator" />
             <tag name="twig.extension" />
         </service>
 
         <service id="easyadmin.configurator" class="JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator">
             <argument>%easyadmin.config%</argument>
-            <argument type="service" id="easyadmin.metadata_inspector"></argument>
-            <argument type="service" id="easyadmin.property_reflector"></argument>
+            <argument type="service" id="easyadmin.metadata_inspector" />
+            <argument type="service" id="easyadmin.property_reflector" />
         </service>
 
         <service id="easyadmin.metadata_inspector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\EntityMetadataInspector" public="false">
-            <argument type="service" id="doctrine"></argument>
+            <argument type="service" id="doctrine" />
         </service>
 
-        <service id="easyadmin.property_reflector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\ClassPropertyReflector" public="false"></service>
+        <service id="easyadmin.property_reflector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\ClassPropertyReflector" public="false" />
+
+        <service id="easyadmin.listener.exception" class="JavierEguiluz\Bundle\EasyAdminBundle\Event\ExceptionListener">
+            <argument type="service" id="templating.engine.twig" />
+            <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="250" />
+        </service>
 
         <service id="easyadmin.listener.exception" class="JavierEguiluz\Bundle\EasyAdminBundle\Listener\ExceptionListener">
             <argument type="service" id="templating"></argument>

--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -764,6 +764,16 @@ body.error .error-solution pre {
     background: none;
     border: 0;
 }
+body.error .error-problem .well {
+    padding-top: 0;
+}
+
+@media (min-width: 768px) {
+    body.error .error-problem .well h3,
+    body.error .error-problem .well h2 {
+        margin-top: 0.8em;
+    }
+}
 
     /*font-size: inherit;*/
 
@@ -1038,6 +1048,9 @@ body.error .error-solution pre {
 
     body.error .container {
         max-width: 50%;
+    }
+    body.error.exception .container {
+        max-width: 100%;
     }
 }
 

--- a/Resources/views/error/error_page.html.twig
+++ b/Resources/views/error/error_page.html.twig
@@ -13,9 +13,9 @@
         <link rel="shortcut icon" type="image/png" href="/favicon.png">
     </head>
 
-    <body class="error">
+    <body class="{% block body_class %}error{% endblock %}">
         <div class="container">
-            <h1>Error</h1>
+            <h1>{% block error_title %}Error{% endblock %}</h1>
 
             <div class="error-problem">
                 <p class="lead">
@@ -23,11 +23,13 @@
                 </p>
             </div>
 
+            {% block solution_wrapper %}
             <div class="error-solution">
                 <h2>How to fix this problem</h2>
 
                 {% block solution %}{% endblock %}
             </div>
+            {% endblock %}
         </div>
     </body>
 </html>

--- a/Resources/views/error/exception.html.twig
+++ b/Resources/views/error/exception.html.twig
@@ -1,0 +1,77 @@
+{% extends '@EasyAdmin/error/error_page.html.twig' %}
+
+{% block page_title 'An exception occured!' %}
+{% block solution_wrapper '' %}
+{% block body_class %}{{ parent() }} exception{% endblock %}
+
+{% block error_title %}An exception occured!{% endblock %}
+
+{% block problem %}
+    <p><a href="{{ path('admin') }}" class="btn btn-info">&laquo; Back to the admin panel.</a></p>
+
+    {% set firstException = (exceptions | slice(0,1) | first) %}
+    {% set exceptions = (exceptions | slice(1, null)) %}
+
+    <div class="well well-sm">
+        <h2>{{ firstException.class | abbr_class }} ({{ firstException.code }})</h2>
+        <p>
+            {{ firstException.message | nl2br | format_file_from_text }}
+        </p>
+        {% if app.debug %}
+            <p>
+                {% for trace in firstException.trace %}
+                    #{{ loop.revindex0 }} -
+                        {% if trace.function %}
+                            <strong>
+                                {% if trace.class is defined %}
+                                    {{ trace.class | abbr_class }}
+                                {% endif %}
+                                {{ (trace.type | default('')) ~ trace.function }}
+                            </strong>
+                        {% endif %}
+                        {% if trace.file is defined and trace.file and trace.line is defined and trace.line %}
+                            {{ trace.file | format_file(trace.line) }}
+                        {% endif %}
+                    <br>
+                {% endfor %}
+            </p>
+        {% endif %}
+    </div>
+
+    {% if exceptions | length %}
+        <div>
+            <p><strong>{{ exceptions | length }}</strong> other exception{{ exceptions | length > 1 ? 's' : '' }}:</p>
+            <ul class="list-unstyled">
+                {% for exception in exceptions %}
+                    <li class="well well-sm">
+                        <h3>#{{ (loop.index+1) }} - {{ exception.class | abbr_class }} ({{ exception.code }})</h3>
+                        <p>
+                            {{ exception.message | nl2br | format_file_from_text }}
+                        </p>
+
+                        {% if app.debug %}
+                            <p>
+                                {% for trace in exception.trace %}
+                                    #{{ loop.revindex0 }} -
+                                    {% if trace.function %}
+                                        <strong>
+                                            {% if trace.class is defined %}
+                                                {{ trace.class | abbr_class }}
+                                            {% endif %}
+                                            {{ (trace.type | default('')) ~ trace.function }}
+                                        </strong>
+                                    {% endif %}
+                                        {% if trace.file is defined and trace.file and trace.line is defined and trace.line %}
+                                    {{ trace.file | format_file(trace.line) }}
+                                {% endif %}
+                                    <br>
+                                {% endfor %}
+                            </p>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+{% endblock %}

--- a/Resources/views/error/http_exception.html.twig
+++ b/Resources/views/error/http_exception.html.twig
@@ -1,0 +1,36 @@
+{% extends '@EasyAdmin/error/error_page.html.twig' %}
+
+{% set firstException = (exceptions | slice(0,1) | first) %}
+{% set exceptions = (exceptions | slice(1, null)) %}
+
+{% block page_title firstException.message %}
+{% block solution_wrapper '' %}
+
+{% block error_title %}{{ firstException.message }}!{% endblock %}
+
+{% block problem %}
+
+    <h2>{{ firstException.statusCode }} {{ firstException.message }}</h2>
+    <p><a href="{{ path('admin') }}" class="btn btn-info">&laquo; Back to the admin panel.</a></p>
+
+    {% if app.debug %}
+        <p>
+            {% for trace in firstException.trace %}
+                #{{ loop.revindex0 }} -
+                    {% if trace.function %}
+                        <strong>
+                            {% if trace.class is defined %}
+                                {{ trace.class | abbr_class }}
+                            {% endif %}
+                            {{ (trace.type | default('')) ~ trace.function }}
+                        </strong>
+                    {% endif %}
+                    {% if trace.file is defined and trace.file and trace.line is defined and trace.line %}
+                        {{ trace.file | format_file(trace.line) }}
+                    {% endif %}
+                <br>
+            {% endfor %}
+        </p>
+    {% endif %}
+
+{% endblock %}

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -46,7 +46,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
     /**
      * @see \JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator::get()
      *
-     * @param null $key
+     * @param string|null $key
      *
      * @return mixed
      */

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -44,31 +44,15 @@ class EasyAdminTwigExtension extends \Twig_Extension
     }
 
     /**
-     * Returns the entire backend configuration or the value corresponding to
-     * the provided key. The dots of the key are automatically transformed into
-     * nested keys. Example: 'assets.css' => $config['assets']['css']
+     * @see \JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator::get()
      *
-     * @param string|null $key
+     * @param null $key
      *
      * @return mixed
      */
     public function getBackendConfiguration($key = null)
     {
-        $config = $this->configurator->getBackendConfig();
-
-        if (!empty($key)) {
-            $parts = explode('.', $key);
-
-            foreach ($parts as $part) {
-                if (!isset($config[$part])) {
-                    $config = null;
-                    break;
-                }
-                $config = $config[$part];
-            }
-        }
-
-        return $config;
+        return $this->configurator->get($key);
     }
 
     /**


### PR DESCRIPTION
Related to #246 

Here is the "new" exception layout in non-debug mode:

![capture d ecran 2015-05-18 a 11 57 15](https://cloud.githubusercontent.com/assets/3369266/7678542/4ca7e4d4-fd55-11e4-9c64-b73be5ac17b0.png)

And here is what it resembles when in debug mode (we add the backtrace, that's all):
![capture d ecran 2015-05-18 a 11 56 43](https://cloud.githubusercontent.com/assets/3369266/7678545/59de0f48-fd55-11e4-9dd1-2e7170df80ef.png)

I was mostly inspired by the good error pages from the `TwigBundle` , so don't mind if it looks similar :)

Before moving on something else I'd like to have some opinions about it :)

Ping @javiereguiluz @ogizanagi @fadoe 
