### PR TITLE
Fix labels css

### DIFF
--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -178,8 +178,10 @@ div.flash-error strong {
 
 /* Labels
    ------------------------------------------------------------------------- */
-.label {
+.label:not([class*=label-]) {
     background: {{ colors.gray_darker }};
+}
+.label {
     color: {{ colors.white }};
     font-size: 11px;
     padding: 2px 4px;


### PR DESCRIPTION
Avoid preventing to use the classic bootstrap label colors (primary, info, ...).

Maybe not the most elegant/efficient solution, but is a quick fix for main usages.
