### PR TITLE
Fixed session less app

### DIFF
--- a/Resources/views/default/flash_messages.html.twig
+++ b/Resources/views/default/flash_messages.html.twig
@@ -1,4 +1,4 @@
-{% if app.session.started %}
+{% if app.session is not null and app.session.started %}
     <div id="flash-messages">
         {% for label, messages in app.session.flashbag.all %}
             {% for message in messages %}


### PR DESCRIPTION
Hi,

I have an API without session and this the introduction of this template I have the following error: (since 1.6.0)

```
An Exception was thrown while handling: Impossible to access an attribute ("started") on a null variable ("") in "@EasyAdmin/default/flash_messages.html.twig" at line 1
```
