### PR TITLE
Improve the profiler when there is no entity

### DIFF
--- a/Resources/views/data_collector/easyadmin.html.twig
+++ b/Resources/views/data_collector/easyadmin.html.twig
@@ -46,12 +46,12 @@
         {% if collector.requestParameters %}
         <div class="metrics">
             <div class="metric">
-                <span class="value">{{ collector.requestParameters.action }}</span>
+                <span class="value">{{ collector.requestParameters.action|default('-') }}</span>
                 <span class="label">Action</span>
             </div>
 
             <div class="metric">
-                <span class="value">{{ collector.requestParameters.entity }}</span>
+                <span class="value">{{ collector.requestParameters.entity|default('-') }}</span>
                 <span class="label">Entity Name</span>
             </div>
 
@@ -60,7 +60,7 @@
                     <span class="value">{{ collector.requestParameters.id }}</span>
                     <span class="label">ID</span>
                 </div>
-            {% else %}
+            {% elseif collector.requestParameters.sort_field %}
                 <div class="metric">
                     <span class="value">{{ collector.requestParameters.sort_field }} <span class="unit">({{ collector.requestParameters.sort_direction }})</span></span>
                     <span class="label">Sorting</span>


### PR DESCRIPTION
When using the [EasyAdmin Demo application](https://github.com/javiereguiluz/easy-admin-demo), the homepage displays a Welcome Message and therefore, no entity is managed during that request.

The problem is that the Symfony profiler is not ready for this:

![before](https://cloud.githubusercontent.com/assets/73419/13297632/91ec2cbe-db33-11e5-9d45-3ab2dd9d46e8.png)

This PR provides some default values for the panel:

![after](https://cloud.githubusercontent.com/assets/73419/13297644/9f4ba1aa-db33-11e5-909f-6b7c04b83cb2.png)
