### PR TITLE
Fixed the way we handle translation domains

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,7 +7,6 @@
 
         <service id="easyadmin.twig.extension" class="JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension" public="false">
             <argument type="service" id="easyadmin.configurator"></argument>
-            <argument type="service" id="translator"></argument>
             <argument>%kernel.debug%</argument>
             <tag name="twig.extension" />
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,6 +7,7 @@
 
         <service id="easyadmin.twig.extension" class="JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension" public="false">
             <argument type="service" id="easyadmin.configurator"></argument>
+            <argument type="service" id="translator"></argument>
             <argument>%kernel.debug%</argument>
             <tag name="twig.extension" />
         </service>

--- a/Resources/translations/EasyAdminBundle.bg.xlf
+++ b/Resources/translations/EasyAdminBundle.bg.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="bg" datatype="plaintext" original="EasyAdminBundle.en.xliff">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Добавяне на %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Преглед</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Редактиране</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Търсене</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Изтриване</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Запис</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Отказ</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Обратно към списъка</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.ca.xlf
+++ b/Resources/translations/EasyAdminBundle.ca.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="ca" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Crear %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Veure</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Modificar</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Buscar</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Borrar</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Guardar canvis</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Cancel·lar</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Tornar al llistat</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.cs.xlf
+++ b/Resources/translations/EasyAdminBundle.cs.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="cs" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Vytvořit %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Zobrazit</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Editace</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Hledat</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Smazat</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Uložit změny</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Zrušit</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Zpět na výpis</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.de.xlf
+++ b/Resources/translations/EasyAdminBundle.de.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>%entity_name% erstellen</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Anzeigen</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Ändern</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Suchen</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Löschen</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Änderungen speichern</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Abbrechen</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Zurück zur Übersicht</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.en.xlf
+++ b/Resources/translations/EasyAdminBundle.en.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Add %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Show</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Edit</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Search</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Delete</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Save changes</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Cancel</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Back to listing</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.es.xlf
+++ b/Resources/translations/EasyAdminBundle.es.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Crear %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Ver</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Modificar</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Buscar</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Borrar</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Guardar cambios</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Cancelar</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Volver al listado</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.eu.xlf
+++ b/Resources/translations/EasyAdminBundle.eu.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="eu" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>%entity_name%-a sortu</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Ikusi</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Aldatu</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Bilatu</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Ezabatu</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Aldaketak gorde</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Ezeztatu</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Zerrendara itzuli</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/Resources/translations/EasyAdminBundle.fr.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Créer %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Voir</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Éditer</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Rechercher</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Supprimer</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Sauvegarder les modifications</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Annuler</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Retour à la liste</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.it.xlf
+++ b/Resources/translations/EasyAdminBundle.it.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Crea %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Vedi</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Modifica</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Cerca</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Elimina</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Salva modifiche</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Annulla</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Torna alla lista</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.nl.xlf
+++ b/Resources/translations/EasyAdminBundle.nl.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Nieuw %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Bekijk</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Bewerken</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Zoeken</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Verwijderen</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Opslaan</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Annuleren</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Terug naar overzicht</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.pl.xlf
+++ b/Resources/translations/EasyAdminBundle.pl.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="pl" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Dodaj %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Pokaż</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Edytuj</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Szukaj</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Usuń</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Zapisz zmiany</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Anuluj</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Wróć do listy</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.pt.xlf
+++ b/Resources/translations/EasyAdminBundle.pt.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="pt" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Adicionar %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Exibir</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Editar</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Pesquisar</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Excluir</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Salvar mudanças</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Cancelar</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Voltar para a lista</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.ru.xlf
+++ b/Resources/translations/EasyAdminBundle.ru.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="ru" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Создать %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Показать</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Редактировать</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Поиск</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Удалить</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Сохранить изменения</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Отклонить</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Вернуться к списку</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.sl.xlf
+++ b/Resources/translations/EasyAdminBundle.sl.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="sl" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Novo %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Prikažite</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Urejanje</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Iskanje</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Izbrišite</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Shranite spremembe</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Prekličite</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Nazaj na poslušanje</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/EasyAdminBundle.sv.xlf
+++ b/Resources/translations/EasyAdminBundle.sv.xlf
@@ -2,40 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
     <file source-language="en" target-language="sv" datatype="plaintext" original="file.ext">
         <body>
-            <!-- generic actions displayed on buttons and links -->
-            <trans-unit id="action.new">
-                <source>action.new</source>
-                <target>Skapa %entity_name%</target>
-            </trans-unit>
-            <trans-unit id="action.show">
-                <source>action.show</source>
-                <target>Visa</target>
-            </trans-unit>
-            <trans-unit id="action.edit">
-                <source>action.edit</source>
-                <target>Redigera</target>
-            </trans-unit>
-            <trans-unit id="action.search">
-                <source>action.search</source>
-                <target>Sök</target>
-            </trans-unit>
-            <trans-unit id="action.delete">
-                <source>action.delete</source>
-                <target>Ta bort</target>
-            </trans-unit>
-            <trans-unit id="action.save">
-                <source>action.save</source>
-                <target>Spara ändringar</target>
-            </trans-unit>
-            <trans-unit id="action.cancel">
-                <source>action.cancel</source>
-                <target>Avbryt</target>
-            </trans-unit>
-            <trans-unit id="action.list">
-                <source>action.list</source>
-                <target>Åter till lista</target>
-            </trans-unit>
-
             <!-- page titles -->
             <trans-unit id="new.page_title">
                 <source>new.page_title</source>

--- a/Resources/translations/messages.bg.xlf
+++ b/Resources/translations/messages.bg.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="bg" datatype="plaintext" original="EasyAdminBundle.en.xliff">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Добавяне на %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Преглед</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Редактиране</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Търсене</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Изтриване</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Запис</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Отказ</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Обратно към списъка</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.ca.xlf
+++ b/Resources/translations/messages.ca.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ca" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Crear %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Veure</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Modificar</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Buscar</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Borrar</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Guardar canvis</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Cancel·lar</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Tornar al llistat</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.cs.xlf
+++ b/Resources/translations/messages.cs.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="cs" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Vytvořit %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Zobrazit</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Editace</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Hledat</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Smazat</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Uložit změny</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Zrušit</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Zpět na výpis</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.de.xlf
+++ b/Resources/translations/messages.de.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>%entity_name% erstellen</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Anzeigen</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Ändern</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Suchen</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Löschen</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Änderungen speichern</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Abbrechen</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Zurück zur Übersicht</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Add %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Show</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Edit</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Search</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Delete</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Save changes</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Cancel</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Back to listing</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.es.xlf
+++ b/Resources/translations/messages.es.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="es" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Crear %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Ver</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Modificar</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Buscar</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Borrar</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Guardar cambios</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Cancelar</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Volver al listado</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.eu.xlf
+++ b/Resources/translations/messages.eu.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="eu" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>%entity_name%-a sortu</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Ikusi</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Aldatu</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Bilatu</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Ezabatu</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Aldaketak gorde</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Ezeztatu</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Zerrendara itzuli</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.fr.xlf
+++ b/Resources/translations/messages.fr.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="fr" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Créer %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Voir</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Éditer</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Rechercher</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Supprimer</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Sauvegarder les modifications</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Annuler</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Retour à la liste</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.it.xlf
+++ b/Resources/translations/messages.it.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="it" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Crea %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Vedi</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Modifica</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Cerca</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Elimina</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Salva modifiche</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Annulla</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Torna alla lista</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.nl.xlf
+++ b/Resources/translations/messages.nl.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="nl" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Nieuw %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Bekijk</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Bewerken</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Zoeken</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Verwijderen</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Opslaan</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Annuleren</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Terug naar overzicht</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.pl.xlf
+++ b/Resources/translations/messages.pl.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pl" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Dodaj %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Pokaż</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Edytuj</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Szukaj</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Usuń</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Zapisz zmiany</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Anuluj</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Wróć do listy</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.pt.xlf
+++ b/Resources/translations/messages.pt.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="pt" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Adicionar %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Exibir</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Editar</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Pesquisar</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Excluir</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Salvar mudanças</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Cancelar</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Voltar para a lista</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.ru.xlf
+++ b/Resources/translations/messages.ru.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="ru" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Создать %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Показать</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Редактировать</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Поиск</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Удалить</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Сохранить изменения</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Отклонить</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Вернуться к списку</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.sl.xlf
+++ b/Resources/translations/messages.sl.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sl" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Novo %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Prikažite</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Urejanje</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Iskanje</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Izbrišite</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Shranite spremembe</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Prekličite</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Nazaj na poslušanje</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/translations/messages.sv.xlf
+++ b/Resources/translations/messages.sv.xlf
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+    <file source-language="en" target-language="sv" datatype="plaintext" original="file.ext">
+        <body>
+            <!-- generic actions displayed on buttons and links -->
+            <trans-unit id="action.new">
+                <source>action.new</source>
+                <target>Skapa %entity_name%</target>
+            </trans-unit>
+            <trans-unit id="action.show">
+                <source>action.show</source>
+                <target>Visa</target>
+            </trans-unit>
+            <trans-unit id="action.edit">
+                <source>action.edit</source>
+                <target>Redigera</target>
+            </trans-unit>
+            <trans-unit id="action.search">
+                <source>action.search</source>
+                <target>Sök</target>
+            </trans-unit>
+            <trans-unit id="action.delete">
+                <source>action.delete</source>
+                <target>Ta bort</target>
+            </trans-unit>
+            <trans-unit id="action.save">
+                <source>action.save</source>
+                <target>Spara ändringar</target>
+            </trans-unit>
+            <trans-unit id="action.cancel">
+                <source>action.cancel</source>
+                <target>Avbryt</target>
+            </trans-unit>
+            <trans-unit id="action.list">
+                <source>action.list</source>
+                <target>Åter till lista</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -44,8 +44,7 @@
                             {% set _delete_action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                                {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                                {{ _delete_action.label|default(_default_action_label)|trans(_trans_parameters) }}
+                                {{ _delete_action.label|default('action.delete')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -1,4 +1,3 @@
-{% trans_default_domain "EasyAdminBundle" %}
 {% form_theme form with easyadmin_config('design.form_theme') %}
 
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
@@ -11,7 +10,8 @@
 {% block body_class 'edit edit-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity_config.edit.title|default('edit.page_title')|trans(_trans_parameters) }}
+    {% set _default_page_title = 'edit.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+    {{ _entity_config.edit.title|default(_default_page_title) }}
 {% endblock %}
 
 {% block main %}
@@ -32,19 +32,20 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-body">
-                        <h4>{{ 'delete_modal.title'|trans(_trans_parameters) }}</h4>
-                        <p>{{ 'delete_modal.content'|trans(_trans_parameters) }}</p>
+                        <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
+                        <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" data-dismiss="modal" class="btn">
-                            {{ 'action.cancel'|trans(_trans_parameters) }}
+                            {{ 'action.cancel'|trans(_trans_parameters, 'EasyAdminBundle') }}
                         </button>
 
                         {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity_config.name) %}
                             {% set _delete_action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                                {{ _delete_action.label|default('action.delete')|trans(_trans_parameters) }}
+                                {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
+                                {{ _delete_action.label|default(_default_action_label) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -10,8 +10,7 @@
 {% block body_class 'edit edit-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {% set _default_page_title = 'edit.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.edit.title|default(_default_page_title)|trans(_trans_parameters) }}
+    {{ _entity_config.edit.title|default('edit.page_title')|easyadmin_trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
@@ -32,19 +31,19 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-body">
-                        <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
-                        <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
+                        <h4>{{ 'delete_modal.title'|easyadmin_trans(_trans_parameters) }}</h4>
+                        <p>{{ 'delete_modal.content'|easyadmin_trans(_trans_parameters) }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" data-dismiss="modal" class="btn">
-                            {{ 'action.cancel'|trans(_trans_parameters, 'EasyAdminBundle') }}
+                            {{ 'action.cancel'|easyadmin_trans(_trans_parameters) }}
                         </button>
 
                         {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity_config.name) %}
                             {% set _delete_action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                                {{ _delete_action.label|default('action.delete')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
+                                {{ _delete_action.label|default('action.delete')|easyadmin_trans(_trans_parameters) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -10,7 +10,8 @@
 {% block body_class 'edit edit-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity_config.edit.title|default('edit.page_title')|easyadmin_trans(_trans_parameters) }}
+    {% set _default_title = 'edit.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+    {{ _entity_config.edit.title|default(_default_title)|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
@@ -31,19 +32,19 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-body">
-                        <h4>{{ 'delete_modal.title'|easyadmin_trans(_trans_parameters) }}</h4>
-                        <p>{{ 'delete_modal.content'|easyadmin_trans(_trans_parameters) }}</p>
+                        <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
+                        <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" data-dismiss="modal" class="btn">
-                            {{ 'action.cancel'|easyadmin_trans(_trans_parameters) }}
+                            {{ 'action.cancel'|trans(_trans_parameters) }}
                         </button>
 
                         {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity_config.name) %}
                             {% set _delete_action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                                {{ _delete_action.label|default('action.delete')|easyadmin_trans(_trans_parameters) }}
+                                {{ _delete_action.label|default('action.delete')|trans(_trans_parameters) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -11,7 +11,7 @@
 
 {% block content_title %}
     {% set _default_page_title = 'edit.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.edit.title|default(_default_page_title) }}
+    {{ _entity_config.edit.title|default(_default_page_title)|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
@@ -45,7 +45,7 @@
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
                                 {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                                {{ _delete_action.label|default(_default_action_label) }}
+                                {{ _delete_action.label|default(_default_action_label)|trans(_trans_parameters) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/field_boolean.html.twig
+++ b/Resources/views/default/field_boolean.html.twig
@@ -1,4 +1,4 @@
-{% trans_default_domain "EasyAdminBundle" %}
+{% trans_default_domain 'EasyAdminBundle' %}
 
 {% if value == true %}
     <span class="label label-success">{{ 'label.true'|trans }}</span>

--- a/Resources/views/default/field_toggle.html.twig
+++ b/Resources/views/default/field_toggle.html.twig
@@ -1,4 +1,4 @@
-{% trans_default_domain "EasyAdminBundle" %}
+{% trans_default_domain 'EasyAdminBundle' %}
 
 {% if view == 'show' %}
     {% if value == true %}

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -36,7 +36,7 @@
                     <div class="form-group field-collection-action">
                         <a href="#" onclick="{{ add_item_javascript|raw }}" class="col-sm-12 text-right">
                             <i class="fa fa-plus-square"></i>
-                            {{ field|length == 0 ? 'action.add_new_item'|trans(domain = 'EasyAdminBundle') : 'action.add_another_item'|trans(domain = 'EasyAdminBundle') }}
+                            {{ (field|length == 0 ? 'action.add_new_item' : 'action.add_another_item')|trans }}
                         </a>
                     </div>
                 {% endif %}
@@ -48,7 +48,7 @@
             {% block item_actions %}
                 {# the 'save' action is hardcoded for the 'edit' and 'new' views #}
                 <button type="submit" class="btn">
-                    <i class="fa fa-save"></i> {{ 'action.save'|trans(_trans_parameters, 'EasyAdminBundle') }}
+                    <i class="fa fa-save"></i> {{ 'action.save'|trans(_trans_parameters) }}
                 </button>
 
                 {% set _entity_actions = (view == 'new')
@@ -64,7 +64,7 @@
 
                     <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|easyadmin_trans(_trans_parameters) }}
+                        {{ _action.label|trans(_trans_parameters) }}
                     </a>
                 {% endfor %}
 
@@ -73,7 +73,7 @@
                         {% set _action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                         <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                             {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                            {{ _action.label|default('action.delete')|easyadmin_trans(_trans_parameters) }}
+                            {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
                         </button>
                     {% endif %}
                 {% endif %}
@@ -88,7 +88,7 @@
                 {% if _list_action is defined %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
                         {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
-                        {{ _list_action.label|default('action.list')|easyadmin_trans(_trans_parameters) }}
+                        {{ _list_action.label|default('action.list')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -73,8 +73,7 @@
                         {% set _action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                         <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                             {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                            {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                            {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
+                            {{ _action.label|default('action.delete')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
                         </button>
                     {% endif %}
                 {% endif %}
@@ -89,8 +88,7 @@
                 {% if _list_action is defined %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
                         {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
-                        {% set _default_action_label = 'action.list'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                        {{ _list_action.label|default(_default_action_label)|trans(_trans_parameters) }}
+                        {{ _list_action.label|default('action.list')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -1,5 +1,3 @@
-{% trans_default_domain "EasyAdminBundle" %}
-
 {{ form_start(form, { attr: form.vars.attr|merge({ novalidate: 'novalidate' }) }) }}
     {% if form.vars.errors|length > 0 %}
         {{ form_errors(form) }}
@@ -38,7 +36,7 @@
                     <div class="form-group field-collection-action">
                         <a href="#" onclick="{{ add_item_javascript|raw }}" class="col-sm-12 text-right">
                             <i class="fa fa-plus-square"></i>
-                            {{ field|length == 0 ? 'action.add_new_item'|trans : 'action.add_another_item'|trans }}
+                            {{ field|length == 0 ? 'action.add_new_item'|trans(domain = 'EasyAdminBundle') : 'action.add_another_item'|trans(domain = 'EasyAdminBundle') }}
                         </a>
                     </div>
                 {% endif %}
@@ -50,7 +48,7 @@
             {% block item_actions %}
                 {# the 'save' action is hardcoded for the 'edit' and 'new' views #}
                 <button type="submit" class="btn">
-                    <i class="fa fa-save"></i> {{ 'action.save'|trans(_trans_parameters) }}
+                    <i class="fa fa-save"></i> {{ 'action.save'|trans(_trans_parameters, 'EasyAdminBundle') }}
                 </button>
 
                 {% set _entity_actions = (view == 'new')
@@ -66,7 +64,7 @@
 
                     <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|trans(_trans_parameters) }}
+                        {{ _action.label|trans(_trans_parameters, 'EasyAdminBundle') }}
                     </a>
                 {% endfor %}
 
@@ -75,7 +73,8 @@
                         {% set _action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                         <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                             {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                            {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
+                            {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
+                            {{ _action.label|default(_default_action_label) }}
                         </button>
                     {% endif %}
                 {% endif %}
@@ -90,7 +89,8 @@
                 {% if _list_action is defined %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
                         {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
-                        {{ _list_action.label|default('action.list')|trans(_trans_parameters) }}
+                        {% set _default_action_label = 'action.list'|trans(_trans_parameters, 'EasyAdminBundle') %}
+                        {{ _list_action.label|default(_default_action_label) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -64,7 +64,7 @@
 
                     <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|trans(_trans_parameters, 'EasyAdminBundle') }}
+                        {{ _action.label|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
                     </a>
                 {% endfor %}
 
@@ -74,7 +74,7 @@
                         <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                             {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                             {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                            {{ _action.label|default(_default_action_label) }}
+                            {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
                         </button>
                     {% endif %}
                 {% endif %}
@@ -90,7 +90,7 @@
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
                         {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
                         {% set _default_action_label = 'action.list'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                        {{ _list_action.label|default(_default_action_label) }}
+                        {{ _list_action.label|default(_default_action_label)|trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -64,7 +64,7 @@
 
                     <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
+                        {{ _action.label|easyadmin_trans(_trans_parameters) }}
                     </a>
                 {% endfor %}
 
@@ -73,7 +73,7 @@
                         {% set _action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                         <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                             {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                            {{ _action.label|default('action.delete')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
+                            {{ _action.label|default('action.delete')|easyadmin_trans(_trans_parameters) }}
                         </button>
                     {% endif %}
                 {% endif %}
@@ -88,7 +88,7 @@
                 {% if _list_action is defined %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _list_action.name, view: view }) ) }}">{% spaceless %}
                         {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
-                        {{ _list_action.label|default('action.list')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
+                        {{ _list_action.label|default('action.list')|easyadmin_trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}

--- a/Resources/views/default/label_empty.html.twig
+++ b/Resources/views/default/label_empty.html.twig
@@ -1,3 +1,1 @@
-{% trans_default_domain "EasyAdminBundle" %}
-
-<span class="label label-empty">{{ 'label.empty'|trans }}</span>
+<span class="label label-empty">{{ 'label.empty'|trans(domain = 'EasyAdminBundle') }}</span>

--- a/Resources/views/default/label_inaccessible.html.twig
+++ b/Resources/views/default/label_inaccessible.html.twig
@@ -1,4 +1,4 @@
-{% trans_default_domain "EasyAdminBundle" %}
+{% trans_default_domain 'EasyAdminBundle' %}
 
 <span class="label label-danger" title="{{ 'label.inaccessible.explanation'|trans }}">
     {{ 'label.inaccessible'|trans }}

--- a/Resources/views/default/label_null.html.twig
+++ b/Resources/views/default/label_null.html.twig
@@ -1,3 +1,1 @@
-{% trans_default_domain "EasyAdminBundle" %}
-
-<span class="label">{{ 'label.null'|trans }}</span>
+<span class="label">{{ 'label.null'|trans(domain = 'EasyAdminBundle') }}</span>

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -1,4 +1,3 @@
-{% trans_default_domain "EasyAdminBundle" %}
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -70,7 +69,7 @@
                         {% if app.user %}
                             <div id="header-security">
                                 <p>
-                                    <small><i class="fa fa-lock"></i> <span>{{ 'header.logged_in_as'|trans }}</span></small>
+                                    <small><i class="fa fa-lock"></i> <span>{{ 'header.logged_in_as'|trans(domain = 'EasyAdminBundle') }}</span></small>
                                     {{ app.user.username|default('Unnamed User') }}
                                 </p>
                             </div>

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -15,8 +15,7 @@
     {% if 'search' == app.request.get('action') %}
         {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
     {% else %}
-        {% set _default_page_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-        {{ _entity_config.list.title|default(_default_page_title)|trans(_trans_parameters) }}
+        {{ _entity_config.list.title|default('list.page_title')|easyadmin_trans(_trans_parameters) }}
     {% endif %}
 {% endblock %}
 
@@ -52,7 +51,7 @@
                             <div id="content-actions">
                                 <a class="btn {{ _action.css_class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                    {{ _action.label|default('action.new')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
+                                    {{ _action.label|default('action.new')|easyadmin_trans(_trans_parameters) }}
                                 </a>
                             </div>
                         {% endblock new_action %}
@@ -67,7 +66,7 @@
                                 <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
                                 <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
                                 <div class="input-group">
-                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
+                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|easyadmin_trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
                                 </div>
                             </form>
                         {% endblock search_action %}
@@ -154,7 +153,7 @@
                                                 <a class="{{ _action.css_class|default('') }}" href="{{ _action_href }}">
                                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                                     {% set _action_trans_parameters = _trans_parameters|merge({ '%entity_id%': _item_id }) %}
-                                                    {{ _action.label|trans(_action_trans_parameters, 'EasyAdminBundle')|trans(_action_trans_parameters) }}
+                                                    {{ _action.label|easyadmin_trans(_action_trans_parameters) }}
                                                 </a>
                                             {% endfor %}
                                         {% endspaceless %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -52,8 +52,7 @@
                             <div id="content-actions">
                                 <a class="btn {{ _action.css_class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                    {% set _default_action_label = 'action.new'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                                    {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
+                                    {{ _action.label|default('action.new')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
                                 </a>
                             </div>
                         {% endblock new_action %}
@@ -68,8 +67,7 @@
                                 <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
                                 <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
                                 <div class="input-group">
-                                    {% set _default_action_label = 'action.search'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
+                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
                                 </div>
                             </form>
                         {% endblock search_action %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -1,5 +1,3 @@
-{% trans_default_domain "EasyAdminBundle" %}
-
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
 {% set _trans_parameters = { '%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans } %}
 
@@ -15,9 +13,10 @@
 
 {% block content_title %}
     {% if 'search' == app.request.get('action') %}
-        {{ 'search.page_title'|transchoice(paginator.nbResults)|raw }}
+        {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
     {% else %}
-        {{ _entity_config.list.title|default('list.page_title')|trans(_trans_parameters) }}
+        {% set _default_page_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+        {{ _entity_config.list.title|default(_default_page_title) }}
     {% endif %}
 {% endblock %}
 
@@ -53,7 +52,8 @@
                             <div id="content-actions">
                                 <a class="btn {{ _action.css_class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                    {{ _action.label|default('action.new')|trans(_trans_parameters) }}
+                                    {% set _default_action_label = 'action.new'|trans(_trans_parameters, 'EasyAdminBundle') %}
+                                    {{ _action.label|default(_default_action_label) }}
                                 </a>
                             </div>
                         {% endblock new_action %}
@@ -68,7 +68,8 @@
                                 <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
                                 <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
                                 <div class="input-group">
-                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
+                                    {% set _default_action_label = 'action.search'|trans(_trans_parameters, 'EasyAdminBundle') %}
+                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default(_default_action_label) }}" value="{{ app.request.get('query')|default('') }}">
                                 </div>
                             </form>
                         {% endblock search_action %}
@@ -119,7 +120,7 @@
 
                             {% if _list_item_actions|length > 0 %}
                                 <th>
-                                    <span>{{ 'list.row_actions'|trans(_trans_parameters) }}</span>
+                                    <span>{{ 'list.row_actions'|trans(_trans_parameters, 'EasyAdminBundle') }}</span>
                                 </th>
                             {% endif %}
                         </tr>
@@ -141,7 +142,7 @@
                                 {% endfor %}
 
                                 {% if _list_item_actions|length > 0 %}
-                                    {% set _column_label =  'list.row_actions'|trans(_trans_parameters) %}
+                                    {% set _column_label =  'list.row_actions'|trans(_trans_parameters, 'EasyAdminBundle') %}
                                     <td data-label="{{ _column_label }}" class="actions">
                                     {% block item_actions %}
                                         {% spaceless %}
@@ -154,7 +155,7 @@
 
                                                 <a class="{{ _action.css_class|default('') }}" href="{{ _action_href }}">
                                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                                    {{ _action.label|trans({'%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans, '%entity_id%': _item_id}) }}
+                                                    {{ _action.label|trans(_trans_parameters|merge({ '%entity_id%': _item_id })) }}
                                                 </a>
                                             {% endfor %}
                                         {% endspaceless %}
@@ -165,7 +166,7 @@
                         {% else %}
                             <tr>
                                 <td class="no-results" colspan="{{ _list_item_actions|length > 0 ? fields|length + 1 : fields|length }}">
-                                    {{ 'search.no_results'|trans(_trans_parameters) }}
+                                    {{ 'search.no_results'|trans(_trans_parameters, 'EasyAdminBundle') }}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -15,7 +15,8 @@
     {% if 'search' == app.request.get('action') %}
         {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
     {% else %}
-        {{ _entity_config.list.title|default('list.page_title')|easyadmin_trans(_trans_parameters) }}
+        {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+        {{ _entity_config.list.title|default(_default_title)|trans(_trans_parameters) }}
     {% endif %}
 {% endblock %}
 
@@ -51,7 +52,7 @@
                             <div id="content-actions">
                                 <a class="btn {{ _action.css_class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                    {{ _action.label|default('action.new')|easyadmin_trans(_trans_parameters) }}
+                                    {{ _action.label|default('action.new')|trans(_trans_parameters) }}
                                 </a>
                             </div>
                         {% endblock new_action %}
@@ -66,7 +67,7 @@
                                 <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
                                 <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
                                 <div class="input-group">
-                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|easyadmin_trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
+                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default('action.search')|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
                                 </div>
                             </form>
                         {% endblock search_action %}
@@ -152,8 +153,7 @@
 
                                                 <a class="{{ _action.css_class|default('') }}" href="{{ _action_href }}">
                                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                                    {% set _action_trans_parameters = _trans_parameters|merge({ '%entity_id%': _item_id }) %}
-                                                    {{ _action.label|easyadmin_trans(_action_trans_parameters) }}
+                                                    {{ _action.label|trans(_trans_parameters|merge({ '%entity_id%': _item_id })) }}
                                                 </a>
                                             {% endfor %}
                                         {% endspaceless %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -16,7 +16,7 @@
         {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
     {% else %}
         {% set _default_page_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-        {{ _entity_config.list.title|default(_default_page_title) }}
+        {{ _entity_config.list.title|default(_default_page_title)|trans(_trans_parameters) }}
     {% endif %}
 {% endblock %}
 
@@ -53,7 +53,7 @@
                                 <a class="btn {{ _action.css_class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                     {% set _default_action_label = 'action.new'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                                    {{ _action.label|default(_default_action_label) }}
+                                    {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
                                 </a>
                             </div>
                         {% endblock new_action %}
@@ -69,7 +69,7 @@
                                 <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
                                 <div class="input-group">
                                     {% set _default_action_label = 'action.search'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default(_default_action_label) }}" value="{{ app.request.get('query')|default('') }}">
+                                    <input class="form-control" id="content-search-query" type="search" name="query" placeholder="{{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}" value="{{ app.request.get('query')|default('') }}">
                                 </div>
                             </form>
                         {% endblock search_action %}
@@ -155,7 +155,8 @@
 
                                                 <a class="{{ _action.css_class|default('') }}" href="{{ _action_href }}">
                                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                                    {{ _action.label|trans(_trans_parameters|merge({ '%entity_id%': _item_id })) }}
+                                                    {% set _action_trans_parameters = _trans_parameters|merge({ '%entity_id%': _item_id }) %}
+                                                    {{ _action.label|trans(_action_trans_parameters, 'EasyAdminBundle')|trans(_action_trans_parameters) }}
                                                 </a>
                                             {% endfor %}
                                         {% endspaceless %}

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -1,4 +1,3 @@
-{% trans_default_domain "EasyAdminBundle" %}
 {% form_theme form with easyadmin_config('design.form_theme') %}
 
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
@@ -10,7 +9,8 @@
 {% block body_class 'new new-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity_config.new.title|default('new.page_title')|trans(_trans_parameters) }}
+    {% set _default_page_title = 'new.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+    {{ _entity_config.new.title|default(_default_page_title) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -9,8 +9,7 @@
 {% block body_class 'new new-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {% set _default_page_title = 'new.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.new.title|default(_default_page_title)|trans(_trans_parameters) }}
+    {{ _entity_config.new.title|default('new.page_title')|easyadmin_trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -10,7 +10,7 @@
 
 {% block content_title %}
     {% set _default_page_title = 'new.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.new.title|default(_default_page_title) }}
+    {{ _entity_config.new.title|default(_default_page_title)|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -9,7 +9,8 @@
 {% block body_class 'new new-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity_config.new.title|default('new.page_title')|easyadmin_trans(_trans_parameters) }}
+    {% set _default_title = 'new.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+    {{ _entity_config.new.title|default(_default_title)|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/default/paginator.html.twig
+++ b/Resources/views/default/paginator.html.twig
@@ -1,9 +1,10 @@
-{% trans_default_domain "EasyAdminBundle" %}
+{% trans_default_domain 'EasyAdminBundle' %}
+
 {% if paginator.haveToPaginate %}
     <div class="list-pagination">
         <div class="row">
             <div class="col-sm-2 hidden-xs" class="list-pagination-counter">
-                {{ 'paginator.counter'|trans({"%start%": paginator.currentPageOffsetStart, "%end%": paginator.currentPageOffsetEnd, "%results%": paginator.nbResults})|raw }}
+                {{ 'paginator.counter'|trans({ '%start%': paginator.currentPageOffsetStart, '%end%': paginator.currentPageOffsetEnd, '%results%': paginator.nbResults})|raw }}
             </div>
 
             <div class="col-xs-12 col-sm-10">

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -8,7 +8,8 @@
 {% block body_class 'show show-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity_config.show.title|default('show.page_title')|easyadmin_trans(_trans_parameters) }}
+    {% set _default_title = 'show.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+    {{ _entity_config.show.title|default(_default_title)|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
@@ -43,7 +44,7 @@
 
                     <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|easyadmin_trans(_trans_parameters) }}
+                        {{ _action.label|trans(_trans_parameters) }}
                     </a>
                 {% endfor %}
 
@@ -51,7 +52,7 @@
                     {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                     <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|default('action.delete')|easyadmin_trans(_trans_parameters) }}
+                        {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
                     </button>
                 {% endif %}
 
@@ -60,7 +61,7 @@
                     {% set _action = easyadmin_get_action_for_show_view('list', _entity_config.name) %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|default('action.list')|easyadmin_trans(_trans_parameters) }}
+                        {{ _action.label|default('action.list')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}
@@ -86,14 +87,14 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" data-dismiss="modal" class="btn">
-                            {{ 'action.cancel'|trans(_trans_parameters, 'EasyAdminBundle') }}
+                            {{ 'action.cancel'|trans(_trans_parameters) }}
                         </button>
 
                         {% if easyadmin_action_is_enabled_for_show_view('delete', _entity_config.name) %}
                             {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                {{ _action.label|default('action.delete')|easyadmin_trans(_trans_parameters) }}
+                                {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -1,5 +1,3 @@
-{% trans_default_domain "EasyAdminBundle" %}
-
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
 {% set _entity_id = attribute(entity, _entity_config.primary_key_field_name) %}
 {% set _trans_parameters = { '%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans, '%entity_id%': _entity_id } %}
@@ -10,7 +8,8 @@
 {% block body_class 'show show-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {{ _entity_config.show.title|default('show.page_title')|trans(_trans_parameters) }}
+    {% set _default_page_title = 'show.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+    {{ _entity_config.show.title|default(_default_page_title) }}
 {% endblock %}
 
 {% block main %}
@@ -18,11 +17,7 @@
         {% for field, metadata in fields %}
             <div class="form-group field-{{ metadata.type|default('default')|lower }} {{ metadata.css_class|default('') }}">
                 <label class="col-sm-2 control-label">
-                    {% if metadata.label %}
-                        {{ metadata.label|trans }}
-                    {% else %}
-                        {{ field|humanize }}
-                    {% endif %}
+                    {{  metadata.label ? metadata.label|trans(_trans_parameters) : field|humanize }}
                 </label>
                 <div class="col-sm-10">
                     <div class="form-control">
@@ -57,7 +52,8 @@
                     {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                     <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
+                        {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
+                        {{ _action.label|default(_default_action_label) }}
                     </button>
                 {% endif %}
 
@@ -66,7 +62,8 @@
                     {% set _action = easyadmin_get_action_for_show_view('list', _entity_config.name) %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|default('action.list')|trans(_trans_parameters) }}
+                        {% set _default_action_label = 'action.list'|trans(_trans_parameters, 'EasyAdminBundle') %}
+                        {{ _action.label|default(_default_action_label) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}
@@ -87,19 +84,20 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-body">
-                        <h4>{{ 'delete_modal.title'|trans(_trans_parameters) }}</h4>
-                        <p>{{ 'delete_modal.content'|trans(_trans_parameters) }}</p>
+                        <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
+                        <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" data-dismiss="modal" class="btn">
-                            {{ 'action.cancel'|trans(_trans_parameters) }}
+                            {{ 'action.cancel'|trans(_trans_parameters, 'EasyAdminBundle') }}
                         </button>
 
                         {% if easyadmin_action_is_enabled_for_show_view('delete', _entity_config.name) %}
                             {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
+                                {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
+                                {{ _action.label|default(_default_action_label) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -52,8 +52,7 @@
                     {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                     <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                        {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
+                        {{ _action.label|default('action.delete')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
                     </button>
                 {% endif %}
 
@@ -62,8 +61,7 @@
                     {% set _action = easyadmin_get_action_for_show_view('list', _entity_config.name) %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {% set _default_action_label = 'action.list'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                        {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
+                        {{ _action.label|default('action.list')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -8,8 +8,7 @@
 {% block body_class 'show show-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-    {% set _default_page_title = 'show.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.show.title|default(_default_page_title)|trans(_trans_parameters) }}
+    {{ _entity_config.show.title|default('show.page_title')|easyadmin_trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
@@ -44,7 +43,7 @@
 
                     <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
+                        {{ _action.label|easyadmin_trans(_trans_parameters) }}
                     </a>
                 {% endfor %}
 
@@ -52,7 +51,7 @@
                     {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                     <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|default('action.delete')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
+                        {{ _action.label|default('action.delete')|easyadmin_trans(_trans_parameters) }}
                     </button>
                 {% endif %}
 
@@ -61,7 +60,7 @@
                     {% set _action = easyadmin_get_action_for_show_view('list', _entity_config.name) %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|default('action.list')|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
+                        {{ _action.label|default('action.list')|easyadmin_trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}
@@ -94,8 +93,7 @@
                             {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                                {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
+                                {{ _action.label|default('action.delete')|easyadmin_trans(_trans_parameters) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -9,7 +9,7 @@
 
 {% block content_title %}
     {% set _default_page_title = 'show.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.show.title|default(_default_page_title) }}
+    {{ _entity_config.show.title|default(_default_page_title)|trans(_trans_parameters) }}
 {% endblock %}
 
 {% block main %}
@@ -44,7 +44,7 @@
 
                     <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|trans(_trans_parameters) }}
+                        {{ _action.label|trans(_trans_parameters, 'EasyAdminBundle')|trans(_trans_parameters) }}
                     </a>
                 {% endfor %}
 
@@ -53,7 +53,7 @@
                     <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                        {{ _action.label|default(_default_action_label) }}
+                        {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
                     </button>
                 {% endif %}
 
@@ -63,7 +63,7 @@
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {% set _default_action_label = 'action.list'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                        {{ _action.label|default(_default_action_label) }}
+                        {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}
@@ -97,7 +97,7 @@
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                 {% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
-                                {{ _action.label|default(_default_action_label) }}
+                                {{ _action.label|default(_default_action_label)|trans(_trans_parameters) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -12,19 +12,16 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Twig;
 
 use Doctrine\ORM\PersistentCollection;
-use Symfony\Component\Translation\Translator;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
 
 class EasyAdminTwigExtension extends \Twig_Extension
 {
     private $configurator;
-    private $translator;
     private $debug;
 
-    public function __construct(Configurator $configurator, Translator $translator, $debug = false)
+    public function __construct(Configurator $configurator, $debug = false)
     {
         $this->configurator = $configurator;
-        $this->translator = $translator;
         $this->debug = $debug;
     }
 
@@ -45,7 +42,6 @@ class EasyAdminTwigExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFilter('easyadmin_truncate', array($this, 'truncateText'), array('needs_environment' => true)),
             new \Twig_SimpleFilter('easyadmin_urldecode', 'urldecode'),
-            new \Twig_SimpleFilter('easyadmin_trans', array($this, 'translateText'), array('is_safe' => array('html'))),
         );
     }
 
@@ -293,14 +289,6 @@ class EasyAdminTwigExtension extends \Twig_Extension
         }
 
         return $value;
-    }
-
-    public function translateText($value, $transParameters)
-    {
-        $firstPassTranslation = $this->translator->trans($value, $transParameters, 'EasyAdminBundle');
-        $secondPassTranslation = $this->translator->trans($firstPassTranslation, $transParameters);
-
-        return $secondPassTranslation;
     }
 
     public function getName()

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -12,16 +12,19 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Twig;
 
 use Doctrine\ORM\PersistentCollection;
+use Symfony\Component\Translation\Translator;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
 
 class EasyAdminTwigExtension extends \Twig_Extension
 {
     private $configurator;
+    private $translator;
     private $debug;
 
-    public function __construct(Configurator $configurator, $debug = false)
+    public function __construct(Configurator $configurator, Translator $translator, $debug = false)
     {
         $this->configurator = $configurator;
+        $this->translator = $translator;
         $this->debug = $debug;
     }
 
@@ -42,6 +45,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
         return array(
             new \Twig_SimpleFilter('easyadmin_truncate', array($this, 'truncateText'), array('needs_environment' => true)),
             new \Twig_SimpleFilter('easyadmin_urldecode', 'urldecode'),
+            new \Twig_SimpleFilter('easyadmin_trans', array($this, 'translateText'), array('is_safe' => array('html'))),
         );
     }
 
@@ -289,6 +293,14 @@ class EasyAdminTwigExtension extends \Twig_Extension
         }
 
         return $value;
+    }
+
+    public function translateText($value, $transParameters)
+    {
+        $firstPassTranslation = $this->translator->trans($value, $transParameters, 'EasyAdminBundle');
+        $secondPassTranslation = $this->translator->trans($firstPassTranslation, $transParameters);
+
+        return $secondPassTranslation;
     }
 
     public function getName()


### PR DESCRIPTION
### Problem

Right now EasyAdmin templates put the following at the beginning:

``` twig
{% trans_default_domain 'EasyAdminBundle' %}
```

**This is wrong** because we are translating ALL the strings using the `EasyAdminBundle` domain. In your application, your own strings should be translated using the `messages` domain.

In this screenshot you can see that the column and menu labels (`Categories`, `Products`, `Purchases`, etc.) are wrongly looked for in the `EasyAdminBundle` domain:

![profiler_translations](https://cloud.githubusercontent.com/assets/73419/10202822/0382c670-67b3-11e5-9f46-c37e14fd28bf.png)
### Solution

In this PR I've removed most of the `trans_default_domain` tags and instead, we now pass the translation domain to the `trans` filter explicitly.

This forces us to do some changes like the following. This is the original code to display the label of the `Delete` action:

``` twig
{{ _action.label|default('action.delete')|trans(_trans_parameters, 'EasyAdminBundle') }}
```

And now we need to use the following:

``` twig
{% set _default_action_label = 'action.delete'|trans(_trans_parameters, 'EasyAdminBundle') %}
{{ _action.label|default(_default_action_label) }}
```

---

Now I have **two questions** and I need help from you to solve them.

**( 1 )** We allow to define custom actions in the backend and they can define labels. But we also have built-in actions (`Show`, `Edit`, etc.)  How can we translate the action label correctly if we don't know if it's a builtin action (should be translated in `EasyAdminBundle` domain) or a custom action (it should be translated in `messages` domain).

Should we do something like this double translation?

``` twig
{% set default_label = 'action_label'|trans(domain = 'EasyAdminBundle') %}
{{ 'custom_label'|default(default_label)|trans }}
```

**( 2 )** Remember the screenshot at the beginning of this PR? Well, after aplying the changes I still see the missing messages associated with `EasyAdminBundle` domain instead of `messages`. I've cleared the cache but nothing changes.
