### PR TITLE
Change `admin` route to `easy_admin`

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -47,6 +47,7 @@ class AdminController extends Controller
     protected $view;
 
     /**
+     * @Route("/", name="easy_admin")
      * @Route("/", name="admin")
      *
      * @param Request $request
@@ -67,7 +68,7 @@ class AdminController extends Controller
 
         // for now, the homepage redirects to the 'list' action and view of the first entity
         if (null === $request->query->get('entity')) {
-            return $this->redirect($this->generateUrl('admin', array(
+            return $this->redirect($this->generateUrl('easy_admin', array(
                 'action' => $action,
                 'entity' => $this->getNameOfTheFirstConfiguredEntity(),
                 'view'   => $this->view,
@@ -220,7 +221,7 @@ class AdminController extends Controller
 
             return !empty($refererUrl)
                 ? $this->redirect(urldecode($refererUrl))
-                : $this->redirect($this->generateUrl('admin', array('action' => 'list', 'view' => 'list', 'entity' => $this->entity['name'])));
+                : $this->redirect($this->generateUrl('easy_admin', array('action' => 'list', 'view' => 'list', 'entity' => $this->entity['name'])));
         }
 
         $this->dispatch(EasyAdminEvents::POST_EDIT);
@@ -313,7 +314,7 @@ class AdminController extends Controller
 
             $refererUrl = $this->request->query->get('referer', '');
 
-            return $this->redirect($this->generateUrl('admin', array('action' => 'list', 'view' => 'new', 'entity' => $this->entity['name'])));
+            return $this->redirect($this->generateUrl('easy_admin', array('action' => 'list', 'view' => 'new', 'entity' => $this->entity['name'])));
         }
 
         $this->dispatch(EasyAdminEvents::POST_NEW, array(
@@ -341,7 +342,7 @@ class AdminController extends Controller
         $this->dispatch(EasyAdminEvents::PRE_DELETE);
 
         if ('DELETE' !== $this->request->getMethod()) {
-            return $this->redirect($this->generateUrl('admin', array('action' => 'list', 'view' => 'list', 'entity' => $this->entity['name'])));
+            return $this->redirect($this->generateUrl('easy_admin', array('action' => 'list', 'view' => 'list', 'entity' => $this->entity['name'])));
         }
 
         $id = $this->request->query->get('id');
@@ -373,7 +374,7 @@ class AdminController extends Controller
 
         return !empty($refererUrl)
             ? $this->redirect(urldecode($refererUrl))
-            : $this->redirect($this->generateUrl('admin', array('action' => 'list', 'view' => 'list', 'entity' => $this->entity['name'])));
+            : $this->redirect($this->generateUrl('easy_admin', array('action' => 'list', 'view' => 'list', 'entity' => $this->entity['name'])));
     }
 
     /**
@@ -654,7 +655,7 @@ class AdminController extends Controller
     protected function createDeleteForm($entityName, $entityId)
     {
         return $this->createFormBuilder()
-            ->setAction($this->generateUrl('admin', array('action' => 'delete', 'entity' => $entityName, 'id' => $entityId)))
+            ->setAction($this->generateUrl('easy_admin', array('action' => 'delete', 'entity' => $entityName, 'id' => $entityId)))
             ->setMethod('DELETE')
             ->add('submit', 'submit', array('label' => 'Delete'))
             ->getForm()

--- a/Resources/doc/tutorials/customizing-admin-controller.md
+++ b/Resources/doc/tutorials/customizing-admin-controller.md
@@ -41,7 +41,7 @@ class AdminController extends BaseAdminController
 
 Extending from the default controller is not enough to override the entire
 backend. You must also **update the routing configuration** to point the
-`admin` route to the new controller.
+`easy_admin` route to the new controller.
 
 Open the `app/config/routing.yml` file and change the value of the `resource`
 option defined by the existing `easy_admin_bundle` route to load your own

--- a/Resources/doc/tutorials/customizing-backend-actions.md
+++ b/Resources/doc/tutorials/customizing-backend-actions.md
@@ -186,13 +186,13 @@ class AdminController extends BaseAdminController
         $this->em->flush();
 
         // redirect to the 'list' view of the given entity
-        return $this->redirectToRoute('admin', array(
+        return $this->redirectToRoute('easy_admin', array(
             'view' => 'list',
             'entity' => $this->request->query->get('entity'),
         ));
 
         // redirect to the 'edit' view of the given entity item
-        return $this->redirectToRoute('admin', array(
+        return $this->redirectToRoute('easy_admin', array(
             'view' => 'edit',
             'id' => $id,
             'entity' => $this->request->query->get('entity'),
@@ -250,7 +250,7 @@ easy_admin:
 ```
 
 Route based actions are displayed as regular links or buttons, but they don't
-point to the usual `admin` route but to the route configured by the action.
+point to the usual `easy_admin` route but to the route configured by the action.
 In addition, the route is passed two parameters in the query string: `entity`
 (the name of the Doctrine entity) and, when available, the `id` of the related
 entity.
@@ -284,13 +284,13 @@ class ProductController extends Controller
         $em->flush();
 
         // redirect to the 'list' view of the given entity
-        return $this->redirectToRoute('admin', array(
+        return $this->redirectToRoute('easy_admin', array(
             'view' => 'list',
             'entity' => $this->request->query->get('entity'),
         ));
 
         // redirect to the 'edit' view of the given entity item
-        return $this->redirectToRoute('admin', array(
+        return $this->redirectToRoute('easy_admin', array(
             'view' => 'edit',
             'id' => $id,
             'entity' => $this->request->query->get('entity'),

--- a/Resources/doc/tutorials/tips-and-tricks.md
+++ b/Resources/doc/tutorials/tips-and-tricks.md
@@ -79,7 +79,7 @@ class AdminController extends BaseAdminController
     /**
      * Don't forget to add this route annotation!
      *
-     * @Route("/", name="admin")
+     * @Route("/", name="easy_admin")
      */
     public function indexAction(Request $request)
     {
@@ -98,7 +98,7 @@ class AdminController extends BaseAdminController
 ```
 
 Beware that the `index()` method of the default `AdminController` defines the
-`admin` route, which is used to generate every backend URL. This means that
+`easy_admin` route, which is used to generate every backend URL. This means that
 when overriding the `index()` method in your own controller, you must also
 redefine the `@Route()` annotation. Otherwise, the backend will stop working.
 

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -1,7 +1,7 @@
 {% if value is iterable %}
     <span class="badge">{{ value|length }}</span>
 {% elseif link_parameters is defined %}
-    <a href="{{ path('admin', link_parameters) }}">{{ value|easyadmin_truncate }}</a>
+    <a href="{{ path('easy_admin', link_parameters) }}">{{ value|easyadmin_truncate }}</a>
 {% else %}
     {{ value|easyadmin_truncate }}
 {% endif %}

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -54,7 +54,7 @@
 
                 {% for _action in _entity_actions %}
                     {% if 'method' == _action.type %}
-                        {% set _action_href = path('admin', { action: _action.name, view: view, entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name) }) %}
+                        {% set _action_href = path('easy_admin', { action: _action.name, view: view, entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name) }) %}
                     {% elseif 'route' == _action.type %}
                         {% set _action_href = path(_action.name, { entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name) }) %}
                     {% endif %}
@@ -83,7 +83,7 @@
                 {% endif %}
 
                 {% if _list_action is defined %}
-                    <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
+                    <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('easy_admin', ({ entity: _entity_config.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
                         {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
                         {{ _list_action.label|default('action.list')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -43,7 +43,7 @@
                         {% set _site_name_length = easyadmin_config('site_name')|length <= 10 ? 'short'
                             : easyadmin_config('site_name')|length <= 12 ? 'medium' : 'long'
                         %}
-                        <a href="{{ path('admin') }}" class="{{ _site_name_length }}">{{ easyadmin_config('site_name')|raw }}</a>
+                        <a href="{{ path('easy_admin') }}" class="{{ _site_name_length }}">{{ easyadmin_config('site_name')|raw }}</a>
                         {% endblock header_logo %}
                     </div>
                     {% endblock navbar_header %}
@@ -55,7 +55,7 @@
                             {% block navigation_items %}
                                 {% for item in easyadmin_config('entities') %}
                                     <li class="{{ item.name|lower == app.request.get('entity')|lower ? 'active' : '' }}">
-                                        <a href="{{ path('admin', { entity: item.name, action: 'list', view: 'list' }) }}">
+                                        <a href="{{ path('easy_admin', { entity: item.name, action: 'list', view: 'list' }) }}">
                                             {{- item.label|trans -}}
                                         </a>
                                     </li>

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -27,7 +27,7 @@
         {% set _request_parameters = _request_parameters|merge({ query: app.request.get('query')|default('') }) %}
     {% endif %}
 
-    {% set _request_parameters = _request_parameters|merge({ referer: path('admin', _request_parameters)|url_encode }) %}
+    {% set _request_parameters = _request_parameters|merge({ referer: path('easy_admin', _request_parameters)|url_encode }) %}
 
     <div class="row">
         <div id="content-header" class="col-sm-12">
@@ -42,7 +42,7 @@
                         {% block new_action %}
                             {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
                             <div id="content-actions">
-                                <a class="btn {{ _action.css_class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
+                                <a class="btn {{ _action.css_class|default('') }}" href="{{ path('easy_admin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                     {{ _action.label|default('action.new')|trans(_trans_parameters) }}
                                 </a>
@@ -53,7 +53,7 @@
                     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
                         {% block search_action %}
                             {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
-                            <form id="content-search" class="col-xs-6 col-sm-8 {{ _action.css_class|default('') }}" method="get" action="{{ path('admin') }}">
+                            <form id="content-search" class="col-xs-6 col-sm-8 {{ _action.css_class|default('') }}" method="get" action="{{ path('easy_admin') }}">
                                 <input type="hidden" name="view" value="list">
                                 <input type="hidden" name="action" value="search">
                                 <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
@@ -92,7 +92,7 @@
                                     {% set _column_label =  metadata.label ? metadata.label|trans(_trans_parameters) : field|humanize %}
 
                                     {% if metadata.sortable %}
-                                        <a href="{{ path('admin', _request_parameters|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
+                                        <a href="{{ path('easy_admin', _request_parameters|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
                                             {% if isSortingField and sortDirection == 'DESC' %}
                                                 <i class="fa fa-caret-up"></i>
                                             {% elseif isSortingField and sortDirection == 'ASC' %}
@@ -139,7 +139,7 @@
                                         {% spaceless %}
                                             {% for _action in _list_item_actions %}
                                                 {% if 'method' == _action.type %}
-                                                    {% set _action_href = path('admin', _request_parameters|merge({ action: _action.name, id: _item_id })) %}
+                                                    {% set _action_href = path('easy_admin', _request_parameters|merge({ action: _action.name, id: _item_id })) %}
                                                 {% elseif 'route' == _action.type %}
                                                     {% set _action_href = path(_action.name, _request_parameters|merge({ action: _action.name, id: _item_id })) %}
                                                 {% endif %}
@@ -189,7 +189,7 @@
                 var columnIndex = $(this).closest('td').index() + 1;
                 var propertyName = $('table th.toggle:nth-child(' + columnIndex + ')').data('property-name');
 
-                var toggleUrl = "{{ path('admin', { action: 'edit', entity: _entity_config.name, view: 'list' })|raw }}"
+                var toggleUrl = "{{ path('easy_admin', { action: 'edit', entity: _entity_config.name, view: 'list' })|raw }}"
                               + "&id=" + $(this).closest('tr').data('id')
                               + "&property=" + propertyName
                               + "&newValue=" + newValue.toString();

--- a/Resources/views/default/paginator.html.twig
+++ b/Resources/views/default/paginator.html.twig
@@ -16,7 +16,7 @@
                         </li>
                     {% else %}
                         <li>
-                            <a href="{{ path('admin', _request_parameters|merge({ page: 1 }) ) }}">
+                            <a href="{{ path('easy_admin', _request_parameters|merge({ page: 1 }) ) }}">
                                 <i class="fa fa-angle-double-left"></i> {{ 'paginator.first'|trans }}
                             </a>
                         </li>
@@ -24,7 +24,7 @@
 
                     {% if paginator.hasPreviousPage %}
                         <li>
-                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.previousPage }) ) }}">
+                            <a href="{{ path('easy_admin', _request_parameters|merge({ page: paginator.previousPage }) ) }}">
                                 <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
                             </a>
                         </li>
@@ -38,7 +38,7 @@
 
                     {% if paginator.hasNextPage %}
                         <li>
-                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.nextPage }) ) }}">
+                            <a href="{{ path('easy_admin', _request_parameters|merge({ page: paginator.nextPage }) ) }}">
                                 {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
                             </a>
                         </li>
@@ -52,7 +52,7 @@
 
                     {% if paginator.currentPage < paginator.nbPages %}
                         <li>
-                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.nbPages }) ) }}">
+                            <a href="{{ path('easy_admin', _request_parameters|merge({ page: paginator.nbPages }) ) }}">
                                 {{ 'paginator.last'|trans }} <i class="fa fa-angle-double-right"></i>
                             </a>
                         </li>

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -40,7 +40,7 @@
                 {% set _show_actions = easyadmin_get_actions_for_show_item(_entity_config.name) %}
                 {% for _action in _show_actions %}
                     {% if 'method' == _action.type %}
-                        {% set _action_href = path('admin', { action: _action.name, view: 'show', entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
+                        {% set _action_href = path('easy_admin', { action: _action.name, view: 'show', entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
                     {% elseif 'route' == _action.type %}
                         {% set _action_href = path(_action.name, { entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
                     {% endif %}
@@ -62,7 +62,7 @@
                 {# for aesthetic reasons, the 'list' action is always displayed as a link instead of a button #}
                 {% if easyadmin_action_is_enabled_for_show_view('list', _entity_config.name) %}
                     {% set _action = easyadmin_get_action_for_show_view('list', _entity_config.name) %}
-                    <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
+                    <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('easy_admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {{ _action.label|default('action.list')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>


### PR DESCRIPTION
We started a discussion about this change in https://github.com/javiereguiluz/EasyAdminBundle/pull/313#discussion_r30712313.

The new EasyAdmin main entrypoint route name is: `easy_admin`.

With this PR, any project defining a route named `admin` will be able to use EasyAdmin.
However, there is a "BC Layer" : 
- Existing projects using the `admin` route name in templates or controllers won't break, and will be able to successfully generate an url using the `admin` name. But they should consider migrating to the new name.
- New applications should use the `easy_admin` name.
- Applications needing to use the `admin` route name for their own purpose should register this route **AFTER** EasyAdminController ones, in order to override it properly:

``` php
# EasyAdminController:
easy_admin_bundle:
    resource: @EasyAdminBundle/Controller/
    type:     annotation
    prefix:   /admin

# EasyAdmin Controller extended:
easy_admin_bundle:
    resource: @AppBundle/Controller/EasyAdminController.php
    type:     annotation
    prefix:   /easyadmin

##################################
# Define your `admin` route AFTER
##################################

# Your app admin controller:
app_admin:
    resource: @AppBundle/Controller/ArbitraryController.php
    type:     annotation

# Single route registration:
app_admin:
    path: /my-admin-page
    defaults: { _controller: AppBundle:Arbitrary:admin }
```

About relying on the route name from the request:

``` php
$routeName = $request->get('_route');
```

`$routeName` will equal `"easy_admin"`, as expected.

Honestly, I don't think this "BC layer" is essential, but doesn't cost (almost) anything. However, I fear we might have some tickets about strange bugs due to misunderstandings or misconfiguration.

If accepted, I think this will be merged just before releasing a new major version version, so @javiereguiluz will update the UPGRADE.md file accordingly.
