### PR TITLE
Fixed the "Back to list" link for associations

### DIFF
--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -6,7 +6,7 @@
                 <li>
                     {% if link_parameters is defined %}
                         {% set primary_key_value = attribute(item, link_parameters.primary_key_name) %}
-                        <a href="{{ path('easyadmin', link_parameters|merge({ id: primary_key_value })) }}">{{ item }}</a>
+                        <a href="{{ path('easyadmin', link_parameters|merge({ id: primary_key_value, referer: '' })) }}">{{ item }}</a>
                     {% else %}
                         {{ item }}
                     {% endif %}
@@ -18,7 +18,7 @@
     {% endif %}
 {# a simple *-to-one value associated with an entity managed by this backend #}
 {% elseif link_parameters is defined %}
-    <a href="{{ path('easyadmin', link_parameters|merge({ referer: app.request.requestUri })) }}">{{ value|easyadmin_truncate }}</a>
+    <a href="{{ path('easyadmin', link_parameters|merge({ referer: '' })) }}">{{ value|easyadmin_truncate }}</a>
 {% else %}
     {{ value|easyadmin_truncate }}
 {% endif %}

--- a/Resources/views/default/includes/_actions.html.twig
+++ b/Resources/views/default/includes/_actions.html.twig
@@ -1,6 +1,6 @@
 {% for action in actions %}
     {% if 'list' == action.name %}
-        {% set action_href = request_parameters.referer is defined ? request_parameters.referer|easyadmin_urldecode : path('easyadmin', request_parameters|merge({ action: 'list' })) %}
+        {% set action_href = request_parameters.referer|default('') ? request_parameters.referer|easyadmin_urldecode : path('easyadmin', request_parameters|merge({ action: 'list' })) %}
     {% elseif 'method' == action.type %}
         {% set action_href = path('easyadmin', request_parameters|merge({ action: action.name, id: item_id })) %}
     {% elseif 'route' == action.type %}


### PR DESCRIPTION
This fixes #905. The solution is not perfect, but it should work "good enough" for all scenarios. We just remove the referer for associations so their "Back to list" always returns to the list of that target entity. 

The edge case we don't solve is: if the related entity is the same as the parent entity (something which is not usual at all) we lose the sorting and pagination.
