### PR TITLE
Fix css class applied to form-group div by using block prefixes

### DIFF
--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -27,7 +27,7 @@ col-sm-2
 {% block form_row -%}
 {% spaceless %}
     {% set _field_type = easyadmin.field.fieldType|default('default') %}
-    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ _field_type }}">
+    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ block_prefixes|slice(-2)|first }}">
 
         {% set _trans_parameters = { '%entity_name%':  easyadmin.entity.name|trans, '%entity_label%': easyadmin.entity.label|trans } %}
         {% set _field_label = easyadmin.field['label']|default(null) %}
@@ -65,7 +65,7 @@ col-sm-2
 
 {% block checkbox_radio_row -%}
 {% spaceless %}
-    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ easyadmin.field.fieldType|default('default') }}">
+    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ block_prefixes|slice(-2)|first }}">
         <div class="{{ block('form_label_class') }}"></div>
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}
@@ -77,7 +77,7 @@ col-sm-2
 
 {% block submit_row -%}
 {% spaceless %}
-    <div class="form-group field-{{ easyadmin.field.fieldType|default('default') }}">
+    <div class="form-group field-{{ block_prefixes|slice(-2)|first }}">
         <div class="{{ block('form_label_class') }}"></div>
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -203,7 +203,7 @@
 
 {% block form_row -%}
     {% set _field_type = easyadmin.field.fieldType|default('default') %}
-    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ _field_type }}">
+    <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ block_prefixes|slice(-2)|first }}">
 
         {% set _trans_parameters = { '%entity_name%':  easyadmin.entity.name|trans, '%entity_label%': easyadmin.entity.label|trans } %}
         {% set _field_label = easyadmin.field['label']|default(null) %}
@@ -263,7 +263,7 @@
 {% endblock collection_row %}
 
 {% block button_row -%}
-    <div class="form-group field-{{ easyadmin.field.fieldType|default('default') }} {{ easyadmin.field.class|default('') }}">
+    <div class="form-group field-{{ block_prefixes|slice(-2)|first }} {{ easyadmin.field.class|default('') }}">
         {{- form_widget(form) -}}
     </div>
 {%- endblock button_row %}
@@ -289,14 +289,14 @@
 {%- endblock datetime_row %}
 
 {% block checkbox_row -%}
-    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ easyadmin.field.fieldType|default('default') }}">
+    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ block_prefixes|slice(-2)|first }}">
         {{- form_widget(form) -}}
         {{- form_errors(form) -}}
     </div>
 {%- endblock checkbox_row %}
 
 {% block radio_row -%}
-    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ easyadmin.field.fieldType|default('default') }}">
+    <div class="form-group {% if not valid %}has-error{% endif %} field-{{ block_prefixes|slice(-2)|first }}">
         {{- form_widget(form) -}}
         {{- form_errors(form) -}}
     </div>


### PR DESCRIPTION
Fixes #699 

Use the most appropriate block prefix representing the form type in order to render the css class, instead of using the `fieldType` metadata.

<img width="753" alt="screenshot 2015-12-28 a 23 22 07" src="https://cloud.githubusercontent.com/assets/2211145/12026471/2f0a4c94-adba-11e5-929a-3cc59a92a988.PNG">

As you can see, there is always multiple block prefixes for a given form field. The good one (the one corresponding to the form type `getBlockPrefix` method) is always the penultimate one.
Hence the strange 

``` twig
field-{{ block_prefixes[-2:][0] }}
```

BTW, thanks @javiereguiluz for making me discover these Twig tips some times ago :wink: 
