### PR TITLE
German remove item translation

### DIFF
--- a/Resources/translations/EasyAdminBundle.de.xlf
+++ b/Resources/translations/EasyAdminBundle.de.xlf
@@ -143,6 +143,10 @@
                 <source>action.add_another_item</source>
                 <target>Ein weiteres Element hinzufügen</target>
             </trans-unit>
+            <trans-unit id="action.remove_item">
+                <source>action.remove_item</source>
+                <target>Element entfernen</target>
+            </trans-unit>
             <trans-unit id="errors">
                 <source>errors</source>
                 <target>Fehler</target>


### PR DESCRIPTION
Adds the German translation for the `action.remove_item` key added in #451.
