### PR TITLE
Disable Select2 widget for date and time related dropdowns

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -587,8 +587,15 @@ class AdminController extends Controller
         foreach ($entityProperties as $name => $metadata) {
             $formFieldOptions = $metadata['type_options'];
 
-            if ('association' === $metadata['fieldType'] && in_array($metadata['associationType'], array(ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY))) {
-                continue;
+            if ('association' === $metadata['type']) {
+                // *-to-many associations are not supported yet
+                $toManyAssociations = array(ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY);
+                if (in_array($metadata['associationType'], $toManyAssociations)) {
+                    continue;
+                }
+
+                // supported associations are displayed using advanced JavaScript widgets
+                $formFieldOptions['attr']['data-use-js-widget'] = 'true';
             }
 
             if ('collection' === $metadata['fieldType']) {

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -595,7 +595,7 @@ class AdminController extends Controller
                 }
 
                 // supported associations are displayed using advanced JavaScript widgets
-                $formFieldOptions['attr']['data-use-js-widget'] = 'true';
+                $formFieldOptions['attr']['data-widget'] = 'select2';
             }
 
             if ('collection' === $metadata['fieldType']) {

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -82,7 +82,7 @@
     <script type="text/javascript">
         $(function() {
             // Select2 widget is only enabled for the <select> elements which explicitly ask for it
-            $('#main form select[data-use-js-widget]').select2({
+            $('#main form select[data-widget="select2"]').select2({
                 theme: 'bootstrap'
             });
         });

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -81,8 +81,8 @@
     <script src="{{ asset('bundles/easyadmin/javascript/select2.min.js') }}"></script>
     <script type="text/javascript">
         $(function() {
-            // enable Select2 for all <select> dropdown, except those related to date and time
-            $('#main form select:not([name*="[date]"], [name*="[time]"])').select2({
+            // Select2 widget is only enabled for the <select> elements which explicitly ask for it
+            $('#main form select[data-use-js-widget]').select2({
                 theme: 'bootstrap'
             });
         });

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -81,7 +81,8 @@
     <script src="{{ asset('bundles/easyadmin/javascript/select2.min.js') }}"></script>
     <script type="text/javascript">
         $(function() {
-            $('#main form select').select2({
+            // enable Select2 for all <select> dropdown, except those related to date and time
+            $('#main form select:not([name*="[date]"], [name*="[time]"])').select2({
                 theme: 'bootstrap'
             });
         });

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -38,7 +38,7 @@
     <script type="text/javascript">
         $(function() {
             // Select2 widget is only enabled for the <select> elements which explicitly ask for it
-            $('#main form select[data-use-js-widget]').select2({
+            $('#main form select[data-widget="select2"]').select2({
                 theme: 'bootstrap'
             });
         });

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -37,7 +37,8 @@
     <script src="{{ asset('bundles/easyadmin/javascript/select2.min.js') }}"></script>
     <script type="text/javascript">
         $(function() {
-            $('#main form select').select2({
+            // enable Select2 for all <select> dropdown, except those related to date and time
+            $('#main form select:not([name*="[date]"], [name*="[time]"])').select2({
                 theme: 'bootstrap'
             });
         });

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -37,8 +37,8 @@
     <script src="{{ asset('bundles/easyadmin/javascript/select2.min.js') }}"></script>
     <script type="text/javascript">
         $(function() {
-            // enable Select2 for all <select> dropdown, except those related to date and time
-            $('#main form select:not([name*="[date]"], [name*="[time]"])').select2({
+            // Select2 widget is only enabled for the <select> elements which explicitly ask for it
+            $('#main form select[data-use-js-widget]').select2({
                 theme: 'bootstrap'
             });
         });


### PR DESCRIPTION
This fixes #490.
### Before

![before_collapsed](https://cloud.githubusercontent.com/assets/73419/10466809/7a85c16c-71f6-11e5-9b80-68eecb2a1f04.png)

![before_revealed](https://cloud.githubusercontent.com/assets/73419/10466812/7d05c662-71f6-11e5-9072-a14c6e3144c7.png)
### After

![after_collapsed](https://cloud.githubusercontent.com/assets/73419/10466819/83bc2bfe-71f6-11e5-8aca-2ab3a494c097.png)

![after_revealed](https://cloud.githubusercontent.com/assets/73419/10466821/868d3706-71f6-11e5-91d9-52ee06757515.png)
