### PR TITLE
Twig 2.0 requires symfony/polyfill-mbstring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="3.0.x-dev as 2.8"
     - php: 5.6
-      env: TWIG_VERSION="2.0.x-dev"
+      env: TWIG_VERSION="2.0.x-dev symfony/polyfill-mbstring:1.0-dev"
   allow_failures:
     - php: hhvm
     - env: SYMFONY_VERSION=2.8.*@dev


### PR DESCRIPTION
Since the polyfill package is not released yet we must explicitly use
its development version.
