### PR TITLE
Refactored the getFormTypeFqcn() method

### DIFF
--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -185,7 +185,7 @@ class EasyAdminFormType extends AbstractType
     }
 
     /**
-     * It returns the FQCN of the given short type.
+     * It returns the FQCN of the given short type name.
      * Example: 'text' -> 'Symfony\Component\Form\Extension\Core\Type\TextType'
      *
      * @param string $shortType
@@ -194,7 +194,7 @@ class EasyAdminFormType extends AbstractType
      */
     private function getFormTypeFqcn($shortType)
     {
-        $typeNames = array(
+        $builtinTypes = array(
             'birthday', 'button', 'checkbox', 'choice', 'collection', 'country',
             'currency', 'datetime', 'date', 'email', 'entity', 'file', 'form',
             'hidden', 'integer', 'language', 'locale', 'money', 'number',
@@ -202,16 +202,20 @@ class EasyAdminFormType extends AbstractType
             'search', 'submit', 'textarea', 'text', 'time', 'timezone', 'url',
         );
 
-        if (!in_array($shortType, $typeNames)) {
+        if (!in_array($shortType, $builtinTypes)) {
             return $shortType;
         }
 
-        return 'entity' === $shortType
-            ? 'Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType'
-            : ('datetime' === $shortType
-                ? 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType'
-                : sprintf('Symfony\\Component\\Form\\Extension\\Core\\Type\\%sType', ucfirst($shortType))
-            );
+        $irregularTypeFqcn = array(
+            'entity' => 'Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType',
+            'datetime' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType',
+        );
+
+        if (array_key_exists($shortType, $irregularTypeFqcn)) {
+            return $irregularTypeFqcn[$shortType];
+        }
+
+        return sprintf('Symfony\\Component\\Form\\Extension\\Core\\Type\\%sType', ucfirst($shortType));
     }
 
     /**

--- a/Tests/Form/Type/EasyAdminFormTypeTest.php
+++ b/Tests/Form/Type/EasyAdminFormTypeTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Form\Type;
 
 use JavierEguiluz\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType;
@@ -9,11 +18,11 @@ class EasyAdminFormTypeTest extends \PHPUnit_Framework_TestCase
     public function shortTypesToFqcnProvider()
     {
         return array(
-            'Symfony native form type'         => array('integer', 'Symfony\Component\Form\Extension\Core\Type\IntegerType'),
-            'Symfony DateTime form type'       => array('datetime', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'),
-            'Doctrine Bridge Entity form type' => array('entity', 'Symfony\Bridge\Doctrine\Form\Type\EntityType'),
-            'Custom form type'                 => array('foo', 'foo'),
-            'FQCN'                             => array('Foo\Bar', 'Foo\Bar'),
+            'Symfony Type (regular name)'   => array('integer', 'Symfony\Component\Form\Extension\Core\Type\IntegerType'),
+            'Symfony Type (irregular name)' => array('datetime', 'Symfony\Component\Form\Extension\Core\Type\DateTimeType'),
+            'Doctrine Bridge Type'          => array('entity', 'Symfony\Bridge\Doctrine\Form\Type\EntityType'),
+            'Custom Type (short name)'      => array('foo', 'foo'),
+            'Custom Type (FQCN)'            => array('Foo\Bar', 'Foo\Bar'),
         );
     }
 
@@ -30,7 +39,9 @@ class EasyAdminFormTypeTest extends \PHPUnit_Framework_TestCase
 
         $method = new \ReflectionMethod($type, 'getFormTypeFqcn');
         $method->setAccessible(true);
+
         $this->assertSame($expected, $method->invoke($type, $shortType));
+
         $method->setAccessible(false);
     }
 }


### PR DESCRIPTION
This is a minor refactoring of #671.

---

@ogizanagi sorry for being picky. Your PR is completely correct, but in the original PR I used the ternary operator to simplify code (which of course was wrong). Looking at your solution, I think it's better to use two `if` instead of chaining ternary operators.
