### PR TITLE
Added CONTRIBUTION guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+Contribution Guidelines
+=======================
+
+First of all, each single contribution is appreciated, whether a typo fix,
+improved documentation, a fixed bug or a whole new feature.
+
+## Feature request
+
+If you think a feature is missing, please report it or implement it . If you report it, describe the more
+precisely what you would like to see implemented. It would be nice if you can do
+some search before submitting it and link the resources to your description.
+
+## Bug report
+
+If you think you have detected a bug or a doc issue, please report it or even better fix it. If you report it,
+please be the more precise possible. Here a little list of required informations:
+
+ * Symfony-standard fork which reproduces the bug.
+ * Precise description of the bug.
+ * Symfony version used.
+ * Bundle version used.
+
+## Making your changes
+
+ 1. Fork the repository on GitHub
+ 2. Pull requests must be sent from a new hotfix/feature branch, not from `master`.
+ 3. Make your modifications, coding standard for the project is [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
+ 4. Commit small logical changes, each with a descriptive commit message.
+    Please don't mix unrelated changes in a single commit.
+
+## Commit messages
+
+Please format your commit messages as follows:
+
+    Short summary of the change (up to 50 characters)
+
+    Optionally add a more extensive description of your change after a
+    blank line. Wrap the lines in this and the following paragraphs after
+    72 characters.
+
+## Submitting your changes
+
+ 1. Push your changes to a topic branch in your fork of the repository.
+ 2. [Submit a pull request][pr] to the original repository.
+    Describe your changes as short as possible, but as detailed as needed for
+    others to get an overview of your modifications.
+ 3. If you have reworked you patch, please squash all your commits in a single one with the following commands (here, we
+    will assume you would like to squash 3 commits in a single one):
+
+    ``` bash
+    $ git rebase -i HEAD~3
+    ```
+ 4. If your branch conflicts with the master branch, you will need to rebase and repush it with the following commands:
+
+    ``` bash
+    $ git remote add upstream git@github.com:javiereguiluz/EasyAdminBundle.git
+    $ git pull --rebase upstream master
+    $ git push origin bug-fix-description -f
+    ```
+## Further information
+
+ * [General GitHub documentation][gh-help]
+ * [GitHub pull request documentation][gh-pr]
+
+ [gh-help]: https://help.github.com
+ [gh-pr]:   https://help.github.com/send-pull-requests
+ [issue]:   https://github.com/javiereguiluz/EasyAdminBundle/issues/new
+ [pr]:      https://github.com/javiereguiluz/EasyAdminBundle/pull/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,68 +1,96 @@
 Contribution Guidelines
 =======================
 
-First of all, each single contribution is appreciated, whether a typo fix,
-improved documentation, a fixed bug or a whole new feature.
+Thank you for considering contributing to this bundle. We welcome any kind of
+contribution, no matter if its huge or small, about documentation or code. We
+also welcome any kind of developers, from experts to people who just started
+working on Open-Source projects.
 
-## Feature request
+Requirements
+------------
 
-If you think a feature is missing, please report it or implement it . If you report it, describe the more
-precisely what you would like to see implemented. It would be nice if you can do
-some search before submitting it and link the resources to your description.
+Before your first contribution, make sure you'll meet these requirements:
 
-## Bug report
+ * You have a user account on [GitHub](https://github.com/).
+ * You have installed in your computer a working environment to develop PHP
+   applications.
+ * You have a basic level of English (code, docs and discussions are in English).
 
-If you think you have detected a bug or a doc issue, please report it or even better fix it. If you report it,
-please be the more precise possible. Here a little list of required informations:
+All submitted contributions (both code and documentation) adhere implicitly to
+the [Open-Source MIT License][mit-license].
 
- * Symfony-standard fork which reproduces the bug.
- * Precise description of the bug.
- * Symfony version used.
- * Bundle version used.
+Proposing New Features
+----------------------
 
-## Making your changes
+We are determined to maintain the original simple and pragmatic philosophy of
+the bundle. This means that we routinely reject any feature that complicates the
+code too much or which doesn't fit in the bundle's philosophy.
 
- 1. Fork the repository on GitHub
- 2. Pull requests must be sent from a new hotfix/feature branch, not from `master`.
- 3. Make your modifications, coding standard for the project is [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- 4. Commit small logical changes, each with a descriptive commit message.
-    Please don't mix unrelated changes in a single commit.
+That's why **we strongly recommend you** to propose new features by
+[opening a new issue][create-issue] in the repository instead of submitting a
+pull request with the code of the proposed feature.
 
-## Commit messages
+Reporting Bugs
+--------------
 
-Please format your commit messages as follows:
+ 1. Go to [the list of EasyAdmin issues][easyadmin-issues] and look for any
+    existing bug similar to yours.
+ 2. If the bug hasn't been reported yet, [create a new issue][create-issue] and
+    provide the following information:
+    * Short but precise description of the bug (attach screenshots if needed);
+    * Symfony version used (because we support both 2.x and 3.x versions);
+    * EasyAdmin version (if it's not the latest one).
 
-    Short summary of the change (up to 50 characters)
+If we cannot reproduce the bug with the information provided, we may ask you to
+create a fork of the [EasyAdmin Demo Application][easyadmin-demo] or the
+[Symfony Standard Edition][symfony-standard] reproducing the bug.
 
-    Optionally add a more extensive description of your change after a
-    blank line. Wrap the lines in this and the following paragraphs after
-    72 characters.
+Sending Pull Requests
+---------------------
 
-## Submitting your changes
+### Making your changes
 
- 1. Push your changes to a topic branch in your fork of the repository.
- 2. [Submit a pull request][pr] to the original repository.
-    Describe your changes as short as possible, but as detailed as needed for
-    others to get an overview of your modifications.
- 3. If you have reworked you patch, please squash all your commits in a single one with the following commands (here, we
-    will assume you would like to squash 3 commits in a single one):
+ 1. Fork [the EasyAdmin repository][easyadmin-repository] on GitHub and clone it
+    in your computer.
+ 2. Create a new branch for the new code (if you are fixing a bug, you can call
+    this branch `fix_NNN`, where `NNN` is the number of the related issue).
+ 3. Make your code changes (use the same code syntax as Symfony described in
+    [PSR-2][psr2-standard]).
+ 4. Make sure that your code is **compatible with PHP 5.3 and Symfony 2.3**.
+    Sometimes it's tricky to develop code compatible with Symfony 2.3 and 3.x.
+    If you get stuck, just ask us and we'll help you.
 
-    ``` bash
-    $ git rebase -i HEAD~3
-    ```
- 4. If your branch conflicts with the master branch, you will need to rebase and repush it with the following commands:
+### Submitting your changes
 
-    ``` bash
-    $ git remote add upstream git@github.com:javiereguiluz/EasyAdminBundle.git
-    $ git pull --rebase upstream master
-    $ git push origin bug-fix-description -f
-    ```
-## Further information
+ 1. Commit and push your changes to your own fork (`git commit -a` and `git push`).
+ 2. [Create a new pull request][create-pr] in the EasyAdmin GitHub repository.
+ 3. Provide a short description about the changes made by the pull request.
+    If you are fixing a bug, add the text `Fixed #NNN` and provide the number of
+    the related issue (this allows us to track which bugs have already been fixed).
+ 4. There is no need to "squash" your commits. We'll do that for you.
+
+In case some changes are merged in the repository since you submitted your pull
+request, we may ask you to rebase it to make it mergeable again:
+
+``` bash
+$ git remote add upstream git@github.com:javiereguiluz/EasyAdminBundle.git
+$ git pull --rebase upstream master
+$ git push -f origin the_name_of_your_branch
+```
+
+Further information
+-------------------
 
  * [General GitHub documentation][gh-help]
  * [GitHub pull request documentation][gh-pr]
 
+ [mit-license]: https://opensource.org/licenses/MIT
  [gh-help]: https://help.github.com
- [gh-pr]:   https://help.github.com/send-pull-requests
- [issue]:   https://github.com/javiereguiluz/EasyAdminBundle/issues/new
- [pr]:      https://github.com/javiereguiluz/EasyAdminBundle/pull/new
+ [gh-pr]: https://help.github.com/send-pull-requests
+ [easyadmin-demo]: https://github.com/javiereguiluz/easy-admin-demo
+ [easyadmin-issues]: https://github.com/javiereguiluz/EasyAdminBundle/issues?utf8=%E2%9C%93&q=is%3Aissue
+ [create-issue]: https://github.com/javiereguiluz/EasyAdminBundle/issues/new
+ [create-pr]: https://github.com/javiereguiluz/EasyAdminBundle/pull/new
+ [easyadmin-repository]: https://github.com/javiereguiluz/EasyAdminBundle
+ [psr2-standard]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+ [symfony-standard]: https://github.com/symfony/symfony-standard


### PR DESCRIPTION
This finishes #686. I've removed some points (like the one describing the "squashing" process which is not needed) and added new ones (like the reminder that submitted code must be compatible with PHP 5.3 and Symfony 2.3).
