### PR TITLE
Doctine/common and PHP requirments problem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php"                           : ">=5.3.0",
-        "doctrine/common"               : "^2.4.0",
+        "doctrine/common"               : "~2.5.0",
         "doctrine/doctrine-bundle"      : "~1.2",
-        "doctrine/orm"                  : "~2.3",
+        "doctrine/orm"                  : "~2.4.0",
         "pagerfanta/pagerfanta"         : "~1.0,>=1.0.1",
         "sensio/distribution-bundle"    : "~2.3|~3.0|~4.0|~5.0",
         "sensio/framework-extra-bundle" : "~3.0,>=3.0.2",


### PR DESCRIPTION
Hi,

```
    "php"                           : ">=5.3.0",
    "doctrine/common"               : "^2.4.0",
    "doctrine/orm"                  : "~2.3",
```

Those requirements don't seem to be OK as doctrine common requires PHP 5.5 as of its 2.6 branch tag and doctrine/orm requires PHP 5.4 as of its 2.5 branch.
