### PR TITLE
Fix ExceptionListener: exception to log isn't necessarily a BaseException instance

### DIFF
--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -72,8 +72,13 @@ class ExceptionListener extends BaseExceptionListener
      */
     protected function logException(\Exception $exception, $message, $original = true)
     {
+        if (!$exception instanceof BaseException) {
+            parent::logException($exception, $message, $original);
+
+            return;
+        }
+
         if (null !== $this->logger) {
-            /** @var BaseException $exception */
             if ($exception->getStatusCode() >= 500) {
                 $this->logger->critical($message, array('exception' => $exception));
             } else {


### PR DESCRIPTION
For instance [when an exception occurs when trying to render the exception template](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/EventListener/ExceptionListener.php#L117-L120).
