### PR TITLE
Add Configurator global cache capabilities & provide default APCu cache impl

### DIFF
--- a/CacheWarmer/CacheWarmer.php
+++ b/CacheWarmer/CacheWarmer.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\CacheWarmer;
+
+use Doctrine\Common\Cache\Cache;
+use Doctrine\Common\Cache\ClearableCache;
+use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+class CacheWarmer implements CacheWarmerInterface, CacheClearerInterface
+{
+    /** @var Configurator */
+    private $configurator;
+
+    /** @var Cache */
+    private $cache;
+
+    /**
+     * @param Configurator $configurator
+     * @param Cache        $cache
+     */
+    public function __construct(Configurator $configurator, Cache $cache)
+    {
+        $this->configurator = $configurator;
+        $this->cache = $cache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        $backendConfig = $this->configurator->getBackendConfig();
+        foreach ($backendConfig['entities'] as $name => $config) {
+            $this->configurator->getEntityConfiguration($name);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear($cacheDir)
+    {
+        if ($this->cache instanceof ClearableCache) {
+            $this->cache->deleteAll();
+        }
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,6 +22,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('easy_admin');
 
+        $this->addCacheSection($rootNode);
         $this->addDeprecationsSection($rootNode);
         $this->addGlobalOptionsSection($rootNode);
         $this->addDesignSection($rootNode);
@@ -366,6 +367,19 @@ class Configuration implements ConfigurationInterface
                 ->variableNode('entities')
                     ->defaultValue(array())
                     ->info('The list of entities to manage in the administration zone.')
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addCacheSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->scalarNode('cache')
+                    ->treatNullLike(false)
+                    ->defaultFalse()
+                    ->info('The caching service to use. Set to "easyadmin.configurator.cache.apc" to enable APC caching.')
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -11,10 +11,11 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection;
 
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class EasyAdminExtension extends Extension
 {
@@ -77,6 +78,19 @@ class EasyAdminExtension extends Extension
         // load bundle's services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        // Cache
+        if (isset($backendConfiguration['cache']) && $backendConfiguration['cache']) {
+            $container->setParameter(
+                'easyadmin.configurator.cache.prefix',
+                'easyadmin_' . hash('sha256', $container->getParameter('kernel.root_dir'))
+            );
+            $cacheServiceReference = new Reference($backendConfiguration['cache']);
+            $container->getDefinition('easyadmin.configurator')->replaceArgument(3, $cacheServiceReference);
+            $container->getDefinition('easyadmin.cache_warmer')->replaceArgument(1, $cacheServiceReference);
+        } else {
+            $container->removeDefinition('easyadmin.cache_warmer');
+        }
     }
 
     /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -3,28 +3,49 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-    <services>
+    <parameters>
+        <parameter key="easyadmin.configurator.cache.prefix" />
+    </parameters>
 
+    <services>
+        <!-- Cache -->
+        <service id="easyadmin.configurator.cache.apc" class="Doctrine\Common\Cache\ApcCache" public="false">
+            <call method="setNamespace">
+                <argument>%easyadmin.configurator.cache.prefix%</argument>
+            </call>
+        </service>
+
+        <service id="easyadmin.cache_warmer" class="JavierEguiluz\Bundle\EasyAdminBundle\CacheWarmer\CacheWarmer" public="false">
+            <argument type="service" id="easyadmin.configurator" />
+            <argument type="service" on-invalid="null"/> <!--cache service -->
+            <tag name="kernel.cache_clearer" />
+            <tag name="kernel.cache_warmer" />
+        </service>
+
+        <!-- Twig -->
         <service id="easyadmin.twig.extension" class="JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension" public="false">
-            <argument type="service" id="easyadmin.configurator"></argument>
+            <argument type="service" id="easyadmin.configurator" />
             <argument>%kernel.debug%</argument>
             <tag name="twig.extension" />
         </service>
 
+        <!-- Configurator -->
         <service id="easyadmin.configurator" class="JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator">
             <argument>%easyadmin.config%</argument>
-            <argument type="service" id="easyadmin.metadata_inspector"></argument>
-            <argument type="service" id="easyadmin.property_reflector"></argument>
+            <argument type="service" id="easyadmin.metadata_inspector" />
+            <argument type="service" id="easyadmin.property_reflector" />
+            <argument type="service" on-invalid="null"/> <!--cache service -->
         </service>
 
         <service id="easyadmin.metadata_inspector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\EntityMetadataInspector" public="false">
-            <argument type="service" id="doctrine"></argument>
+            <argument type="service" id="doctrine" />
         </service>
 
-        <service id="easyadmin.property_reflector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\ClassPropertyReflector" public="false"></service>
+        <service id="easyadmin.property_reflector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\ClassPropertyReflector" public="false" />
 
+        <!-- Exception listener -->
         <service id="easyadmin.listener.exception" class="JavierEguiluz\Bundle\EasyAdminBundle\Listener\ExceptionListener">
-            <argument type="service" id="templating"></argument>
+            <argument type="service" id="templating" />
             <argument>%kernel.debug%</argument>
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,7 +17,7 @@
 
         <service id="easyadmin.cache_warmer" class="JavierEguiluz\Bundle\EasyAdminBundle\CacheWarmer\CacheWarmer" public="false">
             <argument type="service" id="easyadmin.configurator" />
-            <argument type="service" on-invalid="null"/> <!--cache service -->
+            <argument>null</argument> <!--cache service -->
             <tag name="kernel.cache_clearer" />
             <tag name="kernel.cache_warmer" />
         </service>
@@ -34,7 +34,7 @@
             <argument>%easyadmin.config%</argument>
             <argument type="service" id="easyadmin.metadata_inspector" />
             <argument type="service" id="easyadmin.property_reflector" />
-            <argument type="service" on-invalid="null"/> <!--cache service -->
+            <argument>null</argument> <!--cache service -->
         </service>
 
         <service id="easyadmin.metadata_inspector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\EntityMetadataInspector" public="false">

--- a/Resources/doc/tutorials/tips-and-tricks.md
+++ b/Resources/doc/tutorials/tips-and-tricks.md
@@ -58,6 +58,16 @@ your Doctrine entities.
 This simple metadata cache configuration can improve your backend performance
 between 20% and 30% depending on the complexity and number of your entities.
 
+EasyAdmin also computes data regarding to your configuration, but this process is done only once per request.
+However, you can enable easyadmin cache in order to compute this only once in production:
+```yaml
+# app/config/config_prod.yml
+easy_admin:
+    cache: easyadmin.configurator.cache.apc # EasyAdmin provided cache implementation
+```
+EasyAdmin provides a base implementation of an APCu cache. But you can provide your own, based on the [`doctrine/cache`
+package](https://github.com/doctrine/cache).
+
 Use a Custom Dashboard as the Index Page of the Backend
 -------------------------------------------------------
 

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
@@ -354,6 +354,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_006.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_006.yml
@@ -8,6 +8,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_011.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_011.yml
@@ -8,6 +8,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_015.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_015.yml
@@ -8,6 +8,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_029.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_029.yml
@@ -8,6 +8,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
@@ -128,6 +128,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
@@ -128,6 +128,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
@@ -128,6 +128,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
@@ -132,6 +132,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
@@ -136,6 +136,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
@@ -139,6 +139,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
@@ -139,6 +139,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
@@ -139,6 +139,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
@@ -144,6 +144,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
@@ -129,6 +129,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
@@ -130,6 +130,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
@@ -130,6 +130,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_044.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_044.yml
@@ -8,6 +8,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
@@ -122,6 +122,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
@@ -121,6 +121,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
@@ -121,6 +121,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
@@ -127,6 +127,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
@@ -108,6 +108,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
@@ -122,6 +122,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
@@ -117,6 +117,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
@@ -127,6 +127,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
@@ -123,6 +123,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
@@ -122,6 +122,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
@@ -122,6 +122,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
@@ -128,6 +128,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
@@ -119,6 +119,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
@@ -102,6 +102,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
@@ -123,6 +123,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
@@ -113,6 +113,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
@@ -157,6 +157,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
@@ -161,6 +161,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
@@ -137,6 +137,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
@@ -181,6 +181,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
@@ -164,6 +164,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
@@ -132,6 +132,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_067.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_067.yml
@@ -13,6 +13,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     disabled_actions: {  }
     list:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
@@ -118,6 +118,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
@@ -118,6 +118,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
@@ -118,6 +118,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
@@ -119,6 +119,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
@@ -137,6 +137,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
@@ -121,6 +121,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
@@ -139,6 +139,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
@@ -138,6 +138,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
@@ -161,6 +161,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
@@ -140,6 +140,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
@@ -163,6 +163,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
@@ -153,6 +153,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
@@ -301,6 +301,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
@@ -268,6 +268,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
@@ -125,6 +125,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
@@ -124,6 +124,7 @@ easy_admin:
                 label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
                 label_null: '@EasyAdmin/default/label_null.html.twig'
                 label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
@@ -131,6 +131,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_103.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_103.yml
@@ -131,6 +131,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
@@ -154,6 +154,7 @@ easy_admin:
                 label_inaccessible: custom_template/label_inaccessible.html.twig
                 label_null: custom_template/label_null.html.twig
                 label_undefined: custom_template/label_undefined.html.twig
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_105.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_105.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_106.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_106.yml
@@ -154,6 +154,7 @@ easy_admin:
                         class: ''
                         icon: edit
             disabled_actions: {  }
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_107.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_107.yml
@@ -130,6 +130,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_108.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_108.yml
@@ -10,6 +10,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_109.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_109.yml
@@ -127,6 +127,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_110.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_110.yml
@@ -125,6 +125,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_111.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_111.yml
@@ -127,6 +127,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_112.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_112.yml
@@ -128,6 +128,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_001.yml
@@ -8,6 +8,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_002.yml
@@ -8,6 +8,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_003.yml
@@ -11,6 +11,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_004.yml
@@ -16,6 +16,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_005.yml
@@ -11,6 +11,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_006.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_006.yml
@@ -16,6 +16,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_007.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_007.yml
@@ -16,6 +16,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_008.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_008.yml
@@ -12,6 +12,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_009.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_009.yml
@@ -12,6 +12,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_010.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_010.yml
@@ -16,6 +16,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_011.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_011.yml
@@ -12,6 +12,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/deprecations/output/config_012.yml
+++ b/Tests/DependencyInjection/fixtures/deprecations/output/config_012.yml
@@ -12,6 +12,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_001.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_002.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_003.yml
@@ -154,6 +154,7 @@ easy_admin:
                 label_inaccessible: custom_template/label_inaccessible.html.twig
                 label_null: custom_template/label_null.html.twig
                 label_undefined: custom_template/label_undefined.html.twig
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_004.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_005.yml
@@ -11,6 +11,7 @@ easy_admin:
         assets:
             css: {  }
             js: {  }
+    cache: false
     entities:
         TestEntity:
             class: AppBundle\Entity\TestEntity

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_001.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_002.yml
@@ -124,6 +124,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_003.yml
@@ -154,6 +154,7 @@ easy_admin:
                 label_inaccessible: custom_template/label_inaccessible.html.twig
                 label_null: custom_template/label_null.html.twig
                 label_undefined: custom_template/label_undefined.html.twig
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_004.yml
@@ -239,6 +239,7 @@ easy_admin:
         brand_color: '#E67E22'
         form_theme:
             - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+    cache: false
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_005.yml
@@ -13,6 +13,7 @@ easy_admin:
         assets:
             css: {  }
             js: {  }
+    cache: false
     entities:
         TestEntity:
             class: AppBundle\Entity\TestEntity

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,10 @@
     },
     "require-dev": {
         "phpunit/phpunit"                   : "~4.4",
-        "doctrine/doctrine-fixtures-bundle" : "~2.2"
+        "doctrine/doctrine-fixtures-bundle" : "~2.2",
+        "doctrine/cache"                    : "~1.4"
     },
     "autoload": {
         "psr-4": { "JavierEguiluz\\Bundle\\EasyAdminBundle\\": "" }
     }
 }
-


### PR DESCRIPTION
Related to discussion in #413 

``` yaml
# app/config/config_prod.yml
easy_admin:
    cache: easyadmin.configurator.cache.apc

```

EasyAdmin demo:
<img width="1298" alt="screenshot 2015-08-23 a 14 47 17" src="https://cloud.githubusercontent.com/assets/2211145/9428241/180a0296-49a6-11e5-9b7d-f1607e46968a.PNG">

As you can see, it has no real gain for now at the request level :/

But when the easy admin cache is enabled, the first call to `getEntityConfiguration` per request will be almost instant (`CacheProvider::fetch`) 
vs. no cache: the `EntityMetadataInspector::getEntityMetadata` method is called and takes +22ms (Doctrine cache was enabled, this is only the call to the service and first metadata retrieval per request).

However, as the implementation is quite straightforward, and as it may have more impact on a bigger app with much more entities, it might make sense.

**Note**: The cache clearer is for other cache implementations, as it will not have any effect for `ApcCache` and `XcacheCache` ones (shared with the webserver and not accessible from cli).
