### PR TITLE
Added option to specify target attribute for link menus

### DIFF
--- a/Resources/views/default/menu.html.twig
+++ b/Resources/views/default/menu.html.twig
@@ -10,7 +10,9 @@
             item.type == 'empty' ? '#' : ''
         %}
 
-        <a href="{{ path }}">
+        <a href="{{ path }}"
+            {% if item.type == 'link' and item.target is defined and item.target is not empty %}target="{{ item.target }}{% endif %}"
+        >
             {% if item.icon is not empty %}<i class="fa {{ item.icon }}"></i>{% endif %}
             {{ item.label|trans }}
             {% if item.children|default([]) is not empty %}<i class="fa fa-angle-left pull-right"></i>{% endif %}


### PR DESCRIPTION
While a very welcome feature the new link menus imo lack the ability to open them in a new tab. This is especially useful for external links where you do not want the user to leave your application.

While opening new tabs is still possible via scroll click, ctrl + click etc this patch makes it possible to make that the default behaviour.

A new `target` property can be set on the link menus which then will be passed on to the generated anchor tag.

Possible values: `_blank|_self|_parent|_top|framename` where `_blank` is by far the most useful one.

@javiereguiluz please tell me how to go about adding tests for this feature.
