### PR TITLE
Improved the way errors/exceptions are displayed

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -31,6 +31,7 @@ use Pagerfanta\Adapter\DoctrineORMAdapter;
 use JavierEguiluz\Bundle\EasyAdminBundle\Event\EasyAdminEvents;
 use JavierEguiluz\Bundle\EasyAdminBundle\Exception\NoEntitiesConfiguredException;
 use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\EntityNotFoundException;
 use JavierEguiluz\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
 
 /**
@@ -173,7 +174,7 @@ class AdminController extends Controller
 
         $id = $this->request->query->get('id');
         if (!$entity = $this->em->getRepository($this->entity['class'])->find($id)) {
-            throw $this->createNotFoundException(sprintf('Unable to find entity (%s #%d).', $this->entity['name'], $id));
+            throw new EntityNotFoundException(array('action' => 'edit', 'entity' => $this->entity, 'entity_id' => $id));
         }
 
         $fields = $this->entity['edit']['fields'];
@@ -228,7 +229,7 @@ class AdminController extends Controller
 
         $id = $this->request->query->get('id');
         if (!$entity = $this->em->getRepository($this->entity['class'])->find($id)) {
-            throw $this->createNotFoundException(sprintf('Unable to find entity (%s #%d).', $this->entity['name'], $id));
+            throw new EntityNotFoundException(array('action' => 'show', 'entity' => $this->entity, 'entity_id' => $id));
         }
 
         $fields = $this->entity['show']['fields'];
@@ -323,7 +324,7 @@ class AdminController extends Controller
 
         if ($form->isValid()) {
             if (!$entity = $this->em->getRepository($this->entity['class'])->find($id)) {
-                throw $this->createNotFoundException('The entity to be deleted does not exist.');
+                throw new EntityNotFoundException(array('action' => 'delete', 'entity' => $this->entity, 'entity_id' => $id));
             }
 
             $this->dispatch(EasyAdminEvents::PRE_REMOVE, array('entity' => $entity));

--- a/Exception/BaseException.php
+++ b/Exception/BaseException.php
@@ -18,6 +18,10 @@ class BaseException extends \Exception
     public function __construct(array $parameters = array())
     {
         $this->parameters = $parameters;
+
+        if (isset($this->parameters['message'])) {
+            parent::__construct(strip_tags($this->parameters['message']));
+        }
     }
 
     public function getParameters()

--- a/Exception/BaseException.php
+++ b/Exception/BaseException.php
@@ -13,19 +13,28 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
 class BaseException extends \Exception
 {
+    protected $message;
     private $parameters;
+    private $htmlMessage;
 
     public function __construct(array $parameters = array())
     {
         $this->parameters = $parameters;
-
-        if (isset($this->parameters['message'])) {
-            parent::__construct(strip_tags($this->parameters['message']));
-        }
     }
 
     public function getParameters()
     {
         return $this->parameters;
+    }
+
+    public function setMessage($message)
+    {
+        $this->htmlMessage = $message;
+        $this->message = strip_tags($message);
+    }
+
+    public function getMessageAsHtml()
+    {
+        return $this->htmlMessage;
     }
 }

--- a/Exception/EntityNotFoundException.php
+++ b/Exception/EntityNotFoundException.php
@@ -11,11 +11,16 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
-class ForbiddenActionException extends BaseException
+class EntityNotFoundException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $parameters['message'] = sprintf('The requested <code>%s</code> action is not allowed.', $parameters['action']);
+        $parameters['message'] = sprintf(
+            'The <code>%s</code> entity with <code>%s = %s</code> does not exist in the database.',
+            $parameters['entity']['name'],
+            $parameters['entity']['primary_key_field_name'],
+            $parameters['entity_id']
+        );
 
         parent::__construct($parameters);
     }

--- a/Exception/EntityNotFoundException.php
+++ b/Exception/EntityNotFoundException.php
@@ -15,13 +15,13 @@ class EntityNotFoundException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $parameters['message'] = sprintf(
+        parent::__construct($parameters);
+
+        $this->setMessage(sprintf(
             'The <code>%s</code> entity with <code>%s = %s</code> does not exist in the database.',
             $parameters['entity']['name'],
             $parameters['entity']['primary_key_field_name'],
             $parameters['entity_id']
-        );
-
-        parent::__construct($parameters);
+        ));
     }
 }

--- a/Exception/ForbiddenActionException.php
+++ b/Exception/ForbiddenActionException.php
@@ -15,8 +15,8 @@ class ForbiddenActionException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $parameters['message'] = sprintf('The requested <code>%s</code> action is not allowed.', $parameters['action']);
-
         parent::__construct($parameters);
+
+        $this->setMessage(sprintf('The requested <code>%s</code> action is not allowed.', $parameters['action']));
     }
 }

--- a/Exception/NoEntitiesConfiguredException.php
+++ b/Exception/NoEntitiesConfiguredException.php
@@ -15,8 +15,8 @@ class NoEntitiesConfiguredException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $parameters['message'] = 'Your backend is empty because you haven\'t configured any Doctrine entity to manage.';
-
         parent::__construct($parameters);
+
+        $this->setMessage('Your backend is empty because you haven\'t configured any Doctrine entity to manage.');
     }
 }

--- a/Exception/NoEntitiesConfiguredException.php
+++ b/Exception/NoEntitiesConfiguredException.php
@@ -13,4 +13,10 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
 class NoEntitiesConfiguredException extends BaseException
 {
+    public function __construct(array $parameters = array())
+    {
+        $parameters['message'] = 'Your backend is empty because you haven\'t configured any Doctrine entity to manage.';
+
+        parent::__construct($parameters);
+    }
 }

--- a/Exception/UndefinedEntityException.php
+++ b/Exception/UndefinedEntityException.php
@@ -15,8 +15,8 @@ class UndefinedEntityException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $parameters['message'] = sprintf('The <code>%s</code> entity is not defined in the configuration of your backend.', $parameters['entity_name']);
-
         parent::__construct($parameters);
+
+        $this->setMessage(sprintf('The <code>%s</code> entity is not defined in the configuration of your backend.', $parameters['entity_name']));
     }
 }

--- a/Exception/UndefinedEntityException.php
+++ b/Exception/UndefinedEntityException.php
@@ -13,4 +13,10 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
 class UndefinedEntityException extends BaseException
 {
+    public function __construct(array $parameters = array())
+    {
+        $parameters['message'] = sprintf('The <code>%s</code> entity is not defined in the configuration of your backend.', $parameters['entity_name']);
+
+        parent::__construct($parameters);
+    }
 }

--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -49,7 +49,9 @@ class ExceptionListener
         }
 
         $templatePath = $exceptionTemplates[$exceptionClassName];
-        $response = $this->templating->renderResponse($templatePath, $exception->getParameters());
+        $parameters = array_merge($exception->getParameters(), array('message' => $exception->getMessageAsHtml()));
+        $response = $this->templating->renderResponse($templatePath, $parameters);
+
         $event->setResponse($response);
     }
 }

--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -19,18 +19,26 @@ use JavierEguiluz\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
 class ExceptionListener
 {
     private $templating;
+    private $debug;
 
-    public function __construct($templating)
+    public function __construct($templating, $debug)
     {
         $this->templating = $templating;
+        $this->debug = $debug;
     }
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
+        // in 'dev' environment, don't override Symfony's exception pages
+        if (true === $this->debug) {
+            return $event->getException()->getMessage();
+        }
+
         $exceptionTemplates = array(
             'ForbiddenActionException' => '@EasyAdmin/error/forbidden_action.html.twig',
             'NoEntitiesConfigurationException' => '@EasyAdmin/error/no_entities.html.twig',
             'UndefinedEntityException' => '@EasyAdmin/error/undefined_entity.html.twig',
+            'EntityNotFoundException' => '@EasyAdmin/error/entity_not_found.html.twig',
         );
 
         $exception = $event->getException();

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,6 +24,7 @@
 
         <service id="easyadmin.listener.exception" class="JavierEguiluz\Bundle\EasyAdminBundle\Listener\ExceptionListener">
             <argument type="service" id="templating"></argument>
+            <argument>%kernel.debug%</argument>
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>
     </services>

--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -719,20 +719,17 @@ body.show .form-control.image {
 /* -------------------------------------------------------------------------
    ERROR PAGES
    ------------------------------------------------------------------------- */
-body.error {
-    background: {{ colors.gray }};
-}
-body.error .container {
+body.error .error-description {
     background: {{ colors.white }};
     height: auto;
-    margin: 3em auto 2em;
-    max-width: 80%;
+    margin: 2em auto 2em;
+    max-width: 90%;
     min-height: 200px;
     padding: 0;
 }
-body.error .container h1 {
+body.error .error-description h1 {
     background: {{ colors.danger }};
-    color: {{ colors.gray_lighter }};
+    color: {{ colors.white }};
     margin-top: 0;
     padding: 15px;
     text-transform: uppercase;
@@ -749,13 +746,13 @@ body.error .error-solution {
 }
 body.error .error-problem p.lead {
     margin-bottom: 0;
-    padding-bottom: 1em;
+    padding-bottom: .5em;
 }
 body.error .error-solution {
-    border-top: 1px solid {{ colors.gray }};
+    border-top: 2px dashed {{ colors.gray_light }};
 }
 body.error .error-solution h2 {
-    margin-top: 0;
+    margin-top: .5em;
 }
 body.error .error-solution code {
     color: {{ colors.success }};
@@ -767,8 +764,6 @@ body.error .error-solution pre {
     background: none;
     border: 0;
 }
-
-    /*font-size: inherit;*/
 
 /* =========================================================================
    RESPONSIVE
@@ -941,6 +936,10 @@ body.error .error-solution pre {
         margin-left: .5em;
         margin-top: 0;
     }
+
+    body.error .error-description {
+        max-width: 80%;
+    }
 }
 
 /* -------------------------------------------------------------------------
@@ -1039,8 +1038,8 @@ body.error .error-solution pre {
         overflow-x: hidden;
     }
 
-    body.error .container {
-        max-width: 50%;
+    body.error .error-description {
+        max-width: 70%;
     }
 }
 
@@ -1205,7 +1204,7 @@ body.error .error-solution pre {
     #content #sidebar {
     }
 
-    body.error #content h1 {
+    body.error .error-description h1 {
         margin-top: .25em;
     }
 }

--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -727,6 +727,7 @@ body.error .container {
     height: auto;
     margin: 3em auto 2em;
     max-width: 80%;
+    min-height: 200px;
     padding: 0;
 }
 body.error .container h1 {
@@ -747,9 +748,11 @@ body.error .error-solution {
     padding: 15px;
 }
 body.error .error-problem p.lead {
-    border-bottom: 1px solid {{ colors.gray }};
     margin-bottom: 0;
     padding-bottom: 1em;
+}
+body.error .error-solution {
+    border-top: 1px solid {{ colors.gray }};
 }
 body.error .error-solution h2 {
     margin-top: 0;

--- a/Resources/views/error/entity_not_found.html.twig
+++ b/Resources/views/error/entity_not_found.html.twig
@@ -1,0 +1,5 @@
+{% extends '@EasyAdmin/error/error_page.html.twig' %}
+
+{% block page_title 'Entity Not Found' %}
+
+{% block problem %}{{ message|raw }}{% endblock %}

--- a/Resources/views/error/error_page.html.twig
+++ b/Resources/views/error/error_page.html.twig
@@ -1,35 +1,24 @@
-<!DOCTYPE html>
-<html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta http-equiv="content-type" content="text/html; charset=utf-8">
-        <meta name="generator" content="EasyAdmin" />
-        <title>{% block page_title %}{% endblock %} | EasyAdmin Error</title>
-        <link href="{{ asset('bundles/easyadmin/stylesheet/bootstrap.min.css') }}" rel="stylesheet">
-        <link href="{{ asset('bundles/easyadmin/stylesheet/font-awesome.min.css') }}" rel="stylesheet">
-        <link rel="stylesheet" href="{{ path('_easyadmin_render_css') }}">
-        <link rel="shortcut icon" type="image/png" href="/favicon.png">
-    </head>
+{% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
+{% extends _entity_config ? _entity_config.templates.layout : '@EasyAdmin/default/layout.html.twig' %}
 
-    <body class="error">
-        <div class="container">
-            <h1>Error</h1>
+{% block body_class 'error' %}
 
-            <div class="error-problem">
-                <p class="lead">
-                    {% block problem %}{% endblock %}
-                </p>
-            </div>
+{% block content %}
+    <div class="error-description">
+        <h1>Error</h1>
 
-            {% if block('solution') is not empty %}
-                <div class="error-solution">
-                    <h2>How to fix this problem</h2>
-
-                    {% block solution %}{% endblock %}
-                </div>
-            {% endif %}
+        <div class="error-problem">
+            <p class="lead">
+                {% block problem %}{% endblock %}
+            </p>
         </div>
-    </body>
-</html>
+
+        {% if block('solution') is not empty %}
+            <div class="error-solution">
+                <h2>How to fix this problem</h2>
+
+                {% block solution %}{% endblock %}
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/Resources/views/error/error_page.html.twig
+++ b/Resources/views/error/error_page.html.twig
@@ -23,11 +23,13 @@
                 </p>
             </div>
 
-            <div class="error-solution">
-                <h2>How to fix this problem</h2>
+            {% if block('solution') is not empty %}
+                <div class="error-solution">
+                    <h2>How to fix this problem</h2>
 
-                {% block solution %}{% endblock %}
-            </div>
+                    {% block solution %}{% endblock %}
+                </div>
+            {% endif %}
         </div>
     </body>
 </html>

--- a/Resources/views/error/forbidden_action.html.twig
+++ b/Resources/views/error/forbidden_action.html.twig
@@ -2,9 +2,7 @@
 
 {% block page_title 'Forbidden action' %}
 
-{% block problem %}
-    The requested <code>{{ action }}</code> action is not allowed.
-{% endblock %}
+{% block problem %}{{ message|raw }}{% endblock %}
 
 {% block solution %}
     <ul>

--- a/Resources/views/error/no_entities.html.twig
+++ b/Resources/views/error/no_entities.html.twig
@@ -2,10 +2,7 @@
 
 {% block page_title 'Configuration error' %}
 
-{% block problem %}
-    Your backend is empty because you haven't configured
-    any Doctrine entity to manage.
-{% endblock %}
+{% block problem %}{{ message|raw }}{% endblock %}
 
 {% block solution %}
     <p>

--- a/Resources/views/error/undefined_entity.html.twig
+++ b/Resources/views/error/undefined_entity.html.twig
@@ -2,10 +2,7 @@
 
 {% block page_title 'Undefined entity' %}
 
-{% block problem %}
-    The <code>{{ entity_name }}</code> entity is not defined in
-    the configuration of your backend.
-{% endblock %}
+{% block problem %}{{ message|raw }}{% endblock %}
 
 {% block solution %}
     <p>

--- a/Resources/views/error/undefined_entity.html.twig
+++ b/Resources/views/error/undefined_entity.html.twig
@@ -7,8 +7,8 @@
 {% block solution %}
     <p>
         Open your <code>app/config/config.yml</code> file and add the
-        class of the <code>{{ entity_name }}</code> entity to the list
-        of entities managed by EasyAdmin.
+        <code>{{ entity_name }}</code> entity to the list of entities
+        managed by EasyAdmin.
     </p>
 
     <pre>
@@ -17,7 +17,8 @@
 easy_admin:
     entities:
         # ...
-        - AppBundle\Entity\{{ entity_name }}
+        {{ entity_name }}:
+            class: AppBundle\Entity\{{ entity_name }}
 {{- '' -}}
     </pre>
 {% endblock %}

--- a/Tests/Controller/BackendErrorsTest.php
+++ b/Tests/Controller/BackendErrorsTest.php
@@ -30,7 +30,6 @@ class BackendErrorsTest extends AbstractTestCase
         ));
 
         $this->assertEquals(500, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('Undefined entity', $crawler->filter('head title')->text());
-        $this->assertEquals("The InexistentEntity entity is not defined in\n    the configuration of your backend.", trim($crawler->filter('body.error .container .error-problem p.lead')->text()));
+        $this->assertContains('The InexistentEntity entity is not defined in the configuration of your backend.', $crawler->filter('head title')->text());
     }
 }

--- a/Tests/Controller/ReadOnlyBackendTest.php
+++ b/Tests/Controller/ReadOnlyBackendTest.php
@@ -52,7 +52,7 @@ class ReadOnlyBackendTest extends AbstractTestCase
         $crawler = $this->requestEditView();
 
         $this->assertEquals(500, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('The requested <code>edit</code> action is not allowed.', $this->client->getResponse()->getContent());
+        $this->assertContains('The requested edit action is not allowed.', $this->client->getResponse()->getContent());
     }
 
     public function testNewActionIsDisabled()
@@ -60,7 +60,7 @@ class ReadOnlyBackendTest extends AbstractTestCase
         $crawler = $this->requestNewView();
 
         $this->assertEquals(500, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('The requested <code>new</code> action is not allowed.', $this->client->getResponse()->getContent());
+        $this->assertContains('The requested new action is not allowed.', $this->client->getResponse()->getContent());
     }
 
     /**


### PR DESCRIPTION
**The first part of this PR** improves the way errors/exceptions are displayed.

In `dev` environment, the exception pages are no longer overridden:

![exception_1_dev](https://cloud.githubusercontent.com/assets/73419/8418155/8916b0da-1eb1-11e5-8817-8111056b7973.png)

![exception_2_dev](https://cloud.githubusercontent.com/assets/73419/8418156/8b0692ac-1eb1-11e5-85bd-7228ebf20e0c.png)

In `prod` environment, we display useful custom error pages:

![exception_1_prod](https://cloud.githubusercontent.com/assets/73419/8418169/9883e4e8-1eb1-11e5-890a-d2eacefedb16.png)

![exception_2_prod](https://cloud.githubusercontent.com/assets/73419/8418170/99b3b4f6-1eb1-11e5-90f8-dfd7d0684b57.png)

**The second part of this PR** adds more custom error pages which are displayed when an error occurs. When an entity is not found, we no longer show a 404 error page. We now display a custom error page explaining the problem.
