### PR TITLE
[EasyAdminFormType] Remove useless html attributes

### DIFF
--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -105,10 +105,6 @@ class EasyAdminFormType extends AbstractType
                 $formFieldOptions[$placeHolderOptionName] = 'form.label.empty_value';
             }
 
-            $formFieldOptions['attr']['field_type'] = $metadata['fieldType'];
-            $formFieldOptions['attr']['field_css_class'] = $metadata['class'];
-            $formFieldOptions['attr']['field_help'] = $metadata['help'];
-
             $formFieldType = $this->useLegacyFormComponent() ? $metadata['fieldType'] : $this->getFormTypeFqcn($metadata['fieldType']);
             $builder->add($name, $formFieldType, $formFieldOptions);
         }

--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -26,8 +26,8 @@ col-sm-2
 
 {% block form_row -%}
 {% spaceless %}
-    {% set _field_type = attr.field_type|default('default') %}
-    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ _field_type }} {{ attr.field_css_class|default('') }}">
+    {% set _field_type = easyadmin.field.fieldType|default('default') %}
+    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ _field_type }} {{ easyadmin.field.class|default('') }}">
 
         {% set _trans_parameters = { '%entity_name%':  easyadmin.entity.name|trans, '%entity_label%': easyadmin.entity.label|trans } %}
         {% set _field_label = easyadmin.field['label']|default(null) %}
@@ -47,8 +47,8 @@ col-sm-2
 
             {{ form_errors(form) }}
 
-            {% if attr.field_help|default('') != '' %}
-                <span class="help-block"><i class="fa fa-info-circle"></i> {{ attr.field_help|trans|raw }}</span>
+            {% if easyadmin.field.help|default('') != '' %}
+                <span class="help-block"><i class="fa fa-info-circle"></i> {{ easyadmin.field.help|trans|raw }}</span>
             {% endif %}
         </div>
     </div>
@@ -65,7 +65,7 @@ col-sm-2
 
 {% block checkbox_radio_row -%}
 {% spaceless %}
-    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
+    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ easyadmin.field.fieldType|default('default') }} {{ easyadmin.field.class|default('') }}">
         <div class="{{ block('form_label_class') }}"></div>
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}
@@ -77,7 +77,7 @@ col-sm-2
 
 {% block submit_row -%}
 {% spaceless %}
-    <div class="form-group field-{{ attr.field_type|default('default') }} {{ attr.field_css_class|default('') }}">
+    <div class="form-group field-{{ easyadmin.field.fieldType|default('default') }} {{ attr.class|default('') }}">
         <div class="{{ block('form_label_class') }}"></div>
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}


### PR DESCRIPTION
Use field metadata injected in the `FormView` attributes by the `Form\Extension\EasyAdminExtension` instead.

Related to https://github.com/javiereguiluz/EasyAdminBundle/pull/668#discussion_r48164204.
