### PR TITLE
Remove easyadmin.property_reflector from services

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -20,8 +20,6 @@
             <argument type="service" id="doctrine" />
         </service>
 
-        <service id="easyadmin.property_reflector" class="JavierEguiluz\Bundle\EasyAdminBundle\Reflection\ClassPropertyReflector" public="false" />
-
         <service id="easyadmin.listener.exception" class="JavierEguiluz\Bundle\EasyAdminBundle\EventListener\ExceptionListener">
             <argument type="service" id="templating" />
             <argument type="string">easyadmin.listener.exception:showExceptionPageAction</argument>


### PR DESCRIPTION
I removed easyadmin.property_reflector from services.xml. That class not exists.
