### PR TITLE
Made EntityTypeConfigurator code more robust

### DIFF
--- a/Form/Type/Configurator/EntityTypeConfigurator.php
+++ b/Form/Type/Configurator/EntityTypeConfigurator.php
@@ -57,7 +57,7 @@ class EntityTypeConfigurator implements TypeConfiguratorInterface
         // Configure "placeholder" option for entity fields
         if (($metadata['associationType'] & ClassMetadata::TO_ONE)
             && !isset($options[$placeHolderOptionName = $this->getPlaceholderOptionName()])
-            && false === $options['required']
+            && isset($options['required']) && false === $options['required']
         ) {
             $options[$placeHolderOptionName] = 'form.label.empty_value';
         }


### PR DESCRIPTION
As commented by @rubengc in https://github.com/javiereguiluz/EasyAdminBundle/issues/868#issuecomment-188319211  the code can be improve to avoid PHP notices in some cases.
