### PR TITLE
Fix cannot disable actions labels

### DIFF
--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -44,7 +44,7 @@
                             {% set _delete_action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
                             <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                                 {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                                {{ _delete_action.label|default('action.delete')|trans(_trans_parameters) }}
+                                {{ _delete_action.label is defined and not _delete_action.label is empty ? _delete_action.label|trans(_trans_parameters) }}
                             </button>
                         {% endif %}
                     </div>

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -52,7 +52,7 @@
                             <div id="content-actions">
                                 <a class="btn {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                    {{ _action.label|default('action.new')|trans(_trans_parameters) }}
+                                    {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
                                 </a>
                             </div>
                         {% endblock new_action %}
@@ -153,7 +153,9 @@
 
                                                 <a class="{{ _action.css_class|default('') }}" href="{{ _action_href }}">
                                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                                    {{ _action.label|trans(_trans_parameters|merge({ '%entity_id%': _item_id })) }}
+                                                    {% if _action.label is defined and not _action.label is empty %}
+                                                        {{ _action.label|trans(_trans_parameters|merge({ '%entity_id%': _item_id })) }}
+                                                    {% endif %}
                                                 </a>
                                             {% endfor %}
                                         {% endspaceless %}

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -44,7 +44,7 @@
 
                     <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|trans(_trans_parameters) }}
+                        {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
                     </a>
                 {% endfor %}
 
@@ -52,7 +52,7 @@
                     {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
                     <button type="button" id="button-delete" class="btn {{ _action.css_class|default('btn-danger') }}">
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
+                        {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
                     </button>
                 {% endif %}
 
@@ -61,7 +61,7 @@
                     {% set _action = easyadmin_get_action_for_show_view('list', _entity_config.name) %}
                     <a class="btn btn-secondary" href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('easyadmin', ({ entity: _entity_config.name, action: _action.name, view: 'show' })) }}">{% spaceless %}
                         {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                        {{ _action.label|default('action.list')|trans(_trans_parameters) }}
+                        {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
                     {% endspaceless %}</a>
                 {% endif %}
             {% endblock item_actions %}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -363,7 +363,7 @@
 
                             <a class="btn {{ _action.css_class|default('') }}" href="{{ _action_href }}">
                                 {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                {{ _action.label|trans(_trans_parameters) }}
+                                {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters, 'messages') }}
                             </a>
                         {% endfor %}
 
@@ -373,7 +373,7 @@
                                 <button type="button" id="button-delete"
                                         class="btn {{ _action.css_class|default('btn-danger') }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                    {{ _action.label|default('action.delete')|trans(_trans_parameters, 'messages') }}
+                                    {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters, 'messages') }}
                                 </button>
                             {% endif %}
                         {% endif %}
@@ -389,7 +389,7 @@
                             <a class="btn btn-secondary"
                                href="{{ app.request.query.has('referer') ? app.request.query.get('referer')|easyadmin_urldecode : path('easyadmin', ({ entity: easyadmin.entity.name, action: _list_action.name, view: easyadmin.view }) ) }}">{% spaceless %}
                                     {% if _list_action.icon %}<i class="fa fa-{{ _list_action.icon }}"></i>{% endif %}
-                                    {{ _list_action.label|default('action.list')|trans(_trans_parameters, 'messages') }}
+                                    {{ _list_action.label is defined and not _list_action.label is empty ? _list_action.label|trans(_trans_parameters, 'messages') }}
                                 {% endspaceless %}</a>
                         {% endif %}
                     {% endblock item_actions %}


### PR DESCRIPTION
As raised by #679, the feature described in ["Removing Action Labels and Displaying Just Icons"](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/Resources/doc/tutorials/tips-and-tricks.md#removing-action-labels-and-displaying-just-icons) was not working consistently everywhere for every actions, because some places used the `default` filter, which replaced the `false` or empty value set by the user in the config by the default translation key.

However, the `default` filter was useless, because the labels of those actions are already normalized in the [`EasyAdminExtension`](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/DependencyInjection/EasyAdminExtension.php#L352-L363).

So now, here is the expected behavior fixed, when the value of the `label` option is:
- `null` or `~` will be normalized to the original translation key (`action.{action_name}`), or the humanized version of the action name for custom actions.
- `false` or `''` will disable completely the label rendering and thus avoid having the translator shouting in the profiler there is no translation for an empty key.
