### PR TITLE
Update sensio/distribution-bundle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/orm"                  : "~2.3",
         "doctrine/doctrine-bundle"      : "~1.2",
         "twig/extensions"               : "~1.0",
-        "sensio/distribution-bundle"    : "~2.3|~3.0",
+        "sensio/distribution-bundle"    : "~2.3|~3.0|~4.0",
         "sensio/framework-extra-bundle" : "~3.0,>=3.0.2",
         "twig/twig"                     : "~1.12,>=1.12.2"
     },


### PR DESCRIPTION
Now that Symfony 2.7.1 has been released, its new dependency on `sensio/distribution-bundle` is `~4.0` , so to avoid conflicts, let's update this in our `composer.json` :smile: 
