### PR TITLE
Replace .theme-bootstrap_3_horizontal_layout by .form-horizontal

### DIFF
--- a/Resources/views/css/admin.css.twig
+++ b/Resources/views/css/admin.css.twig
@@ -715,13 +715,13 @@ body.new form #form-actions-row button,
 body.new form #form-actions-row a.btn {
     margin-bottom: 10px;
 }
-body.new form.theme-bootstrap_3_horizontal_layout #form-actions-row {
+body.new form.form-horizontal #form-actions-row {
     padding-left: 15px;
     padding-right: 15px;
 }
 
 @media (min-width: 768px) {
-    body.new form.theme-bootstrap_3_horizontal_layout #form-actions-row {
+    body.new form.form-horizontal #form-actions-row {
         margin-left: 16.66666667%;
     }
 }
@@ -747,13 +747,13 @@ body.edit form #form-actions-row button,
 body.edit form #form-actions-row a.btn {
     margin-bottom: 10px;
 }
-body.edit form.theme-bootstrap_3_horizontal_layout #form-actions-row {
+body.edit form.form-horizontal #form-actions-row {
     padding-left: 15px;
     padding-right: 15px;
 }
 
 @media (min-width: 768px) {
-    body.edit form.theme-bootstrap_3_horizontal_layout #form-actions-row {
+    body.edit form.form-horizontal #form-actions-row {
         margin-left: 16.66666667%;
     }
 }


### PR DESCRIPTION
I noticed that class theme-bootstrap_3_horizontal_layout has been replaced by form-horizontal but admin.css.twig has not been updated, so here is the fix
