### PR TITLE
[EasyAdminFormType] Fix getFormTypeFqcn returns DateTimeType instead of EntityType

### DIFF
--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -206,9 +206,12 @@ class EasyAdminFormType extends AbstractType
             return $shortType;
         }
 
-        return 'entity' === $shortType ? 'Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType'
-            : 'datetime' === $shortType ? 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType'
-            : sprintf('Symfony\\Component\\Form\\Extension\\Core\\Type\\%sType', ucfirst($shortType));
+        return 'entity' === $shortType
+            ? 'Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType'
+            : ('datetime' === $shortType
+                ? 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType'
+                : sprintf('Symfony\\Component\\Form\\Extension\\Core\\Type\\%sType', ucfirst($shortType))
+            );
     }
 
     /**

--- a/Tests/Form/Type/EasyAdminFormTypeTest.php
+++ b/Tests/Form/Type/EasyAdminFormTypeTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Form\Type;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType;
+
+class EasyAdminFormTypeTest extends \PHPUnit_Framework_TestCase
+{
+    public function shortTypesToFqcnProvider()
+    {
+        return array(
+            'Symfony native form type'         => array('integer', 'Symfony\Component\Form\Extension\Core\Type\IntegerType'),
+            'Symfony DateTime form type'       => array('datetime', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'),
+            'Doctrine Bridge Entity form type' => array('entity', 'Symfony\Bridge\Doctrine\Form\Type\EntityType'),
+            'Custom form type'                 => array('foo', 'foo'),
+            'FQCN'                             => array('Foo\Bar', 'Foo\Bar'),
+        );
+    }
+
+    /**
+     * @dataProvider shortTypesToFqcnProvider
+     */
+    public function testGetFormTypeFqcn($shortType, $expected)
+    {
+        $type = new EasyAdminFormType(
+            $this->getMockBuilder('JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator')->disableOriginalConstructor()->getMock(),
+            array(),
+            $this->getMockBuilder('Symfony\Component\Form\FormTypeGuesserInterface')->disableOriginalConstructor()->getMock()
+        );
+
+        $method = new \ReflectionMethod($type, 'getFormTypeFqcn');
+        $method->setAccessible(true);
+        $this->assertSame($expected, $method->invoke($type, $shortType));
+        $method->setAccessible(false);
+    }
+}


### PR DESCRIPTION
7ecba6e0dc90a0108ea1052e7906ce5928ab9c87 unfortunately introduced a bug. I fixed the ternary operator, but I'm not sure it is really readable ^^'

I've  added this dumb test in order to avoid future regressions.
