### PR TITLE
Create a new `getEntityFormOptions()` method

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -603,13 +603,29 @@ class AdminController extends Controller
      */
     protected function createEntityFormBuilder($entity, $view)
     {
-        $formOptions = $this->entity[$view]['form_options'];
-        $formOptions['entity'] = $this->entity['name'];
-        $formOptions['view'] = $view;
+        $formOptions = $this->executeDynamicMethod('get<EntityName>EntityFormOptions', array($entity, $view));
 
         $formType = $this->useLegacyFormComponent() ? 'easyadmin' : 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Form\\Type\\EasyAdminFormType';
 
         return $this->get('form.factory')->createNamedBuilder('form', $formType, $entity, $formOptions);
+    }
+
+    /**
+     * Retrieves the list of form options before sending them to the form builder.
+     * This allows adding dynamic logic to the default form options.
+     *
+     * @param object $entity
+     * @param string $view
+     *
+     * @return array
+     */
+    protected function getEntityFormOptions($entity, $view)
+    {
+        $formOptions = $this->entity[$view]['form_options'];
+        $formOptions['entity'] = $this->entity['name'];
+        $formOptions['view'] = $view;
+
+        return $formOptions;
     }
 
     /**


### PR DESCRIPTION
Why doing this?

Because I want to setup the form options dynamically depending on the request, and depending on some other things that require php logic.

For example, configuring the translation domain for the whole form is feasible by changing the `form_options` parameter in the easyadmin config, but actually if you want to update it dynamically, you have to copy/paste the whole `createEntityFormBuilder` method and add your own logic.

This method allows creating a custom method to retrieve the actual form options and update them dynamically with PHP code, services, etc.

What do you think?
