### PR TITLE
Forgotten tip in the UPGRADE file

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -121,6 +121,16 @@ easy_admin:
             label: 'My Fancy Entity!'
 ```
 
+### Changed variables names in twig views
+
+The former `_entity` variable was used to retrieve the current entity configuration. 
+This variable has been renamed to `_entity_config` for convenience and readability reasons.
+
+The old `item` variable was used to carry the currently created/edited entity.
+This variable has been renamed to `entity` for better understandability.
+
+Be sure that you did not override these variables, if so, you just have to change the name.
+
 Upgrade to 1.4.0
 ----------------
 


### PR DESCRIPTION
Actually, I upgraded from 1.4 to the latest 1.5 ver, and it has been a hell since yesterday. Every admin section was a blank page, and I couldn't find out what was going wrong until I saw the problem in the logs: variable names has changed, and it's kind of important to notice it to developers.
