### PR TITLE
Add missing translation for DELETE button on modal

### DIFF
--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -39,6 +39,10 @@
                 <source>form.label.empty_value</source>
                 <target>None</target>
             </trans-unit>
+            <trans-unit id="modal.action.delete">
+                <source>modal.action.delete</source>
+                <target>Delete</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/messages.es.xlf
+++ b/Resources/translations/messages.es.xlf
@@ -39,6 +39,10 @@
                 <source>form.label.empty_value</source>
                 <target>Ninguno</target>
             </trans-unit>
+            <trans-unit id="modal.action.delete">
+                <source>modal.action.delete</source>
+                <target>Borrar</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/messages.fr.xlf
+++ b/Resources/translations/messages.fr.xlf
@@ -39,6 +39,10 @@
                 <source>form.label.empty_value</source>
                 <target>Aucun(e)</target>
             </trans-unit>
+            <trans-unit id="modal.action.delete">
+                <source>modal.action.delete</source>
+                <target>Supprimer</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/default/includes/delete_form.html.twig
+++ b/Resources/views/default/includes/delete_form.html.twig
@@ -22,7 +22,7 @@
                     {% set _delete_action = easyadmin_get_action(view, 'delete', _entity_config.name) %}
                     <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                         {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                        {{ _delete_action.label is defined and not _delete_action.label is empty ? _delete_action.label|trans(_trans_parameters) }}
+                        {{ 'modal.action.delete'|trans(_trans_parameters) }}
                     </button>
                 {% endif %}
             </div>


### PR DESCRIPTION
This add a missing translation to DELETE button as discussed previously with @ogizanagi 
