### PR TITLE
Define FormType class instead of a classic `type`

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -616,7 +616,9 @@ class AdminController extends Controller
 
             // Adds a custom FormType for this field if the `fieldType` property contains a FormTypeInterface
             if (isset($metadata['fieldType'])) {
+
                 $formType = null;
+
                 if (class_exists($metadata['fieldType'])) {
                     // If the "type" or "fieldType" is a class, we create a new instance of it
                     $formType = new $metadata['fieldType'];
@@ -624,6 +626,7 @@ class AdminController extends Controller
                     // If the type starts with "@", we try to retrive the associated service.
                     $formType = $this->get(substr($metadata['fieldType'], 1));
                 }
+
                 if ($formType) {
                     if (!($formType instanceof FormTypeInterface)) {
                         throw new InvalidConfigurationException('formType', 'an AbstractFormType or a FormTypeInterface', get_class($formType));
@@ -688,6 +691,8 @@ class AdminController extends Controller
     protected function getNameOfTheFirstConfiguredEntity()
     {
         $entityNames = array_keys($this->config['entities']);
+
+
 
         return $entityNames[0];
     }
@@ -802,7 +807,7 @@ class AdminController extends Controller
      *
      * @throws EntityNotFoundException
      */
-    private function findCurrentEntity()
+    protected function findCurrentEntity()
     {
         $id = $this->request->query->get('id');
         if (!$entity = $this->em->getRepository($this->entity['class'])->find($id)) {

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -616,8 +616,15 @@ class AdminController extends Controller
 
             // Adds a custom FormType for this field if the `fieldType` property contains a FormTypeInterface
             if (isset($metadata['fieldType'])) {
+                $formType = null;
                 if (class_exists($metadata['fieldType'])) {
+                    // If the "type" or "fieldType" is a class, we create a new instance of it
                     $formType = new $metadata['fieldType'];
+                } elseif (strpos($metadata['fieldType'], '@') === 0) {
+                    // If the type starts with "@", we try to retrive the associated service.
+                    $formType = $this->get(substr($metadata['fieldType'], 1));
+                }
+                if ($formType) {
                     if (!($formType instanceof FormTypeInterface)) {
                         throw new InvalidConfigurationException('formType', 'an AbstractFormType or a FormTypeInterface', get_class($formType));
                     }

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -20,11 +20,14 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Controller;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\InvalidConfigurationException;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -610,6 +613,17 @@ class AdminController extends Controller
             $formFieldOptions['attr']['field_type'] = $metadata['fieldType'];
             $formFieldOptions['attr']['field_css_class'] = $metadata['class'];
             $formFieldOptions['attr']['field_help'] = $metadata['help'];
+
+            // Adds a custom FormType for this field if the `fieldType` property contains a FormTypeInterface
+            if (isset($metadata['fieldType'])) {
+                if (class_exists($metadata['fieldType'])) {
+                    $formType = new $metadata['fieldType'];
+                    if (!($formType instanceof FormTypeInterface)) {
+                        throw new InvalidConfigurationException('formType', 'an AbstractFormType or a FormTypeInterface', get_class($formType));
+                    }
+                    $metadata['fieldType'] = $formType;
+                }
+            }
 
             $formBuilder->add($name, $metadata['fieldType'], $formFieldOptions);
         }

--- a/Exception/InvalidConfigurationException.php
+++ b/Exception/InvalidConfigurationException.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
+
+class InvalidConfigurationException extends BaseException
+{
+    public function __construct($property, $expected, $given, array $parameters = array())
+    {
+        $parameters['property'] = $property;
+
+        parent::__construct($parameters);
+
+        $this->setMessage(sprintf(
+            "Invalid EasyAdmin configuration.\n".
+            "The <code>%s</code> property expected %s.\n".
+            "%s given.",
+            $property, $expected, $given
+        ));
+    }
+}

--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -23,6 +23,7 @@ class ExceptionListener
         'NoEntitiesConfigurationException' => '@EasyAdmin/error/no_entities.html.twig',
         'UndefinedEntityException' => '@EasyAdmin/error/undefined_entity.html.twig',
         'EntityNotFoundException' => '@EasyAdmin/error/entity_not_found.html.twig',
+        'InvalidConfigurationException' => '@EasyAdmin/error/invalid_configuration.html.twig',
     );
 
     public function __construct($templating, $debug)
@@ -33,7 +34,7 @@ class ExceptionListener
 
     public function onKernelException(GetResponseForExceptionEvent $event)
     {
-        // in 'dev' environment, don't override Symfony's exception pages
+        // in 'debug' mode, don't override Symfony's exception pages
         if (true === $this->debug) {
             return $event->getException()->getMessage();
         }

--- a/Resources/views/error/invalid_configuration.html.twig
+++ b/Resources/views/error/invalid_configuration.html.twig
@@ -1,0 +1,7 @@
+{% extends '@EasyAdmin/error/error_page.html.twig' %}
+
+{% block page_title 'Invalid configuration' %}
+
+{% block problem %}
+    {{ message|raw|nl2br }}
+{% endblock %}

--- a/Tests/Controller/CustomFieldFormTypeTest.php
+++ b/Tests/Controller/CustomFieldFormTypeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Controller;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Controller\AdminController;
+use Symfony\Component\HttpFoundation\Request;
+
+class CustomFieldFormTypeTest extends AbstractTestCase
+{
+    /**
+     * @var AdminController
+     */
+    protected $controller;
+
+    public function setUp()
+    {
+        // Only here to avoid the `initClient` method to be used.
+        // It's useless in this test.
+    }
+
+    /**
+     * @param array $options
+     *
+     * @return AdminController
+     */
+    public function getController(array $options = array())
+    {
+        static::bootKernel($options);
+        $controller = new AdminController();
+        $controller->setContainer(static::$kernel->getContainer());
+        return $controller;
+    }
+
+    public function testFormTypeIsString()
+    {
+        $controller = static::getController(array('environment' => 'form_type_checker'));
+        // Simulates the "new" action
+        $controller->initialize(new Request(array('entity' => 'Customer', 'action' => 'new')));
+        $entity = $controller->findCurrentEntity();
+        $fields = $controller->entity['new']['fields'];
+
+        $builder = $controller->createEntityFormBuilder($entity, $fields, 'new');
+
+        // TODO
+    }
+}

--- a/Tests/Fixtures/AbstractTestCase.php
+++ b/Tests/Fixtures/AbstractTestCase.php
@@ -57,4 +57,21 @@ abstract class AbstractTestCase extends WebTestCase
     {
         return $this->getBackendPage(array('entity' => 'Category', 'view' => 'list'));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected static function bootKernel(array $options = array())
+    {
+        // Because `bootKernel` does cool things but it does not exist in SF2.3
+        if (method_exists('\Symfony\Bundle\FrameworkBundle\Test\KernelTestCase', 'bootKernel')) {
+            parent::bootKernel($options);
+            return;
+        }
+
+        static::ensureKernelShutdown();
+
+        static::$kernel = static::createKernel($options);
+        static::$kernel->boot();
+    }
 }

--- a/Tests/Fixtures/App/config/config_form_type_checker.yml
+++ b/Tests/Fixtures/App/config/config_form_type_checker.yml
@@ -1,0 +1,30 @@
+imports:
+    - { resource: config.yml }
+
+# Let's imagine we want to setup valid country codes in parameters.yml
+parameters:
+    country_codes_iso: { FRA: France, USA: "United States", DEU: Germany, ESP: Spain }
+
+# We register the service and inject the codes into it
+services:
+    country_code:
+        class: JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Form\CountryCodeType
+        arguments:
+            - %country_codes_iso%
+
+easy_admin:
+    entities:
+        Customer:
+            class: JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Entity\Customer
+            label: 'Categories'
+            form:
+                fields:
+                    # Simple string
+                    - { property: 'firstName', type: 'string' }
+                    - { property: 'lastName', type: 'string' }
+
+                    # The real class extending AbstractType
+                    - { property: 'address', type: 'JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\AddressType' }
+
+                    # The service to get in the container for this form type
+                    - { property: 'countryCode', type: '@country_code' }

--- a/Tests/Fixtures/AppTestBundle/Controller/AdminController.php
+++ b/Tests/Fixtures/AppTestBundle/Controller/AdminController.php
@@ -12,9 +12,30 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Request;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController as EasyAdminController;
 
+/**
+ * Class AdminController
+ * Many methods are only here to make the method public
+ *   so they can be unit tested
+ */
 class AdminController extends EasyAdminController
 {
+
+    public $entity;
+
+    public function initialize(Request $request)
+    {
+        parent::initialize($request);
+    }
+
+    public function createEntityFormBuilder($entity, array $entityProperties, $view)
+    {
+        return parent::createEntityFormBuilder($entity, $entityProperties, $view);
+    }
+
+    public function findCurrentEntity()
+    {
+        return parent::findCurrentEntity();
+    }
 }

--- a/Tests/Fixtures/AppTestBundle/Entity/Customer.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/Customer.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Class Customer.
+ *
+ * @ORM\Table(name="customer")
+ * @ORM\Entity
+ */
+class Customer
+{
+    /**
+     * @var integer
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id = null;
+
+    /**
+     * @var string
+     * @ORM\Column(name="first_name", type="string")
+     */
+    protected $firstName;
+
+    /**
+     * @var string
+     * @ORM\Column(name="last_name", type="string")
+     */
+    protected $lastName;
+
+    /**
+     * @var string
+     * @ORM\Column(name="address", type="string")
+     */
+    protected $address;
+
+    /**
+     * @var \DateTime
+     * @ORM\Column(name="date_of_birth", type="date")
+     */
+    protected $dateOfBirth;
+
+    /**
+     * @var string
+     * @ORM\Column(name="country_code", type="string", length=3)
+     */
+    protected $countryCode;
+
+    /**
+     * The creation date of the customer.
+     *
+     * @var \DateTime
+     * @ORM\Column(type="datetime", name="created_at")
+     */
+    protected $createdAt = null;
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @param string $firstName
+     *
+     * @return Customer
+     */
+    public function setFirstName($firstName)
+    {
+        $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+    /**
+     * @param string $lastName
+     *
+     * @return Customer
+     */
+    public function setLastName($lastName)
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    /**
+     * @param string $address
+     *
+     * @return Customer
+     */
+    public function setAddress($address)
+    {
+        $this->address = $address;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getDateOfBirth()
+    {
+        return $this->dateOfBirth;
+    }
+
+    /**
+     * @param \DateTime $dateOfBirth
+     *
+     * @return Customer
+     */
+    public function setDateOfBirth($dateOfBirth)
+    {
+        $this->dateOfBirth = $dateOfBirth;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCountryCode()
+    {
+        return $this->countryCode;
+    }
+
+    /**
+     * @param string $countryCode
+     *
+     * @return Customer
+     */
+    public function setCountryCode($countryCode)
+    {
+        $this->countryCode = $countryCode;
+
+        return $this;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param \DateTime $createdAt
+     *
+     * @return Customer
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+}

--- a/Tests/Fixtures/AppTestBundle/Entity/Purchase.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/Purchase.php
@@ -32,7 +32,7 @@ class Purchase
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
-    public $id = null;
+    protected $id = null;
 
     /**
      * The Unique id of the purchase.
@@ -40,7 +40,7 @@ class Purchase
      * @var string
      * @ORM\Column(type="guid")
      */
-    public $guid = null;
+    protected $guid = null;
 
     /**
      * The day of the delivery.
@@ -48,7 +48,7 @@ class Purchase
      * @var \DateTime
      * @ORM\Column(type="date")
      */
-    public $deliverySelected = null;
+    protected $deliverySelected = null;
 
     /**
      * The purchase date in the customer timezone.
@@ -56,7 +56,7 @@ class Purchase
      * @var \DateTime
      * @ORM\Column(type="datetimetz")
      */
-    public $purchaseAt = null;
+    protected $purchaseAt = null;
 
     /**
      * The shipping information.
@@ -64,7 +64,7 @@ class Purchase
      * @var Shipment
      * @ORM\Column(type="object")
      */
-    public $shipping = null;
+    protected $shipping = null;
 
     /**
      * The customer preferred time of the day for the delivery.
@@ -72,7 +72,7 @@ class Purchase
      * @var \DateTime
      * @ORM\Column(type="time")
      */
-    public $preferredDeliveryHour = null;
+    protected $preferredDeliveryHour = null;
 
     /**
      * The customer billing address.
@@ -80,19 +80,19 @@ class Purchase
      * @var array
      * @ORM\Column(type="json_array")
      */
-    public $billingAddress = array();
+    protected $billingAddress = array();
 
     /**
      * Items that have been purchased.
      *
-     * @var OrderItem[]
+     * @var PurchaseItem[]
      * @ORM\ManyToMany(targetEntity="PurchaseItem")
      * @ORM\JoinTable(name="purchase_purchase_item",
      *                  joinColumns={@ORM\JoinColumn(name="purchase_id", referencedColumnName="id")},
      *                  inverseJoinColumns={@ORM\JoinColumn(name="item_id", referencedColumnName="id", unique=true)}
      *                  )
      */
-    public $purchasedItems;
+    protected $purchasedItems;
 
     /**
      * Constructor of the Purchase class.
@@ -162,7 +162,7 @@ class Purchase
     /**
      * Set all items ordered.
      *
-     * @param OrderItem[] $purchasedItems
+     * @param PurchaseItem[] $purchasedItems
      */
     public function setPurchasedItems($purchasedItems)
     {
@@ -172,7 +172,7 @@ class Purchase
     /**
      * Get all ordered items.
      *
-     * @return OrderItem[]
+     * @return PurchaseItem[]
      */
     public function getPurchasedItems()
     {
@@ -237,6 +237,26 @@ class Purchase
     public function getShipping()
     {
         return $this->shipping;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIncrementId()
+    {
+        return $this->incrementId;
+    }
+
+    /**
+     * @param string $incrementId
+     *
+     * @return Purchase
+     */
+    public function setIncrementId($incrementId)
+    {
+        $this->incrementId = $incrementId;
+
+        return $this;
     }
 
     /**

--- a/Tests/Fixtures/AppTestBundle/Form/AddressType.php
+++ b/Tests/Fixtures/AppTestBundle/Form/AddressType.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class AddressType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('address1', 'text')
+            ->add('address2', 'text')
+            ->add('postcode', 'text')
+            ->add('city', 'text')
+        ;
+    }
+}

--- a/Tests/Fixtures/AppTestBundle/Form/CountryCodeType.php
+++ b/Tests/Fixtures/AppTestBundle/Form/CountryCodeType.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class CountryCodeType extends AbstractType
+{
+    /**
+     * @var array
+     */
+    protected $countryCodesISO;
+
+    public function __construct(array $countryCodesISO = array())
+    {
+        $this->countryCodesISO = $countryCodesISO;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('countryCode', 'choice', array('choices' => $this->countryCodesISO))
+        ;
+    }
+
+    /**
+     * Returns the name of this type.
+     *
+     * @return string The name of this type
+     */
+    public function getName()
+    {
+        return 'country_code';
+    }
+}


### PR DESCRIPTION
Before:

![capture d ecran 2015-07-08 a 11 15 13](https://cloud.githubusercontent.com/assets/3369266/8567614/22053c42-2567-11e5-93e4-939d219a0dbd.png)
![capture d ecran 2015-07-08 a 11 16 31](https://cloud.githubusercontent.com/assets/3369266/8567616/24869bbe-2567-11e5-9e86-f43396516774.png)

After:

![capture d ecran 2015-07-08 a 11 15 00](https://cloud.githubusercontent.com/assets/3369266/8567619/2a789dce-2567-11e5-828b-61314292333d.png)
![capture d ecran 2015-07-08 a 11 14 39](https://cloud.githubusercontent.com/assets/3369266/8567622/2f3f8cfa-2567-11e5-87bd-fe72d59af97d.png)

If you set up correct `cascade` options on your entities, it works.

BONUS: I added a new `InvalidConfigurationException` class to futurely manage all configuration errors and show them in the back-end directly. It'll allow us to replace all different exceptions in the controller with this one when they depend on configuration.
