### PR TITLE
Add missing string translation

### DIFF
--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -39,6 +39,10 @@
                 <source>form.label.empty_value</source>
                 <target>None</target>
             </trans-unit>
+            <trans-unit id="_delete_action.label">
+                <source>_delete_action.label</source>
+                <target>Delete</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/messages.es.xlf
+++ b/Resources/translations/messages.es.xlf
@@ -39,6 +39,10 @@
                 <source>form.label.empty_value</source>
                 <target>Ninguno</target>
             </trans-unit>
+            <trans-unit id="_delete_action.label">
+                <source>_delete_action.label</source>
+                <target>Borrar</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
This PR fix missing `_delete_action.label` translation which is used when delete modal shows up
