### PR TITLE
Add the "Add another item" action for all collections

### DIFF
--- a/Resources/views/default/form.html.twig
+++ b/Resources/views/default/form.html.twig
@@ -15,31 +15,6 @@
                     {% set _field_label = _field_metadata['label']|default(null) %}
                     {{ form_row(field, { label: _field_label|trans(_trans_parameters) }) }}
                 {% endif %}
-
-                {% if _field_metadata['fieldType'] == 'collection' %}
-                    {% set add_item_javascript %}
-                        $(function() {
-                            if(event.preventDefault) event.preventDefault(); else event.returnValue = false;
-
-                            var collection = $('#{{ form.vars.name }}_{{ field.vars.name|escape('js') }}');
-                            var numItems = collection.children('div.form-group').length;
-
-                            var newItem = collection.attr('data-prototype')
-                                .replace(/__name__label__/g, numItems)
-                                .replace(/__name__/g, numItems)
-                            ;
-
-                            collection.append(newItem);
-                        });
-                    {% endset %}
-
-                    <div class="form-group field-collection-action">
-                        <a href="#" onclick="{{ add_item_javascript|raw }}" class="col-sm-12 text-right">
-                            <i class="fa fa-plus-square"></i>
-                            {{ (field|length == 0 ? 'action.add_new_item' : 'action.add_another_item')|trans(_trans_parameters, 'EasyAdminBundle') }}
-                        </a>
-                    </div>
-                {% endif %}
             </div>
         {% endfor %}
 

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -282,13 +282,13 @@
             $(function() {
                 if(event.preventDefault) event.preventDefault(); else event.returnValue = false;
 
-                var collection = $('#{{ form.vars.id }}');
+                var collection = $('#{{ id }}');
                 var numItems = collection.children('div.form-group').length;
 
                 var newItem = collection.attr('data-prototype')
                     .replace(/\>__name__label__\</g, '>' + numItems + '<')
-                    .replace(/_{{ form.vars.name}}___name__/g, '_{{ form.vars.name}}_' + numItems)
-                    .replace(/{{ form.vars.name}}\]\[__name__\]/g, '{{ form.vars.name}}][' + numItems + ']')
+                    .replace(/_{{ name }}___name__/g, '_{{ name }}_' + numItems)
+                    .replace(/{{ name }}\]\[__name__\]/g, '{{ name }}][' + numItems + ']')
                 ;
 
                 collection.append(newItem);

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -287,7 +287,7 @@
 
                 var newItem = collection.attr('data-prototype')
                     .replace(/\>__name__label__\</g, '>' + numItems + '<')
-                    .replace(/_{{ form.vars.name}}___name__/g, numItems)
+                    .replace(/_{{ form.vars.name}}___name__/g, '_{{ form.vars.name}}_' + numItems)
                     .replace(/{{ form.vars.name}}\]\[__name__\]/g, '{{ form.vars.name}}][' + numItems + ']')
                 ;
 

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -273,3 +273,33 @@
         </div>
     {% endif %}
 {%- endblock form_widget_compound -%}
+
+{% block collection_row %}
+    {{ block('form_row') }}
+
+    {% if allow_add|default(false) %}
+        {% set js_add_item %}
+            $(function() {
+                if(event.preventDefault) event.preventDefault(); else event.returnValue = false;
+
+                var collection = $('#{{ form.vars.id }}');
+                var numItems = collection.children('div.form-group').length;
+
+                var newItem = collection.attr('data-prototype')
+                    .replace(/\>__name__label__\</g, '>' + numItems + '<')
+                    .replace(/_{{ form.vars.name}}___name__/g, numItems)
+                    .replace(/{{ form.vars.name}}\]\[__name__\]/g, '{{ form.vars.name}}][' + numItems + ']')
+                ;
+
+                collection.append(newItem);
+            });
+        {% endset %}
+
+        <div class="form-group field-collection-action">
+            <a href="#" onclick="{{ js_add_item|raw }}" class="col-sm-12 text-right">
+                <i class="fa fa-plus-square"></i>
+                {{ (form|length == 0 ? 'action.add_new_item' : 'action.add_another_item')|trans({}, 'EasyAdminBundle') }}
+            </a>
+        </div>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Use case:
I have an entity that has a property that has a collection. This collection has also a collection.
Ex: Entity->Collection1->Collection2

So I expected to have to "Add another Item" for the collection of level 1 and 2. But only the first level displayed the "add" button.

The "add button" was not handled within the symfony widgets, that is why the behaviour was not generic.

I moved the JS and the html from Resources/views/default/form.html.twig to Resources/views/form/bootstrap_3_horizontal_layout.html.twig
