### PR TITLE
[Doc] Mention how to import routes when extending EasyAdminController

### DIFF
--- a/Resources/doc/tutorials/customizing-admin-controller.md
+++ b/Resources/doc/tutorials/customizing-admin-controller.md
@@ -70,6 +70,35 @@ This `indexAction()` method overrides the default `admin` route, which is
 essential to make your controller override the default `AdminController`
 behavior.
 
+However, in order to activate this route, you need to import it and other routes defined in this controller through annotations by adding your controller as a resource in your routing files:
+```yaml
+# app/config/routing.yml
+
+app:
+    resource: @AppBundle/Controller/AdminController.php
+    type:     annotation
+```
+
+At this point, you don't even need to import easyadmin routes from the original controller, and could simply replace the old definition:
+
+```yaml
+# app/config/routing.yml
+
+# Old definition:
+#easy_admin_bundle:
+#    resource: "@EasyAdminBundle/Controller/"
+#    type:     annotation
+#    prefix:   /admin
+
+# New
+app_admin:
+    resource: "@AppBundle/Controller/AdminController.php"
+    type:     annotation
+    prefix:   /admin
+```
+
+and delete the `indexAction()` method in your controller (if you don't need to do anything within it).
+
 Keep reading the practical examples of the next sections to learn which
 methods you can override in the backend.
 


### PR DESCRIPTION
According to #314 ,  I think there is something missing in [this section](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/Resources/doc/tutorials/customizing-admin-controller.md#customization-based-on-controller-methods) about how to create a controller extending easyadmin one. Nothing is mentioned about routing files.

However, it might not be the better way to express it, @javiereguiluz would certainly be better than me at doing this ^^.
