### PR TITLE
[Menu] Fix menu for Safari browsers

### DIFF
--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -1075,7 +1075,9 @@ body.error .error-solution pre {
     #header-contents {
         min-height: 100%;
         display: flex;
+        display: -webkit-flex;
         flex-direction: column;
+        -webkit-flex-direction: column;
     }
     #header-logo {
         float: none;
@@ -1104,6 +1106,7 @@ body.error .error-solution pre {
     }
     #header #header-nav {
         flex: 1;
+        -webkit-flex: 1;
         height: 0 !important;
         margin: 0;
         overflow: hidden;


### PR DESCRIPTION
Safari still needs the `-webkit-` prefix when using flexboxes.

Fixes #331 

Before:
![capture d ecran 2015-05-21 a 17 00 45](https://cloud.githubusercontent.com/assets/2211145/7751534/dacf0c7e-ffda-11e4-94ee-dc13935cdf63.PNG)
After:
![capture d ecran 2015-05-21 a 16 55 10](https://cloud.githubusercontent.com/assets/2211145/7751495/a4433b3a-ffda-11e4-88eb-ebf5b1a5691c.PNG)
