### PR TITLE
Maintain the selected menu item after searching

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -47,6 +47,8 @@
                     <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
                     <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
                     <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
+                    <input type="hidden" name="menuIndex" value="{{ _request_parameters.menuIndex }}">
+                    <input type="hidden" name="submenuIndex" value="{{ _request_parameters.submenuIndex }}">
                     <div class="input-group">
                         <input class="form-control" type="search" name="query" value="{{ app.request.get('query')|default('') }}">
                         <span class="input-group-btn">


### PR DESCRIPTION
Previously, when using the search engine, the selected menu item was lost. This is now fixed.

And now the mandatory GIF which proves the fix (the menu item `List Products` remains selected):

![search_results_menu](https://cloud.githubusercontent.com/assets/73419/13090617/23f9f480-d4f7-11e5-8ddc-707cf7964b4a.gif)
