### PR TITLE
Fix easyadmin dump not marked as safe and consistent EasyAdminDataCollector::dump

### DIFF
--- a/DataCollector/EasyAdminDataCollector.php
+++ b/DataCollector/EasyAdminDataCollector.php
@@ -95,16 +95,20 @@ class EasyAdminDataCollector extends DataCollector
      */
     public function dump($variable)
     {
+        $dumpedData = '';
         if (class_exists('Symfony\Component\VarDumper\Dumper\HtmlDumper')) {
             $cloner = new VarCloner();
             $dumper = new HtmlDumper();
 
-            return $dumper->dump($cloner->cloneVar($variable));
+            $dumper->dump($cloner->cloneVar($variable), $output = fopen('php://memory', 'r+b'));
+            $dumpedData = stream_get_contents($output, -1, 0);
         } elseif (class_exists('Symfony\Component\Yaml\Yaml')) {
-            return sprintf('<pre class="sf-dump">%s</pre>', Yaml::dump((array) $variable, 1024));
+            $dumpedData = sprintf('<pre class="sf-dump">%s</pre>', Yaml::dump((array) $variable, 1024));
         } else {
-            return sprintf('<pre class="sf-dump">%s</pre>', var_export($variable, true));
+            $dumpedData = sprintf('<pre class="sf-dump">%s</pre>', var_export($variable, true));
         }
+
+        return $dumpedData;
     }
 
     public function getName()

--- a/Resources/views/data_collector/easyadmin.html.twig
+++ b/Resources/views/data_collector/easyadmin.html.twig
@@ -75,7 +75,7 @@
         <div class="tab">
             <h3 class="tab-title">Current Entity Configuration</h3>
             <div class="tab-content">
-                {{ collector.dump(collector.currentEntityConfiguration) }}
+                {{ collector.dump(collector.currentEntityConfiguration)|raw }}
             </div>
 
             <br>
@@ -89,12 +89,12 @@
                 {{ collector.dump({
                     'site_name': collector.backendConfiguration['site_name'],
                     'formats': collector.backendConfiguration['formats']
-                }) }}
+                })|raw }}
 
                 <h4>Design Configuration</h4>
                 {{ collector.dump({
                     'design': collector.backendConfiguration['design']
-                }) }}
+                })|raw }}
 
                 <h4>Actions Configuration</h4>
                 {{ collector.dump({
@@ -103,17 +103,17 @@
                     'edit': collector.backendConfiguration['edit'],
                     'new': collector.backendConfiguration['new'],
                     'show': collector.backendConfiguration['show'],
-                }) }}
+                })|raw }}
 
                 <h4>Entities Configuration</h4>
                 {{ collector.dump({
                     'entities': collector.backendConfiguration['entities']
-                }) }}
+                })|raw }}
 
                 <h4>Full Backend Configuration</h4>
                 {{ collector.dump({
                     'easy_admin': collector.backendConfiguration
-                }) }}
+                })|raw }}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Using **sf 2.3.34**, here's what looks like the easyadmin panel:

<img width="779" alt="screenshot 2015-12-07 a 14 09 47" src="https://cloud.githubusercontent.com/assets/2211145/11627694/ed031e9e-9cec-11e5-951f-87087f002778.PNG">

Of course, it's easy to solve by using the `raw` filter in the data collector template:

<img width="786" alt="screenshot 2015-12-07 a 14 10 51" src="https://cloud.githubusercontent.com/assets/2211145/11627671/c05d9f7c-9cec-11e5-89b8-d73c69557afc.PNG">

However, the issue **is not present with sf 2.7+** :interrobang:, which is a bit weird... Any hint ? (This is especially what I'm curious about, not so much the 2.3 support which will be dropped anytime soon)

Also the easyadmin icon is offset downwards:
<img width="202" alt="screenshot 2015-12-07 a 14 20 41" src="https://cloud.githubusercontent.com/assets/2211145/11627869/13cecbe4-9cee-11e5-9bba-c2b8a213fa85.PNG">
