### PR TITLE
Fixed #694

### DIFF
--- a/Resources/translations/messages.es.xlf
+++ b/Resources/translations/messages.es.xlf
@@ -35,6 +35,10 @@
                 <source>action.list</source>
                 <target>Volver al listado</target>
             </trans-unit>
+            <trans-unit id="form.label.empty_value">
+                <source>form.label.empty_value</source>
+                <target>Ninguno</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
In [Issue #694](https://github.com/javiereguiluz/EasyAdminBundle/issues/694) you can see that if use "es" as default locale you get the "form.label.empty_value" missing translation key.
