### PR TITLE
form.html.twig: remove unreachable statement

### DIFF
--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -9,12 +9,8 @@
         {% for field in form.children if 'hidden' not in field.vars.block_prefixes %}
             {% set _field_metadata = entity_fields[field.vars.name] %}
             <div class="{{ _field_metadata.css_class|default('col-xs-12') }}">
-                {% if _field_metadata['fieldType'] == 'association' %}
-                    {{ easyadmin_render_field_for_edit_view(entity, _field_metadata) }}
-                {% else %}
-                    {% set _field_label = _field_metadata['label']|default(null) %}
-                    {{ form_row(field, { label: _field_label|trans(_trans_parameters) }) }}
-                {% endif %}
+                {% set _field_label = _field_metadata['label']|default(null) %}
+                {{ form_row(field, { label: _field_label|trans(_trans_parameters) }) }}
 
                 {% if _field_metadata['fieldType'] == 'collection' %}
                     {% set add_item_javascript %}


### PR DESCRIPTION
Please, tell me if I'm wrong, but I think this is unreachable, as the `association` is a dataType and not a fieldType in EasyAdmin. Also I don't understand why it would make sense in this view to render a view instead of a form field.
