### PR TITLE
Make the Symfony Debug toolbar look always nice

### DIFF
--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -44,6 +44,15 @@
 {% set colors = color_schemes[color_scheme] %}
 
 {% autoescape false %}
+/* -------------------------------------------------------------------------
+   RESET STYLES
+   ------------------------------------------------------------------------- */
+/* make the Symfony Web Toolbar look nice by neutralizing the aliasing applied
+   globally by the AdminLTE template styles */
+.sf-toolbarreset {
+    -webkit-font-smoothing: subpixel-antialiased;
+    -moz-osx-font-smoothing: auto;
+}
 
 /* -------------------------------------------------------------------------
    BASIC STYLES


### PR DESCRIPTION
This is a port of https://github.com/symfony/symfony/pull/17860 to fix how the Symfony Debug Toolbar looks inside EasyAdmin.

I want to include this fix in our CSS styles because that will make the Symfony toolbar look always nice inside EasyAdmin. Otherwise, only people with the latest Symfony versions will see it right.
