### PR TITLE
Add php-cs-fixer task to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.app/cache
 
 env:
   global:
     - deps="no"
     - SYMFONY_VERSION=""
+    - PHP_CS="no"
 
 matrix:
   fast_finish: true
@@ -40,6 +42,8 @@ matrix:
     - env: SYMFONY_VERSION="3.0.x-dev as 2.8"
 
 before_install:
+  - if [[ "$TRAVIS_PHP_VERSION" =~ 5.3 ]] && [[ "$COMPOSER_FLAGS" != "--prefer-lowest" ]]; then export PHP_CS="yes"; fi;
+  - if [[ "$PHP_CS" == "yes" ]]; then mv $HOME/.app/cache/.php_cs.cache ./.php_cs.cache 2>/dev/null || true ;fi;
   - if [[ "$SYMFONY_VERSION" = "" ]] && [[ "$TWIG_VERSION" = "" ]] && [[ "$TRAVIS_PHP_VERSION" =~ 5.[45] ]] && [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then export skip="yes"; fi;
   - if [[ "$skip" != "yes" ]]; then composer selfupdate; fi
   - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
@@ -47,12 +51,15 @@ before_install:
   - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" != "2.7.*" && "$TRAVIS_PHP_VERSION" != 7.0 && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
 
 install:
+  - if [[ "$PHP_CS" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;
   - if [[ "$skip" != "yes" ]]; then composer update --prefer-dist --no-interaction $COMPOSER_FLAGS; fi
   - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" == "2.7.*" ]]; then composer require --dev satooshi/php-coveralls:~0.6; fi
 
 script:
   - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" == "2.7.*" ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else if [[ "$skip" != "yes" ]]; then phpunit; fi; fi
   - if [[ "$skip" = "yes" ]]; then echo "Skipping matrix entry for pull requests"; fi
+  - if [[ "$PHP_CS" == "yes" ]]; then php php-cs-fixer --no-interaction --dry-run --diff -v fix; fi;
+  - if [[ "$PHP_CS" == "yes" ]]; then mv ./.php_cs.cache $HOME/.app/cache/.php_cs.cache 2>/dev/null || true; fi;
 
 after_success: |
     if [[ "$SYMFONY_VERSION" == "2.7.*" ]]; then php vendor/bin/coveralls -v --config .coveralls.yml; fi;


### PR DESCRIPTION
I chose to add it to the PHP 5.3 build only, and here is what it'll look like for a PR not respecting the coding style: https://travis-ci.org/ogizanagi/EasyAdminBundle/builds/88381184

Failing build cs-fixer report: https://travis-ci.org/ogizanagi/EasyAdminBundle/jobs/88381185#L577

What do you think ?
