### PR TITLE
Fixed a problem when displaying the number of elements of Doctrine collections

### DIFF
--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -1,4 +1,4 @@
-{% if value is iterable and value|length > 1 %}
+{% if value is iterable %}
     <span class="badge">{{ value|length }}</span>
 {% elseif link_parameters is defined %}
     <a href="{{ path('admin', link_parameters) }}">{{ value|easyadmin_truncate }}</a>


### PR DESCRIPTION
Now when an associated Doctrine collection has zero elements, the backend displays a badge with the number "0".

This fixes #320
