### PR TITLE
Renamed "class" option to "css_class"

### DIFF
--- a/Resources/doc/getting-started/4-views-and-actions.md
+++ b/Resources/doc/getting-started/4-views-and-actions.md
@@ -291,7 +291,7 @@ These are the options that you can define for each field:
     title is the "humanized" version of the property name.
   * `help` (optional): the help message displayed below the form field in the
     `edit`, `new` and `show` views.
-  * `class` (optional): the CSS class applied to the form field widget
+  * `css_class` (optional): the CSS class applied to the form field widget
     container element in the `edit`, `new` and `show` views. For example, when
     using the default Bootstrap based form theme, this value is applied to the
     `<div class="form-group">` element which wraps the label, the widget and

--- a/Resources/doc/getting-started/5-design-customization.md
+++ b/Resources/doc/getting-started/5-design-customization.md
@@ -127,9 +127,10 @@ easy_admin:
 ### Multiple-Column Forms
 
 EasyAdmin doesn't provide any mechanism to create multi-column form layouts.
-However, you can use the `class` form field to create these advanced layouts.
-The `class` value is applied to the parent `<div>` element which contains the
-field label, the field widget, the field help and the optional field errors:
+However, you can use the `css_class` form field to create these advanced
+layouts. The `css_class` value is applied to the parent `<div>` element which
+contains the field label, the field widget, the field help and the optional
+field errors:
 
 ![Multi-column form](../images/easyadmin-form-multi-column.png)
 
@@ -144,11 +145,11 @@ easy_admin:
             # ...
             form:
                 fields:
-                    - { property: name, class: 'col-sm-12' }
-                    - { property: price, type: 'number', help: 'Prices are always in euros', class: 'col-sm-6' }
-                    - { property: 'ean', label: 'EAN', help: 'EAN 13 valid code. Leave empty if unknown.', class: 'col-sm-6' }
-                    - { property: 'enabled', class: 'col-sm-12' }
-                    - { property: 'description', class: 'col-sm-12' }
+                    - { property: name, css_class: 'col-sm-12' }
+                    - { property: price, type: 'number', help: 'Prices are always in euros', css_class: 'col-sm-6' }
+                    - { property: 'ean', label: 'EAN', help: 'EAN 13 valid code. Leave empty if unknown.', css_class: 'col-sm-6' }
+                    - { property: 'enabled', css_class: 'col-sm-12' }
+                    - { property: 'description', css_class: 'col-sm-12' }
     # ...
 ```
 

--- a/Resources/doc/tutorials/configuration-reference.md
+++ b/Resources/doc/tutorials/configuration-reference.md
@@ -97,7 +97,7 @@ easy_admin:
                 fields:
                     - { property: 'code', help: 'Alphanumeric characters only' }
                     - { property: 'description', type: 'textarea' }
-                    - { property: 'price', type: 'number', class: 'input-lg' }
+                    - { property: 'price', type: 'number', css_class: 'input-lg' }
                     - { property: 'category', label: 'Commercial Category' }
 ```
 
@@ -120,6 +120,6 @@ easy_admin:
                 fields:
                     - { property: 'code', help: 'Alphanumeric characters only' }
                     - { property: 'description', type: 'textarea' }
-                    - { property: 'price', type: 'number', class: 'input-lg' }
+                    - { property: 'price', type: 'number', css_class: 'input-lg' }
                     - { property: 'category', label: 'Commercial Category' }
 ```

--- a/Resources/doc/tutorials/customizing-backend-actions.md
+++ b/Resources/doc/tutorials/customizing-backend-actions.md
@@ -116,8 +116,8 @@ The following properties can be configured for each action:
   * `label`, is the text displayed in the button or link associated with the
     action. If not defined, the action label is the *humanized* version of its
     `name` option.
-  * `class`, is the CSS class or classes applied to the link or button used to
-    render the action.
+  * `css_class`, is the CSS class or classes applied to the link or button used
+    to render the action.
   * `icon`, is the name of the FontAwesome icon displayed next to the link or
     inside the button used to render the action. You don't have to include the
     `fa-` prefix of the icon name (e.g. to display the icon of a user, don't

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -59,7 +59,7 @@
                         {% set _action_href = path(_action.name, { entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name) }) %}
                     {% endif %}
 
-                    <a class="btn {{ _action.class|default('') }}" href="{{ _action_href }}">
+                    <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {{ _action.label|trans(_trans_parameters) }}
                     </a>
@@ -68,7 +68,7 @@
                 {% if view == 'edit' %}
                     {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity_config.name) %}
                         {% set _action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
-                        <button type="button" id="button-delete" class="btn {{ _action.class|default('btn-danger') }}">
+                        <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                             {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                             {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
                         </button>

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -42,7 +42,7 @@
                         {% block new_action %}
                             {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
                             <div id="content-actions">
-                                <a class="btn {{ _action.class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
+                                <a class="btn {{ _action.css_class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                     {{ _action.label|default('action.new')|trans(_trans_parameters) }}
                                 </a>
@@ -53,7 +53,7 @@
                     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
                         {% block search_action %}
                             {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
-                            <form id="content-search" class="col-xs-6 col-sm-8" method="get" action="{{ path('admin') }}">
+                            <form id="content-search" class="col-xs-6 col-sm-8 {{ _action.css_class|default('') }}" method="get" action="{{ path('admin') }}">
                                 <input type="hidden" name="view" value="list">
                                 <input type="hidden" name="action" value="search">
                                 <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
@@ -143,7 +143,7 @@
                                                 {% set _action_href = path(_action.name, _request_parameters|merge({ action: _action.name, id: _item_id })) %}
                                             {% endif %}
 
-                                            <a class="{{ _action.class|default('') }}" href="{{ _action_href }}">{% spaceless %}
+                                            <a class="{{ _action.css_class|default('') }}" href="{{ _action_href }}">{% spaceless %}
                                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                                 {{ _action.label|trans({'%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans, '%entity_id%': _item_id}) }}
                                             {% endspaceless %}</a>

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -14,7 +14,7 @@
 {% block main %}
     <div class="form-horizontal">
         {% for field, metadata in fields %}
-            <div class="form-group field_{{ metadata.type|default('default')|lower }} {{ metadata.class|default('') }}">
+            <div class="form-group field_{{ metadata.type|default('default')|lower }} {{ metadata.css_class|default('') }}">
                 <label class="col-sm-2 control-label">
                     {% if metadata.label %}
                         {{ metadata.label|trans }}
@@ -45,7 +45,7 @@
                         {% set _action_href = path(_action.name, { entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
                     {% endif %}
 
-                    <a class="btn {{ _action.class|default('') }}" href="{{ _action_href }}">
+                    <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {{ _action.label|trans(_trans_parameters) }}
                     </a>
@@ -53,7 +53,7 @@
 
                 {% if easyadmin_action_is_enabled_for_show_view('delete', _entity_config.name) %}
                     {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
-                    <button type="button" id="button-delete" class="btn {{ _action.class|default('btn-danger') }}">
+                    <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
                     </button>

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -51,6 +51,7 @@ class CustomizedBackendTest extends AbstractTestCase
         );
 
         $this->assertEquals('Look for Categories', $crawler->filter('#content-search input[type=search]')->attr('placeholder'));
+        $this->assertContains('custom_class_search', $crawler->filter('#content-search')->attr('class'));
 
         $i = 0;
         foreach ($hiddenParameters as $name => $value) {
@@ -66,6 +67,7 @@ class CustomizedBackendTest extends AbstractTestCase
         $crawler = $this->requestListView();
 
         $this->assertEquals('New Category', trim($crawler->filter('#content-actions a.btn')->text()));
+        $this->assertEquals('btn custom_class_new', $crawler->filter('#content-actions a.btn')->attr('class'));
         $this->assertEquals('fa fa-plus-circle', $crawler->filter('#content-actions a.btn i')->attr('class'));
         $this->assertStringStartsWith('/admin/?view=list&action=new&entity=Category&sortField=id&sortDirection=DESC&page=1', $crawler->filter('#content-actions a.btn')->attr('href'));
     }
@@ -295,10 +297,15 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testEditViewFieldClasses()
     {
         $crawler = $this->requestEditView();
-        $fieldClasses = array('integer', 'text', 'default');
+        $fieldDefaultClasses = array('integer', 'text', 'default');
+        $fieldCustomClasses = array('integer', 'text', 'default');
 
-        foreach ($fieldClasses as $i => $cssClass) {
+        foreach ($fieldDefaultClasses as $i => $cssClass) {
             $this->assertContains('field_'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
+        }
+
+        foreach ($fieldCustomClasses as $i => $cssClass) {
+            $this->assertContains($cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
         }
     }
 

--- a/Tests/Fixtures/App/config/config_customized_backend.yml
+++ b/Tests/Fixtures/App/config/config_customized_backend.yml
@@ -18,8 +18,8 @@ easy_admin:
             list:
                 title: 'Product %%entity_label%%'
                 actions:
-                    - { name: 'new', label: 'New %%entity_name%%', icon: 'plus-circle' }
-                    - { name: 'search', label: 'Look for %%entity_label%%' }
+                    - { name: 'new', label: 'New %%entity_name%%', icon: 'plus-circle', css_class: 'custom_class_new' }
+                    - { name: 'search', label: 'Look for %%entity_label%%', css_class: 'custom_class_search' }
                 fields:
                     - 'id'
                     - { property: 'name', label: 'Label' }
@@ -39,9 +39,9 @@ easy_admin:
                 actions:
                     - { name: 'list', label: 'Return to listing', icon: 'list' }
                 fields:
-                    - { property: 'id' }
-                    - { property: 'name', label: 'Label' }
-                    - { property: 'parent', label: 'Parent Category Label' }
+                    - { property: 'id', css_class: 'custom_class_id' }
+                    - { property: 'name', label: 'Label', css_class: 'custom_class_name' }
+                    - { property: 'parent', label: 'Parent Category Label', css_class: 'custom_class_parent' }
             edit:
                 title: 'Modify %%entity_name%% (%%entity_id%%) details'
                 actions:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,37 @@ This document describes the backwards incompatible changes introduced by each
 EasyAdminBundle version and the needed changes to be made before upgrading to
 the next version.
 
+Upgrade to 1.5.3
+----------------
+
+The `css` option has been renamed to `css_class`.
+
+Before:
+
+```yaml
+easy_admin:
+    actions:
+        # ...
+            - { name: 'edit', class: 'danger' }
+    entities:
+        # ...
+        fields:
+            - { property: 'id', class: 'col-md-12' }
+```
+
+After:
+
+```yaml
+easy_admin:
+    actions:
+        # ...
+            - { name: 'edit', css_class: 'danger' }
+    entities:
+        # ...
+        fields:
+            - { property: 'id', css_class: 'col-md-12' }
+```
+
 Upgrade to 1.5.0
 ----------------
 


### PR DESCRIPTION
The reason for this change is that I want to change the current proposal for #323 and allow to define form type options directly in the field:

``` yaml
# instead of this ...
fields:
    - 'id'
    - { property: 'email', type: 'email', type_options: { trim: true } }
    - { property: 'interests', type_options: { expanded: true, multiple: true } }
    - { property: 'updated_at', type_options: { read_only: true } }

# ... I want to allow this:
fields:
    - 'id'
    - { property: 'email', type: 'email', trim: true }
    - { property: 'interests', expanded: true, multiple: true }
    - { property: 'updated_at', read_only: true }
```

The problem is that the current `class` option collides with the `class` option defined for form types. By the way, `class` is a very bad name for this option because it refers to CSS instead of PHP.
