### PR TITLE
Allow to set date/time form fields to null

### DIFF
--- a/Resources/public/javascript/admin.js
+++ b/Resources/public/javascript/admin.js
@@ -43,8 +43,9 @@ function createNullableControls() {
             $(this).prop('disabled', formFiledIsDisabled);
 
             if (formFiledIsDisabled) {
-                $(this).not(':has(option[value=""])').prepend('<option value=""></option>');
-                $(this).val('');
+                $(this).parent().slideUp({ duration: 200 });
+            } else {
+                $(this).parent().slideDown({ duration: 200 });
             }
         });
     };

--- a/Resources/public/javascript/admin.js
+++ b/Resources/public/javascript/admin.js
@@ -39,10 +39,10 @@ function createNullableControls() {
         var checkbox = $(this);
 
         checkbox.closest('.form-group').find('select').each(function() {
-            var formFiledIsDisabled = checkbox.is(':checked');
-            $(this).prop('disabled', formFiledIsDisabled);
+            var formFieldIsDisabled = checkbox.is(':checked');
+            $(this).prop('disabled', formFieldIsDisabled);
 
-            if (formFiledIsDisabled) {
+            if (formFieldIsDisabled) {
                 $(this).parent().slideUp({ duration: 200 });
             } else {
                 $(this).parent().slideDown({ duration: 200 });

--- a/Resources/public/javascript/admin.js
+++ b/Resources/public/javascript/admin.js
@@ -39,7 +39,13 @@ function createNullableControls() {
         var checkbox = $(this);
 
         checkbox.closest('.form-group').find('select').each(function() {
-            $(this).prop('disabled', checkbox.is(':checked'))
+            var formFiledIsDisabled = checkbox.is(':checked');
+            $(this).prop('disabled', formFiledIsDisabled);
+
+            if (formFiledIsDisabled) {
+                $(this).not(':has(option[value=""])').prepend('<option value=""></option>');
+                $(this).val('');
+            }
         });
     };
 

--- a/Resources/public/javascript/admin.js
+++ b/Resources/public/javascript/admin.js
@@ -9,6 +9,7 @@ $(function () {
 
     mainMenuDropShadow.apply(mainMenu);
     mainMenuResponsiveCollapse();
+    createNullableControls();
 });
 
 function mainMenuDropShadow() {
@@ -31,4 +32,16 @@ function mainMenuResponsiveCollapse() {
     } else {
         mainMenuItems.flexMenu({ 'undo': true });
     }
+}
+
+function createNullableControls() {
+    var fnNullDates = function() {
+        var checkbox = $(this);
+
+        checkbox.closest('.form-group').find('select').each(function() {
+            $(this).prop('disabled', checkbox.is(':checked'))
+        });
+    };
+
+    $('.nullable-control :checkbox').bind('change', fnNullDates).each(fnNullDates);
 }

--- a/Resources/translations/EasyAdminBundle.en.xlf
+++ b/Resources/translations/EasyAdminBundle.en.xlf
@@ -75,21 +75,9 @@
                 <source>label.null</source>
                 <target>Null</target>
             </trans-unit>
-            <trans-unit id="label.nullable_date">
-                <source>label.nullable_date</source>
-                <target>Disable date</target>
-            </trans-unit>
-            <trans-unit id="label.nullable_time">
-                <source>label.nullable_time</source>
-                <target>Disable time</target>
-            </trans-unit>
-            <trans-unit id="label.nullable_datetime">
-                <source>label.nullable_datetime</source>
-                <target>Disable date and time</target>
-            </trans-unit>
-            <trans-unit id="label.nullable_datetimetz">
-                <source>label.nullable_datetimetz</source>
-                <target>Disable date and time</target>
+            <trans-unit id="label.nullable_field">
+                <source>label.nullable_field</source>
+                <target>Leave empty</target>
             </trans-unit>
             <trans-unit id="label.object">
                 <source>label.object</source>

--- a/Resources/translations/EasyAdminBundle.en.xlf
+++ b/Resources/translations/EasyAdminBundle.en.xlf
@@ -75,6 +75,22 @@
                 <source>label.null</source>
                 <target>Null</target>
             </trans-unit>
+            <trans-unit id="label.nullable_date">
+                <source>label.nullable_date</source>
+                <target>Disable date</target>
+            </trans-unit>
+            <trans-unit id="label.nullable_time">
+                <source>label.nullable_time</source>
+                <target>Disable time</target>
+            </trans-unit>
+            <trans-unit id="label.nullable_datetime">
+                <source>label.nullable_datetime</source>
+                <target>Disable date and time</target>
+            </trans-unit>
+            <trans-unit id="label.nullable_datetimetz">
+                <source>label.nullable_datetimetz</source>
+                <target>Disable date and time</target>
+            </trans-unit>
             <trans-unit id="label.object">
                 <source>label.object</source>
                 <target>PHP Object</target>

--- a/Resources/translations/EasyAdminBundle.es.xlf
+++ b/Resources/translations/EasyAdminBundle.es.xlf
@@ -75,6 +75,22 @@
                 <source>label.null</source>
                 <target>Null</target>
             </trans-unit>
+            <trans-unit id="label.nullable_date">
+                <source>label.nullable_date</source>
+                <target>Desactivar fecha</target>
+            </trans-unit>
+            <trans-unit id="label.nullable_time">
+                <source>label.nullable_time</source>
+                <target>Desactivar hora</target>
+            </trans-unit>
+            <trans-unit id="label.nullable_datetime">
+                <source>label.nullable_datetime</source>
+                <target>Desactivar fecha y hora</target>
+            </trans-unit>
+            <trans-unit id="label.nullable_datetimetz">
+                <source>label.nullable_datetimetz</source>
+                <target>Desactivar fecha y hora</target>
+            </trans-unit>
             <trans-unit id="label.object">
                 <source>label.object</source>
                 <target>Objecto PHP</target>

--- a/Resources/translations/EasyAdminBundle.es.xlf
+++ b/Resources/translations/EasyAdminBundle.es.xlf
@@ -75,21 +75,9 @@
                 <source>label.null</source>
                 <target>Null</target>
             </trans-unit>
-            <trans-unit id="label.nullable_date">
-                <source>label.nullable_date</source>
-                <target>Desactivar fecha</target>
-            </trans-unit>
-            <trans-unit id="label.nullable_time">
-                <source>label.nullable_time</source>
-                <target>Desactivar hora</target>
-            </trans-unit>
-            <trans-unit id="label.nullable_datetime">
-                <source>label.nullable_datetime</source>
-                <target>Desactivar fecha y hora</target>
-            </trans-unit>
-            <trans-unit id="label.nullable_datetimetz">
-                <source>label.nullable_datetimetz</source>
-                <target>Desactivar fecha y hora</target>
+            <trans-unit id="label.nullable_field">
+                <source>label.nullable_field</source>
+                <target>Dejar vacío</target>
             </trans-unit>
             <trans-unit id="label.object">
                 <source>label.object</source>

--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -361,6 +361,10 @@ button.btn-danger {
     margin-bottom: .5em;
 }
 
+.nullable-control {
+    padding-top: 5px;
+}
+
 /* Field: collection
    ------------------------------------------------------------------------- */
 .field-collection .collection-empty {

--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -40,7 +40,7 @@ col-sm-2
                 <div class="nullable-control">
                     <label>
                         <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>
-                        {{ ('label.nullable_' ~ _field_type)|trans({}, 'EasyAdminBundle')}}
+                        {{ 'label.nullable_field'|trans({}, 'EasyAdminBundle')}}
                     </label>
                 </div>
             {% endif %}

--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -26,7 +26,8 @@ col-sm-2
 
 {% block form_row -%}
 {% spaceless %}
-    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
+    {% set _field_type = attr.field_type|default('default') %}
+    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ _field_type }} {{ attr.field_css_class|default('') }}">
 
         {% set _trans_parameters = { '%entity_name%':  easyadmin.entity.name|trans, '%entity_label%': easyadmin.entity.label|trans } %}
         {% set _field_label = easyadmin.field['label']|default(null) %}
@@ -34,6 +35,16 @@ col-sm-2
         {{ form_label(form, _field_label|trans(_trans_parameters)) }}
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}
+
+            {% if _field_type in ['datetime', 'datetimetz', 'date', 'time'] and easyadmin.field.nullable %}
+                <div class="nullable-control">
+                    <label>
+                        <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>
+                        {{ ('label.nullable_' ~ _field_type)|trans({}, 'EasyAdminBundle')}}
+                    </label>
+                </div>
+            {% endif %}
+
             {{ form_errors(form) }}
 
             {% if attr.field_help|default('') != '' %}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -191,7 +191,7 @@
             <div class="nullable-control">
                 <label>
                     <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>
-                    {{ ('label.nullable_' ~ _field_type)|trans({}, 'EasyAdminBundle')}}
+                    {{ 'label.nullable_field'|trans({}, 'EasyAdminBundle')}}
                 </label>
             </div>
         {% endif %}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -178,13 +178,24 @@
 {# Rows #}
 
 {% block form_row -%}
-    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
+    {% set _field_type = attr.field_type|default('default') %}
+    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ _field_type }} {{ attr.field_css_class|default('') }}">
 
         {% set _trans_parameters = { '%entity_name%':  easyadmin.entity.name|trans, '%entity_label%': easyadmin.entity.label|trans } %}
         {% set _field_label = easyadmin.field['label']|default(null) %}
 
         {{- form_label(form, _field_label|trans(_trans_parameters)) -}}
         {{- form_widget(form) -}}
+
+        {% if _field_type in ['datetime', 'datetimetz', 'date', 'time'] and easyadmin.field.nullable %}
+            <div class="nullable-control">
+                <label>
+                    <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>
+                    {{ ('label.nullable_' ~ _field_type)|trans({}, 'EasyAdminBundle')}}
+                </label>
+            </div>
+        {% endif %}
+
         {{- form_errors(form) -}}
 
         {% if attr.field_help|default('') != '' %}


### PR DESCRIPTION
This supersedes #207.

The only thing I'm not happy with is the label dispalyed to the users: I don't want to use _"Null"_ or _"Set to null"_ because `null` is for machines, not for humans. But I don't know if _"Disable date"_ is the appropriate label.
