### PR TITLE
Add a delete button for removing non-compound items from collection.

### DIFF
--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -693,6 +693,10 @@ body.new form .field-date select + select {
 body.new form .field-collection-action {
     margin-top: -15px;
 }
+body.new form .field-collection-item-action {
+    margin-bottom: 0;
+    margin-top: 5px;
+}
 
 body.new form #form-actions-row button,
 body.new form #form-actions-row a.btn {
@@ -720,6 +724,10 @@ body.edit form .field-date select + select {
 }
 body.edit form .field-collection-action {
     margin-top: -15px;
+}
+body.edit form .field-collection-item-action {
+    margin-bottom: 0;
+    margin-top: 5px;
 }
 
 body.edit form #form-actions-row button,

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -3,6 +3,30 @@
 
 {# Widgets #}
 
+{% block form_widget %}
+    {{- parent() -}}
+
+    {% if form.parent.vars.allow_delete|default(false) %}
+        {% set remove_item_javascript %}
+            $(function() {
+            if (event.preventDefault) event.preventDefault(); else event.returnValue = false;
+
+            var containerDiv = $('#{{ id }}').parents('.form-group:first');
+            containerDiv.remove();
+            });
+        {% endset %}
+
+        <div class="form-group field-collection-item-action">
+            <div class="col-sm-12">
+                <a href="#" onclick="{{ remove_item_javascript|raw }}" class="pull-right text-danger">
+                    <i class="fa fa-remove"></i>
+                    {{ 'action.remove_item'|trans }}
+                </a>
+            </div>
+        </div>
+    {% endif %}
+{% endblock form_widget %}
+
 {% block form_widget_simple -%}
     {% if type is not defined or 'file' != type %}
         {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
@@ -228,10 +252,12 @@
         {% endset %}
 
         <div class="form-group field-collection-action">
-            <a href="#" onclick="{{ js_add_item|raw }}" class="col-sm-12 text-right">
-                <i class="fa fa-plus-square"></i>
-                {{ (form|length == 0 ? 'action.add_new_item' : 'action.add_another_item')|trans({}, 'EasyAdminBundle') }}
-            </a>
+            <div class="col-sm-12">
+                <a href="#" onclick="{{ js_add_item|raw }}" class="pull-right text-primary">
+                    <i class="fa fa-plus-square"></i>
+                    {{ (form|length == 0 ? 'action.add_new_item' : 'action.add_another_item')|trans({}, 'EasyAdminBundle') }}
+                </a>
+            </div>
         </div>
     {% endif %}
 {% endblock collection_row %}
@@ -303,24 +329,6 @@
     {% endif %}
 
     {{ parent() }}
-
-    {% if form.parent.vars.allow_delete|default(false) %}
-        {% set remove_item_javascript %}
-            $(function() {
-                if (event.preventDefault) event.preventDefault(); else event.returnValue = false;
-
-                var containerDiv = $('#{{ id }}').parents('.form-group:first');
-                containerDiv.remove();
-            });
-        {% endset %}
-
-        <div class="form-group">
-            <a href="#" onclick="{{ remove_item_javascript|raw }}" class="col-sm-12 text-right">
-                <i class="fa fa-remove"></i>
-                {{ 'action.remove_item'|trans }}
-            </a>
-        </div>
-    {% endif %}
 {%- endblock form_widget_compound -%}
 
 {# Easy admin form type #}


### PR DESCRIPTION
As reported in #383, the feature added in #451 only worked for compound field.
Using the collection form type to handle simple array of strings like tags didn't show a removal link:

<img width="698" alt="screenshot 2015-12-21 a 18 03 17" src="https://cloud.githubusercontent.com/assets/2211145/11936306/3a4edeec-a80d-11e5-848d-e8936b809f16.PNG">

Here what it'll looks like now:

<img width="690" alt="screenshot 2015-12-21 a 18 51 18" src="https://cloud.githubusercontent.com/assets/2211145/11937318/df117f06-a813-11e5-95b9-86269c98873c.PNG">

I also fixed the markup in order to avoid considering the whole link as a block (The previous markup had for consequence to make the link clickable on the whole width of the form).

> :grey_question: Won't you prefer [proper buttons](https://cloud.githubusercontent.com/assets/2211145/11937444/bfe8883a-a814-11e5-90a9-542f4bba27ac.PNG) ?
