### PR TITLE
Fix Travis issue with ChoiceView and wrong twig-bridge version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/framework-bundle"      : "~2.3|~3.0",
         "symfony/http-foundation"       : "~2.3|~3.0",
         "symfony/http-kernel"           : "~2.3|~3.0",
-        "symfony/twig-bridge"           : "^2.3.4",
+        "symfony/twig-bridge"           : "^2.3.4|~3.0",
         "twig/extensions"               : "~1.0",
         "twig/twig"                     : "~1.14,>=1.14.2|~2.0"
     },


### PR DESCRIPTION
Should fix recent issues with Travis about `ChoiceView`.

However, I think we should also rework the `.travis.yml` file, now that PHP 7, sf 2.8 and 3.0 are released.
