### PR TITLE
Workaround composer memory exhausted issue on travis with php 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
     - env: SYMFONY_VERSION="2.8.x-dev"
 
 before_install:
+  - if [ "$(phpenv version-name)" = "5.3" ]; then echo 'memory_limit = 1280M' >> ~/.phpenv/versions/5.3/etc/conf.d/travis.ini; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:$SYMFONY_VERSION; fi
 
 install:


### PR DESCRIPTION
About Travis issue with php 5.3: I managed to get a successful build by increasing php `memory_limit`.
By default, Composer set it to 1024M if lower in php configuration.

[Here is a build with profiling informations](https://travis-ci.org/ogizanagi/EasyAdminBundle/builds/64696388) (_You can see it by expanding l.109 of each job_).

PHP 5.3:

> [260.8MB/100.56s] Memory usage: 260.78MB (peak: 1032.49MB), time: 100.56s

PHP 5.4:

> [194.6MB/63.50s] Memory usage: 194.55MB (peak: 657.27MB), time: 63.5s

PHP 5.6:

> [194.5MB/108.30s] Memory usage: 194.53MB (peak: 657.2MB), time: 108.3s

I think there is an obvious memory consumption issue with Composer and PHP 5.3.
For now, we could eventually increase php `memory_limit` to something like `1280M` to be safe for the php 5.3 builds.
