### PR TITLE
Remove listener from EasyAdminExtension

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -87,6 +87,11 @@ class EasyAdminExtension extends Extension
         // load bundle's services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        // Don't register our exception listener if debug is enabled
+        if ($container->getParameter('kernel.debug')) {
+            $container->removeDefinition('easyadmin.listener.exception');
+        }
     }
 
     /**

--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -35,13 +35,9 @@ class ExceptionListener extends BaseExceptionListener
     /** @var EngineInterface */
     private $templating;
 
-    /** @var bool */
-    private $debug;
-
-    public function __construct(EngineInterface $templating, $debug, $controller, LoggerInterface $logger = null)
+    public function __construct(EngineInterface $templating, $controller, LoggerInterface $logger = null)
     {
         $this->templating = $templating;
-        $this->debug = $debug;
 
         parent::__construct($controller, $logger);
     }
@@ -50,7 +46,7 @@ class ExceptionListener extends BaseExceptionListener
     {
         $exception = $event->getException();
 
-        if (!$exception instanceof BaseException || true === $this->debug) {
+        if (!$exception instanceof BaseException) {
             return;
         }
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,7 +24,6 @@
 
         <service id="easyadmin.listener.exception" class="JavierEguiluz\Bundle\EasyAdminBundle\EventListener\ExceptionListener">
             <argument type="service" id="templating" />
-            <argument>%kernel.debug%</argument>
             <argument type="string">easyadmin.listener.exception:showExceptionPageAction</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <tag name="monolog.logger" channel="request" />

--- a/Tests/DependencyInjection/EasyAdminExtensionTest.php
+++ b/Tests/DependencyInjection/EasyAdminExtensionTest.php
@@ -30,7 +30,20 @@ class EasyAdminExtensionTest extends CommonPhpUnitTestCase
     public function setUp()
     {
         $this->container = new ContainerBuilder();
+        $this->container->setParameter('kernel.debug', false);
         $this->loader = new EasyAdminExtension();
+    }
+
+    public function testEasyAdminExceptionListenerIsRemovedOnDebug()
+    {
+        $this->container->getParameterBag()->add(array(
+            'kernel.debug' => true,
+            'kernel.root_dir' => __DIR__,
+        ));
+
+        $this->loader->load(array(), $this->container);
+
+        $this->assertFalse($this->container->has('easyadmin.listener.exception'));
     }
 
     /**

--- a/Tests/EventListener/ExceptionListenerTest.php
+++ b/Tests/EventListener/ExceptionListenerTest.php
@@ -54,9 +54,8 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
         ));
         $event = $this->getEventExceptionThatShouldBeCalledOnce($exception);
         $templating = $this->getTemplating();
-        $debug = false;
 
-        $listener = new ExceptionListener($templating, $debug, 'easyadmin.listener.exception:showExceptionPageAction');
+        $listener = new ExceptionListener($templating, 'easyadmin.listener.exception:showExceptionPageAction');
         $listener->onKernelException($event);
     }
 
@@ -76,9 +75,8 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
         $exception = new EntityNotFoundException();
         $event = $this->getEventExceptionThatShouldNotBeCalled($exception);
         $templating = $this->getTemplating();
-        $debug = false;
 
-        $listener = new ExceptionListener($templating, $debug, 'easyadmin.listener.exception:showExceptionPageAction');
+        $listener = new ExceptionListener($templating, 'easyadmin.listener.exception:showExceptionPageAction');
         $listener->onKernelException($event);
     }
 }


### PR DESCRIPTION
This is quite peculiar, as we do the exact opposite of what we are used to (i.e: removing something when we are in `debug` mode, instead of removing something when we are in `prod` / `non-debug`), so there is no real performance gain or whatever...

Anyway, let me know if it makes sense to you, or if you fear that it might induce confusion.
