### PR TITLE
Minor changes

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -74,6 +74,16 @@ class Configurator
     }
 
     /**
+     * Exposes the backend configuration to any external method that needs it.
+     *
+     * @return array
+     */
+    public function getBackendConfig()
+    {
+        return $this->backendConfig;
+    }
+
+    /**
      * Processes and returns the full configuration for the given entity name.
      * This configuration includes all the information about the form fields
      * and properties of the entity.
@@ -81,6 +91,8 @@ class Configurator
      * @param string $entityName
      *
      * @return array The full entity configuration
+     *
+     * @throws \InvalidArgumentException when the entity isn't managed by EasyAdmin
      */
     public function getEntityConfiguration($entityName)
     {
@@ -201,7 +213,7 @@ class Configurator
      *
      * @return array The list of fields to show and their metadata
      */
-    protected function getFieldsForFormBasedViews($view, array $entityConfiguration)
+    private function getFieldsForFormBasedViews($view, array $entityConfiguration)
     {
         if (0 === count($entityConfiguration[$view]['fields'])) {
             $excludedFieldNames = array($entityConfiguration['primary_key_field_name']);
@@ -515,15 +527,5 @@ class Configurator
         return array_key_exists($doctrineType, $this->doctrineTypeToFormTypeMap)
             ? $this->doctrineTypeToFormTypeMap[$doctrineType]
             : $doctrineType;
-    }
-
-    /**
-     * Exposes the backend configuration to any external method that needs it.
-     *
-     * @return array
-     */
-    public function getBackendConfig()
-    {
-        return $this->backendConfig;
     }
 }

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -166,7 +166,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 try {
                     $associatedEntityConfig = $this->configurator->getEntityConfiguration($associatedEntityClassName);
                     $associatedEntityPrimaryKey = $associatedEntityConfig['primary_key_field_name'];
-                } catch (\Exception $e) {
+                } catch (\InvalidArgumentException $e) {
                     // if the entity isn't managed by EasyAdmin, don't link to it and just display its raw value
                     return $twig->render($entityConfiguration['templates']['field_association'], $templateParameters);
                 }


### PR DESCRIPTION
Some very minor changes that might make sense, and that I encountered while digging back into some parts:
- public methods before protected and private ones
- protected method that doesn't make sense
- only expect to catch an `\InvalidArgumentException` when trying to call `Configurator:: getEntityConfiguration`
