### PR TITLE
Fixed the list/search page title when it contains HTML tags

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -25,7 +25,7 @@
     <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/bootstrap-toggle.min.css') }}">
 {% endblock %}
 
-{% block page_title %}
+{% block content_title %}
     {% if 'search' == app.request.get('action') %}
         {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
     {% else %}
@@ -33,8 +33,6 @@
         {{ _entity_config.list.title|default(_default_title)|trans(_trans_parameters) }}
     {% endif %}
 {% endblock %}
-
-{% block content_title %}{{ block('page_title') }}{% endblock %}
 
 {% block global_actions %}
     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}


### PR DESCRIPTION
### Before

![before](https://cloud.githubusercontent.com/assets/73419/12866510/a1738a04-ccd0-11e5-9cf9-98bee90e2195.png)
### After

![after](https://cloud.githubusercontent.com/assets/73419/12866511/a42b41c4-ccd0-11e5-8035-16a00aaf6033.png)
