### PR TITLE
[Travis] Speed up & really require only required dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   global:
     - deps="no"
     - SYMFONY_VERSION=""
+    - SYMFONY_LOWEST_REQUIREMENT="~2.3"
 
 matrix:
   fast_finish: true
@@ -40,19 +41,32 @@ matrix:
     - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 
 before_install:
-  - if [[ "$SYMFONY_VERSION" = "" ]] && [[ "$TWIG_VERSION" = "" ]] && [[ "$TRAVIS_PHP_VERSION" =~ 5.[45] ]] && [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then export skip="yes"; fi;
-  - if [[ "$skip" != "yes" ]]; then composer selfupdate; fi
-  - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-  - if [[ "$skip" != "yes" && "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
-  - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" != "2.7.*" && "$TRAVIS_PHP_VERSION" != 7.0 && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
+  - |
+      if [[ "$SYMFONY_VERSION" = "" && "$TWIG_VERSION" = "" && "$TRAVIS_PHP_VERSION" =~ 5.[45] && "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+        export skip="yes";
+      else
+        if [[ "$TRAVIS_PHP_VERSION" != hhvm ]]; then echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;
+        composer selfupdate;
+        if [[ "$SYMFONY_VERSION" == "" ]]; then SYMFONY_VERSION=$SYMFONY_LOWEST_REQUIREMENT; fi;
+        php travis/dependencies.php $SYMFONY_VERSION;
+        if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
+        cat composer.json;
+        if [[ "$SYMFONY_VERSION" != "2.7.*" && "$TRAVIS_PHP_VERSION" != 7.0 && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
+      fi
 
 install:
   - if [[ "$skip" != "yes" ]]; then composer update --prefer-dist --no-interaction $COMPOSER_FLAGS; fi
   - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" == "2.7.*" ]]; then composer require --dev satooshi/php-coveralls:~0.6; fi
 
 script:
-  - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" == "2.7.*" ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else if [[ "$skip" != "yes" ]]; then phpunit; fi; fi
-  - if [[ "$skip" = "yes" ]]; then echo "Skipping matrix entry for pull requests"; fi
+  - |
+    if [[ "$skip" != "yes" && "$SYMFONY_VERSION" == "2.7.*" ]]; then
+      phpunit --coverage-text --coverage-clover build/logs/clover.xml
+    elif [[ "$skip" != "yes" ]]; then
+      phpunit
+    else
+      echo "Skipping matrix entry for pull requests"
+    fi;
 
 after_success: |
     if [[ "$SYMFONY_VERSION" == "2.7.*" ]]; then php vendor/bin/coveralls -v --config .coveralls.yml; fi;

--- a/travis/composer.json
+++ b/travis/composer.json
@@ -1,0 +1,39 @@
+{
+    "require": {
+        "php"                           : ">=5.3.0",
+        "doctrine/common"               : "^2.4.0",
+        "doctrine/doctrine-bundle"      : "~1.2",
+        "doctrine/orm"                  : "~2.3",
+        "pagerfanta/pagerfanta"         : "~1.0,>=1.0.1",
+        "sensio/distribution-bundle"    : "~2.3|~3.0|~4.0",
+        "sensio/framework-extra-bundle" : "~3.0,>=3.0.2",
+        "symfony/config"                : "%SYMFONY_VERSION%",
+        "symfony/dependency-injection"  : "%SYMFONY_VERSION%",
+        "symfony/doctrine-bridge"       : "%SYMFONY_VERSION%",
+        "symfony/event-dispatcher"      : "%SYMFONY_VERSION%",
+        "symfony/form"                  : "%SYMFONY_VERSION%",
+        "symfony/framework-bundle"      : "%SYMFONY_VERSION%",
+        "symfony/http-foundation"       : "%SYMFONY_VERSION%",
+        "symfony/http-kernel"           : "%SYMFONY_VERSION%",
+        "symfony/twig-bridge"           : "%SYMFONY_VERSION%,>=2.3.4",
+        "twig/extensions"               : "~1.0",
+        "twig/twig"                     : "~1.14,>=1.14.2|~2.0"
+    },
+    "require-dev": {
+        "doctrine/doctrine-fixtures-bundle" : "~2.2",
+        "phpunit/phpunit"                   : "~4.4",
+        "symfony/browser-kit"               : "%SYMFONY_VERSION%",
+        "symfony/console"                   : "%SYMFONY_VERSION%",
+        "symfony/css-selector"              : "%SYMFONY_VERSION%",
+        "symfony/dom-crawler"               : "%SYMFONY_VERSION%",
+        "symfony/finder"                    : "%SYMFONY_VERSION%",
+        "symfony/security-bundle"           : "%SYMFONY_VERSION%",
+        "symfony/twig-bundle"               : "%SYMFONY_VERSION%",
+        "symfony/validator"                 : "%SYMFONY_VERSION%",
+        "symfony/yaml"                      : "%SYMFONY_VERSION%"
+    },
+    "autoload": {
+        "psr-4": { "JavierEguiluz\\Bundle\\EasyAdminBundle\\": "" }
+    }
+}
+

--- a/travis/dependencies.php
+++ b/travis/dependencies.php
@@ -1,0 +1,16 @@
+<?php
+
+$symfonyVersion = $argv[1];
+
+$content = str_replace('%SYMFONY_VERSION%', $symfonyVersion, file_get_contents(__DIR__ . '/composer.json'));
+
+if ("2.3.*" === $symfonyVersion) {
+    $data = json_decode($content, true);
+    $data['conflict'] = array(
+        'symfony/security-acl' => '*',
+        'symfony/security-core' => '*',
+    );
+    $content = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+}
+
+file_put_contents(__DIR__ . '/../composer.json', $content);


### PR DESCRIPTION
This was a try I gave this afternoon, but there is still unresolved issues.

I haven't dig into those yet, but the 2.3 build fail seems strange:

> InvalidArgumentException: The "/home/travis/build/javiereguiluz/EasyAdminBundle/vendor/symfony/security-core/Exception/../../Resources/translations" directory does not exist.

~~**Update:** looks like a bug in 2.3 => https://github.com/symfony/symfony/pull/16089~~
`symfony/twig-bridge` requires `symfony/security-acl` which requires `symfony/security-core` and both are installed in `2.7.x`, which is incompatible with the `2.3.x` `FrameworkExtension`. I don't know how to solve this. Also, `symfony/security` subpackages are only available as a standalone package since `2.4`.

However, what do you think ?
