### PR TITLE
Fix and enhance `createEntityform`

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -641,7 +641,12 @@ class AdminController extends Controller
             return $form;
         }
 
-        $formBuilder = $this->createEntityFormBuilder($entity, $entityProperties, $view);
+        if (method_exists($this, $customBuilderMethodName = 'create'.$this->entity['name'].'EntityFormBuilder')) {
+            $formBuilder = $this->{$customBuilderMethodName}($entity, $entityProperties, $view);
+        } else {
+            $formBuilder = $this->createEntityFormBuilder($entity, $entityProperties, $view);
+        }
+
         if (!$formBuilder instanceof FormBuilderInterface) {
             throw new \Exception(sprintf(
                 'The "%s" method must return a FormBuilderInterface, "%s" given.',

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -638,6 +638,7 @@ class AdminController extends Controller
                     $customMethodName, is_object($form) ? get_class($form) : gettype($form)
                 ));
             }
+            return $form;
         }
 
         $formBuilder = $this->createEntityFormBuilder($entity, $entityProperties, $view);


### PR DESCRIPTION
I fixed a major bug in the `createEntityForm` method: when using the customized `create{EntityName}EntityForm` method, the form was not returned.

Also, I added the possibility to create a custom form builder method with the same pattern:
`create{EntityName}EntityFormBuilder`, so we can customize only the builder and don't need to remember we have to use the `->getForm()` method when finishing the `create*EntityForm` method.
