### PR TITLE
form themes: don't explicitly call form.vars.x when not needed.

### DIFF
--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -26,14 +26,14 @@ col-sm-2
 
 {% block form_row -%}
 {% spaceless %}
-    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ form.vars.attr.field_type|default('default') }} {{ form.vars.attr.field_css_class|default('') }}">
+    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
         {{ form_label(form) }}
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}
             {{ form_errors(form) }}
 
-            {% if form.vars.attr.field_help|default('') != '' %}
-                <span class="help-block"><i class="fa fa-info-circle"></i> {{ form.vars.attr.field_help|trans|raw }}</span>
+            {% if attr.field_help|default('') != '' %}
+                <span class="help-block"><i class="fa fa-info-circle"></i> {{ attr.field_help|trans|raw }}</span>
             {% endif %}
         </div>
     </div>
@@ -50,7 +50,7 @@ col-sm-2
 
 {% block checkbox_radio_row -%}
 {% spaceless %}
-    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ form.vars.attr.field_type|default('default') }} {{ form.vars.attr.field_css_class|default('') }}">
+    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
         <div class="{{ block('form_label_class') }}"></div>
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}
@@ -62,7 +62,7 @@ col-sm-2
 
 {% block submit_row -%}
 {% spaceless %}
-    <div class="form-group field-{{ form.vars.attr.field_type|default('default') }} {{ form.vars.attr.field_css_class|default('') }}">
+    <div class="form-group field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
         <div class="{{ block('form_label_class') }}"></div>
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -178,19 +178,19 @@
 {# Rows #}
 
 {% block form_row -%}
-    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ form.vars.attr.field_type|default('default') }} {{ form.vars.attr.field_css_class|default('') }}">
+    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
         {{- form_label(form) -}}
         {{- form_widget(form) -}}
         {{- form_errors(form) -}}
 
-        {% if form.vars.attr.field_help|default('') != '' %}
-            <span class="help-block"><i class="fa fa-info-circle"></i> {{ form.vars.attr.field_help|trans|raw }}</span>
+        {% if attr.field_help|default('') != '' %}
+            <span class="help-block"><i class="fa fa-info-circle"></i> {{ attr.field_help|trans|raw }}</span>
         {% endif %}
     </div>
 {%- endblock form_row %}
 
 {% block button_row -%}
-    <div class="form-group field-{{ form.vars.attr.field_type|default('default') }} {{ form.vars.attr.field_css_class|default('') }}">
+    <div class="form-group field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
         {{- form_widget(form) -}}
     </div>
 {%- endblock button_row %}
@@ -216,14 +216,14 @@
 {%- endblock datetime_row %}
 
 {% block checkbox_row -%}
-    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ form.vars.attr.field_type|default('default') }} {{ form.vars.attr.field_css_class|default('') }}">
+    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
         {{- form_widget(form) -}}
         {{- form_errors(form) -}}
     </div>
 {%- endblock checkbox_row %}
 
 {% block radio_row -%}
-    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ form.vars.attr.field_type|default('default') }} {{ form.vars.attr.field_css_class|default('') }}">
+    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
         {{- form_widget(form) -}}
         {{- form_errors(form) -}}
     </div>
@@ -260,7 +260,7 @@
                     event.returnValue = false;
                 }
 
-                var containerDiv = $('#{{ form.vars.id }}').parents('.form-group:first');
+                var containerDiv = $('#{{ id }}').parents('.form-group:first');
                 containerDiv.remove();
             });
         {% endset %}


### PR DESCRIPTION
In form themes, there is no need to call `form.vars.x` but can directly call `x` instead.
