### PR TITLE
Added support for setting form type options on parent form (edit, new, form levels)

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -569,10 +569,10 @@ class AdminController extends Controller
             return sprintf('theme_%s %s', strtolower(str_replace('.html.twig', '', basename($formTheme))), $previousClass);
         });
 
-        $formBuilder = $this->createFormBuilder($entity, array(
+        $formBuilder = $this->createFormBuilder($entity, array_replace($this->entity[$view]['form_options'], array(
             'data_class' => $this->entity['class'],
             'attr' => array('class' => $formCssClass, 'id' => $view.'-form'),
-        ));
+        )));
 
         foreach ($entityProperties as $name => $metadata) {
             $formFieldOptions = array();

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -459,6 +459,10 @@ class EasyAdminExtension extends Extension
                 if (count($config[$view]['fields']) > 0) {
                     $config[$view]['fields'] = $this->normalizeFieldsConfiguration($config[$view]['fields'], $view, $entityConfiguration);
                 }
+
+                if (in_array($view, array('edit', 'new')) && !isset($config[$view]['form_options'])) {
+                    $config[$view]['form_options'] = array();
+                }
             }
 
             $entities[$entityName] = $config;

--- a/Tests/Configuration/fixtures/output/config_001.yml
+++ b/Tests/Configuration/fixtures/output/config_001.yml
@@ -3,10 +3,12 @@ label: TestEntity
 name: TestEntity
 edit:
     fields: []
+    form_options: []
 list:
     fields: []
 new:
     fields: []
+    form_options: []
 search:
     fields: []
 show:

--- a/Tests/DependencyInjection/fixtures/configurations/input/admin_113.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/input/admin_113.yml
@@ -1,0 +1,9 @@
+# if the special 'form' view is defined, use its options to complete 'new' and 'edit' actions 'form_options'
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        TestEntity:
+            class: AppBundle\Entity\TestEntity
+            form:
+                form_options: { validation_groups: ['Default', 'my_validation_group'] }

--- a/Tests/DependencyInjection/fixtures/configurations/input/admin_114.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/input/admin_114.yml
@@ -1,0 +1,13 @@
+# 'new' and 'edit' actions 'form_options' overrides 'form' ones
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        TestEntity:
+            class: AppBundle\Entity\TestEntity
+            form:
+                form_options: { validation_groups: ['Default'] }
+            new:
+                form_options: { validation_groups: ['Register'] }
+            edit:
+                form_options: { validation_groups: ['Update'] }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: OtherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: TestEntity2
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -236,6 +240,7 @@ easy_admin:
             name: TestEntity3
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -284,6 +289,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: CustomEntityName
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: CustomEntityName
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: CustomEntityName
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: CustomEntityName
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
@@ -10,6 +10,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -58,6 +59,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
@@ -8,6 +8,7 @@ easy_admin:
                         property: field1
                     field2:
                         property: field2
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -19,6 +20,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
@@ -8,6 +8,7 @@ easy_admin:
                         property: field1
                     field2:
                         property: field2
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -58,6 +59,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
@@ -8,6 +8,7 @@ easy_admin:
                         property: field1
                     field2:
                         property: field2
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -21,6 +22,7 @@ easy_admin:
                         property: field3
                     field4:
                         property: field4
+                form_options: {  }
                 actions:
                     delete:
                         name: delete

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
@@ -14,6 +14,7 @@ easy_admin:
                         property: field1
                     field2:
                         property: field2
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -27,6 +28,7 @@ easy_admin:
                         property: field1
                     field2:
                         property: field2
+                form_options: {  }
                 actions:
                     delete:
                         name: delete

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
@@ -14,6 +14,7 @@ easy_admin:
                     field4:
                         property: field4
                 custom_option: 'custom value'
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -30,6 +31,7 @@ easy_admin:
                     field2:
                         property: field2
                 custom_option: 'custom value'
+                form_options: {  }
                 actions:
                     delete:
                         name: delete

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
@@ -14,6 +14,7 @@ easy_admin:
                     field4:
                         property: field4
                 custom_option: 'custom value'
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -36,6 +37,7 @@ easy_admin:
                     field2:
                         property: field2
                 custom_option: 'custom value'
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
@@ -14,6 +14,7 @@ easy_admin:
                     field2:
                         property: field2
                 custom_option: 'another custom value'
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -28,6 +29,7 @@ easy_admin:
                     field4:
                         property: field4
                 custom_option: 'custom value'
+                form_options: {  }
                 actions:
                     delete:
                         name: delete

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
@@ -4,6 +4,7 @@ easy_admin:
             class: AppBundle\Entity\TestEntity
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -13,6 +14,7 @@ easy_admin:
                         icon: null
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
@@ -8,6 +8,7 @@ easy_admin:
                         property: field1
                     field2:
                         property: field2
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -21,6 +22,7 @@ easy_admin:
                         property: field3
                     field4:
                         property: field4
+                form_options: {  }
                 actions:
                     delete:
                         name: delete

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
@@ -43,6 +43,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -58,6 +59,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
@@ -44,6 +44,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -59,6 +60,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
@@ -44,6 +44,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -59,6 +60,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
@@ -10,6 +10,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -52,6 +53,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
@@ -9,6 +9,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -51,6 +52,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
@@ -9,6 +9,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -57,6 +58,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
@@ -9,6 +9,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -57,6 +58,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
@@ -14,6 +14,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -38,6 +39,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
@@ -10,6 +10,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -52,6 +53,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
@@ -11,6 +11,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -59,6 +60,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
@@ -9,6 +9,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -57,6 +58,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
@@ -11,6 +11,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -53,6 +54,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
@@ -10,6 +10,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -52,6 +53,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
@@ -10,6 +10,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -58,6 +59,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
@@ -10,6 +10,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -58,6 +59,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
@@ -19,6 +19,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -55,6 +56,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
@@ -26,6 +26,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -44,6 +45,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
@@ -23,6 +23,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -59,6 +60,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
@@ -37,6 +37,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -55,6 +56,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
@@ -39,6 +39,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -87,6 +88,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
@@ -19,6 +19,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -79,6 +80,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
@@ -19,6 +19,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -67,6 +68,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
@@ -39,6 +39,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -99,6 +100,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
@@ -34,6 +34,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -82,6 +83,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     custom_action_for_new:
                         name: custom_action_for_new

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
@@ -14,6 +14,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -62,6 +63,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
@@ -33,6 +33,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -48,6 +49,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
@@ -11,6 +11,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             list:
@@ -48,6 +49,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
@@ -21,6 +21,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -69,6 +70,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
@@ -11,10 +11,12 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
@@ -51,6 +51,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -75,6 +76,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
@@ -63,6 +63,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -93,6 +94,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
@@ -53,6 +53,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -77,6 +78,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
@@ -65,6 +65,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -95,6 +96,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
@@ -64,6 +64,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -94,6 +95,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
@@ -75,6 +75,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -117,6 +118,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
@@ -66,6 +66,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -96,6 +97,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
@@ -77,6 +77,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -119,6 +120,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
@@ -79,6 +79,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -109,6 +110,7 @@ easy_admin:
                         class: ''
                         icon: entity-list-icon
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
@@ -39,6 +39,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -159,6 +160,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
@@ -122,6 +122,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -224,6 +225,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             label: TestEntity
             name: TestEntity
             search:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
@@ -16,6 +16,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -64,6 +65,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
@@ -15,6 +15,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -63,6 +64,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
@@ -13,6 +13,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -61,6 +62,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
@@ -17,6 +17,7 @@ easy_admin:
                         class: ''
                         icon: null
                 fields: {  }
+                form_options: {  }
             show:
                 actions:
                     delete:
@@ -75,6 +76,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
@@ -45,6 +45,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -93,6 +94,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_105.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_105.yml
@@ -36,6 +36,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -84,6 +85,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_106.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_106.yml
@@ -75,6 +75,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -123,6 +124,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_107.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_107.yml
@@ -14,6 +14,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -62,6 +63,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_109.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_109.yml
@@ -8,6 +8,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -56,6 +57,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_110.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_110.yml
@@ -8,6 +8,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -56,6 +57,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_111.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_111.yml
@@ -10,6 +10,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -58,6 +59,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_112.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_112.yml
@@ -11,6 +11,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -59,6 +60,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_113.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_113.yml
@@ -1,53 +1,46 @@
 easy_admin:
-    edit:
-        actions:
-            - delete
-            - list
-    show:
-        actions:
-            - edit
     entities:
         TestEntity:
             class: AppBundle\Entity\TestEntity
-            edit:
-                actions:
-                    delete:
-                        name: delete
-                        type: method
-                        label: action.delete
-                        class: ''
-                        icon: trash
-                    list:
-                        name: list
-                        type: method
-                        label: action.list
-                        class: ''
-                        icon: null
-                fields: {  }
-                form_options: {  }
-            show:
-                actions:
-                    delete:
-                        name: delete
-                        type: method
-                        label: action.delete
-                        class: ''
-                        icon: trash
-                    list:
-                        name: list
-                        type: method
-                        label: action.list
-                        class: ''
-                        icon: null
-                    edit:
-                        name: edit
-                        type: method
-                        label: action.edit
-                        class: ''
-                        icon: edit
-                fields: {  }
+            form:
+                form_options:
+                    validation_groups:
+                        - Default
+                        - my_validation_group
             label: TestEntity
             name: TestEntity
+            new:
+                form_options:
+                    validation_groups:
+                        - Default
+                        - my_validation_group
+                fields: {  }
+                actions:
+                    list:
+                        name: list
+                        type: method
+                        label: action.list
+                        class: ''
+                        icon: null
+            edit:
+                form_options:
+                    validation_groups:
+                        - Default
+                        - my_validation_group
+                fields: {  }
+                actions:
+                    delete:
+                        name: delete
+                        type: method
+                        label: action.delete
+                        class: ''
+                        icon: trash
+                    list:
+                        name: list
+                        type: method
+                        label: action.list
+                        class: ''
+                        icon: null
             list:
                 fields: {  }
                 actions:
@@ -81,18 +74,29 @@ easy_admin:
                         label: action.list
                         class: ''
                         icon: null
-            new:
+            search:
                 fields: {  }
-                form_options: {  }
+            show:
+                fields: {  }
                 actions:
+                    delete:
+                        name: delete
+                        type: method
+                        label: action.delete
+                        class: ''
+                        icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
                         class: ''
                         icon: null
-            search:
-                fields: {  }
+                    edit:
+                        name: edit
+                        type: method
+                        label: action.edit
+                        class: ''
+                        icon: edit
             disabled_actions: {  }
             templates:
                 layout: '@EasyAdmin/default/layout.html.twig'
@@ -142,5 +146,9 @@ easy_admin:
     list:
         actions: {  }
         max_results: 15
+    edit:
+        actions: {  }
     new:
+        actions: {  }
+    show:
         actions: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_114.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_114.yml
@@ -1,15 +1,28 @@
 easy_admin:
-    edit:
-        actions:
-            - delete
-            - list
-    show:
-        actions:
-            - edit
     entities:
         TestEntity:
             class: AppBundle\Entity\TestEntity
+            form:
+                form_options:
+                    validation_groups:
+                        - Default
+            new:
+                form_options:
+                    validation_groups:
+                        - Register
+                fields: {  }
+                actions:
+                    list:
+                        name: list
+                        type: method
+                        label: action.list
+                        class: ''
+                        icon: null
             edit:
+                form_options:
+                    validation_groups:
+                        - Update
+                fields: {  }
                 actions:
                     delete:
                         name: delete
@@ -23,29 +36,6 @@ easy_admin:
                         label: action.list
                         class: ''
                         icon: null
-                fields: {  }
-                form_options: {  }
-            show:
-                actions:
-                    delete:
-                        name: delete
-                        type: method
-                        label: action.delete
-                        class: ''
-                        icon: trash
-                    list:
-                        name: list
-                        type: method
-                        label: action.list
-                        class: ''
-                        icon: null
-                    edit:
-                        name: edit
-                        type: method
-                        label: action.edit
-                        class: ''
-                        icon: edit
-                fields: {  }
             label: TestEntity
             name: TestEntity
             list:
@@ -81,18 +71,29 @@ easy_admin:
                         label: action.list
                         class: ''
                         icon: null
-            new:
+            search:
                 fields: {  }
-                form_options: {  }
+            show:
+                fields: {  }
                 actions:
+                    delete:
+                        name: delete
+                        type: method
+                        label: action.delete
+                        class: ''
+                        icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
                         class: ''
                         icon: null
-            search:
-                fields: {  }
+                    edit:
+                        name: edit
+                        type: method
+                        label: action.edit
+                        class: ''
+                        icon: edit
             disabled_actions: {  }
             templates:
                 layout: '@EasyAdmin/default/layout.html.twig'
@@ -142,5 +143,9 @@ easy_admin:
     list:
         actions: {  }
         max_results: 15
+    edit:
+        actions: {  }
     new:
+        actions: {  }
+    show:
         actions: {  }

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_001.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_002.yml
@@ -36,6 +36,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -84,6 +85,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_003.yml
@@ -45,6 +45,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -93,6 +94,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_004.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_005.yml
@@ -48,6 +48,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -96,6 +97,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -163,6 +165,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -211,6 +214,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_001.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_002.yml
@@ -36,6 +36,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -84,6 +85,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_003.yml
@@ -45,6 +45,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -93,6 +94,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_004.yml
@@ -6,6 +6,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -54,6 +55,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -121,6 +123,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -169,6 +172,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_005.yml
@@ -50,6 +50,7 @@ easy_admin:
             name: TestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -98,6 +99,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list
@@ -165,6 +167,7 @@ easy_admin:
             name: AnotherTestEntity
             edit:
                 fields: {  }
+                form_options: {  }
                 actions:
                     delete:
                         name: delete
@@ -213,6 +216,7 @@ easy_admin:
                         icon: null
             new:
                 fields: {  }
+                form_options: {  }
                 actions:
                     list:
                         name: list

--- a/Tests/Fixtures/App/config/config_customized_backend.yml
+++ b/Tests/Fixtures/App/config/config_customized_backend.yml
@@ -47,7 +47,8 @@ easy_admin:
                 actions:
                     - { name: 'delete', label: 'Remove', icon: 'minus-circle' }
                     - { name: 'list', label: 'Return to listing', icon: 'list' }
-            new: ~
+            new:
+                form_options: { validation_groups: ['Default', 'Validate'], attr: { novalidate: ~ } }
         Image:
             class: JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Entity\Image
             label: 'Images'

--- a/Tests/Fixtures/AppTestBundle/Entity/Category.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/Category.php
@@ -12,6 +12,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Enti
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Class Category.
@@ -38,6 +39,7 @@ class Category
      *
      * @var string
      * @ORM\Column(type="string")
+     * @Assert\NotNull(groups={"Validate"})
      */
     protected $name;
 


### PR DESCRIPTION
Follows #323.

This PR will allow to set options in order to configure the parent form. For instance : 

``` php
entities:
    TestEntity:
        class: AppBundle\Entity\TestEntity
        form:
            form_options: { validation_groups: ['Default', 'my_validation_group'] }
```

will create the form using the following options:

``` php
array(
    'validation_groups' => array('Default', 'my_validation_group'),
    'data_class' => 'AppBundle\Entity\TestEntity',
    'attr' => array('class' => '...', 'id' => '...'),
)))
```

Do you think `form_options` is more appropriated here, or `type_options` should be used to be consistent ?
