### PR TITLE
Another round of teaks

### DIFF
--- a/DependencyInjection/Compiler/EasyAdminFormTypePass.php
+++ b/DependencyInjection/Compiler/EasyAdminFormTypePass.php
@@ -33,20 +33,5 @@ class EasyAdminFormTypePass implements CompilerPassInterface
         $guesserChain = new Definition('Symfony\Component\Form\FormTypeGuesserChain', array($guessers));
 
         $formTypeDefinition->replaceArgument(2, $guesserChain);
-
-        if (!$this->useLegacyFormComponent()) {
-            $formTypeDefinition->clearTag('form.type');
-            $formTypeDefinition->addTag('form.type');
-        }
-    }
-
-    /**
-     * Returns true if the legacy Form component is being used by the application.
-     *
-     * @return bool
-     */
-    private function useLegacyFormComponent()
-    {
-        return false === class_exists('Symfony\\Component\\Form\\Util\\StringUtil');
     }
 }

--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -19,15 +19,15 @@ class RequestPostInitializeListener
     /** @var Request|null */
     private $request;
 
-    /** @var Request|null */
+    /** @var RequestStack|null */
     private $requestStack;
 
     /** @var Registry */
     private $doctrine;
 
     /**
-     * @param Registry     $doctrine
-     * @param RequestStack $requestStack
+     * @param Registry          $doctrine
+     * @param RequestStack|null $requestStack
      */
     public function __construct(Registry $doctrine, RequestStack $requestStack = null)
     {

--- a/Form/Extension/EasyAdminExtension.php
+++ b/Form/Extension/EasyAdminExtension.php
@@ -28,12 +28,10 @@ class EasyAdminExtension extends AbstractTypeExtension
     /** @var Request|null */
     private $request;
 
-    /** @var Request|null */
+    /** @var RequestStack|null */
     private $requestStack;
 
     /**
-     * EasyAdminExtension constructor.
-     *
      * @param RequestStack|null $requestStack
      */
     public function __construct(RequestStack $requestStack = null)
@@ -41,6 +39,9 @@ class EasyAdminExtension extends AbstractTypeExtension
         $this->requestStack = $requestStack;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
         if (null !== $this->requestStack) {
@@ -83,7 +84,7 @@ class EasyAdminExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return $this->useLegacyFormComponent() ? 'form' : 'Symfony\Component\Form\Extension\Core\Type\FormType';
+        return $this->useLegacyFormComponent() ? 'form' : 'Symfony\\Component\\Form\\Extension\\Core\\Type\\FormType';
     }
 
     /**


### PR DESCRIPTION
- remove duplication
- missing/wrong docblocks
- reorganize imports
- use fluent interfaces when it make sense
- consistent way to compare Kernel version with `version_compare`
- public methods before protected and private ones
- protected method that doesn't make sense
- move forms BC layer logic to the `DependencyInjection/Extension` instead of the compiler pass.
