### PR TITLE
Tweaked the delete form template

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -172,7 +172,7 @@ class AdminController extends Controller
         return $this->render($this->entity['templates']['list'], array(
             'paginator' => $paginator,
             'fields' => $fields,
-            'delete_form_template' => $this->createDeleteForm($this->entity['name'], '{{ ID }}')->createView(),
+            'delete_form_template' => $this->createDeleteForm($this->entity['name'], '__id__')->createView(),
         ));
     }
 
@@ -370,7 +370,7 @@ class AdminController extends Controller
         return $this->render($this->entity['templates']['list'], array(
             'paginator' => $paginator,
             'fields' => $fields,
-            'delete_form_template' => $this->createDeleteForm($this->entity['name'], '{{ ID }}')->createView(),
+            'delete_form_template' => $this->createDeleteForm($this->entity['name'], '__id__')->createView(),
         ));
     }
 

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -237,7 +237,7 @@
                 $('#modal-delete').modal({ backdrop: true, keyboard: true })
                     .one('click', '#modal-delete-button', function (e) {
                         var deleteForm = $('#delete-form');
-                        deleteForm.attr('action', deleteForm.attr('action').replace('%7B%7B+ID+%7D%7D', id));
+                        deleteForm.attr('action', deleteForm.attr('action').replace('__id__', id));
                         deleteForm.trigger('submit');
                     });
             });


### PR DESCRIPTION
After merging #690, I wonder if we could mimic Symfony Forms behavior and use `__id__` as the placeholder in the delete form template.
