### PR TITLE
Tweak form attributes

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -609,7 +609,7 @@ class AdminController extends Controller
 
         $formType = $this->useLegacyFormComponent() ? 'easyadmin' : 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Form\\Type\\EasyAdminFormType';
 
-        return $this->get('form.factory')->createNamedBuilder('form', $formType, $entity, $formOptions);
+        return $this->get('form.factory')->createNamedBuilder(strtolower($this->entity['name']), $formType, $entity, $formOptions);
     }
 
     /**

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -130,7 +130,7 @@ class EasyAdminFormType extends AbstractType
     {
         return function (Options $options, $value) {
             return array_replace(array(
-                'id' => $options['view'].'-form',
+                'id' => sprintf('%s-%s-form', $options['view'], strtolower($options['entity'])),
             ), $value);
         };
     }

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -1,6 +1,18 @@
 {% use "form_div_layout.html.twig" %}
 {% trans_default_domain "EasyAdminBundle" %}
 
+{% block form_start -%}
+    {% if 'easyadmin' == block_prefixes|slice(-2)|first %}
+        {% set attr = attr|merge({
+            'data-view': easyadmin.view,
+            'data-entity': easyadmin.entity.name,
+            'data-entity-id': attribute(value, easyadmin.entity.primary_key_field_name),
+        }) %}
+    {% endif %}
+
+    {{- parent() -}}
+{%- endblock form_start %}
+
 {# Widgets #}
 
 {% block form_widget %}

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -415,7 +415,7 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->assertSame(200, $this->client->getResponse()->getStatusCode());
 
         // test 'novalidate' attribute
-        $this->assertSame('novalidate', $crawler->filter('#new-form')->first()->attr('novalidate'));
+        $this->assertSame('novalidate', $crawler->filter('#new-category-form')->first()->attr('novalidate'));
 
         $form = $crawler->selectButton('Save changes')->form();
         $form->remove('form[name]');

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -272,6 +272,16 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->assertEquals('Modify Category (200) details', trim($crawler->filter('h1.title')->text()));
     }
 
+    public function testEditViewFormAttributes()
+    {
+        $crawler = $this->requestEditView();
+        $form = $crawler->filter('#main form')->eq(0);
+
+        $this->assertSame('edit', trim($form->attr('data-view')));
+        $this->assertSame('Category', trim($form->attr('data-entity')));
+        $this->assertSame('200', trim($form->attr('data-entity-id')));
+    }
+
     public function testEditViewFieldLabels()
     {
         $crawler = $this->requestEditView();
@@ -349,6 +359,16 @@ class CustomizedBackendTest extends AbstractTestCase
 
         $this->assertEquals('Add a new Category', trim($crawler->filter('head title')->text()));
         $this->assertEquals('Add a new Category', trim($crawler->filter('h1.title')->text()));
+    }
+
+    public function testNewViewFormAttributes()
+    {
+        $crawler = $this->requestNewView();
+        $form = $crawler->filter('#main form')->eq(0);
+
+        $this->assertSame('new', trim($form->attr('data-view')));
+        $this->assertSame('Category', trim($form->attr('data-entity')));
+        $this->assertEmpty($form->attr('data-entity-id'));
     }
 
     public function testNewViewFieldLabels()

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -343,6 +343,16 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertEquals('Edit Category (#200)', trim($crawler->filter('h1.title')->text()));
     }
 
+    public function testEditViewFormAttributes()
+    {
+        $crawler = $this->requestEditView();
+        $form = $crawler->filter('#main form')->eq(0);
+
+        $this->assertSame('edit', trim($form->attr('data-view')));
+        $this->assertSame('Category', trim($form->attr('data-entity')));
+        $this->assertSame('200', trim($form->attr('data-entity-id')));
+    }
+
     public function testEditViewFieldLabels()
     {
         $crawler = $this->requestEditView();
@@ -415,6 +425,16 @@ class DefaultBackendTest extends AbstractTestCase
 
         $this->assertEquals('Create Category', trim($crawler->filter('head title')->text()));
         $this->assertEquals('Create Category', trim($crawler->filter('h1.title')->text()));
+    }
+
+    public function testNewViewFormAttributes()
+    {
+        $crawler = $this->requestNewView();
+        $form = $crawler->filter('#main form')->eq(0);
+
+        $this->assertSame('new', trim($form->attr('data-view')));
+        $this->assertSame('Category', trim($form->attr('data-entity')));
+        $this->assertEmpty($form->attr('data-entity-id'));
     }
 
     public function testNewViewFieldLabels()

--- a/Tests/Controller/TypeOptionsTest.php
+++ b/Tests/Controller/TypeOptionsTest.php
@@ -27,20 +27,20 @@ class TypeOptionsTest extends AbstractTestCase
     {
         $crawler = $this->requestNewView();
 
-        $this->assertEquals('Lorem Ipsum', $crawler->filter('#main form #form_name')->attr('value'));
+        $this->assertEquals('Lorem Ipsum', $crawler->filter('#main form #category_name')->attr('value'));
 
-        $this->assertCount(201, $crawler->filter('#main form #form_parent input[type=radio]'));
+        $this->assertCount(201, $crawler->filter('#main form #category_parent input[type=radio]'));
     }
 
     public function testEditViewTypeOptions()
     {
         $crawler = $this->requestEditView();
 
-        $this->assertContains('col-sm-6', $crawler->filter('#main form label[for=form_name]')->attr('class'));
-        $this->assertContains('col-sm-6', $crawler->filter('#main form input#form_name')->attr('class'));
+        $this->assertContains('col-sm-6', $crawler->filter('#main form label[for=category_name]')->attr('class'));
+        $this->assertContains('col-sm-6', $crawler->filter('#main form input#category_name')->attr('class'));
 
-        $this->assertContains('col-sm-4', $crawler->filter('#main form label[for=form_parent]')->attr('class'));
-        $this->assertContains('col-sm-10', $crawler->filter('#main form select#form_parent')->attr('class'));
+        $this->assertContains('col-sm-4', $crawler->filter('#main form label[for=category_parent]')->attr('class'));
+        $this->assertContains('col-sm-10', $crawler->filter('#main form select#category_parent')->attr('class'));
     }
 
     /**


### PR DESCRIPTION
- [x] change the `id` to `{view}-{entity}-form` (id should be as accurate as possible)
- [x] add `data-` attributes for `entity`, `view`, and `entity-id` for `edit` forms
- [x] change the form name to the entity name instead of using `form` 

Related to #734 
