### PR TITLE
[Tests] Refactor WebTestCases in order to hold a client instance

### DIFF
--- a/Tests/AppBundleTest/CategoryEntityTest.php
+++ b/Tests/AppBundleTest/CategoryEntityTest.php
@@ -200,12 +200,11 @@ class CategoryEntityTest extends AbstractTestCase
         );
 
         // 1. visit a specific 'list' view page
-        $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/?'.http_build_query($parameters));
+        $crawler = $this->doGetRequest($parameters);
 
         // 2. click on the 'Show' link of the first item
         $link = $crawler->filter('td.actions a:contains("Show")')->eq(0)->link();
-        $crawler = $client->click($link);
+        $crawler = $this->client->click($link);
 
         // 3. the 'referer' parameter should point to the previous specific 'list' view page
         $refererUrl = $crawler->filter('.form-actions a:contains("Back to Category listing")')->attr('href');
@@ -219,7 +218,7 @@ class CategoryEntityTest extends AbstractTestCase
      * The 'referer' parameter stores the original 'list' or 'search' page
      * from which the user browsed to other pages (edit, delete, show). When
      * visiting several consecutive pages, the 'referer' value should be kept
-     * without changes,
+     * without changes.
      */
     public function testChainedReferer()
     {
@@ -233,16 +232,15 @@ class CategoryEntityTest extends AbstractTestCase
         );
 
         // 1. visit a specific 'list' view page
-        $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/?'.http_build_query($parameters));
+        $crawler = $this->doGetRequest($parameters);
 
         // 2. click on the 'Show' link of the first item
         $link = $crawler->filter('td.actions a:contains("Show")')->eq(0)->link();
-        $crawler = $client->click($link);
+        $crawler = $this->client->click($link);
 
         // 3. click on the 'Edit' button
         $link = $crawler->filter('.form-actions a:contains("Modify Category")')->link();
-        $crawler = $client->click($link);
+        $crawler = $this->client->click($link);
 
         // 4. the 'referer' parameter should point to the previous specific 'list' view page
         $refererUrl = $crawler->filter('#form-actions-row a:contains("Return to listing")')->attr('href');
@@ -323,12 +321,11 @@ class CategoryEntityTest extends AbstractTestCase
         );
 
         // 1. visit a specific 'list' view page
-        $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/?'.http_build_query($parameters));
+        $crawler = $this->doGetRequest($parameters);
 
         // 2. click on the 'Edit' link of the first item
         $link = $crawler->filter('td.actions a:contains("Edit")')->eq(0)->link();
-        $crawler = $client->click($link);
+        $crawler = $this->client->click($link);
 
         // 3. the 'referer' parameter should point to the previous specific 'list' view page
         $refererUrl = $crawler->filter('#form-actions-row a:contains("Return to listing")')->attr('href');
@@ -406,12 +403,11 @@ class CategoryEntityTest extends AbstractTestCase
         );
 
         // 1. visit a specific 'list' view page
-        $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/?'.http_build_query($parameters));
+        $crawler = $this->doGetRequest($parameters);
 
         // 2. click on the 'New' link to browse the 'new' view
         $link = $crawler->filter('#content-actions a:contains("New Category")')->link();
-        $crawler = $client->click($link);
+        $crawler = $this->client->click($link);
 
         // 3. the 'referer' parameter should point to the previous specific 'list' view page
         $refererUrl = $crawler->filter('#form-actions-row a:contains("Return to listing")')->attr('href');
@@ -525,12 +521,11 @@ class CategoryEntityTest extends AbstractTestCase
         );
 
         // 1. visit a specific 'search' view page
-        $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/?'.http_build_query($parameters));
+        $crawler = $this->doGetRequest($parameters);
 
         // 2. click on the 'Show' action of the first result
         $link = $crawler->filter('td.actions a:contains("Show")')->eq(0)->link();
-        $crawler = $client->click($link);
+        $crawler = $this->client->click($link);
 
         // 3. the 'referer' parameter should point to the previous specific 'search' view page
         $refererUrl = $crawler->filter('.form-actions a:contains("Back to Category listing")')->attr('href');
@@ -538,16 +533,6 @@ class CategoryEntityTest extends AbstractTestCase
         parse_str($queryString, $refererParameters);
 
         $this->assertEquals($parameters, $refererParameters);
-    }
-
-    /**
-     * @return Crawler
-     */
-    private function doGetRequest(array $parameters)
-    {
-        $client = static::createClient();
-
-        return $client->request('GET', '/admin/?'.http_build_query($parameters, '', '&'));
     }
 
     /**

--- a/Tests/AppBundleTest/DefaultBackendTest.php
+++ b/Tests/AppBundleTest/DefaultBackendTest.php
@@ -11,19 +11,18 @@
 
 namespace AppBundle\Tests;
 
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
-class DefaultBackendTest extends WebTestCase
+class DefaultBackendTest extends AbstractTestCase
 {
     public function testIndexRedirectsToTheFirstEntityListing()
     {
-        $client = static::createClient();
-        $client->request('GET', '/admin/');
+        $this->doGetRequest();
 
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertEquals(302, $this->client->getResponse()->getStatusCode());
         $this->assertEquals(
             '/admin/?action=list&entity=Category',
-            $client->getResponse()->getTargetUrl()
+            $this->client->getResponse()->getTargetUrl()
         );
     }
 
@@ -35,9 +34,8 @@ class DefaultBackendTest extends WebTestCase
             '/_css/admin.css',
         );
 
-        $client = static::createClient();
-        $client->followRedirects(true);
-        $crawler = $client->request('GET', '/admin/');
+        $this->client->followRedirects(true);
+        $crawler = $this->doGetRequest();
 
         foreach ($cssFiles as $i => $url) {
             $this->assertEquals($url, $crawler->filterXPath('//link[@rel="stylesheet"]')->eq($i)->attr('href'));
@@ -46,9 +44,8 @@ class DefaultBackendTest extends WebTestCase
 
     public function testLogo()
     {
-        $client = static::createClient();
-        $client->followRedirects(true);
-        $crawler = $client->request('GET', '/admin/');
+        $this->client->followRedirects(true);
+        $crawler = $this->doGetRequest();
 
         $this->assertEquals('ACME Backend', $crawler->filter('#header-logo a')->text());
         $this->assertEquals('/admin/', $crawler->filter('#header-logo a')->attr('href'));
@@ -65,9 +62,8 @@ class DefaultBackendTest extends WebTestCase
             'Products' => '/admin/?entity=Product&action=list&view=list',
         );
 
-        $client = static::createClient();
-        $client->followRedirects(true);
-        $crawler = $client->request('GET', '/admin/');
+        $this->client->followRedirects(true);
+        $crawler = $this->doGetRequest();
 
         $i = 0;
         foreach ($menuItems as $label => $url) {
@@ -86,22 +82,20 @@ class DefaultBackendTest extends WebTestCase
             'view' => 'list',
         );
 
-        $client = static::createClient();
-        $crawler = $client->request('GET', '/admin/?'.http_build_query($parameters, '', '&'));
+        $crawler = $this->doGetRequest($parameters);
 
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
         $this->assertContains('Undefined entity', $crawler->filter('head title')->text());
         $this->assertEquals("The InexistentEntity entity is not defined in\n    the configuration of your backend.", trim($crawler->filter('body.error .container .error-problem p.lead')->text()));
     }
 
     public function testAdminCss()
     {
-        $client = static::createClient();
-        $crawler = $client->request('GET', '/_css/admin.css');
+        $this->client->request('GET', '/_css/admin.css');
 
-        $this->assertEquals('text/css; charset=UTF-8', $client->getResponse()->headers->get('Content-Type'));
-        $this->assertEquals(21, substr_count($client->getResponse()->getContent(), '#123456'), 'The custom brand_color option is used in the admin CSS.');
+        $this->assertEquals('text/css; charset=UTF-8', $this->client->getResponse()->headers->get('Content-Type'));
+        $this->assertEquals(21, substr_count($this->client->getResponse()->getContent(), '#123456'), 'The custom brand_color option is used in the admin CSS.');
         // #FAFAFA color is only used by the "light" color scheme, not the "dark" one
-        $this->assertEquals(12, substr_count($client->getResponse()->getContent(), '#FAFAFA'), 'The selected "light" color scheme is used in the admin CSS.');
+        $this->assertEquals(12, substr_count($this->client->getResponse()->getContent(), '#FAFAFA'), 'The selected "light" color scheme is used in the admin CSS.');
     }
 }

--- a/Tests/AppBundleTest/ProductEntityTest.php
+++ b/Tests/AppBundleTest/ProductEntityTest.php
@@ -21,9 +21,11 @@ class ProductEntityTest extends AbstractTestCase
      */
     private function requestListView()
     {
-        $client = static::createClient();
-
-        return $client->request('GET', '/admin/?entity=Product&action=list&view=list');
+        return $this->doGetRequest(array(
+            'entity' => 'Product',
+            'action' => 'list',
+            'view' => 'list',
+        ));
     }
 
     public function testListViewVirtualFields()

--- a/Tests/Controller/AdminControllerTest.php
+++ b/Tests/Controller/AdminControllerTest.php
@@ -17,16 +17,15 @@ class AdminControllerTest extends AbstractTestCase
 {
     public function testNoEntityInBackend()
     {
-        $client = static::createClient(array('environment' => 'empty'));
+        $this->initClient(array('environment' => 'empty'));
+        $this->client->request('GET', '/admin');
 
-        $client->request('GET', '/admin');
+        $this->assertEquals(301, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('http://localhost/admin/', $this->client->getResponse()->headers->get('Location'));
 
-        $this->assertEquals(301, $client->getResponse()->getStatusCode());
-        $this->assertEquals('http://localhost/admin/', $client->getResponse()->headers->get('Location'));
+        $crawler = $this->client->followRedirect();
 
-        $crawler = $client->followRedirect();
-
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        $this->assertEquals(404, $this->client->getResponse()->getStatusCode());
         $this->assertEquals("Your backend is empty because you haven't configured\n    any Doctrine entity to manage.", trim($crawler->filter('body.error .container .error-problem p.lead')->text()));
     }
 }

--- a/Tests/DependencyInjection/EasyAdminExtensionTest.php
+++ b/Tests/DependencyInjection/EasyAdminExtensionTest.php
@@ -21,14 +21,10 @@ use JavierEguiluz\Bundle\EasyAdminBundle\Tests\CommonPhpUnitTestCase;
 
 class EasyAdminExtensionTest extends CommonPhpUnitTestCase
 {
-    /**
-     * @var ContainerBuilder
-     */
+    /** @var ContainerBuilder */
     private $container;
 
-    /**
-     * @var EasyAdminExtension
-     */
+    /** @var EasyAdminExtension */
     private $loader;
 
     public function setUp()

--- a/Tests/Fixtures/AbstractTestCase.php
+++ b/Tests/Fixtures/AbstractTestCase.php
@@ -11,9 +11,9 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures;
 
+use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * Class AbstractTestCase. Code copied from
@@ -22,37 +22,31 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 abstract class AbstractTestCase extends WebTestCase
 {
-    /**
-     * @var ContainerInterface
-     */
-    protected static $container;
+    /** @var Client */
+    protected $client;
 
-    /**
-     * @param array $options
-     */
-    protected static function bootKernel(array $options = array())
+    protected function setUp()
     {
-        if (method_exists('Symfony\Bundle\FrameworkBundle\Test\KernelTestCase', 'bootKernel')) {
-            parent::bootKernel($options);
-        } else {
-            if (null !== static::$kernel) {
-                static::$kernel->shutdown();
-            }
-            static::$kernel = static::createKernel($options);
-            static::$kernel->boot();
-            static::$kernel;
-        }
+        $this->initClient();
+    }
+
+    protected function tearDown()
+    {
+        $this->client = null;
+    }
+
+    protected function initClient(array $options = array())
+    {
+        $this->client = static::createClient($options);
     }
 
     /**
-     * @param array $options An array of options to pass to the createKernel class
+     * @param array $parameters
      *
-     * @return KernelInterface
+     * @return Crawler
      */
-    protected function getKernel(array $options = array())
+    protected function doGetRequest(array $parameters = array())
     {
-        static::bootKernel($options);
-
-        return static::$kernel;
+        return $this->client->request('GET', '/admin/'.(empty($parameters) ? '' : '?'.http_build_query($parameters, '', '&')));
     }
 }


### PR DESCRIPTION
…and simplify code

WebTestCases almost always required a client instance. Refactor AbstractTestCase in order to hold a client for each test and ease making requests.

Note that it will have some drawbacks if the bundle needs one day to load a lot of different configurations using environments for creating a client, as for now, a default client is always created using the `test` environment. Except in `AdminControllerTest` where we re-init the client with another environment, which means recreating a kernel and booting it...

The best solution would be to have tests classes for each used environments, and init the default client accordingly. (For instance, `AdminControllerTest` should became `AdminControllerEmptyTest`, or should be in a different folder, and the default options for creating the client will be `array('environment' => 'empty')`).
