### PR TITLE
Fixed Symfony version comparison

### DIFF
--- a/Tests/DependencyInjection/EasyAdminExtensionTest.php
+++ b/Tests/DependencyInjection/EasyAdminExtensionTest.php
@@ -38,7 +38,7 @@ class EasyAdminExtensionTest extends CommonPhpUnitTestCase
      */
     public function testBackendConfigurations($inputFixtureFilepath, $outputFixtureFilepath)
     {
-        if ('2' === Kernel::MAJOR_VERSION && '3' === Kernel::MINOR_VERSION && !$this->isTestCompatibleWithYamlComponent($inputFixtureFilepath)) {
+        if (2 === Kernel::MAJOR_VERSION && 3 === Kernel::MINOR_VERSION && !$this->isTestCompatibleWithYamlComponent($inputFixtureFilepath)) {
             $this->markTestSkipped('The YAML component does not ignore duplicate keys in Symfony 2.3.');
         }
 

--- a/Tests/DependencyInjection/EasyAdminExtensionTest.php
+++ b/Tests/DependencyInjection/EasyAdminExtensionTest.php
@@ -38,7 +38,7 @@ class EasyAdminExtensionTest extends CommonPhpUnitTestCase
      */
     public function testBackendConfigurations($inputFixtureFilepath, $outputFixtureFilepath)
     {
-        $isSymfony23 = '2' === Kernel::MAJOR_VERSION && '3' === Kernel::MINOR_VERSION;
+        $isSymfony23 = 2 == Kernel::MAJOR_VERSION && 3 == Kernel::MINOR_VERSION;
         if ($isSymfony23 && !$this->isTestCompatibleWithSymfony23($inputFixtureFilepath)) {
             $this->markTestSkipped('This test is not compatible with Symfony 2.3 because the YAML component of that version does not ignore duplicate keys.');
         }

--- a/Tests/DependencyInjection/EasyAdminExtensionTest.php
+++ b/Tests/DependencyInjection/EasyAdminExtensionTest.php
@@ -38,8 +38,9 @@ class EasyAdminExtensionTest extends CommonPhpUnitTestCase
      */
     public function testBackendConfigurations($inputFixtureFilepath, $outputFixtureFilepath)
     {
-        if (2 === Kernel::MAJOR_VERSION && 3 === Kernel::MINOR_VERSION && !$this->isTestCompatibleWithYamlComponent($inputFixtureFilepath)) {
-            $this->markTestSkipped('The YAML component does not ignore duplicate keys in Symfony 2.3.');
+        $isSymfony23 = '2' === Kernel::MAJOR_VERSION && '3' === Kernel::MINOR_VERSION;
+        if ($isSymfony23 && !$this->isTestCompatibleWithSymfony23($inputFixtureFilepath)) {
+            $this->markTestSkipped('This test is not compatible with Symfony 2.3 because the YAML component of that version does not ignore duplicate keys.');
         }
 
         $this->parseConfigurationFile($inputFixtureFilepath);
@@ -245,7 +246,7 @@ class EasyAdminExtensionTest extends CommonPhpUnitTestCase
         $this->assertEquals($expectedConfiguration['easy_admin'], $actualConfiguration);
     }
 
-    private function isTestCompatibleWithYamlComponent($filepath)
+    private function isTestCompatibleWithSymfony23($filepath)
     {
         $incompatibleTests = array(
             'configurations/input/admin_007.yml',


### PR DESCRIPTION
Because of the behaviour of the YAML component in Symfony 2.3, some tests must be skipped for that version. Previously, Symfony defined its version numbers using strings but they very recently switched to integers ([see commit](https://github.com/symfony/symfony/commit/4b45bb91abac20cc05d325c9a2c6a34145be4276)). Although this is probably a BC break in Symfony 2.3, the fix is very easy for us.
