### PR TITLE
Add support for rendering flash messages in templates

### DIFF
--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -86,6 +86,7 @@
                 <div class="row">
                     <div id="content-header" class="col-sm-12">
                         {% block content_header %}
+                            {{ include('@EasyAdmin/default/notification.html.twig') }}
                             <div class="row">
                                 <div class="col-sm-6">
                                     <h1 class="title">{% block content_title %}{% endblock %}</h1>

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -39,6 +39,7 @@
     <div class="row">
         <div id="content-header" class="col-sm-12">
             {% block content_header %}
+            {{ include('@EasyAdmin/default/notification.html.twig') }}
             <div class="row">
                 <div class="col-xs-12 col-sm-5">
                     <h1 class="title">{{ block('content_title') }}</h1>

--- a/Resources/views/default/notification.html.twig
+++ b/Resources/views/default/notification.html.twig
@@ -1,0 +1,11 @@
+{% block notification %}
+    <div id="notification" class="row">
+        {% for label, flashes in app.session.flashbag.all %}
+            {% for flash in flashes %}
+                <div class="alert alert-{{ label }}">
+                    {{ flash }}
+                </div>
+            {% endfor %}
+        {% endfor %}
+    </div>
+{% endblock notification %}


### PR DESCRIPTION
I have added flash notification in templates. looks like this for me: 
![image](https://cloud.githubusercontent.com/assets/5156054/9155370/7824c744-3ebe-11e5-90c4-e6f1dfd2eef3.png)

in code, I generate them like this:

``` php
class AdminController extends BaseAdminController
{
    public function extendAction()
    {
        $em = $this->getDoctrine()->getManager();
        $repository = $this->getDoctrine()->getRepository("GabiUJobeetBundle:Job");

        $id = $this->request->query->get('id');

        $entity = $repository->find($id);
        $entity->extend();

        $em->persist($entity);
        $em->flush();

        $this->addFlash("success", "Entity updated");

        return $this->redirectToRoute('admin', array(
            "view" => 'edit',
            "entity" => $this->request->query->get('entity')
        ));
    }
}
```
