### PR TITLE
Fix route name admin to easyadmin

### DIFF
--- a/Resources/doc/tutorials/tips-and-tricks.md
+++ b/Resources/doc/tutorials/tips-and-tricks.md
@@ -79,7 +79,7 @@ class AdminController extends BaseAdminController
     /**
      * Don't forget to add this route annotation!
      *
-     * @Route("/", name="easyadminadmin")
+     * @Route("/", name="easyadmin")
      */
     public function indexAction(Request $request)
     {

--- a/Resources/doc/tutorials/tips-and-tricks.md
+++ b/Resources/doc/tutorials/tips-and-tricks.md
@@ -79,7 +79,7 @@ class AdminController extends BaseAdminController
     /**
      * Don't forget to add this route annotation!
      *
-     * @Route("/", name="admin")
+     * @Route("/", name="easyadminadmin")
      */
     public function indexAction(Request $request)
     {


### PR DESCRIPTION
According to this [#630](https://github.com/javiereguiluz/EasyAdminBundle/issues/630) as @ogizanagi says, in 1.8 the admin route was deprecated. That change wasn't updated in the [documentation code](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/Resources/doc/tutorials/tips-and-tricks.md#use-a-custom-dashboard-as-the-index-page-of-the-backend)
