### PR TITLE
Fix HTML page title for search

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -29,7 +29,7 @@
 
 {% block content_title %}
     {% if 'search' == app.request.get('action') %}
-        {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
+        {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|striptags|raw }}
     {% else %}
         {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
         {{ _entity_config.list.title|default(_default_title)|trans(_trans_parameters) }}


### PR DESCRIPTION
Preconditions:
- have an entity configured
- have some data available for testing

Steps to reproduce:
- go to easy admin bundle
- search for something

What happens:
- you see page title with HTML content - see attach. 

![image](https://cloud.githubusercontent.com/assets/5156054/13048601/ae1215ca-d3ef-11e5-8a20-ff32d502cff5.png)

What should happen:
- HTML tags should be stripped for search too
