### PR TITLE
Fix a bug with exceptions in the exception listener

### DIFF
--- a/Listener/ExceptionListener.php
+++ b/Listener/ExceptionListener.php
@@ -11,6 +11,7 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Listener;
 
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\BaseException;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
 class ExceptionListener
@@ -41,7 +42,7 @@ class ExceptionListener
         $exception = $event->getException();
         $exceptionClassName = basename(str_replace('\\', '/', get_class($exception)));
 
-        if (!array_key_exists($exceptionClassName, $this->exceptionTemplates)) {
+        if (!$exception instanceof BaseException || !array_key_exists($exceptionClassName, $this->exceptionTemplates)) {
             return;
         }
 

--- a/Tests/Listener/EntityNotFoundException.php
+++ b/Tests/Listener/EntityNotFoundException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Listener;
+
+/**
+* Test class for event listener test
+*/
+class EntityNotFoundException extends \Exception
+{
+}

--- a/Tests/Listener/ExceptionListenerTest.php
+++ b/Tests/Listener/ExceptionListenerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Listener;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Listener\ExceptionListener;
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\EntityNotFoundException as EasyEntityNotFoundException;
+
+class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
+{
+    private function getTemplating()
+    {
+        $response = $this->getMockBuilder('Symfony\Component\HttpFoundation\Response')
+                         ->disableOriginalConstructor()
+                         ->getMock();
+        $templating = $this->getMockBuilder('\stdClass')
+                           ->disableOriginalConstructor()
+                           ->setMethods(array('renderResponse'))
+                           ->getMock();
+        $templating->method('renderResponse')
+                   ->willReturn($response);
+
+        return $templating;
+    }
+
+    private function getEventExceptionThatShouldBeCalledOnce($exception)
+    {
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent')
+                           ->disableOriginalConstructor()
+                           ->getMock();
+        $event->method('getException')
+                ->willReturn($exception);
+        $event->expects($this->once())
+              ->method('setResponse');
+
+        return $event;
+    }
+
+    public function testCatchBaseExceptions()
+    {
+        $exception = new EasyEntityNotFoundException(
+            array(
+                'entity' => array(
+                    'name' => 'Test',
+                    'primary_key_field_name' => 'Test key'
+                ),
+                'entity_id' => 2
+            )
+        );
+        $event = $this->getEventExceptionThatShouldBeCalledOnce($exception);
+        $templating = $this->getTemplating();
+        $debug = false;
+
+        $listener = new ExceptionListener($templating, $debug);
+        $listener->onKernelException($event);
+    }
+
+    private function getEventExceptionThatShouldNotBeCalled($exception)
+    {
+        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent')
+                           ->disableOriginalConstructor()
+                           ->getMock();
+        $event->method('getException')
+                ->willReturn($exception);
+        $event->expects($this->never())
+              ->method('setResponse');
+
+        return $event;
+    }
+
+    public function testShouldNotCatchExceptionsWithSameName()
+    {
+        $exception = new EntityNotFoundException;
+        $event = $this->getEventExceptionThatShouldNotBeCalled($exception);
+        $templating = $this->getTemplating();
+        $debug = false;
+
+        $listener = new ExceptionListener($templating, $debug);
+        $listener->onKernelException($event);
+    }
+}


### PR DESCRIPTION
The listener catch exceptions that finish with **EntityNotFoundException** and some other even if they don't extends the BaseException. Changed to also check this extension.
