### PR TITLE
Set the referer URL in the links displayed for associations

### DIFF
--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -1,7 +1,7 @@
 {% if value is iterable %}
     <span class="badge">{{ value|length }}</span>
 {% elseif link_parameters is defined %}
-    <a href="{{ path('easyadmin', link_parameters) }}">{{ value|easyadmin_truncate }}</a>
+    <a href="{{ path('easyadmin', link_parameters|merge({ referer: app.request.requestUri })) }}">{{ value|easyadmin_truncate }}</a>
 {% else %}
     {{ value|easyadmin_truncate }}
 {% endif %}


### PR DESCRIPTION
This fixes #850.

In this example, I navigate through the `list` view and then, after clicking a link, I can return to the exact same `list` page I was:

![list_bug_fixed](https://cloud.githubusercontent.com/assets/73419/12796449/14053c52-cabf-11e5-85f6-46a315ba3258.gif)
