### PR TITLE
Fix tests autoloader require

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -22,7 +22,7 @@ $file = __DIR__.'/../vendor/autoload.php';
 if (!file_exists($file)) {
     throw new RuntimeException('Install dependencies using Composer to run the test suite.');
 }
-$autoload = require_once $file;
+$autoload = require $file;
 
 AnnotationRegistry::registerLoader(function ($class) use ($autoload) {
     $autoload->loadClass($class);


### PR DESCRIPTION
This bothered me multiple times, where the `require_once` instruction returns `true` instead of the expected autoloader, because the file would have been  supposedly already required (??).

> PHP Fatal error:  Call to a member function loadClass() on boolean
