### PR TITLE
[Configurator] Explicitly use "entity" type for associations instead of guessing it later

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -44,7 +44,7 @@ class Configurator
 
     private $doctrineTypeToFormTypeMap = array(
         'array' => 'collection',
-        'association' => null,
+        'association' => 'entity',
         'bigint' => 'text',
         'blob' => 'textarea',
         'boolean' => 'checkbox',

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -62,7 +62,13 @@ class EasyAdminFormType extends AbstractType
         foreach ($entityProperties as $name => $metadata) {
             $formFieldOptions = $metadata['type_options'];
 
-            if ('association' === $metadata['type']) {
+            if ('entity' === $metadata['fieldType'] && 'association' === $metadata['type']) {
+                if (!isset($formFieldOptions['class'])) {
+                    $guessedOptions = $this->guesser->guessType($builder->getDataClass(), $name)->getOptions();
+                    $formFieldOptions['class'] = $guessedOptions['class'];
+                    $formFieldOptions['multiple'] = $guessedOptions['multiple'];
+                    $formFieldOptions['em'] = $guessedOptions['em'];
+                }
                 if ($metadata['associationType'] & ClassMetadata::TO_MANY) {
                     $formFieldOptions['attr']['multiple'] = true;
                 }
@@ -97,7 +103,7 @@ class EasyAdminFormType extends AbstractType
             }
 
             // Configure "placeholder" option for entity fields
-            if ('association' === $metadata['type']
+            if ('entity' === $metadata['fieldType'] && 'association' === $metadata['type']
                 && ($metadata['associationType'] & ClassMetadata::TO_ONE)
                 && !isset($formFieldOptions[$placeHolderOptionName = $this->getPlaceholderOptionName()])
                 && false === $formFieldOptions['required']

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -295,8 +295,8 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testEditViewFieldClasses()
     {
         $crawler = $this->requestEditView();
-        $fieldDefaultClasses = array('integer', 'text', 'default');
-        $fieldCustomClasses = array('integer', 'text', 'default');
+        $fieldDefaultClasses = array('integer', 'text', 'entity');
+        $fieldCustomClasses = array('integer', 'text', 'entity');
 
         foreach ($fieldDefaultClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
@@ -384,7 +384,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testNewViewFieldClasses()
     {
         $crawler = $this->requestNewView();
-        $fieldClasses = array('integer', 'text', 'default');
+        $fieldClasses = array('integer', 'text', 'entity');
 
         foreach ($fieldClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -366,7 +366,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testEditViewFieldClasses()
     {
         $crawler = $this->requestEditView();
-        $fieldClasses = array('text', 'default');
+        $fieldClasses = array('text', 'entity');
 
         foreach ($fieldClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
@@ -450,7 +450,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testNewViewFieldClasses()
     {
         $crawler = $this->requestNewView();
-        $fieldClasses = array('text', 'default');
+        $fieldClasses = array('text', 'entity');
 
         foreach ($fieldClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));


### PR DESCRIPTION
Related to #661. 
Depends on the #671 bug fix.

As you can see in tests, this would probably cause some issues if someone is relying on the `field-default` css class instead of the `field-entity` one.
I hope that'll be the only one.
