### PR TITLE
Update layout to make override easier

### DIFF
--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -83,7 +83,7 @@
         <div id="content" class="col-lg-10 col-lg-offset-2">
             {% block content %}
                 {% block flash_messages %}
-                    {{ include(_entity_config.templates.flash_messages) }}
+                    {{ _entity_config is defined ? include(_entity_config.templates.flash_messages) }}
                 {% endblock flash_messages %}
 
                 <div class="row">

--- a/Tests/Controller/OverrideEasyAdminTemplateTest.php
+++ b/Tests/Controller/OverrideEasyAdminTemplateTest.php
@@ -22,10 +22,10 @@ class OverrideEasyAdminTemplateTest extends AbstractTestCase
         $this->initClient(array('environment' => 'override_templates'));
     }
 
-    public function testLayoutIsOverriden()
+    public function testLayoutIsOverridden()
     {
         $crawler = $this->client->request('GET', '/override_layout');
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
-        $this->assertEquals('Layout is overriden.', trim($crawler->filter('#main')->text()));
+        $this->assertEquals('Layout is overridden.', trim($crawler->filter('#main')->text()));
     }
 }

--- a/Tests/Controller/OverrideEasyAdminTemplateTest.php
+++ b/Tests/Controller/OverrideEasyAdminTemplateTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Controller;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+
+class OverrideEasyAdminTemplateTest extends AbstractTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initClient(array('environment' => 'override_templates'));
+    }
+
+    public function testLayoutIsOverriden()
+    {
+        $crawler = $this->client->request('GET', '/override_layout');
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('Layout is overriden.', trim($crawler->filter('#main')->text()));
+    }
+}

--- a/Tests/Fixtures/App/Resources/views/override_templates/layout.html.twig
+++ b/Tests/Fixtures/App/Resources/views/override_templates/layout.html.twig
@@ -1,0 +1,3 @@
+{% extends '@EasyAdmin/default/layout.html.twig' %}
+
+{% block main %}Layout is overriden.{% endblock %}

--- a/Tests/Fixtures/App/Resources/views/override_templates/layout.html.twig
+++ b/Tests/Fixtures/App/Resources/views/override_templates/layout.html.twig
@@ -1,3 +1,3 @@
 {% extends '@EasyAdmin/default/layout.html.twig' %}
 
-{% block main %}Layout is overriden.{% endblock %}
+{% block main %}Layout is overridden.{% endblock %}

--- a/Tests/Fixtures/App/config/config.yml
+++ b/Tests/Fixtures/App/config/config.yml
@@ -1,5 +1,5 @@
 # Basic config common to all functional tests
-# Can be easily overriden in each test config
+# Can be easily overridden in each test config
 parameters:
     locale: en
     database_path: %kernel.root_dir%/../../../build/test.db

--- a/Tests/Fixtures/App/config/config_override_templates.yml
+++ b/Tests/Fixtures/App/config/config_override_templates.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    # This file overrides the EasyAdmin controller
+    router: { resource: "%kernel.root_dir%/config/routing_override_templates.yml" }

--- a/Tests/Fixtures/App/config/routing_override_templates.yml
+++ b/Tests/Fixtures/App/config/routing_override_templates.yml
@@ -1,0 +1,9 @@
+easy_admin_bundle:
+    resource: "@EasyAdminBundle/Controller/"
+    type:     annotation
+    prefix:   /admin/
+
+override_easyadmin:
+    resource: "@AppTestBundle/Controller/OverridingEasyAdminController.php"
+    type:     annotation
+    prefix:   /

--- a/Tests/Fixtures/AppTestBundle/Controller/AdminController.php
+++ b/Tests/Fixtures/AppTestBundle/Controller/AdminController.php
@@ -11,8 +11,6 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Controller;
 
-use Symfony\Component\HttpFoundation\Request;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController as EasyAdminController;
 
 class AdminController extends EasyAdminController

--- a/Tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
+++ b/Tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+class OverridingEasyAdminController extends Controller
+{
+
+    /**
+     * @Route("/override_layout", name="override_layout")
+     * @return Response
+     */
+    public function overrideLayout()
+    {
+        return $this->render('override_templates/layout.html.twig');
+    }
+
+}

--- a/Tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
+++ b/Tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
@@ -9,7 +9,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class OverridingEasyAdminController extends Controller
 {
-
     /**
      * @Route("/override_layout", name="override_layout")
      * @return Response
@@ -18,5 +17,4 @@ class OverridingEasyAdminController extends Controller
     {
         return $this->render('override_templates/layout.html.twig');
     }
-
 }


### PR DESCRIPTION
Use case:

In one of my backends (which I just updated from EasyAdmin 1.4 to 1.9), I use FOSUserBundle to login in the backend, and the login template extends EasyAdmin's one.

The problem is that after updating EasyAdmin, I come with this error : 
`Variable "_entity_config" does not exist in @EasyAdmin/default/layout.html.twig at line 86`

This update is here to allow overriding the layout in a route that is used by something else than EasyAdmin.

Plus, it's only Flash messages, so it won't hurt any backend if we add this check.
