### PR TITLE
EasyAdminFormType::getFormTypeFqcn fix

### DIFF
--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -195,15 +195,19 @@ class EasyAdminFormType extends AbstractType
     private function getFormTypeFqcn($shortType)
     {
         $typeNames = array(
-            'base', 'birthday', 'button', 'checkbox', 'choice', 'collection',
-            'country', 'currency', 'datetime', 'date', 'email', 'file', 'form',
-            'hidden', 'integer', 'language', 'money', 'number', 'password',
-            'percent', 'radio', 'repeated', 'reset', 'search', 'submit',
-            'textarea', 'text', 'time', 'timezone', 'url',
+            'birthday', 'button', 'checkbox', 'choice', 'collection', 'country',
+            'currency', 'datetime', 'date', 'email', 'entity', 'file', 'form',
+            'hidden', 'integer', 'language', 'locale', 'money', 'number',
+            'password', 'percent', 'radio', 'range', 'repeated', 'reset',
+            'search', 'submit', 'textarea', 'text', 'time', 'timezone', 'url',
         );
 
         if (!in_array($shortType, $typeNames)) {
             return $shortType;
+        }
+
+        if ('entity' === $shortType) {
+            return 'Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType';
         }
 
         // take into account the irregular class name for 'datetime' type


### PR DESCRIPTION
- `locale` and `range` types were missing.
- I never had to specify myself `entity` in the easyadmin config because the type is guessed, but I guess it might happen. So handle this particular form type FQCN.
- The `base` type isn't a real type. Just an abstract class used by the `form` and `button` types.
