### PR TITLE
Guess required option using guessers

### DIFF
--- a/DependencyInjection/Compiler/EasyAdminFormTypePass.php
+++ b/DependencyInjection/Compiler/EasyAdminFormTypePass.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
+ */
+class EasyAdminFormTypePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $formTypeDefinition = $container->getDefinition('easyadmin.form.type');
+
+        $guessers = array_map(function ($guesserId) {
+            return new Reference($guesserId);
+        }, array_keys($container->findTaggedServiceIds('form.type_guesser')));
+        $guesserChain = new Definition('Symfony\Component\Form\FormTypeGuesserChain', array($guessers));
+
+        $formTypeDefinition->replaceArgument(2, $guesserChain);
+    }
+}

--- a/EasyAdminBundle.php
+++ b/EasyAdminBundle.php
@@ -11,6 +11,8 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle;
 
+use JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection\Compiler\EasyAdminFormTypePass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -18,4 +20,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class EasyAdminBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new EasyAdminFormTypePass());
+    }
 }

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormTypeGuesserInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -33,14 +34,19 @@ class EasyAdminFormType extends AbstractType
     /** @var array */
     private $config;
 
+    /** @var FormTypeGuesserInterface */
+    private $guesser;
+
     /**
-     * @param Configurator $configurator
-     * @param array        $config
+     * @param Configurator             $configurator
+     * @param array                    $config
+     * @param FormTypeGuesserInterface $guesser
      */
-    public function __construct(Configurator $configurator, array $config)
+    public function __construct(Configurator $configurator, array $config, FormTypeGuesserInterface $guesser)
     {
         $this->configurator = $configurator;
         $this->config = $config;
+        $this->guesser = $guesser;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -80,6 +86,10 @@ class EasyAdminFormType extends AbstractType
                 }
             } elseif ('checkbox' === $metadata['fieldType'] && !isset($formFieldOptions['required'])) {
                 $formFieldOptions['required'] = false;
+            }
+
+            if (!isset($formFieldOptions['required'])) {
+                $formFieldOptions['required'] = $this->guesser->guessRequired($builder->getOption('data_class'), $name)->getValue();
             }
 
             $formFieldOptions['attr']['field_type'] = $metadata['fieldType'];

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -38,6 +38,7 @@
         <service id="easyadmin.form.type" class="JavierEguiluz\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType">
             <argument type="service" id="easyadmin.configurator" />
             <argument>%easyadmin.config%</argument>
+            <argument /> <!-- type guesser chain -->
             <tag name="form.type" alias="easyadmin" />
         </service>
 


### PR DESCRIPTION
Related to #564 

Using existing type guessers allow us to guess if a field should be required based on Doctrine or Validation metadata for instance.

So an entity `User` having its field `firstname` defined as `nullable` in Doctrine metadata will not have this field as required.

I'd like to inject the guesser (it's a [FormTypeGuesserChain](https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Form/FormTypeGuesserChain.php) instance) directly into the `EasyAdminFormType`, it would make more sense, but this requires a compiler pass. 
What do you think ?
