### PR TITLE
Fixed a bug with properties that include underscores in their names

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -149,9 +149,6 @@ class Configurator
 
         // introspect regular entity fields
         foreach ($entityMetadata->fieldMappings as $fieldName => $fieldMetadata) {
-            // field names are tweaked this way to simplify Twig templates and extensions
-            $fieldName = str_replace('_', '', $fieldName);
-
             $entityPropertiesMetadata[$fieldName] = $fieldMetadata;
         }
 


### PR DESCRIPTION
This fixes #579.

After investigating the error described in #579, I found that the cause was that we normalize the name of the properties (`is_active` -> `isactive`) but only in some places, not consistently across the bundle.

I remember that this normalization is a legacy of the code we used in the first versions of this bundle and which was inherited from the SensioGeneratorBundle. My guess is that we can safely remove this code and no problem will occur in the Twig templates.
