### PR TITLE
Added support for setting form type options

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -35,7 +35,7 @@ class Configurator
         'virtual'   => false, // is a virtual field or a real Doctrine entity property?
         'sortable'  => true,  // listings can be sorted according to the values of this field
         'template'  => null,  // the path of the template used to render the field in 'show' and 'list' views
-        'type_options' => array(), // the Symfony Form Type options used to build the form field
+        'type_options' => array(), // the options passed to the Symfony Form type used to render the form field
     );
 
     private $doctrineTypeToFormTypeMap = array(

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -35,6 +35,7 @@ class Configurator
         'virtual'   => false, // is a virtual field or a real Doctrine entity property?
         'sortable'  => true,  // listings can be sorted according to the values of this field
         'template'  => null,  // the path of the template used to render the field in 'show' and 'list' views
+        'type_options' => array(), // the Symfony Form Type options used to build the form field
     );
 
     private $doctrineTypeToFormTypeMap = array(

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -582,7 +582,7 @@ class AdminController extends Controller
         $formBuilder = $this->createFormBuilder($entity, $formOptions);
 
         foreach ($entityProperties as $name => $metadata) {
-            $formFieldOptions = array();
+            $formFieldOptions = $metadata['type_options'];
 
             if ('association' === $metadata['fieldType'] && in_array($metadata['associationType'], array(ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY))) {
                 continue;

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -589,10 +589,18 @@ class AdminController extends Controller
             }
 
             if ('collection' === $metadata['fieldType']) {
-                $formFieldOptions = array('allow_add' => true, 'allow_delete' => true);
+                if (!isset($formFieldOptions['allow_add'])) {
+                    $formFieldOptions = array('allow_add' => true);
+                }
+
+                if (!isset($formFieldOptions['allow_delete'])) {
+                    $formFieldOptions = array('allow_delete' => true);
+                }
 
                 if (version_compare(\Symfony\Component\HttpKernel\Kernel::VERSION, '2.5.0', '>=')) {
-                    $formFieldOptions['delete_empty'] = true;
+                    if (!isset($formFieldOptions['delete_empty'])) {
+                        $formFieldOptions = array('delete_empty' => true);
+                    }
                 }
             }
 

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -590,16 +590,16 @@ class AdminController extends Controller
 
             if ('collection' === $metadata['fieldType']) {
                 if (!isset($formFieldOptions['allow_add'])) {
-                    $formFieldOptions = array('allow_add' => true);
+                    $formFieldOptions['allow_add'] = true;
                 }
 
                 if (!isset($formFieldOptions['allow_delete'])) {
-                    $formFieldOptions = array('allow_delete' => true);
+                    $formFieldOptions['allow_delete'] = true;
                 }
 
                 if (version_compare(\Symfony\Component\HttpKernel\Kernel::VERSION, '2.5.0', '>=')) {
                     if (!isset($formFieldOptions['delete_empty'])) {
-                        $formFieldOptions = array('delete_empty' => true);
+                        $formFieldOptions['delete_empty'] = true;
                     }
                 }
             }

--- a/Resources/doc/getting-started/4-views-and-actions.md
+++ b/Resources/doc/getting-started/4-views-and-actions.md
@@ -320,6 +320,28 @@ field, allowing to create very powerful backend customizations, as explained
 in the [Advanced Design Customization] [advanced-design-customization]
 tutorial.
 
+  * `type_options` (optional), a hash which can include any of the valid
+    options defined for the Symfony Form type used by the field.
+
+The `type_options` is the most powerful option because it literally comprises
+tens of options suited for each form type:
+
+```yaml
+easy_admin:
+    entities:
+        Customer:
+            class: AppBundle\Entity\Customer
+            form:
+                fields:
+                    - 'id'
+                    - { property: 'email', type: 'email', type_options: { trim: true } }
+                    - { property: 'interests', type_options: { expanded: true, multiple: true } }
+                    - { property: 'updated_at', type_options: { read_only: true } }
+```
+
+Read the [Symfony Form type reference](http://symfony.com/doc/current/reference/forms/types.html)
+to learn about all the available options, their usage and allowed values.
+
 ### Translate Property Labels
 
 Before translating the labels, make sure that the `translator` service is

--- a/Resources/doc/getting-started/4-views-and-actions.md
+++ b/Resources/doc/getting-started/4-views-and-actions.md
@@ -313,15 +313,8 @@ These are the options that you can define for each field:
       * `raw`, displays the value unescaped (thanks to the `raw` Twig filter),
         which is useful when the content stores HTML code that must be rendered
         instead of displayed as HTML tags (as explained later in this chapter).
-
-In addition to these "official" options, you can define any custom option for
-the fields. These custom options are passed to the template that renders each
-field, allowing to create very powerful backend customizations, as explained
-in the [Advanced Design Customization] [advanced-design-customization]
-tutorial.
-
-  * `type_options` (optional), a hash which can include any of the valid
-    options defined for the Symfony Form type used by the field.
+  * `type_options` (optional), a hash which can define the value of any of the
+    valid options defined by the Symfony Form type associated with the field.
 
 The `type_options` is the most powerful option because it literally comprises
 tens of options suited for each form type:
@@ -341,6 +334,11 @@ easy_admin:
 
 Read the [Symfony Form type reference](http://symfony.com/doc/current/reference/forms/types.html)
 to learn about all the available options, their usage and allowed values.
+
+> In addition to these options defined by EasyAdmin, you can pass any custom
+> option to the form fields. This way you can create very powerful backend
+> customizations, as explained in the
+> [Advanced Design Customization] [advanced-design-customization] tutorial.
 
 ### Translate Property Labels
 

--- a/Tests/Controller/TypeOptionsTest.php
+++ b/Tests/Controller/TypeOptionsTest.php
@@ -27,10 +27,9 @@ class TypeOptionsTest extends AbstractTestCase
     {
         $crawler = $this->requestNewView();
 
-        $this->assertEquals('readonly', $crawler->filter('#main form #form_name')->eq(0)->attr('readonly'));
+        $this->assertEquals('readonly', $crawler->filter('#main form #form_name')->attr('readonly'));
 
         $this->assertCount(201, $crawler->filter('#main form #form_parent input[type=radio]'));
-        $this->assertEquals('Select a category...', $crawler->filter('#main form #form_parent div.radio')->eq(0)->text());
     }
 
     public function testEditViewTypeOptions()

--- a/Tests/Controller/TypeOptionsTest.php
+++ b/Tests/Controller/TypeOptionsTest.php
@@ -27,7 +27,7 @@ class TypeOptionsTest extends AbstractTestCase
     {
         $crawler = $this->requestNewView();
 
-        $this->assertEquals('readonly', $crawler->filter('#main form #form_name')->attr('readonly'));
+        $this->assertEquals('readonly', $crawler->filter('#main form #form_name')->eq(0)->attr('readonly'));
 
         $this->assertCount(201, $crawler->filter('#main form #form_parent input[type=radio]'));
         $this->assertEquals('Select a category...', $crawler->filter('#main form #form_parent div.radio')->eq(0)->text());

--- a/Tests/Controller/TypeOptionsTest.php
+++ b/Tests/Controller/TypeOptionsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Controller;
+
+use Symfony\Component\DomCrawler\Crawler;
+use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+
+class TypeOptionsTest extends AbstractTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initClient(array('environment' => 'type_options'));
+    }
+
+    public function testNewViewTypeOptions()
+    {
+        $crawler = $this->requestNewView();
+
+        $this->assertEquals('readonly', $crawler->filter('#main form #form_name')->attr('readonly'));
+
+        $this->assertCount(201, $crawler->filter('#main form #form_parent input[type=radio]'));
+        $this->assertEquals('Select a category...', $crawler->filter('#main form #form_parent div.radio')->eq(0)->text());
+    }
+
+    public function testEditViewTypeOptions()
+    {
+        $crawler = $this->requestEditView();
+
+        $this->assertContains('col-sm-6', $crawler->filter('#main form label[for=form_name]')->attr('class'));
+        $this->assertContains('col-sm-6', $crawler->filter('#main form input#form_name')->attr('class'));
+
+        $this->assertContains('col-sm-4', $crawler->filter('#main form label[for=form_parent]')->attr('class'));
+        $this->assertContains('col-sm-10', $crawler->filter('#main form select#form_parent')->attr('class'));
+    }
+
+    /**
+     * @return Crawler
+     */
+    private function requestNewView()
+    {
+        return $this->getBackendPage(array(
+            'action' => 'new',
+            'entity' => 'Category',
+        ));
+    }
+
+    /**
+     * @return Crawler
+     */
+    private function requestEditView()
+    {
+        return $this->getBackendPage(array(
+            'action' => 'edit',
+            'entity' => 'Category',
+            'id' => '50',
+        ));
+    }
+}

--- a/Tests/Fixtures/App/config/config_type_options.yml
+++ b/Tests/Fixtures/App/config/config_type_options.yml
@@ -12,7 +12,7 @@ easy_admin:
             label: 'Categories'
             new:
                 fields:
-                    - { property: 'name', type_options: { read_only: true } }
+                    - { property: 'name', type_options: { disabled: true } }
                     - { property: 'parent', type_options: { placeholder: 'Select a category...', multiple: false, expanded: true } }
             edit:
                 fields:

--- a/Tests/Fixtures/App/config/config_type_options.yml
+++ b/Tests/Fixtures/App/config/config_type_options.yml
@@ -13,7 +13,7 @@ easy_admin:
             new:
                 fields:
                     - { property: 'name', type_options: { read_only: true } }
-                    - { property: 'parent', type_options: { placeholder: 'Select a category...', multiple: false, expanded: true } }
+                    - { property: 'parent', type_options: { multiple: false, expanded: true } }
             edit:
                 fields:
                     - { property: 'name', type_options: { label_attr: { class: 'col-sm-6' }, attr: { class: 'col-sm-6' } } }

--- a/Tests/Fixtures/App/config/config_type_options.yml
+++ b/Tests/Fixtures/App/config/config_type_options.yml
@@ -12,7 +12,7 @@ easy_admin:
             label: 'Categories'
             new:
                 fields:
-                    - { property: 'name', type_options: { disabled: true } }
+                    - { property: 'name', type_options: { read_only: true } }
                     - { property: 'parent', type_options: { placeholder: 'Select a category...', multiple: false, expanded: true } }
             edit:
                 fields:

--- a/Tests/Fixtures/App/config/config_type_options.yml
+++ b/Tests/Fixtures/App/config/config_type_options.yml
@@ -1,0 +1,20 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    # This file overrides the EasyAdmin controller
+    router: { resource: "%kernel.root_dir%/config/routing_override.yml" }
+
+easy_admin:
+    entities:
+        Category:
+            class: JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Entity\Category
+            label: 'Categories'
+            new:
+                fields:
+                    - { property: 'name', type_options: { read_only: true } }
+                    - { property: 'parent', type_options: { placeholder: 'Select a category...', multiple: false, expanded: true } }
+            edit:
+                fields:
+                    - { property: 'name', type_options: { label_attr: { class: 'col-sm-6' }, attr: { class: 'col-sm-6' } } }
+                    - { property: 'parent', type_options: { label_attr: { class: 'col-sm-4' }, attr: { class: 'col-sm-10' } } }


### PR DESCRIPTION
This is based on #304 and #217.

I've decided to use the `type_options` name because I think it's the more precise one: you are setting the options used to build the associated form type.

@Pierstoval do you think we still need to modify the templates as you proposed in #217? I've tested tihs PR and all options are applied correctly without passing them to `form_row()` function.
