### PR TITLE
Improve how associations are displayed in the "show" view

### DIFF
--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -11,6 +11,8 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
 
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
 /**
  * Exposes the configuration of the backend fully and on a per-entity basis.
  *
@@ -19,20 +21,32 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
 class Configurator
 {
     private $backendConfig;
+    private $accessor;
 
-    public function __construct(array $backendConfig)
+    public function __construct(array $backendConfig, PropertyAccessor $accessor)
     {
         $this->backendConfig = $backendConfig;
+        $this->accessor = $accessor;
     }
 
     /**
-     * Returns the entire backend configuration.
+     * Returns the entire backend configuration or just the configuration for
+     * the optional property path. Example: getBackendConfig('design.menu')
+     *
+     * @param string $propertyPath
      *
      * @return array
      */
-    public function getBackendConfig()
+    public function getBackendConfig($propertyPath = null)
     {
-        return $this->backendConfig;
+        if (empty($propertyPath)) {
+            return $this->backendConfig;
+        }
+
+        // turns 'design.menu' into '[design][menu]', the format required by PropertyAccess
+        $propertyPath = '['.str_replace('.', '][', $propertyPath).']';
+
+        return $this->accessor->getValue($this->backendConfig, $propertyPath);
     }
 
     /**

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -40,16 +40,85 @@ class Configurator
      *
      * @param string $entityName
      *
+     * @deprecated Use getEntityConfig()
      * @return array The full entity configuration
      *
      * @throws \InvalidArgumentException when the entity isn't managed by EasyAdmin
      */
     public function getEntityConfiguration($entityName)
     {
+        return $this->getEntityConfig($entityName);
+    }
+
+    /**
+     * Returns the configuration for the given entity name.
+     *
+     * @param string $entityName
+     *
+     * @return array The full entity configuration
+     *
+     * @throws \InvalidArgumentException when the entity isn't managed by EasyAdmin
+     */
+    public function getEntityConfig($entityName)
+    {
         if (!isset($this->backendConfig['entities'][$entityName])) {
             throw new \InvalidArgumentException(sprintf('Entity "%s" is not managed by EasyAdmin.', $entityName));
         }
 
         return $this->backendConfig['entities'][$entityName];
+    }
+
+    /**
+     * Returns the full entity config for the given entity class.
+     *
+     * @param string $fqcn The full qualified class name of the entity
+     *
+     * @return array The full entity configuration
+     *
+     * @throws \InvalidArgumentException when the entity isn't managed by EasyAdmin
+     */
+    public function getEntityConfigByClass($fqcn)
+    {
+        $backendConfig = $this->getBackendConfig();
+        foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
+            if ($entityConfig['class'] === $fqcn) {
+                return $entityConfig;
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('Entity "%s" is not managed by EasyAdmin.', $fqcn));
+    }
+
+    /**
+     * Returns the full action configuration for the given 'entity' and 'view'.
+     *
+     * @param string $entityName
+     * @param string $view
+     * @param string $action
+     *
+     * @return bool
+     */
+    public function getActionConfig($entityName, $view, $action)
+    {
+        $entityConfig = $this->getEntityConfig($entityName);
+
+        return isset($entityConfig[$view]['actions'][$action]) ? $entityConfig[$view]['actions'][$action] : array();
+    }
+
+    /**
+     * Checks whether the given 'action' is enabled for the given 'entity' and
+     * 'view'.
+     *
+     * @param string $entityName
+     * @param string $view
+     * @param string $action
+     *
+     * @return bool
+     */
+    public function isActionEnabled($entityName, $view, $action)
+    {
+        $entityConfig = $this->getEntityConfig($entityName);
+
+        return !in_array($action, $entityConfig['disabled_actions']);
     }
 }

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -69,11 +69,17 @@ class Configurator
      *
      * @param string $entityName
      *
-     * @return array|null The full entity configuration
+     * @return array The full entity configuration
+     *
+     * @throws \InvalidArgumentException
      */
     public function getEntityConfig($entityName)
     {
-        return isset($this->backendConfig['entities'][$entityName]) ? $this->backendConfig['entities'][$entityName] : null;
+        if (!isset($this->backendConfig['entities'][$entityName])) {
+            throw new \InvalidArgumentException(sprintf('Entity "%s" is not managed by EasyAdmin.', $entityName));
+        }
+
+        return $this->backendConfig['entities'][$entityName];
     }
 
     /**
@@ -100,11 +106,15 @@ class Configurator
      * @param string $view
      * @param string $action
      *
-     * @return bool
+     * @return array
      */
     public function getActionConfig($entityName, $view, $action)
     {
-        $entityConfig = $this->getEntityConfig($entityName);
+        try {
+            $entityConfig = $this->getEntityConfig($entityName);
+        } catch (\Exception $e) {
+            $entityConfig = array();
+        }
 
         return isset($entityConfig[$view]['actions'][$action]) ? $entityConfig[$view]['actions'][$action] : array();
     }

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -69,17 +69,11 @@ class Configurator
      *
      * @param string $entityName
      *
-     * @return array The full entity configuration
-     *
-     * @throws \InvalidArgumentException when the entity isn't managed by EasyAdmin
+     * @return array|null The full entity configuration
      */
     public function getEntityConfig($entityName)
     {
-        if (!isset($this->backendConfig['entities'][$entityName])) {
-            throw new \InvalidArgumentException(sprintf('Entity "%s" is not managed by EasyAdmin.', $entityName));
-        }
-
-        return $this->backendConfig['entities'][$entityName];
+        return isset($this->backendConfig['entities'][$entityName]) ? $this->backendConfig['entities'][$entityName] : null;
     }
 
     /**
@@ -87,9 +81,7 @@ class Configurator
      *
      * @param string $fqcn The full qualified class name of the entity
      *
-     * @return array The full entity configuration
-     *
-     * @throws \InvalidArgumentException when the entity isn't managed by EasyAdmin
+     * @return array|null The full entity configuration
      */
     public function getEntityConfigByClass($fqcn)
     {
@@ -99,8 +91,6 @@ class Configurator
                 return $entityConfig;
             }
         }
-
-        throw new \InvalidArgumentException(sprintf('Entity "%s" is not managed by EasyAdmin.', $fqcn));
     }
 
     /**

--- a/Configuration/Configurator.php
+++ b/Configuration/Configurator.php
@@ -117,8 +117,13 @@ class Configurator
      */
     public function isActionEnabled($entityName, $view, $action)
     {
+        if ($view === $action) {
+            return true;
+        }
+
         $entityConfig = $this->getEntityConfig($entityName);
 
-        return !in_array($action, $entityConfig['disabled_actions']);
+        return !in_array($action, $entityConfig['disabled_actions'])
+            && array_key_exists($action, $entityConfig[$view]['actions']);
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,6 +13,7 @@
 
         <service id="easyadmin.configurator" class="JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator">
             <argument /> <!-- easyadmin.config parameter -->
+            <argument type="service" id="property_accessor" />
         </service>
 
         <service id="easyadmin.listener.exception" class="JavierEguiluz\Bundle\EasyAdminBundle\EventListener\ExceptionListener">

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -1,6 +1,10 @@
 {% if value is iterable %}
     {% if 'show' == view %}
-        {{ value|join(', ') }}
+        <ul>
+            {% for element in value %}
+                <li>{{ element }}</li>
+            {% endfor %}
+        </ul>
     {% else %}
         <span class="badge">{{ value|length }}</span>
     {% endif %}

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -1,13 +1,24 @@
+{# a *-to-many collection of values #}
 {% if value is iterable %}
     {% if 'show' == view %}
         <ul>
-            {% for element in value %}
-                <li><a href="{{ path('easyadmin', link_parameters|merge({ id: attribute(element, link_parameters.primary_key_name) })) }}">{{ element }}</a></li>
+            {% for item in value %}
+                {% if link_parameters is defined %}
+                    {% set primary_key_value = attribute(item, link_parameters.primary_key_name) %}
+                    <li>
+                        <a href="{{ path('easyadmin', link_parameters|merge({ id: primary_key_value })) }}">{{ item }}</a>
+                    </li>
+                {% else %}
+                    <li>
+                        {{ item }}
+                    </li>
+                {% endif %}
             {% endfor %}
         </ul>
-    {% else %}
+    {% elseif 'list' == view %}
         <span class="badge">{{ value|length }}</span>
     {% endif %}
+{# a simple *-to-one value associated with an entity managed by this backend #}
 {% elseif link_parameters is defined %}
     <a href="{{ path('easyadmin', link_parameters|merge({ referer: app.request.requestUri })) }}">{{ value|easyadmin_truncate }}</a>
 {% else %}

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -3,16 +3,14 @@
     {% if 'show' == view %}
         <ul>
             {% for item in value %}
-                {% if link_parameters is defined %}
-                    {% set primary_key_value = attribute(item, link_parameters.primary_key_name) %}
-                    <li>
+                <li>
+                    {% if link_parameters is defined %}
+                        {% set primary_key_value = attribute(item, link_parameters.primary_key_name) %}
                         <a href="{{ path('easyadmin', link_parameters|merge({ id: primary_key_value })) }}">{{ item }}</a>
-                    </li>
-                {% else %}
-                    <li>
+                    {% else %}
                         {{ item }}
-                    </li>
-                {% endif %}
+                    {% endif %}
+                </li>
             {% endfor %}
         </ul>
     {% elseif 'list' == view %}

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -1,5 +1,9 @@
 {% if value is iterable %}
-    <span class="badge">{{ value|length }}</span>
+    {% if 'show' == view %}
+        {{ value|join(', ') }}
+    {% else %}
+        <span class="badge">{{ value|length }}</span>
+    {% endif %}
 {% elseif link_parameters is defined %}
     <a href="{{ path('easyadmin', link_parameters|merge({ referer: app.request.requestUri })) }}">{{ value|easyadmin_truncate }}</a>
 {% else %}

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -2,7 +2,7 @@
     {% if 'show' == view %}
         <ul>
             {% for element in value %}
-                <li>{{ element }}</li>
+                <li><a href="{{ path('easyadmin', link_parameters|merge({ id: attribute(element, link_parameters.primary_key_name) })) }}">{{ element }}</a></li>
             {% endfor %}
         </ul>
     {% else %}

--- a/Tests/Configuration/ConfiguratorTest.php
+++ b/Tests/Configuration/ConfiguratorTest.php
@@ -25,18 +25,26 @@ class ConfiguratorTest extends \PHPUnit_Framework_TestCase
         $this->extension = new EasyAdminExtension();
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Entity "TestEntity" is not managed by EasyAdmin.
+     */
     public function testEmptyConfiguration()
     {
         $backendConfig = array('easy_admin' => null);
         $configurator = new Configurator($backendConfig, new PropertyAccessor());
-        $this->assertNull($configurator->getEntityConfiguration('TestEntity'));
+        $configurator->getEntityConfiguration('TestEntity');
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Entity "UnmanagedEntity" is not managed by EasyAdmin.
+     */
     public function testAccessingAnUnmanagedEntity()
     {
         $backendConfig = array('easy_admin' => array('entities' => array('AppBundle\\Entity\\TestEntity')));
         $configurator = new Configurator($backendConfig, new PropertyAccessor());
-        $this->assertNull($configurator->getEntityConfiguration('UnmanagedEntity'));
+        $configurator->getEntityConfiguration('UnmanagedEntity');
     }
 }
 

--- a/Tests/Configuration/ConfiguratorTest.php
+++ b/Tests/Configuration/ConfiguratorTest.php
@@ -25,26 +25,18 @@ class ConfiguratorTest extends \PHPUnit_Framework_TestCase
         $this->extension = new EasyAdminExtension();
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Entity "TestEntity" is not managed by EasyAdmin.
-     */
     public function testEmptyConfiguration()
     {
         $backendConfig = array('easy_admin' => null);
         $configurator = new Configurator($backendConfig, new PropertyAccessor());
-        $configurator->getEntityConfiguration('TestEntity');
+        $this->assertNull($configurator->getEntityConfiguration('TestEntity'));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Entity "UnmanagedEntity" is not managed by EasyAdmin.
-     */
     public function testAccessingAnUnmanagedEntity()
     {
         $backendConfig = array('easy_admin' => array('entities' => array('AppBundle\\Entity\\TestEntity')));
         $configurator = new Configurator($backendConfig, new PropertyAccessor());
-        $configurator->getEntityConfiguration('UnmanagedEntity');
+        $this->assertNull($configurator->getEntityConfiguration('UnmanagedEntity'));
     }
 }
 

--- a/Tests/Configuration/ConfiguratorTest.php
+++ b/Tests/Configuration/ConfiguratorTest.php
@@ -14,6 +14,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Configuration;
 use InvalidArgumentException;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator;
 use JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection\EasyAdminExtension;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 class ConfiguratorTest extends \PHPUnit_Framework_TestCase
 {
@@ -31,7 +32,7 @@ class ConfiguratorTest extends \PHPUnit_Framework_TestCase
     public function testEmptyConfiguration()
     {
         $backendConfig = array('easy_admin' => null);
-        $configurator = new Configurator($backendConfig);
+        $configurator = new Configurator($backendConfig, new PropertyAccessor());
         $configurator->getEntityConfiguration('TestEntity');
     }
 
@@ -42,7 +43,7 @@ class ConfiguratorTest extends \PHPUnit_Framework_TestCase
     public function testAccessingAnUnmanagedEntity()
     {
         $backendConfig = array('easy_admin' => array('entities' => array('AppBundle\\Entity\\TestEntity')));
-        $configurator = new Configurator($backendConfig);
+        $configurator = new Configurator($backendConfig, new PropertyAccessor());
         $configurator->getEntityConfiguration('UnmanagedEntity');
     }
 }

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -239,7 +239,12 @@ class EasyAdminTwigExtension extends \Twig_Extension
      */
     public function getActionsForItem($view, $entityName)
     {
-        $entityConfig = $this->configurator->getEntityConfig($entityName);
+        try {
+            $entityConfig = $this->configurator->getEntityConfig($entityName);
+        } catch (\Exception $e) {
+            return array();
+        }
+
         $disabledActions = $entityConfig['disabled_actions'];
         $viewActions = $entityConfig[$view]['actions'];
 

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -66,21 +66,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
      */
     public function getBackendConfiguration($key = null)
     {
-        $config = $this->configurator->getBackendConfig();
-
-        if (!empty($key)) {
-            $parts = explode('.', $key);
-
-            foreach ($parts as $part) {
-                if (!isset($config[$part])) {
-                    $config = null;
-                    break;
-                }
-                $config = $config[$part];
-            }
-        }
-
-        return $config;
+        return $this->configurator->getBackendConfig($key);
     }
 
     /**

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -150,6 +150,11 @@ class EasyAdminTwigExtension extends \Twig_Extension
 
             if ('association' === $fieldType) {
                 $targetEntityConfig = $this->configurator->getEntityConfigByClass($fieldMetadata['targetEntity']);
+                if (null === $targetEntityConfig) {
+                    // the associated entity is not managed by EasyAdmin
+                    return $twig->render($entityConfiguration['templates']['field_association'], $templateParameters);
+                }
+
                 $isShowActionAllowed = $this->isActionEnabled($view, 'show', $targetEntityConfig['name']);
             }
 


### PR DESCRIPTION
@yceruto I like your original idea, but instead of displaying the elements "imploded", I prefer to display them as a `<ul>` list (which is useful for elements with long names/titles):

**Before**

![before](https://cloud.githubusercontent.com/assets/73419/12378983/d80eb858-bd4f-11e5-8422-8607dbc9e202.png)

**After**

![after](https://cloud.githubusercontent.com/assets/73419/12378984/d8e1f632-bd4f-11e5-908e-7b148f6a06f3.png)
