### PR TITLE
Boolean fields are displayed as "flip switches" by default

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -456,8 +456,8 @@ class Configurator
                 // this prevents the template from displaying the 'id' primary key formatted as a number
                 if ('id' === $fieldName) {
                     $template = $entityConfiguration['templates']['field_id'];
-                } elseif (array_key_exists('field_'.$fieldMetadata['type'], $entityConfiguration['templates'])) {
-                    $template = $entityConfiguration['templates']['field_'.$fieldMetadata['type']];
+                } elseif (array_key_exists('field_'.$fieldMetadata['dataType'], $entityConfiguration['templates'])) {
+                    $template = $entityConfiguration['templates']['field_'.$fieldMetadata['dataType']];
                 } else {
                     $template = $entityConfiguration['templates']['label_undefined'];
                 }


### PR DESCRIPTION
This fixes #667.

---

I know @Pierstoval has said several times that having several types properties is confusing. Maybe we can improve this in the future, but for now, we have: `type` (provided by Doctrine metadata), `dataType` (what we use when displaying this data in `list` or `show`), `fieldType` (the Symfony Form type used in `new` and `edit`). So it's clear that to decide which template to use in `list` and `show`, we must use p dateType`and not`type`.
