### PR TITLE
Fix findCurrentItem exception

### DIFF
--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -67,10 +67,10 @@ class RequestPostInitializeListener
      */
     private function findCurrentItem(array $entity, $id)
     {
-        if (!$entity = $this->doctrine->getRepository($entity['class'])->find($id)) {
+        if (!$item = $this->doctrine->getRepository($entity['class'])->find($id)) {
             throw new EntityNotFoundException(array('entity' => $entity, 'entity_id' => $id));
         }
 
-        return $entity;
+        return $item;
     }
 }


### PR DESCRIPTION
This fixes the fact the `entity` parameter was `null` due to a variable name collision.
