### PR TITLE
Minor renaming to use the same names as Symfony

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -470,8 +470,8 @@ class Configurator
                 $isPublic = $this->reflector->isPublic($entityConfiguration['class'], $fieldName);
                 $fieldConfiguration['isPublic'] = $isPublic;
 
-                $fieldConfiguration['canBeGet'] = $getter || $isPublic;
-                $fieldConfiguration['canBeSet'] = $setter || $isPublic;
+                $fieldConfiguration['isReadable'] = $getter || $isPublic;
+                $fieldConfiguration['isWritable'] = $setter || $isPublic;
 
                 $entityConfiguration[$view]['fields'][$fieldName] = $fieldConfiguration;
             }

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -387,7 +387,7 @@ class AdminController extends Controller
             throw new \Exception(sprintf('The "%s" property is not a switchable toggle.', $propertyName));
         }
 
-        if (!$propertyMetadata['canBeSet']) {
+        if (!$propertyMetadata['isWritable']) {
             throw new \Exception(sprintf('It\'s not possible to toggle the value of the "%s" boolean property of the "%s" entity.', $propertyName, $this->entity['name']));
         }
 

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -109,7 +109,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
     {
         $entityConfiguration = $this->configurator->getEntityConfiguration($entityName);
 
-        if (!$fieldMetadata['canBeGet']) {
+        if (!$fieldMetadata['isReadable']) {
             return $twig->render($entityConfiguration['templates']['label_inaccessible'], array('view' => $view));
         }
 


### PR DESCRIPTION
I never liked the previous names and besides, the new PropertyInfo component form Symfony uses `isReadable` and `isWritable` too, so this change prepares us in case we want to swtich to PropertyInfo in the future.
