### PR TITLE
Fixes a date field margin error

### DIFF
--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -795,9 +795,6 @@ form label.control-label.required:after {
 body.new textarea {
     min-height: 250px;
 }
-body.new .field-date select + select {
-    margin-top: .5em;
-}
 body.new .field-collection-action {
     margin: -15px 0 10px;
 }


### PR DESCRIPTION
This fixes a visual bug with the default datepicker where the three selects are not aligned properly. I don't think this intervenes or breaks other parts of the app, however correct me if I'm wrong.

Cheers.

Before:
![Screenshot](http://i.imgur.com/RK2IQz7.png)
