### PR TITLE
Enhance entity form type empty label (placeholder)

### DIFF
--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -96,6 +96,15 @@ class EasyAdminFormType extends AbstractType
                 }
             }
 
+            // Configure "placeholder" option for entity fields
+            if ('association' === $metadata['type']
+                && ($metadata['associationType'] & ClassMetadata::TO_ONE)
+                && !isset($formFieldOptions[$placeHolderOptionName = $this->getPlaceholderOptionName()])
+                && false === $formFieldOptions['required']
+            ) {
+                $formFieldOptions[$placeHolderOptionName] = 'form.label.empty_value';
+            }
+
             $formFieldOptions['attr']['field_type'] = $metadata['fieldType'];
             $formFieldOptions['attr']['field_css_class'] = $metadata['class'];
             $formFieldOptions['attr']['field_help'] = $metadata['help'];
@@ -212,5 +221,16 @@ class EasyAdminFormType extends AbstractType
     private function useLegacyFormComponent()
     {
         return false === class_exists('Symfony\\Component\\Form\\Util\\StringUtil');
+    }
+
+    /**
+     * BC for Sf < 2.6
+     *
+     * The "empty_value" option in the types "choice", "date", "datetime" and "time"
+     * was deprecated in 2.6 and replaced by a new option "placeholder".
+     */
+    private function getPlaceholderOptionName()
+    {
+        return version_compare(Kernel::VERSION, '2.6.0', '>=') ? 'placeholder' : 'empty_value';
     }
 }

--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -35,6 +35,10 @@
                 <source>action.list</source>
                 <target>Back to listing</target>
             </trans-unit>
+            <trans-unit id="form.label.empty_value">
+                <source>form.label.empty_value</source>
+                <target>None</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/messages.fr.xlf
+++ b/Resources/translations/messages.fr.xlf
@@ -35,6 +35,10 @@
                 <source>action.list</source>
                 <target>Retour à la liste</target>
             </trans-unit>
+            <trans-unit id="form.label.empty_value">
+                <source>form.label.empty_value</source>
+                <target>Aucun(e)</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Currently, the empty value is present in entity fields, but not very noticeable with the `select2` widget:

<img width="694" alt="screenshot 2015-12-14 a 14 54 39" src="https://cloud.githubusercontent.com/assets/2211145/11784965/9cda6e16-a27f-11e5-8a26-9f1d37377aa5.PNG">

With those changes, the empty value is (as currently) only displayed if the field is required (or forced in easyadmin type_options config), but shows a proper label:

<img width="711" alt="screenshot 2015-12-14 a 16 30 30" src="https://cloud.githubusercontent.com/assets/2211145/11785061/08bc8452-a280-11e5-91b1-7479c59a483b.PNG">

> :memo: **_NOTE_**: I think there is another issue in the fact we check `'association' === $metadata['type']` instead of `'entity' === $metadata['fieldType']`, where another fieldType than `entity` might be used for associations. 
> But I prefer not fixing it in this PR, as the field type for now is guessed, so `$metadata['fieldType']` is `null`.
