### PR TITLE
Fixed some design issues for Select2 widgets

### DIFF
--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -335,6 +335,8 @@ a.btn-secondary:active {
 .select2-container--bootstrap .select2-selection--multiple .select2-selection__choice__remove {
     color: {{ colors.danger }};
     font-weight: bold;
+    position: relative;
+    top: -1px;
 }
 .select2-container--bootstrap .select2-search--dropdown .select2-search__field {
     border: 1px solid {{ colors.gray_dark }};

--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -312,8 +312,12 @@ a.btn-secondary:active {
     -webkit-transition: none;
     transition: none;
 }
+.select2-container--bootstrap .select2-selection .select2-search--inline {
+    margin: 0;
+}
 .select2-container--bootstrap .select2-selection--single .select2-selection__rendered {
     color: {{ colors.text }};
+    padding-top: 4px;
 }
 .select2-container--bootstrap .select2-results__option {
     margin-bottom: 0;


### PR DESCRIPTION
This was on my top list since long ago. Select2 widgets display an ugly bottom padding which was driving me crazy.
### Before (single elements)

![single_before](https://cloud.githubusercontent.com/assets/73419/12428526/6396a00c-bee5-11e5-8e07-b475618da59d.png)
### After (single elements)

![single_after](https://cloud.githubusercontent.com/assets/73419/12428528/65c33b06-bee5-11e5-8d8f-93bcf48864c4.png)
### Before (multiple elements)

![multiple_before](https://cloud.githubusercontent.com/assets/73419/12428532/69762c4a-bee5-11e5-99c7-42986607aa4c.png)
### After (multiple elements)

![multiple_after](https://cloud.githubusercontent.com/assets/73419/12428534/6d150812-bee5-11e5-9323-0a6d90efa658.png)

Of course if there are a lot of elements, the widget grows vertically (but without the ugly bottom padding!)

![multiple_after_lots_items](https://cloud.githubusercontent.com/assets/73419/12428537/712982f2-bee5-11e5-8a74-34fd4792f199.png)
