### PR TITLE
Return a FormBuilder instead of a Form object.

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -22,6 +22,7 @@ use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -559,7 +560,7 @@ class AdminController extends Controller
      */
     protected function createEditForm($entity, array $entityProperties)
     {
-        return $this->createEntityForm($entity, $entityProperties, 'edit');
+        return $this->createEntityFormBuilder($entity, $entityProperties, 'edit')->getForm();
     }
 
     /**
@@ -572,7 +573,7 @@ class AdminController extends Controller
      */
     protected function createNewForm($entity, array $entityProperties)
     {
-        return $this->createEntityForm($entity, $entityProperties, 'new');
+        return $this->createEntityFormBuilder($entity, $entityProperties, 'new')->getForm();
     }
 
     /**
@@ -582,9 +583,9 @@ class AdminController extends Controller
      * @param array  $entityProperties
      * @param string $view             The name of the view where this form is used ('new' or 'edit')
      *
-     * @return Form
+     * @return FormBuilder
      */
-    protected function createEntityForm($entity, array $entityProperties, $view)
+    protected function createEntityFormBuilder($entity, array $entityProperties, $view)
     {
         $formCssClass = array_reduce($this->config['design']['form_theme'], function ($previousClass, $formTheme) {
             return sprintf('theme-%s %s', strtolower(str_replace('.html.twig', '', basename($formTheme))), $previousClass);
@@ -617,7 +618,19 @@ class AdminController extends Controller
             $formBuilder->add($name, $metadata['fieldType'], $formFieldOptions);
         }
 
-        return $formBuilder->getForm();
+        return $formBuilder;
+    }
+
+    /**
+     * @see \JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController::createEntityFormBuilder
+     *
+     * @deprecated since 1.6.0
+     */
+    protected function createEntityForm($entity, array $entityProperties, $view)
+    {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.6.0, Please use the "createEntityFormBuilder" method to construct a fully customizable form.', E_USER_DEPRECATED);
+
+        return $this->createEntityFormBuilder($entity, $entityProperties, $view)->getForm();
     }
 
     /**


### PR DESCRIPTION
I wanted to get rid of the old behavior of the `createEntityForm` method.

Actually, to customize some form fields, you have to override this method and copy/paste the whole code of the initial `createEntityForm` method, and add your custom logic between the lines.

With this PR, the `->getForm()` method is only called by the two default `createNewForm` and `createEditForm` so the behavior "outside" this code is unchanged.

This way, you can override the `createEditForm` method and simply do this kind of stuff:

``` php
$formBuilder = $this->createEntityFormBuilder(...);
// Custom logic here
return $formBuilder->getForm();
```

**Note:** I also thought about adding a hack in the `newAction` and `editAction` to automatically execute the `getForm()` method once retrieving a `FormBuilder` instance, but I don't know if it's a good idea yet, I'll wait for feedbacks for this.

Why did I do this? 

Because when executing `->getForm()`, the form is sort of "frozen", or "locked", and even if we can override some parts of the form, we cannot override everything, like datas or other things.

The **best** case for this use is the way to manage `choice` fields. Right now, to setup `choices` inside the field, you are forced to do silly things.
Here's a **basic** (and I could not find a better solution yet for this use) implementation I issued some weeks ago:

``` diff
public function createEntityForm($entity, array $entityProperties, $view)
{
    $formCssClass = array_reduce($this->config['design']['form_theme'], function ($previousClass, $formTheme) {
        return sprintf('theme_%s %s', strtolower(str_replace('.html.twig', '', basename($formTheme))), $previousClass);
    });

    $formBuilder = $this->createFormBuilder($entity, array(
        'data_class' => $this->entity['class'],
        'attr' => array('class' => $formCssClass, 'id' => $view.'-form'),
    ));

    foreach ($entityProperties as $name => $metadata) {
        $formFieldOptions = array();

        if ('association' === $metadata['fieldType'] && in_array($metadata['associationType'], array(ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY))) {
            continue;
        }

        if ('collection' === $metadata['fieldType']) {
            $formFieldOptions = array('allow_add' => true, 'allow_delete' => true);

            if (version_compare(Kernel::VERSION, '2.5.0', '>=')) {
                $formFieldOptions['delete_empty'] = true;
            }
        }

        $formFieldOptions['attr']['field_type'] = $metadata['fieldType'];
        $formFieldOptions['attr']['field_css_class'] = $metadata['class'];
        $formFieldOptions['attr']['field_help'] = $metadata['help'];

+        if ($this->entity['name'] === 'MyEntity' && $name === 'my_field') {
+            $formFieldOptions['custom_option'] = 'value';
+        }


        $formBuilder->add($name, $metadata['fieldType'], $formFieldOptions);

    }

+    if ($this->entity['name'] === 'MyEntity') {
+        $formBuilder->addEventListener(...);
+    }

    return $formBuilder->getForm();
}
```

The "non-diffed" code was a simple copy/paste from the parent method's code.

Now, with the new behavior, the override is much more simpler because you don't have to copy/paste the parent code:

``` php
public function createEntityForm($entity, array $entityProperties, $view)
{
    $form = $this->createEntityFormBuilder($entity, $entityProperties, $view);

    if ($this->entity['name'] === 'MyEntity') {
        $field = $form->get('my_field');
        $options = $field->getOptions();
        $options['custom_options'] = 'value';
        $form->add($field->getName(), $field->getType(), $options);
        $form->addEventListener(...);
    }

    return $form->getForm();
}
```

As known in Symfony, the `$formBuilder->add()` will simply replace the existing field by the "new one" which is simply a merge of the basic one, with some added options.

This is the easiest implementation, and allows better form overridance for users. Unless you want a specific method for each form field, so it's much more work :wink: 

What do you think?
