### PR TITLE
Allow to override _request_parameters

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -21,8 +21,14 @@
 {% endblock %}
 
 {% block content %}
-    {% set _request_parameters = _request_parameters|default({}) %}
-    {% set _request_parameters = _request_parameters|merge({ view: 'list', action: app.request.get('action'), entity: _entity_config.name, sortField: app.request.get('sortField', ''), sortDirection: app.request.get('sortDirection', 'DESC'), page: app.request.get('page', 1) }) %}
+    {% set _request_parameters = _request_parameters|default({})|merge({
+        view: 'list',
+        action: app.request.get('action'),
+        entity: _entity_config.name,
+        sortField: app.request.get('sortField', ''),
+        sortDirection: app.request.get('sortDirection', 'DESC'),
+        page: app.request.get('page', 1)
+    }) %}
 
     {% if 'search' == app.request.get('action') %}
         {% set _request_parameters = _request_parameters|merge({ query: app.request.get('query')|default('') }) %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -21,7 +21,8 @@
 {% endblock %}
 
 {% block content %}
-    {% set _request_parameters = { view: 'list', action: app.request.get('action'), entity: _entity_config.name, sortField: app.request.get('sortField', ''), sortDirection: app.request.get('sortDirection', 'DESC'), page: app.request.get('page', 1) } %}
+    {% set _request_parameters = _request_parameters|default({}) %}
+    {% set _request_parameters = _request_parameters|merge({ view: 'list', action: app.request.get('action'), entity: _entity_config.name, sortField: app.request.get('sortField', ''), sortDirection: app.request.get('sortDirection', 'DESC'), page: app.request.get('page', 1) }) %}
 
     {% if 'search' == app.request.get('action') %}
         {% set _request_parameters = _request_parameters|merge({ query: app.request.get('query')|default('') }) %}


### PR DESCRIPTION
This allows to override `_request_parameters` in the `list` view, whether by sending from the controller or by overriding it in twig.

If you like the proposal, I'll add the same behavior for the views.

In fact, the big initial issue was that I added some custom GET attributes on the list page, as a filter, and the table headers and pagination could not retrieve these parameters, so this is the reason why I need to add them manually in the view.
At the moment, this is impossible, and it'll be with this PR :)

What do you think?
