### PR TITLE
Extra events for Doctrine QueryBuilder manipulation

### DIFF
--- a/Event/EasyAdminEvents.php
+++ b/Event/EasyAdminEvents.php
@@ -41,4 +41,8 @@ final class EasyAdminEvents
     const POST_UPDATE = 'easy_admin.post_update';
     const PRE_REMOVE = 'easy_admin.pre_remove';
     const POST_REMOVE = 'easy_admin.post_remove';
+
+    // Events related to Doctrine Query Builder usage
+    const POST_LIST_QUERY_BUILDER = 'easy_admin.post_list_query_builder';
+    const POST_SEARCH_QUERY_BUILDER = 'easy_admin.post_search_query_builder';
 }


### PR DESCRIPTION
Extra events for easy (without the need to override findAll and findBy methods in AdminController) Doctrine QueryBuilder manipulation before passing it into Pagerfanta where it gets converted to Query and user is unable to modify it for his needs.

Use case? Let's say you want to split `User` entity into `Administrators` (users with `ROLE_ADMIN` role) and `Users` (users with `ROLE_USER` role). This will allow you to properly modify your `QueryBuilder` based on `entity` metadata. You are not required to override `AdminController::findBy` and `AdminController::findAll` methods anymore.

BCB? None.
