### PR TITLE
EasyAdmin form type

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -19,7 +19,6 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Controller;
 
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
@@ -566,62 +565,17 @@ class AdminController extends Controller
      * Creates the form builder of the form used to create or edit the given entity.
      *
      * @param object $entity
-     * @param array  $entityProperties
-     * @param string $view             The name of the view where this form is used ('new' or 'edit')
+     * @param string $view   The name of the view where this form is used ('new' or 'edit')
      *
      * @return FormBuilder
      */
-    protected function createEntityFormBuilder($entity, array $entityProperties, $view)
+    protected function createEntityFormBuilder($entity, $view)
     {
-        $formCssClass = array_reduce($this->config['design']['form_theme'], function ($previousClass, $formTheme) {
-            return sprintf('theme-%s %s', strtolower(str_replace('.html.twig', '', basename($formTheme))), $previousClass);
-        });
+        $formOptions = $this->entity[$view]['form_options'];
+        $formOptions['entity'] = $this->entity['name'];
+        $formOptions['view'] = $view;
 
-        $formOptions = array_replace_recursive(array(
-            'data_class' => $this->entity['class'],
-            'attr' => array('class' => $formCssClass, 'id' => $view.'-form'),
-        ), $this->entity[$view]['form_options']);
-
-        $formBuilder = $this->createFormBuilder($entity, $formOptions);
-
-        foreach ($entityProperties as $name => $metadata) {
-            $formFieldOptions = $metadata['type_options'];
-
-            if ('association' === $metadata['type']) {
-                // *-to-many associations are not supported yet
-                $toManyAssociations = array(ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY);
-                if (in_array($metadata['associationType'], $toManyAssociations)) {
-                    continue;
-                }
-
-                // supported associations are displayed using advanced JavaScript widgets
-                $formFieldOptions['attr']['data-widget'] = 'select2';
-            }
-
-            if ('collection' === $metadata['fieldType']) {
-                if (!isset($formFieldOptions['allow_add'])) {
-                    $formFieldOptions['allow_add'] = true;
-                }
-
-                if (!isset($formFieldOptions['allow_delete'])) {
-                    $formFieldOptions['allow_delete'] = true;
-                }
-
-                if (version_compare(\Symfony\Component\HttpKernel\Kernel::VERSION, '2.5.0', '>=')) {
-                    if (!isset($formFieldOptions['delete_empty'])) {
-                        $formFieldOptions['delete_empty'] = true;
-                    }
-                }
-            }
-
-            $formFieldOptions['attr']['field_type'] = $metadata['fieldType'];
-            $formFieldOptions['attr']['field_css_class'] = $metadata['class'];
-            $formFieldOptions['attr']['field_help'] = $metadata['help'];
-
-            $formBuilder->add($name, $metadata['fieldType'], $formFieldOptions);
-        }
-
-        return $formBuilder;
+        return $this->get('form.factory')->createNamedBuilder('form', 'easyadmin', $entity, $formOptions);
     }
 
     /**
@@ -652,7 +606,7 @@ class AdminController extends Controller
         if (method_exists($this, $customBuilderMethodName = 'create'.$this->entity['name'].'EntityFormBuilder')) {
             $formBuilder = $this->{$customBuilderMethodName}($entity, $entityProperties, $view);
         } else {
-            $formBuilder = $this->createEntityFormBuilder($entity, $entityProperties, $view);
+            $formBuilder = $this->createEntityFormBuilder($entity, $view);
         }
 
         if (!$formBuilder instanceof FormBuilderInterface) {

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Form\Type;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class EasyAdminFormType extends AbstractType
+{
+    /** @var Configurator */
+    private $configurator;
+
+    /** @var array */
+    private $config;
+
+    /**
+     * @param Configurator $configurator
+     * @param array        $config
+     */
+    public function __construct(Configurator $configurator, array $config)
+    {
+        $this->configurator = $configurator;
+        $this->config = $config;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $entity = $options['entity'];
+        $view = $options['view'];
+        $entityConfig = $this->configurator->getEntityConfiguration($entity);
+        $entityProperties = $entityConfig[$view]['fields'];
+
+        foreach ($entityProperties as $name => $metadata) {
+            $formFieldOptions = $metadata['type_options'];
+
+            if ('association' === $metadata['type']) {
+                // *-to-many associations are not supported yet
+                $toManyAssociations = array(ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY);
+                if (in_array($metadata['associationType'], $toManyAssociations)) {
+                    continue;
+                }
+
+                // supported associations are displayed using advanced JavaScript widgets
+                $formFieldOptions['attr']['data-widget'] = 'select2';
+            }
+
+            if ('collection' === $metadata['fieldType']) {
+                if (!isset($formFieldOptions['allow_add'])) {
+                    $formFieldOptions['allow_add'] = true;
+                }
+
+                if (!isset($formFieldOptions['allow_delete'])) {
+                    $formFieldOptions['allow_delete'] = true;
+                }
+
+                if (version_compare(\Symfony\Component\HttpKernel\Kernel::VERSION, '2.5.0', '>=')) {
+                    if (!isset($formFieldOptions['delete_empty'])) {
+                        $formFieldOptions['delete_empty'] = true;
+                    }
+                }
+            }
+
+            $formFieldOptions['attr']['field_type'] = $metadata['fieldType'];
+            $formFieldOptions['attr']['field_css_class'] = $metadata['class'];
+            $formFieldOptions['attr']['field_help'] = $metadata['help'];
+
+            $builder->add($name, $metadata['fieldType'], $formFieldOptions);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $configurator = $this->configurator;
+        $config = $this->config;
+
+        $resolver
+            ->setDefaults(array(
+                'allow_extra_fields' => true,
+                'data_class' => function (Options $options) use ($configurator) {
+                    $entity = $options['entity'];
+                    $entityConfig = $configurator->getEntityConfiguration($entity);
+
+                    return $entityConfig['class'];
+                },
+            ))
+            ->setNormalizers(array(
+                'attr' => function (Options $options, $value) use ($config) {
+                    $formCssClass = array_reduce($config['design']['form_theme'], function ($previousClass, $formTheme) {
+                        return sprintf('theme-%s %s', strtolower(str_replace('.html.twig', '', basename($formTheme))), $previousClass);
+                    });
+
+                    return array_replace_recursive(array(
+                        'class' => $formCssClass,
+                        'id' => $options['view'].'-form',
+                    ), $value);
+                },
+            ))
+            ->setRequired(array('entity', 'view'));
+    }
+
+    // BC for SF < 2.7
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'easyadmin';
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -34,5 +34,11 @@
             <tag name="data_collector" template="@EasyAdmin/data_collector/easyadmin.html.twig" id="easyadmin" />
         </service>
 
+        <service id="easyadmin.form.type" class="JavierEguiluz\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType">
+            <argument type="service" id="easyadmin.configurator" />
+            <argument>%easyadmin.config%</argument>
+            <tag name="form.type" alias="easyadmin" />
+        </service>
+
     </services>
 </container>

--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -1,4 +1,4 @@
-{{ form_start(form, { attr: form.vars.attr|merge({ novalidate: 'novalidate' }) }) }}
+{{ form_start(form) }}
     {% if form.vars.errors|length > 0 %}
         {{ form_errors(form) }}
     {% endif %}

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -438,9 +438,8 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->assertSame('novalidate', $crawler->filter('#new-form')->first()->attr('novalidate'));
 
         $form = $crawler->selectButton('Save changes')->form();
-        $form->remove('category[name]');
+        $form->remove('form[name]');
         $crawler = $this->client->submit($form);
-
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         // test validation groups

--- a/Tests/Fixtures/App/config/config_customized_backend.yml
+++ b/Tests/Fixtures/App/config/config_customized_backend.yml
@@ -48,7 +48,7 @@ easy_admin:
                     - { name: 'delete', label: 'Remove', icon: 'minus-circle' }
                     - { name: 'list', label: 'Return to listing', icon: 'list' }
             new:
-                form_options: { validation_groups: ['Default', 'Validate'], attr: { novalidate: ~ } }
+                form_options: { validation_groups: ['Default', 'Validate'], attr: { novalidate: 'novalidate' } }
         Image:
             class: JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Entity\Image
             label: 'Images'


### PR DESCRIPTION
This is a first step about what I mentioned in https://github.com/javiereguiluz/EasyAdminBundle/issues/499#issuecomment-151652690 and eliminates some logic from the AdminController.

Next step would eventually be to:
- make an option to specify which form type to use for each entity/view couple (Default: `easyadmin`). Then, it should be trivial to extend the default `easyadmin` form type and use our own.
- add a way to register listeners to alter the form type without extending it.
- add an easyadmin extension (as mentioned in #403) for accessing entity metadata from the form theme and move some of the logic in `form.html.twig` to the `bootstrap_3_layout.html.twig`
- ...

So it doesn't solve anything for now, but at least separate the logic.

Also, I removed the `novalidate` attribute from default, in `form.html.twig` view, because there is no way to remove it otherwise. Instead, if needed, it should be added (like in the tests) using the new `form_options` config option.
