### PR TITLE
[WIP] Batch Actions

### DIFF
--- a/Batch/Action/BatchActionInterface.php
+++ b/Batch/Action/BatchActionInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Batch\Action;
+
+/**
+ * This interface must be implement by all the batch actions.
+ *
+ * @author unexge <unexge@yandex.com>
+ */
+interface BatchActionInterface
+{
+    /**
+     * Process the given data with given options.
+     *
+     * Must return an array with two elements
+     *  first one is boolean, the process is success or not
+     *  second one is string, the message shows the user
+     *
+     * @param array|string $data The data variable might be array of ids or string 'all'
+     * @param $entity
+     * @param $options
+     *
+     * @return array
+     */
+    public function process($data, $entity, $options);
+
+    /**
+     * Returns boolean, whether this action support the given entity and action or not.
+     *
+     * @param $entity
+     * @param $action
+     *
+     * @return bool
+     */
+    public function supports($entity, $action);
+
+    /**
+     * Returns the name of the action.
+     *
+     * @return string
+     */
+    public function getName();
+}

--- a/Batch/Action/BatchDeleteAction.php
+++ b/Batch/Action/BatchDeleteAction.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Batch\Action;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Batch delete action.
+ *
+ * @author unexge <unexge@yandex.com>
+ */
+class BatchDeleteAction implements BatchActionInterface
+{
+    /**
+     * @var Registry
+     */
+    protected $doctrine;
+
+
+    /**
+     * BatchDeleteAction constructor.
+     *
+     * @param Registry $doctrine
+     */
+    public function __construct(Registry $doctrine)
+    {
+        $this->doctrine = $doctrine;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function process($data, $entity, $options)
+    {
+        /** @var EntityManagerInterface $manager */
+        $manager = $this->doctrine->getManagerForClass($entity['class']);
+
+        $qb = $manager
+            ->createQueryBuilder()
+            ->delete($entity['class'], 'e')
+        ;
+
+        if (is_array($data)) {
+            $qb
+                ->where($qb->expr()->in(
+                    'e.' . $entity['primary_key_field_name'],
+                    ':data'
+                ))
+                ->setParameter('data', $data)
+            ;
+        }
+
+        if ( ! $qb->getQuery()->execute()) {
+            return array(false, 'Something went wrong.');
+        }
+
+        $message = is_string($data)
+            ? 'Success! All entities deleted.'
+            : 'Success! Selected entities deleted.'
+        ;
+
+        return array(true, $message);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supports($entity, $action)
+    {
+        return true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getName()
+    {
+        return 'delete';
+    }
+
+}

--- a/Batch/BatchActionManager.php
+++ b/Batch/BatchActionManager.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Batch;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Batch\Action\BatchActionInterface;
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\InvalidBatchActionException;
+
+/**
+ * Manages all the batch actions.
+ *
+ * @author unexge <unexge@yandex.com>
+ */
+class BatchActionManager
+{
+    /**
+     * Holds action instances.
+     *
+     * @var BatchActionInterface[]
+     */
+    private $actions = array();
+
+
+    /**
+     * Adds new action.
+     *
+     * @param BatchActionInterface $action
+     */
+    public function addAction(BatchActionInterface $action)
+    {
+        $this->actions[$action->getName()] = $action;
+    }
+
+    /**
+     * Gets an action.
+     *
+     * @param $name
+     *
+     * @throws InvalidBatchActionException if the action does not exists.
+     *
+     * @return BatchActionInterface
+     */
+    public function getAction($name)
+    {
+        if ( ! isset($this->actions[$name])) {
+            throw new InvalidBatchActionException($name);
+        }
+
+        return $this->actions[$name];
+    }
+
+    /**
+     * Returns array of actions, that supports given entity and action.
+     *
+     * @param        $entity
+     * @param string $action
+     *
+     * @return BatchActionInterface[]
+     */
+    public function getSupportedActions($entity, $action = 'list')
+    {
+        return array_filter($this->actions, function(BatchActionInterface $batchAction) use ($entity, $action) {
+            return $batchAction->supports($entity, $action);
+        });
+    }
+
+    /**
+     * Process given action and return its response.
+     *
+     * @param       $name
+     * @param       $data
+     * @param       $entity
+     * @param array $options
+     *
+     * @return array
+     */
+    public function processAction($name, $data, $entity, $options = array())
+    {
+        return $this->getAction($name)->process($data, $entity, $options);
+    }
+}

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -166,6 +166,7 @@ class AdminController extends Controller
 
         $fields = $this->entity['list']['fields'];
         $paginator = $this->findAll($this->entity['class'], $this->request->query->get('page', 1), $this->config['list']['max_results'], $this->request->query->get('sortField'), $this->request->query->get('sortDirection'));
+        $supportedActions = $this->get('easyadmin.batch.manager')->getSupportedActions($this->entity);
 
         $this->dispatch(EasyAdminEvents::POST_LIST, array('paginator' => $paginator));
 
@@ -173,6 +174,7 @@ class AdminController extends Controller
             'paginator' => $paginator,
             'fields' => $fields,
             'delete_form_template' => $this->createDeleteForm($this->entity['name'], '__id__')->createView(),
+            'supported_actions' => $supportedActions,
         ));
     }
 
@@ -361,6 +363,7 @@ class AdminController extends Controller
         $searchableFields = $this->entity['search']['fields'];
         $paginator = $this->findBy($this->entity['class'], $this->request->query->get('query'), $searchableFields, $this->request->query->get('page', 1), $this->config['list']['max_results']);
         $fields = $this->entity['list']['fields'];
+        $supportedActions = $this->get('easyadmin.batch.manager')->getSupportedActions($this->entity, 'search');
 
         $this->dispatch(EasyAdminEvents::POST_SEARCH, array(
             'fields' => $fields,
@@ -371,6 +374,38 @@ class AdminController extends Controller
             'paginator' => $paginator,
             'fields' => $fields,
             'delete_form_template' => $this->createDeleteForm($this->entity['name'], '__id__')->createView(),
+            'supported_actions' => $supportedActions,
+        ));
+    }
+
+    /**
+     * The method that is executed when the user performs a 'batch action'.
+     *
+     * @return RedirectResponse
+     */
+    protected function processAction()
+    {
+        // TODO: dispatch PRE_BATCH_PROCESS event.
+
+        if (null === $action = $this->request->query->get('batch_action')) {
+            return $this->redirectToBackendHomepage();
+        }
+
+        $data = $this->request->query->get('data');
+
+        $manager = $this->get('easyadmin.batch.manager');
+
+        list($status, $message) = $manager->processAction($action, $data, $entity = $this->entity);
+
+        $type = $status ? 'success' : 'error';
+
+        $this->addFlash($type, $message);
+
+        // TODO: dispatch POST_BATCH_PROCESS event.
+
+        return $this->redirectToRoute('easyadmin', array(
+            'action' => 'list',
+            'entity' => $this->entity['name'],
         ));
     }
 

--- a/DependencyInjection/Compiler/EasyAdminBatchActionPass.php
+++ b/DependencyInjection/Compiler/EasyAdminBatchActionPass.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author unexge <unexge@yandex.com>
+ */
+class EasyAdminBatchActionPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ( ! $container->hasDefinition('easyadmin.batch.manager')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('easyadmin.batch.manager');
+
+        foreach ($container->findTaggedServiceIds('easyadmin.batch.action') as $id => $tags) {
+            $definition->addMethodCall('addAction', array(new Reference($id)));
+        }
+    }
+}

--- a/EasyAdminBundle.php
+++ b/EasyAdminBundle.php
@@ -11,6 +11,7 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle;
 
+use JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection\Compiler\EasyAdminBatchActionPass;
 use JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection\Compiler\EasyAdminFormTypePass;
 use JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection\Compiler\EasyAdminConfigurationPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -26,5 +27,6 @@ class EasyAdminBundle extends Bundle
     {
         $container->addCompilerPass(new EasyAdminConfigurationPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new EasyAdminFormTypePass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new EasyAdminBatchActionPass(), PassConfig::TYPE_BEFORE_REMOVING);
     }
 }

--- a/Exception/InvalidBatchActionException.php
+++ b/Exception/InvalidBatchActionException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
+
+/**
+ * @author unexge <unexge@yandex.com>
+ */
+class InvalidBatchActionException extends BaseException
+{
+    public function __construct($name)
+    {
+        $errorMessage = sprintf('The batch action named "%s" does not exists.', $name);
+        $proposedSolution = sprintf('Make sure the defined "%s".', $name);
+
+        parent::__construct($errorMessage, $proposedSolution, 404);
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -11,6 +11,14 @@
             <tag name="twig.extension" />
         </service>
 
+        <service id="easyadmin.batch.manager" class="JavierEguiluz\Bundle\EasyAdminBundle\Batch\BatchActionManager">
+        </service>
+
+        <service id="easyadmin.batch.action.delete" class="JavierEguiluz\Bundle\EasyAdminBundle\Batch\Action\BatchDeleteAction" public="false">
+            <argument type="service" id="doctrine" />
+            <tag name="easyadmin.batch.action" />
+        </service>
+
         <service id="easyadmin.configurator" class="JavierEguiluz\Bundle\EasyAdminBundle\Configuration\Configurator">
             <argument /> <!-- easyadmin.config parameter -->
         </service>

--- a/Resources/public/javascript/easyadmin.js
+++ b/Resources/public/javascript/easyadmin.js
@@ -1,10 +1,15 @@
 $(function () {
-    var body = $('body');
+    var body = $('body'),
+        batchActionsAvaiable = !!body.find('.js-batch-actions').length;
 
     body
         .on('expanded.pushMenu', toggleNavigation(false))
         .on('collapsed.pushMenu', toggleNavigation(true))
     ;
+
+    if (batchActionsAvaiable) {
+        initBatchActions();
+    }
 
     createNullableControls();
 });
@@ -48,4 +53,156 @@ function createPersistentCookie(name, value)
 function deleteCookie(name)
 {
     document.cookie = encodeURIComponent(name) + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+}
+
+// thanks to http://stackoverflow.com/a/901144/2780840
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
+function initBatchActions() {
+    var selectedRecords = [], // keeps selected record id's
+        selectAll = false, // if its true, that means all records selected
+        allToggled = false, // the state of toggling all
+        $main = $('#main'),
+        $records = $main.find('.js-is-selected'),
+        $message = $main.find('.js-batch-message');
+
+    // show message on the target element
+    var showMessage = function(message) {
+        $message.html(message || '');
+    };
+
+    // shows selected element count
+    var showSelectedCount = function() {
+        var message = selectedRecords.length + ' records selected.';
+
+        if ( ! selectedRecords.length) {
+            message = '';
+        }
+
+        showMessage(message);
+    };
+
+    // gets id of the record from checkbox element
+    var getIdFromCheckbox = function(element) {
+        return element.closest('tr[data-id]').data('id');
+    };
+
+    // toggles given id
+    var toggleSelected = function(id, remove) {
+        var idx = selectedRecords.indexOf(id);
+
+        if ('undefined' === typeof remove) {
+            remove = true;
+        }
+
+        if (-1 === idx) {
+            selectedRecords.push(id);
+        } else if (remove) {
+            selectedRecords.splice(idx, 1);
+        }
+    };
+
+    // toggles all records
+    var toggleAll = function(active) {
+        if ('undefined' === typeof active) {
+            selectAll = false; // when all elements toggled, selectAll became false
+
+            active = allToggled = ! allToggled;
+        }
+
+        if (active) {
+            $records
+                .each(function() {
+                    var $this = $(this);
+
+                    $this.prop('checked', true);
+
+                    toggleSelected(
+                        getIdFromCheckbox($this),
+                        false
+                    );
+                })
+            ;
+        } else {
+            selectedRecords = [];
+
+            $records.prop('checked', false);
+        }
+
+        showSelectedCount();
+    };
+
+    // listen checkboxes change event, and toggle them in selectedRecords array
+    $main
+        .find('.js-is-selected')
+        .on('change', function() {
+            selectAll = false; // when any element changed, selectAll became false
+
+            toggleSelected(
+                getIdFromCheckbox($(this))
+            );
+
+            showSelectedCount();
+
+            // if all checkbox became unchecked, make false the allToggled
+            if ( ! selectedRecords.length) {
+                allToggled = false
+            }
+        })
+    ;
+
+    // listen toggle all button, and toggle all records
+    $main
+        .find('.js-toggle-all')
+        .on('click', function() {
+            toggleAll();
+        })
+    ;
+
+    // listen select all button
+    $main
+        .find('.js-select-all')
+        .on('click', function() {
+            selectAll = allToggled = true;
+
+            toggleAll(true);
+
+            showMessage('All records selected.');
+        })
+    ;
+
+    // listen batch action's click event
+    $('.js-batch-action')
+        .on('click', function() {
+            if ( ! selectAll && ! selectedRecords.length) {
+                alert('You need to select at least one record for applying batch actions.');
+
+                return;
+            }
+
+            $action = $(this).data('action-name');
+
+            var params = {
+                entity: getParameterByName('entity'),
+                action: 'process',
+                batch_action: $action
+            };
+
+            if (selectAll) {
+                params.data = 'all';
+            } else {
+                params.data = selectedRecords;
+            }
+
+            location.search = decodeURIComponent($.param(params));
+        })
+    ;
 }

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -72,12 +72,53 @@
 
 {% block main %}
     {% set _list_item_actions = easyadmin_get_actions_for_list_item(_entity_config.name) %}
+    {% set _batch_actions_aviable = paginator.count and supported_actions is defined and supported_actions is not empty %}
+
+    {% if _batch_actions_aviable %}
+        <div class="row js-batch-actions">
+            <div class="col-sm-12">
+                <div class="btn-group">
+                    <button type="button" class="btn btn-default js-toggle-all">Select</button>
+                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+                        <span class="caret"></span>
+                        <span class="sr-only">Toggle Dropdown</span>
+                    </button>
+
+                    <ul class="dropdown-menu" role="menu">
+                        <li class="js-select-all"><a href="#">Select all records</a></li>
+                    </ul>
+                </div>
+
+                <div class="btn-group">
+                    <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                        Actions
+                        <span class="fa fa-caret-down"></span>
+                    </button>
+
+                    <ul class="dropdown-menu">
+                        {% for action in supported_actions %}
+                            <li class="js-batch-action" data-action-name="{{ action.name }}"><a href="#">{{ action.name | title }}</a></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+
+                <span class="js-batch-message"></span>
+            </div>
+        </div>
+
+        <br />
+    {% endif %}
 
     <div class="table-responsive">
     <table class="table">
         <thead>
         {% block table_head %}
+
             <tr>
+                {% if _batch_actions_aviable %}
+                    <th data-propert-name="Selected" width="20"></th>
+                {% endif %}
+
                 {% for field, metadata in fields %}
                     {% set isSortingField = metadata.property == app.request.get('sortField') %}
                     {% set nextSortDirection = isSortingField ? (app.request.get('sortDirection') == 'DESC' ? 'ASC' : 'DESC') : 'DESC' %}
@@ -110,6 +151,12 @@
             {% for item in paginator.currentPageResults %}
                 {% set _item_id = attribute(item, _entity_config.primary_key_field_name) %}
                 <tr data-id="{{ _item_id }}">
+                    {% if _batch_actions_aviable %}
+                        <td data-label="Is Selected">
+                            <input type="checkbox" class="js-is-selected">
+                        </td>
+                    {% endif %}
+
                     {% for field, metadata in fields %}
                         {% set isSortingField = metadata.property == app.request.get('sortField') %}
                         {% set _column_label =  (metadata.label ?: field|humanize)|trans(_trans_parameters)  %}

--- a/Tests/Batch/BatchActionManagerTest.php
+++ b/Tests/Batch/BatchActionManagerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\DependencyInjection\Batch;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Batch\Action\BatchActionInterface;
+use JavierEguiluz\Bundle\EasyAdminBundle\Batch\BatchActionManager;
+use Prophecy\Argument;
+
+class BatchActionManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var BatchActionManager
+     */
+    protected $manager;
+
+    /**
+     * @var BatchActionInterface
+     */
+    protected $actionOne;
+
+    /**
+     * @var BatchActionInterface
+     */
+    protected $actionTwo;
+
+
+    public function setUp()
+    {
+        $manager = new BatchActionManager();
+
+        $actionOne = $this->prophesize(BatchActionInterface::class);
+        $actionOne->supports(Argument::any(), Argument::type('string'))->will(function($args) {
+            return 'list' === $args[1];
+        });
+        $actionOne->getName()->willReturn('action_one');
+        $actionOne->process(Argument::type('array'), Argument::any(), Argument::type('array'))->willReturn(array(true, 'Success!'));
+
+        $manager->addAction($this->actionOne = $actionOne->reveal());
+
+        $actionTwo = $this->prophesize(BatchActionInterface::class);
+        $actionTwo->supports(Argument::any(), Argument::type('string'))->willReturn(false);
+        $actionTwo->getName()->willReturn('action_two');
+
+        $manager->addAction($this->actionTwo = $actionTwo->reveal());
+
+        $this->manager = $manager;
+    }
+
+    public function testGetAction()
+    {
+        $this->assertEquals($this->actionOne, $this->manager->getAction('action_one'));
+        $this->assertEquals($this->actionTwo, $this->manager->getAction('action_two'));
+    }
+
+    public function testGetSupportedActions()
+    {
+        $this->assertEquals(
+            array(
+                'action_one' => $this->actionOne
+            ),
+            $this->manager->getSupportedActions(null, 'list')
+        );
+    }
+
+    public function testReturnEmptyArrayIfNoneOfTheActionsSupportsTheCondition()
+    {
+        $this->assertEquals(array(), $this->manager->getSupportedActions(null, 'search'));
+    }
+
+    /**
+     * @expectedException \JavierEguiluz\Bundle\EasyAdminBundle\Exception\InvalidBatchActionException
+     */
+    public function testFailToTryingGetInvalidAction()
+    {
+        $this->manager->getAction('not_exists');
+    }
+
+    public function testProcessAction()
+    {
+        $this->assertEquals(
+            array(true, 'Success!'),
+            $this->manager->processAction('action_one', array(50, 57), null, array())
+        );
+    }
+}


### PR DESCRIPTION
With this PR, we are able to add batch actions.

![screen shot 2016-02-10 at 12 59 41](https://cloud.githubusercontent.com/assets/16212576/12945470/33c413c4-cff6-11e5-84cf-6cc59818f127.png)

You need to define a service with custom tag(`easyadmin.batch.action`) for define a batch action. This service class needs to be implement [BatchActionInterface](https://github.com/unexge/EasyAdminBundle/blob/a990c7c89009664f8c43b21c52eaabb9b9549345/Batch/Action/BatchActionInterface.php). For example, [delete batch action](https://github.com/unexge/EasyAdminBundle/blob/a990c7c89009664f8c43b21c52eaabb9b9549345/Batch/Action/BatchDeleteAction.php).

TODO List:
- [ ] Merge `list` and `search` actions
- [ ] Some test are failing (DefaultBackendTest and CustomizedBackendTest)
- [ ] Since all batch actions done with entities, maybe instead of giving pure data, we can pass the entities directly.
- [ ] Add options for actions.
- [ ] Add CSV exporter.
