### PR TITLE
Added all the missing PHPdoc information

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -16,6 +16,13 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use JavierEguiluz\Bundle\EasyAdminBundle\Reflection\EntityMetadataInspector;
 use JavierEguiluz\Bundle\EasyAdminBundle\Reflection\ClassPropertyReflector;
 
+/**
+ * Completes the entities configuration with the information that can only be
+ * determined during runtime, not during the container compilation phase (most
+ * of the entities configuration is resolved in EasyAdminExtension class)
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class Configurator
 {
     private $backendConfig = array();

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -7,12 +7,6 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Some parts of this file are copied and/or inspired by the
- * DoctrineCRUDGenerator included in the SensioGeneratorBundle.
- *   License: MIT License
- *   Copyright: (c) Fabien Potencier <fabien@symfony.com>
- *   Source: https://github.com/sensiolabs/SensioGeneratorBundle
  */
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Controller;
@@ -37,7 +31,9 @@ use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use JavierEguiluz\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
 
 /**
- * Class AdminController.
+ * The controller used to render all the default EasyAdmin actions.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 class AdminController extends Controller
 {

--- a/DataCollector/EasyAdminDataCollector.php
+++ b/DataCollector/EasyAdminDataCollector.php
@@ -16,6 +16,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
 
+/**
+ * Collects information about the requests related to EasyAdmin and displays
+ * it both in the web debug toolbar and in the profiler.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class EasyAdminDataCollector extends DataCollector
 {
     private $configurator;

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -15,6 +15,11 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
+/**
+ * Defines the configuration options of the bundle and validates its values.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -16,6 +16,13 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
+/**
+ * Resolves all the backend configuration values and most of the entities
+ * configuration. The information that must resolved during runtime is handled
+ * by the Configurator class.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class EasyAdminExtension extends Extension
 {
     private $views = array('edit', 'list', 'new', 'show');

--- a/Event/EasyAdminEvents.php
+++ b/Event/EasyAdminEvents.php
@@ -11,6 +11,9 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Event;
 
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 final class EasyAdminEvents
 {
     // Events related to initialization

--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -14,6 +14,12 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\EventListener;
 use JavierEguiluz\Bundle\EasyAdminBundle\Exception\BaseException;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 
+/**
+ * This listener allows to display customized error pages in the production
+ * environment.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class ExceptionListener
 {
     private $templating;

--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Request;
  * Adds some custom attributes to the request object to store information
  * related to EasyAdmin.
  *
- * @author Maxime Steinhausser
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
 class RequestPostInitializeListener
 {

--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -7,6 +7,12 @@ use JavierEguiluz\Bundle\EasyAdminBundle\Exception\EntityNotFoundException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * Adds some custom attributes to the request object to store information
+ * related to EasyAdmin.
+ *
+ * @author Maxime Steinhausser
+ */
 class RequestPostInitializeListener
 {
     /** @var Request|null */

--- a/Exception/BaseException.php
+++ b/Exception/BaseException.php
@@ -11,6 +11,9 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class BaseException extends \Exception
 {
     protected $message;

--- a/Exception/EntityNotFoundException.php
+++ b/Exception/EntityNotFoundException.php
@@ -11,6 +11,9 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class EntityNotFoundException extends BaseException
 {
     public function __construct(array $parameters = array())

--- a/Exception/ForbiddenActionException.php
+++ b/Exception/ForbiddenActionException.php
@@ -11,6 +11,9 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class ForbiddenActionException extends BaseException
 {
     public function __construct(array $parameters = array())

--- a/Exception/NoEntitiesConfiguredException.php
+++ b/Exception/NoEntitiesConfiguredException.php
@@ -11,6 +11,9 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class NoEntitiesConfiguredException extends BaseException
 {
     public function __construct(array $parameters = array())

--- a/Exception/UndefinedEntityException.php
+++ b/Exception/UndefinedEntityException.php
@@ -11,6 +11,9 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
 
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class UndefinedEntityException extends BaseException
 {
     public function __construct(array $parameters = array())

--- a/Form/Extension/EasyAdminExtension.php
+++ b/Form/Extension/EasyAdminExtension.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
@@ -7,6 +16,12 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * Extension that injects EasyAdmin related information in the view used to
+ * render the form.
+ *
+ * @author Maxime Steinhausser
+ */
 class EasyAdminExtension extends AbstractTypeExtension
 {
     /** @var Request|null */

--- a/Form/Extension/EasyAdminExtension.php
+++ b/Form/Extension/EasyAdminExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
  * Extension that injects EasyAdmin related information in the view used to
  * render the form.
  *
- * @author Maxime Steinhausser
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
 class EasyAdminExtension extends AbstractTypeExtension
 {

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  * Custom form type that deals with some of the logic used to render the
  * forms used to create and edit EasyAdmin entities.
  *
- * @author Maxime Steinhausser
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
 class EasyAdminFormType extends AbstractType
 {

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Form\Type;
 
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -10,6 +19,12 @@ use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
+/**
+ * Custom form type that deals with some of the logic used to render the
+ * forms used to create and edit EasyAdmin entities.
+ *
+ * @author Maxime Steinhausser
+ */
 class EasyAdminFormType extends AbstractType
 {
     /** @var Configurator */

--- a/Reflection/ClassPropertyReflector.php
+++ b/Reflection/ClassPropertyReflector.php
@@ -15,6 +15,8 @@ use Doctrine\Common\Inflector\Inflector;
 
 /**
  * Introspects information about the properties of the given class.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 class ClassPropertyReflector
 {

--- a/Reflection/EntityMetadataInspector.php
+++ b/Reflection/EntityMetadataInspector.php
@@ -16,6 +16,8 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
 
 /**
  * Introspects information about the properties of the given entity class.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 class EntityMetadataInspector
 {

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -14,6 +14,11 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Twig;
 use Doctrine\ORM\PersistentCollection;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
 
+/**
+ * Defines the filters and functions used to render the bundle's templates.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
 class EasyAdminTwigExtension extends \Twig_Extension
 {
     private $configurator;


### PR DESCRIPTION
I've added all the missing PHPdoc information. I've followed the same syntax used by Symfony, so I've also added the author of each class.

@ogizanagi appears as the sole author of `EasyAdminExtension` and `EasyAdminFormType` Thanks! @Pierstoval unfortunately for you, authorship is not included in the tests classes, which is where you created the classes. I'm sorry about this.

If I forgot someone as the author of some class, I apologize and please, feel free to add yourself in a new pull request. Thanks!
