### PR TITLE
Improved the way associations are displayed/handled

### DIFF
--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -303,7 +303,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
      * It returns the last part of the fully qualified class name
      * (e.g. 'AppBundle\Entity\User' -> 'User')
      *
-     * @param  string $fqcn
+     * @param string $fqcn
      *
      * @return string
      */

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -161,7 +161,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
                     return $twig->render($entityConfiguration['templates']['field_association'], $templateParameters);
                 }
 
-                $targetEntityClassName = $this->getClassFromNamespace($fieldMetadata['targetEntity']);
+                $targetEntityClassName = $this->getClassShortName($fieldMetadata['targetEntity']);
                 $targetEntityConfig = $this->getEntityConfiguration($targetEntityClassName);
                 $targetEntityPrimaryKeyGetter = (null !== $targetEntityConfig) ? 'get'.ucfirst($targetEntityConfig['primary_key_field_name']) : null;
 
@@ -169,10 +169,10 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 // associated value (this depends on the target entity methods)
                 if (method_exists($value, '__toString')) {
                     $templateParameters['value'] = (string) $value;
-                } elseif (false && method_exists($value, $targetEntityPrimaryKeyGetter)) {
+                } elseif (method_exists($value, $targetEntityPrimaryKeyGetter)) {
                     $templateParameters['value'] = sprintf('%s #%s', $targetEntityConfig['name'], $value->$targetEntityPrimaryKeyGetter());
                 } else {
-                    $templateParameters['value'] = $this->getClassFromNamespace(get_class($value));
+                    $templateParameters['value'] = $this->getClassShortName(get_class($value));
                 }
 
                 // if the target entity has a primary key getter, it's displayed
@@ -303,13 +303,13 @@ class EasyAdminTwigExtension extends \Twig_Extension
      * It returns the last part of the fully qualified class name
      * (e.g. 'AppBundle\Entity\User' -> 'User')
      *
-     * @param  string $fullyQualifiedClassName
+     * @param  string $fqcn
      *
      * @return string
      */
-    private function getClassFromNamespace($fullyQualifiedClassName)
+    private function getClassShortName($fqcn)
     {
-        $classParts = explode('\\', $fullyQualifiedClassName);
+        $classParts = explode('\\', $fqcn);
         $className = end($classParts);
 
         return $className;

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -53,7 +53,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
     /**
      * Returns the entire backend configuration or the value corresponding to
      * the provided key. The dots of the key are automatically transformed into
-     * nested keys. Example: 'assets.css' => $config['assets']['css']
+     * nested keys. Example: 'assets.css' => $config['assets']['css'].
      *
      * @param string|null $key
      *
@@ -249,7 +249,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
         $actionsExcludedForItems = array(
             'list' => array('delete', 'list', 'new', 'search'),
             'edit' => array('list', 'delete'),
-            'new'  => array('list'),
+            'new' => array('list'),
             'show' => array('list', 'delete'),
         );
         $excludedActions = $actionsExcludedForItems[$view];
@@ -298,10 +298,9 @@ class EasyAdminTwigExtension extends \Twig_Extension
         return $value;
     }
 
-
     /**
      * It returns the last part of the fully qualified class name
-     * (e.g. 'AppBundle\Entity\User' -> 'User')
+     * (e.g. 'AppBundle\Entity\User' -> 'User').
      *
      * @param string $fqcn
      *


### PR DESCRIPTION
This fixes #539 and any other issue related to associations with entities that don't define the usual `__toString()` method. This is the new behavior:

1) Common case: backend displays a link to the "show" view of the target entity.

2) If the target entity is not managed by EasyAdmin, its string representation is displayed without a link.

3) If it's a collection of values, we show the count of elements (as we do now).

The main change is in how we determine the string representation of an associated value:

1) If the target entity has a `__toString()` method, we display `(string) $value`

2) If the target entity has a `getId()` method, we display `Name_of_class #ID` (e.g. `Category #20`)

3) Otherwise, we display the name of the class (e.g. `User`)
