### PR TITLE
Updated the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ install:
   - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then composer require --dev satooshi/php-coveralls:~0.6; fi
 
 script:
-  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else; then phpunit; fi; fi
+  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else phpunit; fi;
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then php php-cs-fixer --no-interaction --dry-run --diff -v fix; fi;
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then mv ./.php_cs.cache $HOME/.app/cache/.php_cs.cache; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-      env: COMPOSER_FLAGS="--prefer-lowest"
+    # define faster jobs first to reduce blocking time
+    - php: 7.0
+      env: PHP_CS=yes
+      env: SYMFONY_VERSION=3.0.*
+    - php: hhvm
       env: SYMFONY_VERSION=2.8.*
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
@@ -29,10 +32,8 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
     - php: 5.6
       env: TWIG_VERSION="2.0.x-dev"
-    - php: 7.0
-      env: PHP_CS=yes
-      env: SYMFONY_VERSION=3.0.*
-    - php: hhvm
+    - php: 5.3
+      env: COMPOSER_FLAGS="--prefer-lowest"
       env: SYMFONY_VERSION=2.8.*
   allow_failures:
     - php: hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,28 +20,31 @@ matrix:
   include:
     # define faster jobs first to reduce blocking time
     - php: 7.0
-      env: PHP_CS=yes
-      env: SYMFONY_VERSION=3.0.*
+      env: CHECK_PHP_SYNTAX="yes"
+      env: SYMFONY_VERSION="3.0.*"
     - php: hhvm
-      env: SYMFONY_VERSION=2.8.*
+      env: SYMFONY_VERSION="2.8.*"
     - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
+      env: SYMFONY_VERSION="2.3.*"
     - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
+      env: SYMFONY_VERSION="2.7.*"
     - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
+      env: SYMFONY_VERSION="2.8.*"
     - php: 5.6
       env: TWIG_VERSION="2.0.x-dev"
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-      env: SYMFONY_VERSION=2.8.*
+      env: SYMFONY_VERSION="2.8.*"
+    - php: 7.0
+      env: SYMFONY_VERSION="3.0.*"
+      env: ENABLE_CODE_COVERAGE="true"
   allow_failures:
     - php: hhvm
     - env: TWIG_VERSION="2.0.x-dev"
+    - env: ENABLE_CODE_COVERAGE="true"
 
 before_install:
   - if [[ "SYMFONY_VERSION" == "2.8.*" || "SYMFONY_VERSION" == "3.0.*" ]]; then export SYMFONY_DEPRECATIONS_HELPER="strict"; fi;
-  - if [[ "$TRAVIS_PHP_VERSION" == 7.0 && $(($RANDOM % 20)) == 0 ]]; then export ENABLE_CODE_COVERAGE="true"; fi;
   - composer selfupdate
   - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
@@ -50,7 +53,7 @@ before_install:
 install:
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
-  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then composer require --dev satooshi/php-coveralls:~0.6; fi
+  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then composer require --dev satooshi/php-coveralls; fi
 
 script:
   - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else phpunit; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ language: php
 
 php:
   - 5.3
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 sudo: false
@@ -18,8 +17,9 @@ env:
   global:
     - deps="no"
     - SYMFONY_VERSION=""
-    - PHP_CS="no"
-    - SYMFONY_DEPRECATIONS_HELPER=weak
+    - CHECK_PHP_SYNTAX="no"
+    - SYMFONY_DEPRECATIONS_HELPER="weak"
+    - ENABLE_CODE_COVERAGE="false"
 
 matrix:
   fast_finish: true
@@ -42,22 +42,21 @@ matrix:
 
 before_install:
   - if [[ "SYMFONY_VERSION" == "2.8.*" || "SYMFONY_VERSION" == "3.0.*" ]]; then export SYMFONY_DEPRECATIONS_HELPER="strict"; fi;
-  - if [[ "$SYMFONY_VERSION" = "" ]] && [[ "$TWIG_VERSION" = "" ]] && [[ "$TRAVIS_PHP_VERSION" =~ 5.[45] ]] && [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then export skip="yes"; fi;
-  - if [[ "$skip" != "yes" ]]; then composer selfupdate; fi
-  - if [[ "$skip" != "yes" && "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-  - if [[ "$skip" != "yes" && "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
-  - if [[ "$skip" != "yes" && "$TRAVIS_PHP_VERSION" != 7.0 && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
+  - if [[ "$TRAVIS_PHP_VERSION" == 7.0 && (RANDOM % 20 == 0) ]]; then export ENABLE_CODE_COVERAGE="true"; fi;
+  - composer selfupdate
+  - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
+  - if [[ "$ENABLE_CODE_COVERAGE" != "true" ]]; then phpenv config-rm xdebug.ini; fi;
 
 install:
-  - if [[ "$PHP_CS" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;
-  - if [[ "$skip" != "yes" ]]; then composer update --prefer-dist --no-interaction $COMPOSER_FLAGS; fi
-  - if [[ "$skip" != "yes" && "$TRAVIS_PHP_VERSION" == 7.0 ]]; then composer require --dev satooshi/php-coveralls:~0.6; fi
+  - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;
+  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then composer require --dev satooshi/php-coveralls:~0.6; fi
 
 script:
-  - if [[ "$skip" != "yes" && "$TRAVIS_PHP_VERSION" == 7.0 ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else if [[ "$skip" != "yes" ]]; then phpunit; fi; fi
-  - if [[ "$skip" = "yes" ]]; then echo "Skipping matrix entry for pull requests"; fi
-  - if [[ "$PHP_CS" == "yes" ]]; then php php-cs-fixer --no-interaction --dry-run --diff -v fix; fi;
-  - if [[ "$PHP_CS" == "yes" ]]; then mv ./.php_cs.cache $HOME/.app/cache/.php_cs.cache; fi;
+  - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else; then phpunit; fi; fi
+  - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then php php-cs-fixer --no-interaction --dry-run --diff -v fix; fi;
+  - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then mv ./.php_cs.cache $HOME/.app/cache/.php_cs.cache; fi;
 
 after_success: |
-    if [[ "$TRAVIS_PHP_VERSION" == 7.0 ]]; then php vendor/bin/coveralls -v --config .coveralls.yml; fi;
+    if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then php vendor/bin/coveralls -v --config .coveralls.yml; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   include:
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
-      env: SYMFONY_VERSION=3.0.*
+      env: SYMFONY_VERSION=2.8.*
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
     - php: 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - composer selfupdate
   - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
-  - if [[ "$ENABLE_CODE_COVERAGE" != "true" ]]; then phpenv config-rm xdebug.ini; fi;
+  - if [[ "$ENABLE_CODE_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
 
 install:
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ matrix:
       env: TWIG_VERSION="2.0.x-dev"
     - php: 7.0
       env: PHP_CS=yes
+    - php: hhvm
+      env: SYMFONY_VERSION=2.8.*
   allow_failures:
     - php: hhvm
     - env: TWIG_VERSION="2.0.x-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: php
 
-php:
-  - 5.3
-  - 5.6
-  - 7.0
-  - hhvm
-
 sudo: false
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,26 +18,27 @@ env:
 matrix:
   fast_finish: true
   include:
-    # define faster jobs first to reduce blocking time
+    # jobs are ordered in a specific way to get Travis results faster (first
+    # execute the fastest jobs, then the slowest and finally the jobs that can fail)
     - php: 7.0
       env: CHECK_PHP_SYNTAX="yes"
       env: SYMFONY_VERSION="3.0.*"
-    - php: hhvm
-      env: SYMFONY_VERSION="2.8.*"
     - php: 5.6
       env: SYMFONY_VERSION="2.3.*"
     - php: 5.6
       env: SYMFONY_VERSION="2.7.*"
     - php: 5.6
       env: SYMFONY_VERSION="2.8.*"
-    - php: 5.6
-      env: TWIG_VERSION="2.0.x-dev"
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+      env: SYMFONY_VERSION="2.8.*"
+    - php: hhvm
       env: SYMFONY_VERSION="2.8.*"
     - php: 7.0
       env: SYMFONY_VERSION="3.0.*"
       env: ENABLE_CODE_COVERAGE="true"
+    - php: 5.6
+      env: TWIG_VERSION="2.0.x-dev"
   allow_failures:
     - php: hhvm
     - env: TWIG_VERSION="2.0.x-dev"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
   include:
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
+      env: SYMFONY_VERSION=3.0.*
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
     - php: 5.6
@@ -30,6 +31,7 @@ matrix:
       env: TWIG_VERSION="2.0.x-dev"
     - php: 7.0
       env: PHP_CS=yes
+      env: SYMFONY_VERSION=3.0.*
     - php: hhvm
       env: SYMFONY_VERSION=2.8.*
   allow_failures:
@@ -38,7 +40,7 @@ matrix:
 
 before_install:
   - if [[ "SYMFONY_VERSION" == "2.8.*" || "SYMFONY_VERSION" == "3.0.*" ]]; then export SYMFONY_DEPRECATIONS_HELPER="strict"; fi;
-  - if [[ "$TRAVIS_PHP_VERSION" == 7.0 && (RANDOM % 20 == 0) ]]; then export ENABLE_CODE_COVERAGE="true"; fi;
+  - if [[ "$TRAVIS_PHP_VERSION" == 7.0 && $(($RANDOM % 20)) == 0 ]]; then export ENABLE_CODE_COVERAGE="true"; fi;
   - composer selfupdate
   - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;


### PR DESCRIPTION
### Problem

Xdebug is too slow:

![xdebug_php7](https://cloud.githubusercontent.com/assets/73419/13198708/3afcad78-d810-11e5-84ea-76eb5840183a.png)
### Solution

We only use Xdebug for code coverage ... so let's enable it randomly only on 5% of the tests.

I also propose to do other changes:
- Let's forget about PHP 5.4 and 5.5 and keep testing on 5.3, 5.6, 7.0 and HHVM.
- Let's rename some env variables to make them more easy to understand.
