### PR TITLE
Fix virtual field should not have a default label

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -339,7 +339,6 @@ class Configurator
                         'columnName' => null,
                         'fieldName' => $fieldName,
                         'id' => false,
-                        'label' => $fieldName,
                         'sortable' => false,
                         // if the 'type' is not set explicitly for a virtual field,
                         // consider it as a string, so the backend displays its contents

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -578,7 +578,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         $this->assertCount(15, $crawler->filter('.table tbody td:contains("Inaccessible")'));
 
-        $this->assertEquals('thisFieldIsVirtual', $crawler->filter('.table tbody td:contains("Inaccessible")')->first()->attr('data-label'));
+        $this->assertEquals('This field is virtual', $crawler->filter('.table tbody td:contains("Inaccessible")')->first()->attr('data-label'));
 
         $firstVirtualField = $crawler->filter('.table tbody td:contains("Inaccessible") span')->first();
         $this->assertEquals('label label-danger', $firstVirtualField->attr('class'));


### PR DESCRIPTION
In order to be humanized, as any other field, when no `label` is explicitly provided.
