### PR TITLE
Allow delete in list view

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -172,6 +172,7 @@ class AdminController extends Controller
         return $this->render($this->entity['templates']['list'], array(
             'paginator' => $paginator,
             'fields' => $fields,
+            'delete_form_template' => $this->createDeleteForm($this->entity['name'], '{{ ID }}')->createView(),
         ));
     }
 
@@ -369,6 +370,7 @@ class AdminController extends Controller
         return $this->render($this->entity['templates']['list'], array(
             'paginator' => $paginator,
             'fields' => $fields,
+            'delete_form_template' => $this->createDeleteForm($this->entity['name'], '{{ ID }}')->createView(),
         ));
     }
 

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -249,6 +249,14 @@ class EasyAdminExtension extends Extension
                     $viewActions = array_merge($viewActions, $this->normalizeActionsConfiguration(array('list')));
                 }
 
+                if (isset($viewActions['delete'])) {
+                    if ('list' === $view) {
+                        $viewActions['delete']['css_class'] .= ' text-danger';
+                    } elseif (in_array($view, array('edit', 'show'))) {
+                        $viewActions['delete']['css_class'] .= ' btn-danger';
+                    }
+                }
+
                 $entityConfiguration[$view]['actions'] = $viewActions;
             }
 
@@ -378,6 +386,10 @@ class EasyAdminExtension extends Extension
                     $normalizedConfiguration = array_replace($defaultActionsConfiguration[$actionName], $normalizedConfiguration);
                 }
             }
+
+            // Add default classes ("action-{actionName}") to each actions configuration:
+            $normalizedConfiguration['css_class'] .= ' action-'.$normalizedConfiguration['name'];
+            $normalizedConfiguration['css_class'] = ltrim($normalizedConfiguration['css_class']);
 
             $configuration[$actionName] = $normalizedConfiguration;
         }

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -20,37 +20,13 @@
     {% endblock entity_form %}
 
     {% block delete_form %}
-        {{
-            form(delete_form, {
-                action: delete_form.vars.action ~ '&referer=' ~ app.request.query.get('referer', ''),
-                method: 'DELETE',
-                attr: { id: 'delete-form', style: 'display: none' }
-            })
-        }}
-
-        <div id="modal-delete" class="modal fade">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-body">
-                        <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
-                        <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" data-dismiss="modal" class="btn">
-                            {{ 'action.cancel'|trans(_trans_parameters) }}
-                        </button>
-
-                        {% if easyadmin_action_is_enabled_for_edit_view('delete', _entity_config.name) %}
-                            {% set _delete_action = easyadmin_get_action_for_edit_view('delete', _entity_config.name) %}
-                            <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
-                                {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                                {{ _delete_action.label is defined and not _delete_action.label is empty ? _delete_action.label|trans(_trans_parameters) }}
-                            </button>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        </div>
+        {{ include('@EasyAdmin/default/includes/delete_form.html.twig', {
+            view: 'edit',
+            referer: app.request.query.get('referer', ''),
+            delete_form: delete_form,
+            _trans_parameters: _trans_parameters,
+            _entity_config: _entity_config,
+        }, with_context = false) }}
     {% endblock delete_form %}
 {% endblock %}
 

--- a/Resources/views/default/includes/delete_form.html.twig
+++ b/Resources/views/default/includes/delete_form.html.twig
@@ -1,0 +1,31 @@
+{{
+    form(delete_form, {
+        action: delete_form.vars.action ~ '&referer=' ~ referer,
+        method: 'DELETE',
+        attr: { id: 'delete-form', style: 'display: none' }
+    })
+}}
+
+<div id="modal-delete" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-body">
+                <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
+                <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" data-dismiss="modal" class="btn">
+                    {{ 'action.cancel'|trans(_trans_parameters) }}
+                </button>
+
+                {% if easyadmin_action_is_enabled_for_view(view, 'delete', _entity_config.name) %}
+                    {% set _delete_action = easyadmin_get_action_for_view(view, 'delete', _entity_config.name) %}
+                    <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
+                        {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
+                        {{ _delete_action.label is defined and not _delete_action.label is empty ? _delete_action.label|trans(_trans_parameters) }}
+                    </button>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/Resources/views/default/includes/delete_form.html.twig
+++ b/Resources/views/default/includes/delete_form.html.twig
@@ -18,8 +18,8 @@
                     {{ 'action.cancel'|trans(_trans_parameters) }}
                 </button>
 
-                {% if easyadmin_action_is_enabled_for_view(view, 'delete', _entity_config.name) %}
-                    {% set _delete_action = easyadmin_get_action_for_view(view, 'delete', _entity_config.name) %}
+                {% if easyadmin_action_is_enabled(view, 'delete', _entity_config.name) %}
+                    {% set _delete_action = easyadmin_get_action(view, 'delete', _entity_config.name) %}
                     <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                         {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
                         {{ _delete_action.label is defined and not _delete_action.label is empty ? _delete_action.label|trans(_trans_parameters) }}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -151,7 +151,7 @@
                                                     {% set _action_href = path(_action.name, _request_parameters|merge({ action: _action.name, id: _item_id })) %}
                                                 {% endif %}
 
-                                                <a class="{{ _action.css_class|default('') }}" href="{{ _action_href }}">
+                                                <a class="{{ 'action-'~_action.name~' '~_action.css_class|default('') }}" href="{{ _action_href }}">
                                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                                     {% if _action.label is defined and not _action.label is empty %}
                                                         {{ _action.label|trans(_trans_parameters|merge({ '%entity_id%': _item_id })) }}
@@ -178,6 +178,41 @@
                     {{ include(_entity_config.templates.paginator) }}
                 {% endblock paginator %}
             </div>
+
+            {% block delete_form %}
+                {{
+                    form(delete_form_template, {
+                        action: delete_form_template.vars.action ~ '&referer=' ~ app.request.requestUri|url_encode,
+                        method: 'DELETE',
+                        attr: { id: 'delete-form', style: 'display: none' }
+                    })
+                }}
+
+                <div id="modal-delete" class="modal fade">
+                    <div class="modal-dialog">
+                        <div class="modal-content">
+                            <div class="modal-body">
+                                <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
+                                <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" data-dismiss="modal" class="btn">
+                                    {{ 'action.cancel'|trans(_trans_parameters) }}
+                                </button>
+
+                                {% if easyadmin_action_is_enabled_for_list_view('delete', _entity_config.name) %}
+                                    {% set _delete_action = easyadmin_get_action_for_list_view('delete', _entity_config.name) %}
+                                    <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
+                                        {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
+                                        {{ _delete_action.label is defined and not _delete_action.label is empty ? _delete_action.label|trans(_trans_parameters) }}
+                                    </button>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endblock delete_form %}
+
         {% endblock main %}
         </div>
     </div>
@@ -212,6 +247,18 @@
                     toggle.bootstrapToggle(oldValue == true ? 'on' : 'off');
                     toggle.bootstrapToggle('disable');
                 });
+            });
+
+            $('.action-delete').on('click', function(e) {
+                e.preventDefault();
+                var id = $(this).parents('tr').first().data('id');
+
+                $('#modal-delete').modal({ backdrop: true, keyboard: true })
+                    .one('click', '#modal-delete-button', function (e) {
+                        var deleteForm = $('#delete-form');
+                        deleteForm.attr('action', deleteForm.attr('action').replace('%7B%7B+ID+%7D%7D', id));
+                        deleteForm.trigger('submit');
+                    });
             });
         });
     </script>

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -151,7 +151,7 @@
                                                     {% set _action_href = path(_action.name, _request_parameters|merge({ action: _action.name, id: _item_id })) %}
                                                 {% endif %}
 
-                                                <a class="{{ 'action-'~_action.name~' '~_action.css_class|default('') }}" href="{{ _action_href }}">
+                                                <a class="{{ _action.css_class|default('') }}" href="{{ _action_href }}">
                                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                                     {% if _action.label is defined and not _action.label is empty %}
                                                         {{ _action.label|trans(_trans_parameters|merge({ '%entity_id%': _item_id })) }}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -180,9 +180,14 @@
             </div>
 
             {% block delete_form %}
+                {% set referer = paginator.currentPage == paginator.nbPages and 0 != paginator.currentPage and 1 == paginator.currentPageResults.count
+                    ? path('easyadmin', app.request.query|merge({ page: app.request.query.get('page') - 1 }))
+                    : app.request.requestUri
+                %}
+
                 {{ include('@EasyAdmin/default/includes/delete_form.html.twig', {
                     view: 'list',
-                    referer: app.request.requestUri|url_encode,
+                    referer: referer|url_encode,
                     delete_form: delete_form_template,
                     _trans_parameters: _trans_parameters,
                     _entity_config: _entity_config,

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -180,37 +180,13 @@
             </div>
 
             {% block delete_form %}
-                {{
-                    form(delete_form_template, {
-                        action: delete_form_template.vars.action ~ '&referer=' ~ app.request.requestUri|url_encode,
-                        method: 'DELETE',
-                        attr: { id: 'delete-form', style: 'display: none' }
-                    })
-                }}
-
-                <div id="modal-delete" class="modal fade">
-                    <div class="modal-dialog">
-                        <div class="modal-content">
-                            <div class="modal-body">
-                                <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
-                                <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
-                            </div>
-                            <div class="modal-footer">
-                                <button type="button" data-dismiss="modal" class="btn">
-                                    {{ 'action.cancel'|trans(_trans_parameters) }}
-                                </button>
-
-                                {% if easyadmin_action_is_enabled_for_list_view('delete', _entity_config.name) %}
-                                    {% set _delete_action = easyadmin_get_action_for_list_view('delete', _entity_config.name) %}
-                                    <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
-                                        {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                                        {{ _delete_action.label is defined and not _delete_action.label is empty ? _delete_action.label|trans(_trans_parameters) }}
-                                    </button>
-                                {% endif %}
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                {{ include('@EasyAdmin/default/includes/delete_form.html.twig', {
+                    view: 'list',
+                    referer: app.request.requestUri|url_encode,
+                    delete_form: delete_form_template,
+                    _trans_parameters: _trans_parameters,
+                    _entity_config: _entity_config,
+                }, with_context = false) }}
             {% endblock delete_form %}
 
         {% endblock main %}

--- a/Resources/views/default/paginator.html.twig
+++ b/Resources/views/default/paginator.html.twig
@@ -1,5 +1,7 @@
 {% trans_default_domain 'EasyAdminBundle' %}
 
+{% set _paginator_request_parameters = _request_parameters|merge({'referer': null}) %}
+
 {% if paginator.haveToPaginate %}
     <div class="list-pagination">
         <div class="row">
@@ -17,7 +19,7 @@
                         </li>
                     {% else %}
                         <li>
-                            <a href="{{ path('easyadmin', _request_parameters|merge({ page: 1 }) ) }}">
+                            <a href="{{ path('easyadmin', _paginator_request_parameters|merge({ page: 1 }) ) }}">
                                 <i class="fa fa-angle-double-left"></i> {{ 'paginator.first'|trans }}
                             </a>
                         </li>
@@ -25,7 +27,7 @@
 
                     {% if paginator.hasPreviousPage %}
                         <li>
-                            <a href="{{ path('easyadmin', _request_parameters|merge({ page: paginator.previousPage }) ) }}">
+                            <a href="{{ path('easyadmin', _paginator_request_parameters|merge({ page: paginator.previousPage }) ) }}">
                                 <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
                             </a>
                         </li>
@@ -39,7 +41,7 @@
 
                     {% if paginator.hasNextPage %}
                         <li>
-                            <a href="{{ path('easyadmin', _request_parameters|merge({ page: paginator.nextPage }) ) }}">
+                            <a href="{{ path('easyadmin', _paginator_request_parameters|merge({ page: paginator.nextPage }) ) }}">
                                 {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
                             </a>
                         </li>
@@ -53,7 +55,7 @@
 
                     {% if paginator.currentPage < paginator.nbPages %}
                         <li>
-                            <a href="{{ path('easyadmin', _request_parameters|merge({ page: paginator.nbPages }) ) }}">
+                            <a href="{{ path('easyadmin', _paginator_request_parameters|merge({ page: paginator.nbPages }) ) }}">
                                 {{ 'paginator.last'|trans }} <i class="fa fa-angle-double-right"></i>
                             </a>
                         </li>

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -70,37 +70,13 @@
     </div>
 
     {% block delete_form %}
-        {{
-            form(delete_form, {
-                action: delete_form.vars.action ~ '&referer=' ~ app.request.query.get('referer', ''),
-                method: 'DELETE',
-                attr: { id: 'delete-form', style: 'display: none' }
-            })
-        }}
-
-        <div id="modal-delete" class="modal fade">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-body">
-                        <h4>{{ 'delete_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
-                        <p>{{ 'delete_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" data-dismiss="modal" class="btn">
-                            {{ 'action.cancel'|trans(_trans_parameters) }}
-                        </button>
-
-                        {% if easyadmin_action_is_enabled_for_show_view('delete', _entity_config.name) %}
-                            {% set _action = easyadmin_get_action_for_show_view('delete', _entity_config.name) %}
-                            <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
-                                {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                {{ _action.label|default('action.delete')|trans(_trans_parameters) }}
-                            </button>
-                        {% endif %}
-                    </div>
-                </div>
-            </div>
-        </div>
+        {{ include('@EasyAdmin/default/includes/delete_form.html.twig', {
+            view: 'show',
+            referer: app.request.query.get('referer', ''),
+            delete_form: delete_form,
+            _trans_parameters: _trans_parameters,
+            _entity_config: _entity_config,
+        }, with_context = false) }}
     {% endblock delete_form %}
 {% endblock %}
 

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -379,7 +379,7 @@
                             {% if easyadmin_action_is_enabled_for_edit_view('delete', easyadmin.entity.name) %}
                                 {% set _action = easyadmin_get_action_for_edit_view('delete', easyadmin.entity.name) %}
                                 <button type="button" id="button-delete"
-                                        class="btn {{ _action.css_class|default('btn-danger') }}">
+                                        class="btn {{ _action.css_class|default('') }}">
                                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                                     {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters, 'messages') }}
                                 </button>

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -67,7 +67,7 @@ class CustomizedBackendTest extends AbstractTestCase
         $crawler = $this->requestListView();
 
         $this->assertEquals('New Category', trim($crawler->filter('#content-actions a.btn')->text()));
-        $this->assertEquals('btn custom_class_new', $crawler->filter('#content-actions a.btn')->attr('class'));
+        $this->assertEquals('btn custom_class_new action-new', $crawler->filter('#content-actions a.btn')->attr('class'));
         $this->assertEquals('fa fa-plus-circle', $crawler->filter('#content-actions a.btn i')->attr('class'));
         $this->assertStringStartsWith('/admin/?action=new&entity=Category&sortField=id&sortDirection=DESC&page=1', $crawler->filter('#content-actions a.btn')->attr('href'));
     }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -256,13 +256,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -271,31 +271,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -305,7 +305,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -316,19 +316,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
@@ -14,7 +14,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -26,13 +26,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -41,31 +41,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
@@ -14,13 +14,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
@@ -14,7 +14,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             edit:
                 fields:
@@ -28,13 +28,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -45,31 +45,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -80,19 +80,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
@@ -20,7 +20,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             edit:
                 fields:
@@ -34,13 +34,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -49,31 +49,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
@@ -20,7 +20,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -37,13 +37,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -52,31 +52,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -87,19 +87,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -43,7 +43,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -52,31 +52,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -87,19 +87,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
@@ -20,7 +20,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             edit:
                 fields:
@@ -35,13 +35,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -52,31 +52,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -87,19 +87,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
@@ -10,7 +10,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             edit:
                 fields: {  }
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -35,31 +35,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             show:
                 fields: {  }
@@ -68,19 +68,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             label: TestEntity
             name: TestEntity

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
@@ -14,7 +14,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             edit:
                 fields:
@@ -28,13 +28,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields:
@@ -49,31 +49,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             show:
                 fields:
@@ -88,19 +88,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             label: TestEntity
             name: TestEntity

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
@@ -14,31 +14,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -50,13 +50,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -66,7 +66,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -77,19 +77,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
@@ -15,31 +15,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -51,13 +51,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -67,7 +67,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -78,19 +78,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
@@ -15,31 +15,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -51,13 +51,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -67,7 +67,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -78,19 +78,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -31,25 +31,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -59,7 +59,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -70,19 +70,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
@@ -15,7 +15,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -24,31 +24,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -58,7 +58,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -69,19 +69,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
@@ -15,13 +15,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -30,31 +30,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -64,7 +64,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -75,13 +75,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
@@ -15,13 +15,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -30,31 +30,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -64,7 +64,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -75,19 +75,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -35,7 +35,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -45,7 +45,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -56,19 +56,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
@@ -16,7 +16,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -25,31 +25,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -59,7 +59,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -70,19 +70,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
@@ -17,13 +17,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -32,31 +32,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -66,7 +66,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -77,7 +77,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
@@ -15,13 +15,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -30,31 +30,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -64,7 +64,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -75,19 +75,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
@@ -17,13 +17,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -32,25 +32,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -60,7 +60,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -71,19 +71,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
@@ -16,7 +16,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -25,31 +25,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -59,7 +59,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -70,19 +70,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -76,13 +76,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
@@ -25,7 +25,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -34,25 +34,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -62,7 +62,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -73,13 +73,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
@@ -32,7 +32,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -41,7 +41,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -51,7 +51,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -62,7 +62,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
@@ -29,7 +29,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -38,25 +38,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -66,7 +66,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -77,13 +77,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
@@ -43,7 +43,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -52,7 +52,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -62,7 +62,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
@@ -45,13 +45,13 @@ easy_admin:
                         name: delete
                         type: route
                         label: custom-delete-label
-                        css_class: custom-delete-class
+                        css_class: 'custom-delete-class action-delete btn-danger'
                         icon: custom-delete-icon
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -60,31 +60,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: route
                         label: custom-edit-label
-                        css_class: custom-edit-class
+                        css_class: 'custom-edit-class action-edit'
                         icon: custom-edit-icon
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -94,7 +94,7 @@ easy_admin:
                         name: list
                         type: route
                         label: custom-list-label
-                        css_class: custom-list-class
+                        css_class: 'custom-list-class action-list'
                         icon: custom-list-icon
             search:
                 fields: {  }
@@ -105,19 +105,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: route
                         label: custom-list-label
-                        css_class: custom-list-class
+                        css_class: 'custom-list-class action-list'
                         icon: custom-list-icon
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
@@ -25,19 +25,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_action_for_edit:
                         name: custom_action_for_edit
                         type: method
                         label: 'Custom action for edit'
-                        css_class: ''
+                        css_class: action-custom_action_for_edit
                         icon: null
             list:
                 fields: {  }
@@ -46,37 +46,37 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     custom_action_for_list:
                         name: custom_action_for_list
                         type: method
                         label: 'Custom action for list'
-                        css_class: ''
+                        css_class: action-custom_action_for_list
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -86,13 +86,13 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_action_for_new:
                         name: custom_action_for_new
                         type: method
                         label: 'Custom action for new'
-                        css_class: ''
+                        css_class: action-custom_action_for_new
                         icon: null
             search:
                 fields: {  }
@@ -103,25 +103,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                     custom_action_for_show:
                         name: custom_action_for_show
                         type: method
                         label: 'Custom action for show'
-                        css_class: ''
+                        css_class: action-custom_action_for_show
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
@@ -25,13 +25,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -40,31 +40,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -74,7 +74,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -85,19 +85,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
@@ -45,19 +45,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_action_for_edit:
                         name: custom_action_for_edit
                         type: route
                         label: custom-edit-label
-                        css_class: custom-edit-class
+                        css_class: 'custom-edit-class action-custom_action_for_edit'
                         icon: custom-edit-icon
             list:
                 fields: {  }
@@ -66,37 +66,37 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     custom_action_for_list:
                         name: custom_action_for_list
                         type: route
                         label: custom-list-label
-                        css_class: custom-list-class
+                        css_class: 'custom-list-class action-custom_action_for_list'
                         icon: custom-list-icon
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -106,13 +106,13 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_action_for_new:
                         name: custom_action_for_new
                         type: route
                         label: custom-new-label
-                        css_class: custom-new-class
+                        css_class: 'custom-new-class action-custom_action_for_new'
                         icon: custom-new-icon
             search:
                 fields: {  }
@@ -123,25 +123,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                     custom_action_for_show:
                         name: custom_action_for_show
                         type: route
                         label: custom-show-label
-                        css_class: custom-show-class
+                        css_class: 'custom-show-class action-custom_action_for_show'
                         icon: custom-show-icon
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
@@ -40,13 +40,13 @@ easy_admin:
                         name: list
                         type: method
                         label: custom-list-label
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_action_for_edit:
                         name: custom_action_for_edit
                         type: method
                         label: 'Custom action for edit'
-                        css_class: ''
+                        css_class: action-custom_action_for_edit
                         icon: null
             list:
                 fields: {  }
@@ -55,31 +55,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: custom-edit-label
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     custom_action_for_list:
                         name: custom_action_for_list
                         type: method
                         label: 'Custom action for list'
-                        css_class: ''
+                        css_class: action-custom_action_for_list
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -89,13 +89,13 @@ easy_admin:
                         name: custom_action_for_new
                         type: method
                         label: custom-action-label
-                        css_class: ''
+                        css_class: action-custom_action_for_new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -106,25 +106,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     edit:
                         name: edit
                         type: method
                         label: custom-edit-label
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                     custom_action_for_show:
                         name: custom_action_for_show
                         type: method
                         label: 'Custom action for show'
-                        css_class: ''
+                        css_class: action-custom_action_for_show
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -35,31 +35,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: 'This label should not be action.search'
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -69,7 +69,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -80,19 +80,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
@@ -8,25 +8,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             label: TestEntity
@@ -39,13 +39,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -55,7 +55,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -66,19 +66,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
@@ -8,7 +8,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -21,31 +21,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -55,7 +55,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -66,19 +66,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
@@ -8,13 +8,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             label: TestEntity
@@ -27,13 +27,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -42,31 +42,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -76,7 +76,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
@@ -8,7 +8,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -22,13 +22,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -37,31 +37,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
@@ -21,25 +21,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -48,7 +48,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -58,13 +58,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             new:
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
@@ -21,31 +21,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -54,13 +54,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -70,19 +70,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                 fields: {  }
             new:
@@ -91,7 +91,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
@@ -23,25 +23,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -50,7 +50,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -60,13 +60,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             new:
@@ -75,7 +75,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
@@ -23,31 +23,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -56,13 +56,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                 fields: {  }
             new:
@@ -93,7 +93,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
@@ -22,31 +22,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -55,13 +55,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -71,19 +71,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                 fields: {  }
             new:
@@ -92,7 +92,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
@@ -21,37 +21,37 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     custom_list_action:
                         name: custom_list_action
                         type: method
                         label: 'Custom list action'
-                        css_class: ''
+                        css_class: action-custom_list_action
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -60,19 +60,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_edit_action:
                         name: custom_edit_action
                         type: method
                         label: 'Custom edit action'
-                        css_class: ''
+                        css_class: action-custom_edit_action
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -82,25 +82,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                     custom_show_action:
                         name: custom_show_action
                         type: method
                         label: 'Custom show action'
-                        css_class: ''
+                        css_class: action-custom_show_action
                         icon: null
                 fields: {  }
             new:
@@ -109,13 +109,13 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_new_action:
                         name: custom_new_action
                         type: method
                         label: 'Custom new action'
-                        css_class: ''
+                        css_class: action-custom_new_action
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
@@ -24,31 +24,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -57,13 +57,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -73,19 +73,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                 fields: {  }
             new:
@@ -94,7 +94,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
@@ -23,37 +23,37 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     custom_list_action:
                         name: custom_list_action
                         type: method
                         label: 'Custom list action'
-                        css_class: ''
+                        css_class: action-custom_list_action
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -62,19 +62,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_edit_action:
                         name: custom_edit_action
                         type: method
                         label: 'Custom edit action'
-                        css_class: ''
+                        css_class: action-custom_edit_action
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -84,25 +84,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                     custom_show_action:
                         name: custom_show_action
                         type: method
                         label: 'Custom show action'
-                        css_class: ''
+                        css_class: action-custom_show_action
                         icon: null
                 fields: {  }
             new:
@@ -111,13 +111,13 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     custom_new_action:
                         name: custom_new_action
                         type: method
                         label: 'Custom new action'
-                        css_class: ''
+                        css_class: action-custom_new_action
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
@@ -37,31 +37,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: 'Entity Edit Label'
-                        css_class: ''
+                        css_class: action-edit
                         icon: entity-edit-icon
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -70,13 +70,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: 'Entity Delete Label'
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: entity-delete-icon
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -86,19 +86,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: route
                         label: 'Entity Edit Label'
-                        css_class: ''
+                        css_class: action-edit
                         icon: entity-edit-icon
                 fields: {  }
             new:
@@ -107,7 +107,7 @@ easy_admin:
                         name: list
                         type: route
                         label: 'Entity List Label'
-                        css_class: ''
+                        css_class: action-list
                         icon: entity-list-icon
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
@@ -45,49 +45,49 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        css_class: ''
+                        css_class: action-CamelCaseAction
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        css_class: ''
+                        css_class: action-snakeCaseAction
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        css_class: ''
+                        css_class: action-underscore_action
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        css_class: ''
+                        css_class: action-UPPERCASE_ACTION
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        css_class: ''
+                        css_class: action-lowercaseaction
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        css_class: ''
+                        css_class: action-WEIRD_caseAction
                         icon: null
             list:
                 fields: {  }
@@ -96,67 +96,67 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        css_class: ''
+                        css_class: action-CamelCaseAction
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        css_class: ''
+                        css_class: action-snakeCaseAction
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        css_class: ''
+                        css_class: action-underscore_action
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        css_class: ''
+                        css_class: action-UPPERCASE_ACTION
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        css_class: ''
+                        css_class: action-lowercaseaction
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        css_class: ''
+                        css_class: action-WEIRD_caseAction
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -166,43 +166,43 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        css_class: ''
+                        css_class: action-CamelCaseAction
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        css_class: ''
+                        css_class: action-snakeCaseAction
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        css_class: ''
+                        css_class: action-underscore_action
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        css_class: ''
+                        css_class: action-UPPERCASE_ACTION
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        css_class: ''
+                        css_class: action-lowercaseaction
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        css_class: ''
+                        css_class: action-WEIRD_caseAction
                         icon: null
             search:
                 fields: {  }
@@ -213,55 +213,55 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        css_class: ''
+                        css_class: action-CamelCaseAction
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        css_class: ''
+                        css_class: action-snakeCaseAction
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        css_class: ''
+                        css_class: action-underscore_action
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        css_class: ''
+                        css_class: action-UPPERCASE_ACTION
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        css_class: ''
+                        css_class: action-lowercaseaction
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        css_class: ''
+                        css_class: action-WEIRD_caseAction
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
@@ -8,67 +8,67 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        css_class: ''
+                        css_class: action-CamelCaseAction
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        css_class: ''
+                        css_class: action-snakeCaseAction
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        css_class: ''
+                        css_class: action-underscore_action
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        css_class: ''
+                        css_class: action-UPPERCASE_ACTION
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        css_class: ''
+                        css_class: action-lowercaseaction
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        css_class: ''
+                        css_class: action-WEIRD_caseAction
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
             edit:
@@ -77,49 +77,49 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        css_class: ''
+                        css_class: action-CamelCaseAction
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        css_class: ''
+                        css_class: action-snakeCaseAction
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        css_class: ''
+                        css_class: action-underscore_action
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        css_class: ''
+                        css_class: action-UPPERCASE_ACTION
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        css_class: ''
+                        css_class: action-lowercaseaction
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        css_class: ''
+                        css_class: action-WEIRD_caseAction
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -129,55 +129,55 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        css_class: ''
+                        css_class: action-CamelCaseAction
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        css_class: ''
+                        css_class: action-snakeCaseAction
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        css_class: ''
+                        css_class: action-underscore_action
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        css_class: ''
+                        css_class: action-UPPERCASE_ACTION
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        css_class: ''
+                        css_class: action-lowercaseaction
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        css_class: ''
+                        css_class: action-WEIRD_caseAction
                         icon: null
                 fields: {  }
             new:
@@ -186,43 +186,43 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        css_class: ''
+                        css_class: action-CamelCaseAction
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        css_class: ''
+                        css_class: action-snakeCaseAction
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        css_class: ''
+                        css_class: action-underscore_action
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        css_class: ''
+                        css_class: action-UPPERCASE_ACTION
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        css_class: ''
+                        css_class: action-lowercaseaction
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        css_class: ''
+                        css_class: action-WEIRD_caseAction
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
@@ -60,13 +60,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -75,31 +75,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -109,7 +109,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -120,19 +120,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
@@ -19,13 +19,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -34,31 +34,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -68,7 +68,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -79,19 +79,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
@@ -8,13 +8,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -24,19 +24,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                 fields: {  }
             label: TestEntity
@@ -48,31 +48,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -82,7 +82,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_103.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_103.yml
@@ -15,13 +15,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -31,19 +31,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
                 fields: {  }
             label: TestEntity
@@ -55,31 +55,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -89,7 +89,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_105.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_105.yml
@@ -47,13 +47,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -62,31 +62,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -96,7 +96,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -107,19 +107,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
     design:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_106.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_106.yml
@@ -94,13 +94,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -109,31 +109,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -143,7 +143,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -154,19 +154,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
     site_name: 'Easy Admin'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_107.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_107.yml
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -35,31 +35,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -69,7 +69,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             show:
                 fields: {  }
@@ -78,19 +78,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_109.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_109.yml
@@ -14,13 +14,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -29,31 +29,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -63,7 +63,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -74,19 +74,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions:
                 - action1

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_110.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_110.yml
@@ -14,13 +14,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -29,31 +29,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -63,7 +63,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -74,19 +74,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             templates:
                 layout: '@EasyAdmin/default/layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_111.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_111.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             templates:
                 layout: '@EasyAdmin/default/layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_112.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_112.yml
@@ -17,13 +17,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -32,31 +32,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -66,7 +66,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -77,19 +77,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             templates:
                 layout: '@EasyAdmin/default/layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_113.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_113.yml
@@ -20,7 +20,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             edit:
                 form_options:
@@ -33,13 +33,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -48,31 +48,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -83,19 +83,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_114.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_114.yml
@@ -16,7 +16,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             edit:
                 form_options:
@@ -28,13 +28,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -45,31 +45,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -80,19 +80,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_124.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_124.yml
@@ -1,17 +1,52 @@
 easy_admin:
     design:
+        form_theme:
+            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/bootstrap_3_layout.html.twig'
+        theme: default
+        color_scheme: dark
+        brand_color: '#E67E22'
         assets:
             css: {  }
             js: {  }
             favicon:
                 path: favicon.ico
                 mime_type: image/x-icon
-        theme: default
-        color_scheme: dark
-        brand_color: '#E67E22'
-        form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
-            - '@EasyAdmin/form/bootstrap_3_layout.html.twig'
+        templates:
+            layout: '@EasyAdmin/default/layout.html.twig'
+            edit: '@EasyAdmin/default/edit.html.twig'
+            list: '@EasyAdmin/default/list.html.twig'
+            new: '@EasyAdmin/default/new.html.twig'
+            show: '@EasyAdmin/default/show.html.twig'
+            exception: '@EasyAdmin/default/exception.html.twig'
+            flash_messages: '@EasyAdmin/default/flash_messages.html.twig'
+            paginator: '@EasyAdmin/default/paginator.html.twig'
+            field_array: '@EasyAdmin/default/field_array.html.twig'
+            field_association: '@EasyAdmin/default/field_association.html.twig'
+            field_bigint: '@EasyAdmin/default/field_bigint.html.twig'
+            field_boolean: '@EasyAdmin/default/field_boolean.html.twig'
+            field_date: '@EasyAdmin/default/field_date.html.twig'
+            field_datetime: '@EasyAdmin/default/field_datetime.html.twig'
+            field_datetimetz: '@EasyAdmin/default/field_datetimetz.html.twig'
+            field_decimal: '@EasyAdmin/default/field_decimal.html.twig'
+            field_float: '@EasyAdmin/default/field_float.html.twig'
+            field_guid: '@EasyAdmin/default/field_guid.html.twig'
+            field_id: '@EasyAdmin/default/field_id.html.twig'
+            field_image: '@EasyAdmin/default/field_image.html.twig'
+            field_json_array: '@EasyAdmin/default/field_json_array.html.twig'
+            field_integer: '@EasyAdmin/default/field_integer.html.twig'
+            field_object: '@EasyAdmin/default/field_object.html.twig'
+            field_raw: '@EasyAdmin/default/field_raw.html.twig'
+            field_simple_array: '@EasyAdmin/default/field_simple_array.html.twig'
+            field_smallint: '@EasyAdmin/default/field_smallint.html.twig'
+            field_string: '@EasyAdmin/default/field_string.html.twig'
+            field_text: '@EasyAdmin/default/field_text.html.twig'
+            field_time: '@EasyAdmin/default/field_time.html.twig'
+            field_toggle: '@EasyAdmin/default/field_toggle.html.twig'
+            label_empty: '@EasyAdmin/default/label_empty.html.twig'
+            label_inaccessible: '@EasyAdmin/default/label_inaccessible.html.twig'
+            label_null: '@EasyAdmin/default/label_null.html.twig'
+            label_undefined: '@EasyAdmin/default/label_undefined.html.twig'
     site_name: 'Easy Admin'
     formats:
         date: Y-m-d

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_001.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_002.yml
@@ -47,13 +47,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -62,31 +62,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -96,7 +96,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -107,19 +107,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
     design:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_003.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_004.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_005.yml
@@ -94,13 +94,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -109,31 +109,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -143,7 +143,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -154,19 +154,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
         AnotherTestEntity:
@@ -216,13 +216,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -231,31 +231,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -265,7 +265,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -276,19 +276,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
     site_name: 'Easy Admin'

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_001.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_002.yml
@@ -47,13 +47,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -62,31 +62,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -96,7 +96,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -107,19 +107,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
     design:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_003.yml
@@ -59,13 +59,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -74,31 +74,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -108,7 +108,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -119,19 +119,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_004.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -134,13 +134,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -149,31 +149,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -183,7 +183,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -194,19 +194,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_005.yml
@@ -94,13 +94,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -109,31 +109,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -143,7 +143,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -154,19 +154,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
         AnotherTestEntity:
@@ -216,13 +216,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             list:
                 fields: {  }
@@ -231,31 +231,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        css_class: ''
+                        css_class: action-show
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        css_class: ''
+                        css_class: action-search
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        css_class: ''
+                        css_class: action-new
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             new:
                 fields: {  }
@@ -265,7 +265,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
             search:
                 fields: {  }
@@ -276,19 +276,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        css_class: ''
+                        css_class: 'action-delete btn-danger'
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        css_class: ''
+                        css_class: action-list
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        css_class: ''
+                        css_class: action-edit
                         icon: edit
             disabled_actions: {  }
     site_name: 'Easy Admin'

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -39,7 +39,9 @@ class EasyAdminTwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('easyadmin_render_field_for_*_view', array($this, 'renderEntityField'), array('is_safe' => array('html'), 'needs_environment' => true)),
             new \Twig_SimpleFunction('easyadmin_config', array($this, 'getBackendConfiguration')),
             new \Twig_SimpleFunction('easyadmin_entity', array($this, 'getEntityConfiguration')),
+            new \Twig_SimpleFunction('easyadmin_action_is_enabled_for_view', array($this, 'isActionEnabled')),
             new \Twig_SimpleFunction('easyadmin_action_is_enabled_for_*_view', array($this, 'isActionEnabled')),
+            new \Twig_SimpleFunction('easyadmin_get_action_for_view', array($this, 'getActionConfiguration')),
             new \Twig_SimpleFunction('easyadmin_get_action_for_*_view', array($this, 'getActionConfiguration')),
             new \Twig_SimpleFunction('easyadmin_get_actions_for_*_item', array($this, 'getActionsForItem')),
         );

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -240,7 +240,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
         // in the 'list' view). Those special actions shouldn't be displayed for
         // each item as a regular action.
         $actionsExcludedForItems = array(
-            'list' => array('delete', 'list', 'new', 'search'),
+            'list' => array('list', 'new', 'search'),
             'edit' => array('list', 'delete'),
             'new' => array('list'),
             'show' => array('list', 'delete'),

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -39,9 +39,9 @@ class EasyAdminTwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('easyadmin_render_field_for_*_view', array($this, 'renderEntityField'), array('is_safe' => array('html'), 'needs_environment' => true)),
             new \Twig_SimpleFunction('easyadmin_config', array($this, 'getBackendConfiguration')),
             new \Twig_SimpleFunction('easyadmin_entity', array($this, 'getEntityConfiguration')),
-            new \Twig_SimpleFunction('easyadmin_action_is_enabled_for_view', array($this, 'isActionEnabled')),
+            new \Twig_SimpleFunction('easyadmin_action_is_enabled', array($this, 'isActionEnabled')),
             new \Twig_SimpleFunction('easyadmin_action_is_enabled_for_*_view', array($this, 'isActionEnabled')),
-            new \Twig_SimpleFunction('easyadmin_get_action_for_view', array($this, 'getActionConfiguration')),
+            new \Twig_SimpleFunction('easyadmin_get_action', array($this, 'getActionConfiguration')),
             new \Twig_SimpleFunction('easyadmin_get_action_for_*_view', array($this, 'getActionConfiguration')),
             new \Twig_SimpleFunction('easyadmin_get_actions_for_*_item', array($this, 'getActionsForItem')),
         );


### PR DESCRIPTION
Hope you had a merry Christmas. Here is my tribute for this day :christmas_tree: :gift: 
- The first commit adds as simply (no ajax, no duplicated forms) but securely as possible the `delete` action in the `list` view. (The `delete` action isn't enabled by default, it should be added in the `EntityName.list.actions`configuration)
- Second commit suggests to extract the delete form and modal in a dedicated & reusable template to be included.
- Third commit is a minor fix about the `css` option which has been renamed `css_class`, but that option wasn't properly named in default config.  
  It also adds for every actions a default "action-{actionName}" class, very useful for styling or js. Plus, it adds by default `text-danger` or `btn-danger` classes according to the view for the `delete` action.

If you prefer, I can submit a dedicated PR for the `css_class` fix, and then we'll review this PR.
