### PR TITLE
Add "psr/log" to "require-dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle" : "~2.2",
         "phpunit/phpunit"                   : "~4.4",
+        "psr/log"                           : "~1.0",
         "symfony/browser-kit"               : "~2.3|~3.0",
         "symfony/console"                   : "~2.3|~3.0",
         "symfony/css-selector"              : "~2.3|~3.0",


### PR DESCRIPTION
Fix https://github.com/javiereguiluz/EasyAdminBundle/pull/638#discussion_r47611998

Thanks @xabbuh. I was not sure we had to explicit this dependency, as the `psr/log` package is already required by `symfony/http-kernel`.
