### PR TITLE
"css_class" should be used instead of "class"

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -29,16 +29,16 @@ class Configurator
     private $defaultEntityFields = array();
 
     private $defaultEntityFieldConfiguration = array(
-        'class'     => null,  // CSS class or classes applied to form field
-        'format'    => null,  // date/time/datetime/number format applied to form field value
-        'help'      => null,  // form field help message
-        'label'     => null,  // form field label (if 'null', autogenerate it)
-        'type'      => null,  // its value matches the value of 'dataType' for list/show and the value of 'fieldType' for new/edit
-        'fieldType' => null,  // Symfony form field type (text, date, number, choice, ...) used to display the field
-        'dataType'  => null,  // Data type (text, date, integer, boolean, ...) of the Doctrine property associated with the field
-        'virtual'   => false, // is a virtual field or a real Doctrine entity property?
-        'sortable'  => true,  // listings can be sorted according to the values of this field
-        'template'  => null,  // the path of the template used to render the field in 'show' and 'list' views
+        'css_class'    => '',    // CSS class or classes applied to form field
+        'format'       => null,  // date/time/datetime/number format applied to form field value
+        'help'         => null,  // form field help message
+        'label'        => null,  // form field label (if 'null', autogenerate it)
+        'type'         => null,  // its value matches the value of 'dataType' for list/show and the value of 'fieldType' for new/edit
+        'fieldType'    => null,  // Symfony form field type (text, date, number, choice, ...) used to display the field
+        'dataType'     => null,  // Data type (text, date, integer, boolean, ...) of the Doctrine property associated with the field
+        'virtual'      => false, // is a virtual field or a real Doctrine entity property?
+        'sortable'     => true,  // listings can be sorted according to the values of this field
+        'template'     => null,  // the path of the template used to render the field in 'show' and 'list' views
         'type_options' => array(), // the options passed to the Symfony Form type used to render the form field
     );
 

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -30,11 +30,11 @@ class EasyAdminExtension extends Extension
     private $views = array('edit', 'list', 'new', 'show');
 
     private $defaultActionConfiguration = array(
-        'name'  => null,     // either the name of a controller method or an application route (it depends on the 'type' option)
-        'type'  => 'method', // 'method' if the action is a controller method; 'route' if it's an application route
-        'label' => null,     // action label (displayed as link or button) (if 'null', autogenerate it)
-        'class' => '',       // the CSS class applied to the button/link displayed by the action
-        'icon'  => null,     // the name of the FontAwesome icon to display next to the 'label' (doesn't include the 'fa-' prefix)
+        'name'      => null,     // either the name of a controller method or an application route (it depends on the 'type' option)
+        'type'      => 'method', // 'method' if the action is a controller method; 'route' if it's an application route
+        'label'     => null,     // action label (displayed as link or button) (if 'null', autogenerate it)
+        'css_class' => '',       // the CSS class applied to the button/link displayed by the action
+        'icon'      => null,     // the name of the FontAwesome icon to display next to the 'label' (doesn't include the 'fa-' prefix)
     );
 
     private $defaultBackendTemplates = array(

--- a/Resources/doc/getting-started/4-views-and-actions.md
+++ b/Resources/doc/getting-started/4-views-and-actions.md
@@ -269,8 +269,8 @@ These are the options that you can define for each field:
   * `css_class` (optional): the CSS class applied to the form field widget
     container element in the `edit`, `new` and `show` views. For example, when
     using the default Bootstrap based form theme, this value is applied to the
-    `<div class="form-group">` element which wraps the label, the widget and
-    the error messages of the field.
+    `<div>` element which wraps the label, the widget and the error messages of 
+    the field.
   * `template` (optional): the name of the custom template used to render the
     contents of the field in the `list` and `show` views. This option is fully
     explained in the [Advanced Design Customization] [advanced-design-customization] tutorial.

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -263,7 +263,7 @@
 {% endblock collection_row %}
 
 {% block button_row -%}
-    <div class="form-group field-{{ easyadmin.field.fieldType|default('default') }} {{ easyadmin.field.class|default('') }}">
+    <div class="form-group field-{{ easyadmin.field.fieldType|default('default') }} {{ easyadmin.field.css_class|default('') }}">
         {{- form_widget(form) -}}
     </div>
 {%- endblock button_row %}
@@ -344,7 +344,7 @@
         <input type="hidden" name="referer" value="{{ app.request.query.get('referer', '') }}"/>
 
         {% for field in form.children if 'hidden' not in field.vars.block_prefixes %}
-            <div class="{{ field.vars.easyadmin.field.class|default('col-xs-12') }}">
+            <div class="{{ field.vars.easyadmin.field.css_class|default('col-xs-12') }}">
                 {{ form_row(field) }}
             </div>
         {% endfor %}

--- a/Tests/DependencyInjection/fixtures/configurations/input/admin_061.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/input/admin_061.yml
@@ -5,16 +5,16 @@
 easy_admin:
     list:
         actions:
-            - { name: 'edit', icon: 'custom-edit-icon', class: 'custom-edit-class', label: 'custom-edit-label', type: 'route' }
+            - { name: 'edit', icon: 'custom-edit-icon', css_class: 'custom-edit-class', label: 'custom-edit-label', type: 'route' }
     edit:
         actions:
-            - { name: 'delete', icon: 'custom-delete-icon', class: 'custom-delete-class', label: 'custom-delete-label', type: 'route' }
+            - { name: 'delete', icon: 'custom-delete-icon', css_class: 'custom-delete-class', label: 'custom-delete-label', type: 'route' }
     show:
         actions:
-            - { name: 'list', icon: 'custom-list-icon', class: 'custom-list-class', label: 'custom-list-label', type: 'route' }
+            - { name: 'list', icon: 'custom-list-icon', css_class: 'custom-list-class', label: 'custom-list-label', type: 'route' }
     new:
         actions:
-            - { name: 'list', icon: 'custom-list-icon', class: 'custom-list-class', label: 'custom-list-label', type: 'route' }
+            - { name: 'list', icon: 'custom-list-icon', css_class: 'custom-list-class', label: 'custom-list-label', type: 'route' }
     entities:
         TestEntity:
             class: AppBundle\Entity\TestEntity

--- a/Tests/DependencyInjection/fixtures/configurations/input/admin_064.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/input/admin_064.yml
@@ -5,16 +5,16 @@
 easy_admin:
     list:
         actions:
-            - { name: 'custom_action_for_list', icon: 'custom-list-icon', class: 'custom-list-class', label: 'custom-list-label', type: 'route' }
+            - { name: 'custom_action_for_list', icon: 'custom-list-icon', css_class: 'custom-list-class', label: 'custom-list-label', type: 'route' }
     edit:
         actions:
-            - { name: 'custom_action_for_edit', icon: 'custom-edit-icon', class: 'custom-edit-class', label: 'custom-edit-label', type: 'route' }
+            - { name: 'custom_action_for_edit', icon: 'custom-edit-icon', css_class: 'custom-edit-class', label: 'custom-edit-label', type: 'route' }
     show:
         actions:
-            - { name: 'custom_action_for_show', icon: 'custom-show-icon', class: 'custom-show-class', label: 'custom-show-label', type: 'route' }
+            - { name: 'custom_action_for_show', icon: 'custom-show-icon', css_class: 'custom-show-class', label: 'custom-show-label', type: 'route' }
     new:
         actions:
-            - { name: 'custom_action_for_new', icon: 'custom-new-icon', class: 'custom-new-class', label: 'custom-new-label', type: 'route' }
+            - { name: 'custom_action_for_new', icon: 'custom-new-icon', css_class: 'custom-new-class', label: 'custom-new-label', type: 'route' }
     entities:
         TestEntity:
             class: AppBundle\Entity\TestEntity

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_001.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_002.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_003.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -254,13 +254,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -269,31 +269,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -303,7 +303,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -314,19 +314,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_004.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_005.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_007.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_008.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_009.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_010.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_012.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_013.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_014.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_016.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_017.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_018.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_019.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_020.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_021.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_022.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_023.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_024.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_025.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_026.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_027.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_028.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_030.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_031.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_032.yml
@@ -14,7 +14,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -26,13 +26,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -41,31 +41,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_033.yml
@@ -14,13 +14,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_034.yml
@@ -14,7 +14,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             edit:
                 fields:
@@ -28,13 +28,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -45,31 +45,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -80,19 +80,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_035.yml
@@ -20,7 +20,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             edit:
                 fields:
@@ -34,13 +34,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -49,31 +49,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_036.yml
@@ -20,7 +20,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -37,13 +37,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -52,31 +52,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -87,19 +87,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_037.yml
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -43,7 +43,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -52,31 +52,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -87,19 +87,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_038.yml
@@ -20,7 +20,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             edit:
                 fields:
@@ -35,13 +35,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -52,31 +52,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -87,19 +87,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_039.yml
@@ -10,7 +10,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             edit:
                 fields: {  }
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -35,31 +35,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             show:
                 fields: {  }
@@ -68,19 +68,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             label: TestEntity
             name: TestEntity

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_040.yml
@@ -14,7 +14,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             edit:
                 fields:
@@ -28,13 +28,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields:
@@ -49,31 +49,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             show:
                 fields:
@@ -88,19 +88,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             label: TestEntity
             name: TestEntity

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_041.yml
@@ -14,31 +14,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -50,13 +50,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -66,7 +66,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -77,19 +77,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_042.yml
@@ -15,31 +15,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -51,13 +51,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -67,7 +67,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -78,19 +78,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_043.yml
@@ -15,31 +15,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -51,13 +51,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -67,7 +67,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -78,19 +78,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_045.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -31,25 +31,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -59,7 +59,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -70,19 +70,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_046.yml
@@ -15,7 +15,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -24,31 +24,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -58,7 +58,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -69,19 +69,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_047.yml
@@ -15,13 +15,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -30,31 +30,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -64,7 +64,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -75,13 +75,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_048.yml
@@ -15,13 +15,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -30,31 +30,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -64,7 +64,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -75,19 +75,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_049.yml
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -35,7 +35,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -45,7 +45,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -56,19 +56,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_050.yml
@@ -16,7 +16,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -25,31 +25,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -59,7 +59,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -70,19 +70,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_051.yml
@@ -17,13 +17,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -32,31 +32,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -66,7 +66,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -77,7 +77,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_052.yml
@@ -15,13 +15,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -30,31 +30,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -64,7 +64,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -75,19 +75,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_053.yml
@@ -17,13 +17,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -32,25 +32,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -60,7 +60,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -71,19 +71,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_054.yml
@@ -16,7 +16,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -25,31 +25,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -59,7 +59,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -70,19 +70,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_055.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -76,13 +76,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_056.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_057.yml
@@ -25,7 +25,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -34,25 +34,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -62,7 +62,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -73,13 +73,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_058.yml
@@ -32,7 +32,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -41,7 +41,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -51,7 +51,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -62,7 +62,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_059.yml
@@ -29,7 +29,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -38,25 +38,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -66,7 +66,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -77,13 +77,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_060.yml
@@ -43,7 +43,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -52,7 +52,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -62,7 +62,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_061.yml
@@ -4,7 +4,7 @@ easy_admin:
             -
                 name: edit
                 icon: custom-edit-icon
-                class: custom-edit-class
+                css_class: custom-edit-class
                 label: custom-edit-label
                 type: route
         max_results: 15
@@ -13,7 +13,7 @@ easy_admin:
             -
                 name: delete
                 icon: custom-delete-icon
-                class: custom-delete-class
+                css_class: custom-delete-class
                 label: custom-delete-label
                 type: route
     show:
@@ -21,7 +21,7 @@ easy_admin:
             -
                 name: list
                 icon: custom-list-icon
-                class: custom-list-class
+                css_class: custom-list-class
                 label: custom-list-label
                 type: route
     new:
@@ -29,7 +29,7 @@ easy_admin:
             -
                 name: list
                 icon: custom-list-icon
-                class: custom-list-class
+                css_class: custom-list-class
                 label: custom-list-label
                 type: route
     entities:
@@ -45,13 +45,13 @@ easy_admin:
                         name: delete
                         type: route
                         label: custom-delete-label
-                        class: custom-delete-class
+                        css_class: custom-delete-class
                         icon: custom-delete-icon
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -60,31 +60,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: route
                         label: custom-edit-label
-                        class: custom-edit-class
+                        css_class: custom-edit-class
                         icon: custom-edit-icon
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -94,7 +94,7 @@ easy_admin:
                         name: list
                         type: route
                         label: custom-list-label
-                        class: custom-list-class
+                        css_class: custom-list-class
                         icon: custom-list-icon
             search:
                 fields: {  }
@@ -105,19 +105,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: route
                         label: custom-list-label
-                        class: custom-list-class
+                        css_class: custom-list-class
                         icon: custom-list-icon
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_062.yml
@@ -25,19 +25,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_action_for_edit:
                         name: custom_action_for_edit
                         type: method
                         label: 'Custom action for edit'
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -46,37 +46,37 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_action_for_list:
                         name: custom_action_for_list
                         type: method
                         label: 'Custom action for list'
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -86,13 +86,13 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_action_for_new:
                         name: custom_action_for_new
                         type: method
                         label: 'Custom action for new'
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -103,25 +103,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                     custom_action_for_show:
                         name: custom_action_for_show
                         type: method
                         label: 'Custom action for show'
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_063.yml
@@ -25,13 +25,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -40,31 +40,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -74,7 +74,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -85,19 +85,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_064.yml
@@ -4,7 +4,7 @@ easy_admin:
             -
                 name: custom_action_for_list
                 icon: custom-list-icon
-                class: custom-list-class
+                css_class: custom-list-class
                 label: custom-list-label
                 type: route
         max_results: 15
@@ -13,7 +13,7 @@ easy_admin:
             -
                 name: custom_action_for_edit
                 icon: custom-edit-icon
-                class: custom-edit-class
+                css_class: custom-edit-class
                 label: custom-edit-label
                 type: route
     show:
@@ -21,7 +21,7 @@ easy_admin:
             -
                 name: custom_action_for_show
                 icon: custom-show-icon
-                class: custom-show-class
+                css_class: custom-show-class
                 label: custom-show-label
                 type: route
     new:
@@ -29,7 +29,7 @@ easy_admin:
             -
                 name: custom_action_for_new
                 icon: custom-new-icon
-                class: custom-new-class
+                css_class: custom-new-class
                 label: custom-new-label
                 type: route
     entities:
@@ -45,19 +45,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_action_for_edit:
                         name: custom_action_for_edit
                         type: route
                         label: custom-edit-label
-                        class: custom-edit-class
+                        css_class: custom-edit-class
                         icon: custom-edit-icon
             list:
                 fields: {  }
@@ -66,37 +66,37 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_action_for_list:
                         name: custom_action_for_list
                         type: route
                         label: custom-list-label
-                        class: custom-list-class
+                        css_class: custom-list-class
                         icon: custom-list-icon
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -106,13 +106,13 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_action_for_new:
                         name: custom_action_for_new
                         type: route
                         label: custom-new-label
-                        class: custom-new-class
+                        css_class: custom-new-class
                         icon: custom-new-icon
             search:
                 fields: {  }
@@ -123,25 +123,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                     custom_action_for_show:
                         name: custom_action_for_show
                         type: route
                         label: custom-show-label
-                        class: custom-show-class
+                        css_class: custom-show-class
                         icon: custom-show-icon
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_065.yml
@@ -40,13 +40,13 @@ easy_admin:
                         name: list
                         type: method
                         label: custom-list-label
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_action_for_edit:
                         name: custom_action_for_edit
                         type: method
                         label: 'Custom action for edit'
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -55,31 +55,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: custom-edit-label
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_action_for_list:
                         name: custom_action_for_list
                         type: method
                         label: 'Custom action for list'
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -89,13 +89,13 @@ easy_admin:
                         name: custom_action_for_new
                         type: method
                         label: custom-action-label
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -106,25 +106,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     edit:
                         name: edit
                         type: method
                         label: custom-edit-label
-                        class: ''
+                        css_class: ''
                         icon: edit
                     custom_action_for_show:
                         name: custom_action_for_show
                         type: method
                         label: 'Custom action for show'
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_066.yml
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -35,31 +35,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: 'This label should not be action.search'
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -69,7 +69,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -80,19 +80,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_068.yml
@@ -8,25 +8,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             label: TestEntity
@@ -39,13 +39,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -55,7 +55,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -66,19 +66,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_069.yml
@@ -8,7 +8,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -21,31 +21,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -55,7 +55,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -66,19 +66,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_070.yml
@@ -8,13 +8,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             label: TestEntity
@@ -27,13 +27,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -42,31 +42,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -76,7 +76,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_071.yml
@@ -8,7 +8,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -22,13 +22,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -37,31 +37,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_072.yml
@@ -21,25 +21,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -48,7 +48,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -58,13 +58,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             new:
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_073.yml
@@ -21,31 +21,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -54,13 +54,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -70,19 +70,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                 fields: {  }
             new:
@@ -91,7 +91,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_074.yml
@@ -23,25 +23,25 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -50,7 +50,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -60,13 +60,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             new:
@@ -75,7 +75,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_075.yml
@@ -23,31 +23,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -56,13 +56,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                 fields: {  }
             new:
@@ -93,7 +93,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_076.yml
@@ -22,31 +22,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -55,13 +55,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -71,19 +71,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                 fields: {  }
             new:
@@ -92,7 +92,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_077.yml
@@ -21,37 +21,37 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_list_action:
                         name: custom_list_action
                         type: method
                         label: 'Custom list action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -60,19 +60,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_edit_action:
                         name: custom_edit_action
                         type: method
                         label: 'Custom edit action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -82,25 +82,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                     custom_show_action:
                         name: custom_show_action
                         type: method
                         label: 'Custom show action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             new:
@@ -109,13 +109,13 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_new_action:
                         name: custom_new_action
                         type: method
                         label: 'Custom new action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_078.yml
@@ -24,31 +24,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -57,13 +57,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -73,19 +73,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                 fields: {  }
             new:
@@ -94,7 +94,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_079.yml
@@ -23,37 +23,37 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_list_action:
                         name: custom_list_action
                         type: method
                         label: 'Custom list action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -62,19 +62,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_edit_action:
                         name: custom_edit_action
                         type: method
                         label: 'Custom edit action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -84,25 +84,25 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                     custom_show_action:
                         name: custom_show_action
                         type: method
                         label: 'Custom show action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             new:
@@ -111,13 +111,13 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     custom_new_action:
                         name: custom_new_action
                         type: method
                         label: 'Custom new action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_080.yml
@@ -37,31 +37,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: 'Entity Edit Label'
-                        class: ''
+                        css_class: ''
                         icon: entity-edit-icon
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -70,13 +70,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: 'Entity Delete Label'
-                        class: ''
+                        css_class: ''
                         icon: entity-delete-icon
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -86,19 +86,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: route
                         label: 'Entity Edit Label'
-                        class: ''
+                        css_class: ''
                         icon: entity-edit-icon
                 fields: {  }
             new:
@@ -107,7 +107,7 @@ easy_admin:
                         name: list
                         type: route
                         label: 'Entity List Label'
-                        class: ''
+                        css_class: ''
                         icon: entity-list-icon
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_081.yml
@@ -45,49 +45,49 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        class: ''
+                        css_class: ''
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        class: ''
+                        css_class: ''
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -96,67 +96,67 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        class: ''
+                        css_class: ''
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        class: ''
+                        css_class: ''
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -166,43 +166,43 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        class: ''
+                        css_class: ''
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        class: ''
+                        css_class: ''
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -213,55 +213,55 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        class: ''
+                        css_class: ''
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        class: ''
+                        css_class: ''
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        class: ''
+                        css_class: ''
                         icon: null
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_082.yml
@@ -8,67 +8,67 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        class: ''
+                        css_class: ''
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        class: ''
+                        css_class: ''
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             edit:
@@ -77,49 +77,49 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        class: ''
+                        css_class: ''
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        class: ''
+                        css_class: ''
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -129,55 +129,55 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        class: ''
+                        css_class: ''
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        class: ''
+                        css_class: ''
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
             new:
@@ -186,43 +186,43 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     CamelCaseAction:
                         name: CamelCaseAction
                         type: method
                         label: 'Camel case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     snakeCaseAction:
                         name: snakeCaseAction
                         type: method
                         label: 'Snake case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     underscore_action:
                         name: underscore_action
                         type: method
                         label: 'Underscore action'
-                        class: ''
+                        css_class: ''
                         icon: null
                     UPPERCASE_ACTION:
                         name: UPPERCASE_ACTION
                         type: method
                         label: 'U p p e r c a s e a c t i o n'
-                        class: ''
+                        css_class: ''
                         icon: null
                     lowercaseaction:
                         name: lowercaseaction
                         type: method
                         label: Lowercaseaction
-                        class: ''
+                        css_class: ''
                         icon: null
                     WEIRD_caseAction:
                         name: WEIRD_caseAction
                         type: method
                         label: 'W e i r d case action'
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_083.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_084.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_085.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_086.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_087.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_088.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_089.yml
@@ -25,13 +25,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -40,31 +40,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -74,7 +74,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -85,19 +85,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_090.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_091.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_092.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_093.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_094.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_095.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_096.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_097.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_098.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_099.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_100.yml
@@ -24,13 +24,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -39,31 +39,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -73,7 +73,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -84,19 +84,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_101.yml
@@ -19,13 +19,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -34,31 +34,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -68,7 +68,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -79,19 +79,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_102.yml
@@ -8,13 +8,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -24,19 +24,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                 fields: {  }
             label: TestEntity
@@ -48,31 +48,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -82,7 +82,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_103.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_103.yml
@@ -15,13 +15,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                 fields: {  }
                 form_options: {  }
@@ -31,19 +31,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
                 fields: {  }
             label: TestEntity
@@ -55,31 +55,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -89,7 +89,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_104.yml
@@ -53,13 +53,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -68,31 +68,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -102,7 +102,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -113,19 +113,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_105.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_105.yml
@@ -46,13 +46,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -61,31 +61,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -95,7 +95,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -106,19 +106,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
     design:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_106.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_106.yml
@@ -87,13 +87,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -102,31 +102,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -136,7 +136,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -147,19 +147,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
     site_name: 'Easy Admin'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_107.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_107.yml
@@ -20,13 +20,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -35,31 +35,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -69,7 +69,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             show:
                 fields: {  }
@@ -78,19 +78,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_109.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_109.yml
@@ -14,13 +14,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -29,31 +29,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -63,7 +63,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -74,19 +74,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions:
                 - action1

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_110.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_110.yml
@@ -14,13 +14,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -29,31 +29,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -63,7 +63,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -74,19 +74,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             templates:
                 layout: '@EasyAdmin/default/layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_111.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_111.yml
@@ -16,13 +16,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -31,31 +31,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -65,7 +65,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -76,19 +76,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             templates:
                 layout: '@EasyAdmin/default/layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_112.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_112.yml
@@ -17,13 +17,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -32,31 +32,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -66,7 +66,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -77,19 +77,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             templates:
                 layout: '@EasyAdmin/default/layout.html.twig'

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_113.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_113.yml
@@ -20,7 +20,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             edit:
                 form_options:
@@ -33,13 +33,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -48,31 +48,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -83,19 +83,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/configurations/output/config_114.yml
+++ b/Tests/DependencyInjection/fixtures/configurations/output/config_114.yml
@@ -16,7 +16,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             edit:
                 form_options:
@@ -28,13 +28,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             label: TestEntity
             name: TestEntity
@@ -45,31 +45,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -80,19 +80,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_001.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_002.yml
@@ -46,13 +46,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -61,31 +61,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -95,7 +95,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -106,19 +106,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
     design:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_003.yml
@@ -53,13 +53,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -68,31 +68,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -102,7 +102,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -113,19 +113,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_004.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_application/output/config_005.yml
@@ -61,13 +61,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -76,31 +76,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -110,7 +110,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -121,19 +121,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
         AnotherTestEntity:
@@ -182,13 +182,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -197,31 +197,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -231,7 +231,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -242,19 +242,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
     site_name: 'Easy Admin'

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_001.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_001.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_002.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_002.yml
@@ -46,13 +46,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -61,31 +61,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -95,7 +95,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -106,19 +106,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
     design:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_003.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_003.yml
@@ -53,13 +53,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -68,31 +68,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -102,7 +102,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -113,19 +113,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_004.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_004.yml
@@ -12,13 +12,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -27,31 +27,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -61,7 +61,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -72,19 +72,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:
@@ -133,13 +133,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -148,31 +148,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -182,7 +182,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -193,19 +193,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
             templates:

--- a/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_005.yml
+++ b/Tests/DependencyInjection/fixtures/templates/overridden_by_entity/output/config_005.yml
@@ -63,13 +63,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -78,31 +78,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -112,7 +112,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -123,19 +123,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
         AnotherTestEntity:
@@ -184,13 +184,13 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             list:
                 fields: {  }
@@ -199,31 +199,31 @@ easy_admin:
                         name: show
                         type: method
                         label: action.show
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
-                        class: ''
+                        css_class: ''
                         icon: null
                     new:
                         name: new
                         type: method
                         label: action.new
-                        class: ''
+                        css_class: ''
                         icon: null
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             new:
                 fields: {  }
@@ -233,7 +233,7 @@ easy_admin:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
             search:
                 fields: {  }
@@ -244,19 +244,19 @@ easy_admin:
                         name: delete
                         type: method
                         label: action.delete
-                        class: ''
+                        css_class: ''
                         icon: trash
                     list:
                         name: list
                         type: method
                         label: action.list
-                        class: ''
+                        css_class: ''
                         icon: null
                     edit:
                         name: edit
                         type: method
                         label: action.edit
-                        class: ''
+                        css_class: ''
                         icon: edit
             disabled_actions: {  }
     site_name: 'Easy Admin'


### PR DESCRIPTION
In #337, the `class` options was renamed to `css_class`. However, this change was not applied to the default configuration of fields and actions, and even worse, [the `class` option was still used by form fields](https://github.com/javiereguiluz/EasyAdminBundle/blob/7ddaf3349cf5edce2ce239dce37d5d389fdc1517/Controller/AdminController.php#L621). So I guess no one noticed, because everyone still used `class` despite [what said the UPGRADE file](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/UPGRADE.md#upgrade-to-153-26may2015).

@javiereguiluz : Thus, you were actually right about https://github.com/javiereguiluz/EasyAdminBundle/pull/665#discussion_r48197281. So I updated the existing occurrences in `Resources/views/form/bootstrap_3_layout.html.twig`.

Let me know if I interpreted anything wrong.
