### PR TITLE
Remove form themes css classes from <form> tag

### DIFF
--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -93,9 +93,9 @@ class EasyAdminFormType extends AbstractType
             ->setRequired(array('entity', 'view'));
 
         if ($this->useLegacyFormComponent()) {
-            $resolver->setNormalizers(array('attr' => $this->getAttributesNormalizer($this->config)));
+            $resolver->setNormalizers(array('attr' => $this->getAttributesNormalizer()));
         } else {
-            $resolver->setNormalizer('attr', $this->getAttributesNormalizer($this->config));
+            $resolver->setNormalizer('attr', $this->getAttributesNormalizer());
         }
     }
 
@@ -124,19 +124,12 @@ class EasyAdminFormType extends AbstractType
     /**
      * Returns a closure normalizing the form html attributes.
      *
-     * @param array $config
-     *
      * @return \Closure
      */
-    private function getAttributesNormalizer(array $config)
+    private function getAttributesNormalizer()
     {
-        return function (Options $options, $value) use ($config) {
-            $formCssClass = array_reduce($config['design']['form_theme'], function ($previousClass, $formTheme) {
-                return sprintf('theme-%s %s', strtolower(str_replace('.html.twig', '', basename($formTheme))), $previousClass);
-            });
-
-            return array_replace_recursive(array(
-                'class' => $formCssClass,
+        return function (Options $options, $value) {
+            return array_replace(array(
                 'id' => $options['view'].'-form',
             ), $value);
         };

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -272,16 +272,6 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->assertEquals('Modify Category (200) details', trim($crawler->filter('h1.title')->text()));
     }
 
-    public function testEditViewFormClasses()
-    {
-        $crawler = $this->requestEditView();
-        $formClasses = array('theme-bootstrap_3_horizontal_layout', 'form-horizontal');
-
-        foreach ($formClasses as $cssClass) {
-            $this->assertContains($cssClass, trim($crawler->filter('#main form')->eq(0)->attr('class')));
-        }
-    }
-
     public function testEditViewFieldLabels()
     {
         $crawler = $this->requestEditView();
@@ -359,16 +349,6 @@ class CustomizedBackendTest extends AbstractTestCase
 
         $this->assertEquals('Add a new Category', trim($crawler->filter('head title')->text()));
         $this->assertEquals('Add a new Category', trim($crawler->filter('h1.title')->text()));
-    }
-
-    public function testNewViewFormClasses()
-    {
-        $crawler = $this->requestNewView();
-        $formClasses = array('theme-bootstrap_3_horizontal_layout', 'form-horizontal');
-
-        foreach ($formClasses as $cssClass) {
-            $this->assertContains($cssClass, trim($crawler->filter('#main form')->eq(0)->attr('class')));
-        }
     }
 
     public function testNewViewFieldLabels()

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -343,16 +343,6 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertEquals('Edit Category (#200)', trim($crawler->filter('h1.title')->text()));
     }
 
-    public function testEditViewFormClasses()
-    {
-        $crawler = $this->requestEditView();
-        $formClasses = array('theme-bootstrap_3_horizontal_layout', 'form-horizontal');
-
-        foreach ($formClasses as $cssClass) {
-            $this->assertContains($cssClass, trim($crawler->filter('#main form')->eq(0)->attr('class')));
-        }
-    }
-
     public function testEditViewFieldLabels()
     {
         $crawler = $this->requestEditView();
@@ -425,16 +415,6 @@ class DefaultBackendTest extends AbstractTestCase
 
         $this->assertEquals('Create Category', trim($crawler->filter('head title')->text()));
         $this->assertEquals('Create Category', trim($crawler->filter('h1.title')->text()));
-    }
-
-    public function testNewViewFormClasses()
-    {
-        $crawler = $this->requestNewView();
-        $formClasses = array('theme-bootstrap_3_horizontal_layout', 'form-horizontal');
-
-        foreach ($formClasses as $cssClass) {
-            $this->assertContains($cssClass, trim($crawler->filter('#main form')->eq(0)->attr('class')));
-        }
     }
 
     public function testNewViewFieldLabels()


### PR DESCRIPTION
~~A very small change to normalize the form theme classes added to the form type:~~
#### ~~Before:~~

``` html
<form name="form" method="post" class="theme-easyadminbundle:form:bootstrap_3_horizontal_layout theme-vichuploaderbundle:form:fields  form-horizontal" id="edit-form">
```
#### ~~After:~~

``` html
<form name="form" method="post" class="theme-easyadminbundle-form-bootstrap_3_horizontal_layout theme-vichuploaderbundle-form-fields  form-horizontal" id="edit-form">
```

**UPDATE:** Let's remove this feature. It didn't really make sense as the configured form themes are applied to the whole EasyAdmin backend. So the classes are always the same everywhere.
## 

Regarding #734, I wonder if we should:
- change the `id` to `{view}-{entity}-form` (id should be as accurate as possible)
- add `data-` attributes for `entity`, `view`, and eventually `entity-id` for `edit` forms
- change the form name to the entity name instead of using `form` ?
- other suggestions ?
