### PR TITLE
[Issue #878] Added support for external admin controllers

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -70,6 +70,18 @@ class AdminController extends Controller
             throw new ForbiddenActionException(array('action' => $action, 'entity' => $this->entity['name']));
         }
 
+        if (isset($this->entity['controller'])) {
+            if (0 === strpos($this->entity['controller'], '@')) {
+                $controller = $this->get(substr($this->entity['controller'],1));
+            }
+            else {
+                $controller = new $this->entity['controller']();
+                $controller->setContainer($this->container);
+            }
+            $controller->initialize($request);
+            return $controller->executeDynamicMethod($action.'<EntityName>Action');
+        }
+
         return $this->executeDynamicMethod($action.'<EntityName>Action');
     }
 

--- a/DependencyInjection/Compiler/EasyAdminConfigurationPass.php
+++ b/DependencyInjection/Compiler/EasyAdminConfigurationPass.php
@@ -45,7 +45,7 @@ class EasyAdminConfigurationPass implements CompilerPassInterface
         });
 
         $configPasses = array(
-            new NormalizerConfigPass(),
+            new NormalizerConfigPass($container),
             new MenuConfigPass(),
             new ActionConfigPass(),
             new MetadataConfigPass($container->get('doctrine')),


### PR DESCRIPTION
Added a 'controller' configuration option where you can specify the location of your admin class. The `indexAction` has been modified to check for the presence of another controller, initialize it and hand off execution.

New config should look like:

``` yaml
easy_admin:
    entities:
        User:
            class: Star\UserBundle\Entity\User
            controller: '@star_user.user_admin'
```

Notice the ability to use either a service or a fully qualified class name.

All admin controllers must derive from `JavierEguiluz\Bundle\EasyAdminBundle\Controller\AdminController` or an exception will be thrown.
