### PR TITLE
Show the installed EasyAdmin version in the toolbar and profiler

### DIFF
--- a/EasyAdminBundle.php
+++ b/EasyAdminBundle.php
@@ -22,6 +22,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class EasyAdminBundle extends Bundle
 {
+    const VERSION = '1.11.6-DEV';
+
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new EasyAdminConfigurationPass(), PassConfig::TYPE_BEFORE_REMOVING);

--- a/Resources/views/data_collector/easyadmin.html.twig
+++ b/Resources/views/data_collector/easyadmin.html.twig
@@ -33,7 +33,7 @@
 {% block panel %}
     {% set profiler_markup_version = profiler_markup_version|default(1) %}
 
-    <h2>EasyAdmin</h2>
+    <h2>EasyAdmin <small>({{ constant('JavierEguiluz\\Bundle\\EasyAdminBundle\\EasyAdminBundle::VERSION') }})</small></h2>
 
     {% if profiler_markup_version == 1 %}
 
@@ -117,14 +117,7 @@
         </div>
     </div>
 
-    <h2>Additional Resources</h2>
-
-        <div class="metrics">
-            <div class="metric">
-                <span class="value">{{ constant('JavierEguiluz\\Bundle\\EasyAdminBundle\\EasyAdminBundle::VERSION') }}</span>
-                <span class="label">EasyAdmin Version</span>
-            </div>
-        </div>
+    <h3>Additional Resources</h3>
 
     <ul>
         <li><a href="https://github.com/javiereguiluz/EasyAdminBundle/issues">Report an issue</a></li>

--- a/Resources/views/data_collector/easyadmin.html.twig
+++ b/Resources/views/data_collector/easyadmin.html.twig
@@ -12,17 +12,16 @@
 
     {% set text %}
     <div class="sf-toolbar-info-piece">
-        <b>EasyAdmin</b>
+        <b>EasyAdmin {{ constant('JavierEguiluz\\Bundle\\EasyAdminBundle\\EasyAdminBundle::VERSION') }}</b>
     </div>
     <div class="sf-toolbar-info-piece">
         <b>Managed entities</b>
-        <span>{{ collector.numEntities }}</span>
+        <span class="sf-toolbar-status">{{ collector.numEntities }}</span>
     </div>
     {% endset %}
 
     {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': true }) }}
 {% endblock %}
-
 
 {% block menu %}
     <span class="label status-{{ not collector.requestParameters ? 'disabled' }}">
@@ -117,4 +116,20 @@
             </div>
         </div>
     </div>
+
+    <h2>Additional Resources</h2>
+
+        <div class="metrics">
+            <div class="metric">
+                <span class="value">{{ constant('JavierEguiluz\\Bundle\\EasyAdminBundle\\EasyAdminBundle::VERSION') }}</span>
+                <span class="label">EasyAdmin Version</span>
+            </div>
+        </div>
+
+    <ul>
+        <li><a href="https://github.com/javiereguiluz/EasyAdminBundle/issues">Report an issue</a></li>
+        <li><a href="https://github.com/javiereguiluz/EasyAdminBundle#documentation">Read documentation</a></li>
+        <li><a href="https://github.com/javiereguiluz/EasyAdminBundle">Project homepage</a></li>
+    </ul>
+
 {% endblock %}

--- a/Resources/views/data_collector/easyadmin.html.twig
+++ b/Resources/views/data_collector/easyadmin.html.twig
@@ -12,7 +12,8 @@
 
     {% set text %}
     <div class="sf-toolbar-info-piece">
-        <b>EasyAdmin {{ constant('JavierEguiluz\\Bundle\\EasyAdminBundle\\EasyAdminBundle::VERSION') }}</b>
+        <b>EasyAdmin version</b>
+        <span class="sf-toolbar-status">{{ constant('JavierEguiluz\\Bundle\\EasyAdminBundle\\EasyAdminBundle::VERSION') }}</span>
     </div>
     <div class="sf-toolbar-info-piece">
         <b>Managed entities</b>


### PR DESCRIPTION
It's a minor thing, but I think we should have done this a while ago. This helps people know exactly which version are using and whether the reported issue has been fixed in their versions or not.

The idea is to display the version in the toolbar...

![toolbar_version](https://cloud.githubusercontent.com/assets/73419/13264606/376b10e4-da6f-11e5-8e40-d81c8b874ddb.png)

... and in the profiler:

![symfony_profiler](https://cloud.githubusercontent.com/assets/73419/13264663/87048036-da6f-11e5-842e-3e9a92b1fae4.png)
