### PR TITLE
Deprecated 'admin' route in favor of 'easyadmin'

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -47,7 +47,10 @@ class AdminController extends Controller
     protected $em;
 
     /**
+     * @Route("/", name="easyadmin")
      * @Route("/", name="admin")
+     *
+     * The 'admin' route is deprecated since version 1.8.0 and it will be removed in 2.0.
      *
      * @param Request $request
      *
@@ -58,7 +61,7 @@ class AdminController extends Controller
         $this->initialize($request);
 
         if (null === $request->query->get('entity')) {
-            return $this->redirect($this->generateUrl('admin', array('action' => 'list', 'entity' => $this->config['default_entity_name'])));
+            return $this->redirect($this->generateUrl('easyadmin', array('action' => 'list', 'entity' => $this->config['default_entity_name'])));
         }
 
         $action = $request->query->get('action', 'list');
@@ -195,7 +198,7 @@ class AdminController extends Controller
 
             return !empty($refererUrl)
                 ? $this->redirect(urldecode($refererUrl))
-                : $this->redirect($this->generateUrl('admin', array('action' => 'list', 'entity' => $this->entity['name'])));
+                : $this->redirect($this->generateUrl('easyadmin', array('action' => 'list', 'entity' => $this->entity['name'])));
         }
 
         $this->dispatch(EasyAdminEvents::POST_EDIT);
@@ -279,7 +282,7 @@ class AdminController extends Controller
 
             $this->dispatch(EasyAdminEvents::POST_PERSIST, array('entity' => $entity));
 
-            return $this->redirect($this->generateUrl('admin', array('action' => 'list', 'entity' => $this->entity['name'])));
+            return $this->redirect($this->generateUrl('easyadmin', array('action' => 'list', 'entity' => $this->entity['name'])));
         }
 
         $this->dispatch(EasyAdminEvents::POST_NEW, array(
@@ -306,7 +309,7 @@ class AdminController extends Controller
         $this->dispatch(EasyAdminEvents::PRE_DELETE);
 
         if ('DELETE' !== $this->request->getMethod()) {
-            return $this->redirect($this->generateUrl('admin', array('action' => 'list', 'entity' => $this->entity['name'])));
+            return $this->redirect($this->generateUrl('easyadmin', array('action' => 'list', 'entity' => $this->entity['name'])));
         }
 
         $id = $this->request->query->get('id');
@@ -337,7 +340,7 @@ class AdminController extends Controller
 
         return !empty($refererUrl)
             ? $this->redirect(urldecode($refererUrl))
-            : $this->redirect($this->generateUrl('admin', array('action' => 'list', 'entity' => $this->entity['name'])));
+            : $this->redirect($this->generateUrl('easyadmin', array('action' => 'list', 'entity' => $this->entity['name'])));
     }
 
     /**
@@ -629,7 +632,7 @@ class AdminController extends Controller
     protected function createDeleteForm($entityName, $entityId)
     {
         return $this->createFormBuilder()
-            ->setAction($this->generateUrl('admin', array('action' => 'delete', 'entity' => $entityName, 'id' => $entityId)))
+            ->setAction($this->generateUrl('easyadmin', array('action' => 'delete', 'entity' => $entityName, 'id' => $entityId)))
             ->setMethod('DELETE')
             ->add('submit', 'submit', array('label' => 'Delete'))
             ->getForm()

--- a/DataCollector/EasyAdminDataCollector.php
+++ b/DataCollector/EasyAdminDataCollector.php
@@ -47,7 +47,8 @@ class EasyAdminDataCollector extends DataCollector
 
     private function getEasyAdminParameters(Request $request)
     {
-        if ('admin' !== $request->attributes->get('_route')) {
+        // 'admin' is the deprecated route name that will be removed in version 2.0.
+        if (!in_array($request->attributes->get('_route'), array('easyadmin', 'admin'))) {
             return;
         }
 

--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -48,7 +48,8 @@ class RequestPostInitializeListener
             return;
         }
 
-        if ('admin' === $this->request->attributes->get('_route')) {
+        if ('admin' === $this->request->attributes->get('_route')
+            && 'AppBundle\Controller\AdminController::indexAction' === $this->request->attributes->get('_controller')) {
             trigger_error('The "admin" route is deprecated since version 1.8.0 and it will be removed in 2.0.0. Use the "easyadmin" route instead.', E_USER_DEPRECATED);
         }
 

--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -48,11 +48,6 @@ class RequestPostInitializeListener
             return;
         }
 
-        if ('admin' === $this->request->attributes->get('_route')
-            && 'AppBundle\Controller\AdminController::indexAction' === $this->request->attributes->get('_controller')) {
-            trigger_error('The "admin" route is deprecated since version 1.8.0 and it will be removed in 2.0.0. Use the "easyadmin" route instead.', E_USER_DEPRECATED);
-        }
-
         $this->request->attributes->set('easyadmin', array(
             'entity' => $entity = $event->getArgument('entity'),
             'view' => $this->request->query->get('action', 'list'),

--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -48,6 +48,10 @@ class RequestPostInitializeListener
             return;
         }
 
+        if ('admin' === $this->request->attributes->get('_route')) {
+            trigger_error('The "admin" route is deprecated since version 1.8.0 and it will be removed in 2.0.0. Use the "easyadmin" route instead.', E_USER_DEPRECATED);
+        }
+
         $this->request->attributes->set('easyadmin', array(
             'entity' => $entity = $event->getArgument('entity'),
             'view' => $this->request->query->get('action', 'list'),

--- a/Resources/doc/tutorials/customizing-admin-controller.md
+++ b/Resources/doc/tutorials/customizing-admin-controller.md
@@ -41,7 +41,7 @@ class AdminController extends BaseAdminController
 
 Extending from the default controller is not enough to override the entire
 backend. You must also **update the routing configuration** to point the
-`admin` route to the new controller.
+`easyadmin` route to the new controller.
 
 Open the `app/config/routing.yml` file and change the value of the `resource`
 option defined by the existing `easy_admin_bundle` route to load your own

--- a/Resources/doc/tutorials/customizing-backend-actions.md
+++ b/Resources/doc/tutorials/customizing-backend-actions.md
@@ -73,7 +73,7 @@ easy_admin:
 
 The value of the `actions` option is merged with the default action
 configuration. This means that in the example above, the `edit` view of all
-entities will include the `list`, `delete` and `show` actions (the first two 
+entities will include the `list`, `delete` and `show` actions (the first two
 are the default actions and the last one is explicitly configured).
 
 Instead of adding new actions, sometimes you want to remove them. To do so, use
@@ -213,8 +213,8 @@ click on any of those links, you'll see an error because the `restockAction()`
 method is not defined in the AdminController.
 
 Therefore, the next step is to create a custom `AdminController` in your
-Symfony application and to make it extend from the base AdminController 
-provided by EasyAdmin. This process will take you less than a minute and it's 
+Symfony application and to make it extend from the base AdminController
+provided by EasyAdmin. This process will take you less than a minute and it's
 explained in detail in the *Customization Based on Controller Methods* section
 in the [Customizing AdminController tutorial] [customizing-admin-controller].
 
@@ -244,7 +244,7 @@ class AdminController extends BaseAdminController
         $this->em->flush();
 
         // redirect to the 'list' view of the given entity
-        return $this->redirectToRoute('admin', array(
+        return $this->redirectToRoute('easyadmin', array(
             'view' => 'list',
             'entity' => $this->request->query->get('entity'),
         ));
@@ -308,7 +308,7 @@ easy_admin:
 ```
 
 Route based actions are displayed as regular links or buttons, but they don't
-point to the usual `admin` route but to the route configured by the action.
+point to the usual `easyadmin` route but to the route configured by the action.
 In addition, the route is passed two parameters in the query string: `entity`
 (the name of the Doctrine entity) and, when available, the `id` of the related
 entity.
@@ -342,13 +342,13 @@ class ProductController extends Controller
         $em->flush();
 
         // redirect to the 'list' view of the given entity
-        return $this->redirectToRoute('admin', array(
+        return $this->redirectToRoute('easyadmin', array(
             'view' => 'list',
             'entity' => $this->request->query->get('entity'),
         ));
 
         // redirect to the 'edit' view of the given entity item
-        return $this->redirectToRoute('admin', array(
+        return $this->redirectToRoute('easyadmin', array(
             'view' => 'edit',
             'id' => $id,
             'entity' => $this->request->query->get('entity'),

--- a/Resources/doc/tutorials/tips-and-tricks.md
+++ b/Resources/doc/tutorials/tips-and-tricks.md
@@ -98,9 +98,9 @@ class AdminController extends BaseAdminController
 ```
 
 Beware that the `index()` method of the default `AdminController` defines the
-`admin` route, which is used to generate every backend URL. This means that
+`easyadmin` route, which is used to generate every backend URL. This means that
 when overriding the `index()` method in your own controller, you must also
-redefine the `@Route()` annotation. Otherwise, the backend will stop working.
+add the `@Route()` annotation. Otherwise, the backend will stop working.
 
 Create a Read-Only Backend
 --------------------------

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -1,7 +1,7 @@
 {% if value is iterable %}
     <span class="badge">{{ value|length }}</span>
 {% elseif link_parameters is defined %}
-    <a href="{{ path('admin', link_parameters) }}">{{ value|easyadmin_truncate }}</a>
+    <a href="{{ path('easyadmin', link_parameters) }}">{{ value|easyadmin_truncate }}</a>
 {% else %}
     {{ value|easyadmin_truncate }}
 {% endif %}

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -42,7 +42,7 @@
                         {% set _site_name_length = easyadmin_config('site_name')|length <= 10 ? 'short'
                             : easyadmin_config('site_name')|length <= 12 ? 'medium' : 'long'
                         %}
-                        <a href="{{ path('admin') }}" class="{{ _site_name_length }}">{{ easyadmin_config('site_name')|raw }}</a>
+                        <a href="{{ path('easyadmin') }}" class="{{ _site_name_length }}">{{ easyadmin_config('site_name')|raw }}</a>
                         {% endblock header_logo %}
                     </div>
                     {% endblock navbar_header %}
@@ -54,7 +54,7 @@
                             {% block navigation_items %}
                                 {% for item in easyadmin_config('entities') %}
                                     <li class="{{ item.name|lower == app.request.get('entity')|lower ? 'active' : '' }}">
-                                        <a href="{{ path('admin', { entity: item.name, action: 'list' }) }}">
+                                        <a href="{{ path('easyadmin', { entity: item.name, action: 'list' }) }}">
                                             {{- item.label|trans -}}
                                         </a>
                                     </li>

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -33,7 +33,7 @@
         {% set _request_parameters = _request_parameters|merge({ query: app.request.get('query')|default('') }) %}
     {% endif %}
 
-    {% set _request_parameters = _request_parameters|merge({ referer: path('admin', _request_parameters)|url_encode }) %}
+    {% set _request_parameters = _request_parameters|merge({ referer: path('easyadmin', _request_parameters)|url_encode }) %}
 
     {% block flash_messages %}{{ parent() }}{% endblock flash_messages %}
 
@@ -50,7 +50,7 @@
                         {% block new_action %}
                             {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
                             <div id="content-actions">
-                                <a class="btn {{ _action.css_class|default('') }}" href="{{ path('admin', _request_parameters|merge({ action: _action.name })) }}">
+                                <a class="btn {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                     {{ _action.label|default('action.new')|trans(_trans_parameters) }}
                                 </a>
@@ -61,7 +61,7 @@
                     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
                         {% block search_action %}
                             {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
-                            <form id="content-search" class="col-xs-6 col-sm-8 {{ _action.css_class|default('') }}" method="get" action="{{ path('admin') }}">
+                            <form id="content-search" class="col-xs-6 col-sm-8 {{ _action.css_class|default('') }}" method="get" action="{{ path('easyadmin') }}">
                                 <input type="hidden" name="action" value="search">
                                 <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
                                 <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
@@ -99,7 +99,7 @@
                                     {% set _column_label =  metadata.label ? metadata.label|trans(_trans_parameters) : field|humanize %}
 
                                     {% if metadata.sortable %}
-                                        <a href="{{ path('admin', _request_parameters|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
+                                        <a href="{{ path('easyadmin', _request_parameters|merge({ sortField: metadata.property, sortDirection: sortDirection|default('DESC') })) }}">
                                             {% if isSortingField and sortDirection == 'DESC' %}
                                                 <i class="fa fa-caret-up"></i>
                                             {% elseif isSortingField and sortDirection == 'ASC' %}
@@ -146,7 +146,7 @@
                                         {% spaceless %}
                                             {% for _action in _list_item_actions %}
                                                 {% if 'method' == _action.type %}
-                                                    {% set _action_href = path('admin', _request_parameters|merge({ action: _action.name, id: _item_id })) %}
+                                                    {% set _action_href = path('easyadmin', _request_parameters|merge({ action: _action.name, id: _item_id })) %}
                                                 {% elseif 'route' == _action.type %}
                                                     {% set _action_href = path(_action.name, _request_parameters|merge({ action: _action.name, id: _item_id })) %}
                                                 {% endif %}
@@ -196,7 +196,7 @@
                 var columnIndex = $(this).closest('td').index() + 1;
                 var propertyName = $('table th.toggle:nth-child(' + columnIndex + ')').data('property-name');
 
-                var toggleUrl = "{{ path('admin', { action: 'edit', entity: _entity_config.name, view: 'list' })|raw }}"
+                var toggleUrl = "{{ path('easyadmin', { action: 'edit', entity: _entity_config.name, view: 'list' })|raw }}"
                               + "&id=" + $(this).closest('tr').data('id')
                               + "&property=" + propertyName
                               + "&newValue=" + newValue.toString();

--- a/Resources/views/default/paginator.html.twig
+++ b/Resources/views/default/paginator.html.twig
@@ -17,7 +17,7 @@
                         </li>
                     {% else %}
                         <li>
-                            <a href="{{ path('admin', _request_parameters|merge({ page: 1 }) ) }}">
+                            <a href="{{ path('easyadmin', _request_parameters|merge({ page: 1 }) ) }}">
                                 <i class="fa fa-angle-double-left"></i> {{ 'paginator.first'|trans }}
                             </a>
                         </li>
@@ -25,7 +25,7 @@
 
                     {% if paginator.hasPreviousPage %}
                         <li>
-                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.previousPage }) ) }}">
+                            <a href="{{ path('easyadmin', _request_parameters|merge({ page: paginator.previousPage }) ) }}">
                                 <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
                             </a>
                         </li>
@@ -39,7 +39,7 @@
 
                     {% if paginator.hasNextPage %}
                         <li>
-                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.nextPage }) ) }}">
+                            <a href="{{ path('easyadmin', _request_parameters|merge({ page: paginator.nextPage }) ) }}">
                                 {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
                             </a>
                         </li>
@@ -53,7 +53,7 @@
 
                     {% if paginator.currentPage < paginator.nbPages %}
                         <li>
-                            <a href="{{ path('admin', _request_parameters|merge({ page: paginator.nbPages }) ) }}">
+                            <a href="{{ path('easyadmin', _request_parameters|merge({ page: paginator.nbPages }) ) }}">
                                 {{ 'paginator.last'|trans }} <i class="fa fa-angle-double-right"></i>
                             </a>
                         </li>

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -37,7 +37,7 @@
                 {% set _show_actions = easyadmin_get_actions_for_show_item(_entity_config.name) %}
                 {% for _action in _show_actions %}
                     {% if 'method' == _action.type %}
-                        {% set _action_href = path('admin', { action: _action.name, entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
+                        {% set _action_href = path('easyadmin', { action: _action.name, entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
                     {% elseif 'route' == _action.type %}
                         {% set _action_href = path(_action.name, { entity: _entity_config.name, id: attribute(entity, _entity_config.primary_key_field_name), referer: app.request.query.get('referer', '') }) %}
                     {% endif %}
@@ -59,7 +59,7 @@
                 {# for aesthetic reasons, the 'list' action is always displayed as a link instead of a button #}
                 {% if easyadmin_action_is_enabled_for_show_view('list', _entity_config.name) %}
                     {% set _action = easyadmin_get_action_for_show_view('list', _entity_config.name) %}
-                    <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
+                    <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('easyadmin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                         {{ _action.label|default('action.list')|trans(_trans_parameters) }}
                     {% endspaceless %}</a>

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -334,24 +334,24 @@
                         <button type="submit" class="btn">
                             <i class="fa fa-save"></i> {{ 'action.save'|trans(_trans_parameters, 'messages') }}
                         </button>
-    
+
                         {% set _entity_actions = (easyadmin.view == 'new')
                         ? easyadmin_get_actions_for_new_item(easyadmin.entity.name)
                         : easyadmin_get_actions_for_edit_item(easyadmin.entity.name) %}
-    
+
                         {% for _action in _entity_actions %}
                             {% if 'method' == _action.type %}
-                                {% set _action_href = path('admin', { action: _action.name, view: view, entity: easyadmin.entity.name, id: attribute(entity, easyadmin.entity.primary_key_field_name) }) %}
+                                {% set _action_href = path('easyadmin', { action: _action.name, view: view, entity: easyadmin.entity.name, id: attribute(entity, easyadmin.entity.primary_key_field_name) }) %}
                             {% elseif 'route' == _action.type %}
                                 {% set _action_href = path(_action.name, { entity: easyadmin.entity.name, id: attribute(entity, easyadmin.entity.primary_key_field_name) }) %}
                             {% endif %}
-    
+
                             <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                 {{ _action.label|trans(_trans_parameters) }}
                             </a>
                         {% endfor %}
-    
+
                         {% if easyadmin.view == 'edit' %}
                             {% if easyadmin_action_is_enabled_for_edit_view('delete', easyadmin.entity.name) %}
                                 {% set _action = easyadmin_get_action_for_edit_view('delete', easyadmin.entity.name) %}
@@ -362,17 +362,17 @@
                                 </button>
                             {% endif %}
                         {% endif %}
-    
+
                         {# for aesthetic reasons, the 'list' action is always displayed as a link instead of a button #}
                         {% if easyadmin.view == 'new' and easyadmin_action_is_enabled_for_new_view('list', easyadmin.entity.name) %}
                             {% set _list_action = easyadmin_get_action_for_new_view('list', easyadmin.entity.name) %}
                         {% elseif easyadmin.view == 'edit' and easyadmin_action_is_enabled_for_edit_view('list', easyadmin.entity.name) %}
                             {% set _list_action = easyadmin_get_action_for_edit_view('list', easyadmin.entity.name) %}
                         {% endif %}
-    
+
                         {% if _list_action is defined %}
                             <a class="btn btn-secondary"
-                               href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('admin', ({ entity: easyadmin.entity.name, action: _list_action.name, view: easyadmin.view }) ) }}">{% spaceless %}
+                               href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('easyadmin', ({ entity: easyadmin.entity.name, action: _list_action.name, view: easyadmin.view }) ) }}">{% spaceless %}
                                     {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
                                     {{ _list_action.label|default('action.list')|trans(_trans_parameters, 'messages') }}
                                 {% endspaceless %}</a>

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,16 @@ This document describes the backwards incompatible changes introduced by each
 EasyAdminBundle version and the needed changes to be made before upgrading to
 the next version.
 
+Upgrade to 2.0.0
+----------------
+
+The route used to generate every backend URL is now called `easyadmin` instead
+of `admin`. This change has been introduce to prevent collisions with your
+existing backend routes, where is common to use the `admin` route name.
+
+In order to upgrade, you just need to replace `admin` by `easyadmin` in all
+`path()`, `generateUrl()` and `redirectToRoute()` calls.
+
 Upgrade to 1.5.5
 ----------------
 
@@ -143,7 +153,7 @@ easy_admin:
 
 ### Changed variables names in twig views
 
-The former `_entity` variable was used to retrieve the current entity configuration. 
+The former `_entity` variable was used to retrieve the current entity configuration.
 This variable has been renamed to `_entity_config` for convenience and readability reasons.
 
 The old `item` variable was used to carry the currently created/edited entity.
@@ -157,7 +167,7 @@ Upgrade to 1.4.0
 These changes affect you only if you have customized any of the following
 templates in your backend:
 
-1) `form/entity_form.html.twig` template has been renamed to `form.html.twig` 
+1) `form/entity_form.html.twig` template has been renamed to `form.html.twig`
 2) `_list_paginator.html.twig` template has been renamed to `_paginator.html.twig`
 3) `_flashes.html.twig` template has been removed because it wasn't used in any other template
 


### PR DESCRIPTION
This pull request deprecates the `admin` route but it doesn't remove it to maintain backwards compatibility. The trick is to use two different routes with the same path in the controller:

``` php
/**
 * @Route("/", name="easyadmin")
 * @Route("/", name="admin")
 */
public function indexAction()
{
    // ...
}
```

This fixes #342.
