### PR TITLE
Allow to hide/show the new and search actions separately

### DIFF
--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -673,12 +673,16 @@ body.easyadmin h1.title {
 
 body.list .global-actions {
     display: table;
+    width: 100%;
 }
 body.list .global-actions .action-new {
     display: table-cell;
     padding-left: 10px;
     vertical-align: middle;
-    width: 1%;
+    width: 120px;
+}
+body.list .global-actions .action-new a {
+    float: right;
 }
 body.list .global-actions .action-search {
     display: table-cell;

--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -670,13 +670,24 @@ body.easyadmin h1.title {
 /* -------------------------------------------------------------------------
    LIST PAGE
    ------------------------------------------------------------------------- */
+
 body.list .global-actions {
-    text-align: right;
+    display: table;
 }
-body.list .global-actions > div[class*=action-] {
-    max-width: 50%;
-    float: right;
+body.list .global-actions .action-new {
+    display: table-cell;
+    padding-left: 10px;
+    vertical-align: middle;
+    width: 1%;
 }
+body.list .global-actions .action-search {
+    display: table-cell;
+    width: 100%;
+}
+body.list .global-actions .action-search .input-group {
+    width: 100%;
+}
+
 body.list .global-actions .form-control {
     box-shadow: none;
 }

--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -673,6 +673,10 @@ body.easyadmin h1.title {
 body.list .global-actions {
     text-align: right;
 }
+body.list .global-actions > div[class*=action-] {
+    max-width: 50%;
+    float: right;
+}
 body.list .global-actions .form-control {
     box-shadow: none;
 }

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -37,17 +37,6 @@
 {% endblock %}
 
 {% block global_actions %}
-    {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
-        {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
-        {% block new_action %}
-            <div class="{{ _action.css_class|default('action-new') }}">
-                <a class="btn btn-primary {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
-                    {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                    {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
-                </a>
-            </div>
-        {% endblock new_action %}
-    {% endif %}
     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
         {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
 
@@ -72,6 +61,18 @@
                 </form>
             </div>
         {% endblock search_action %}
+    {% endif %}
+
+    {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
+        {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
+        {% block new_action %}
+            <div class="{{ _action.css_class|default('action-new') }}">
+                <a class="btn btn-primary {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
+                    {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
+                    {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
+                </a>
+            </div>
+        {% endblock new_action %}
     {% endif %}
 {% endblock %}
 

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -40,10 +40,12 @@
     {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
         {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
         {% block new_action %}
-            <a class="btn btn-primary {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
-                {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
-            </a>
+            <div class="{{ _action.css_class|default('action-new') }}">
+                <a class="btn btn-primary {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
+                    {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
+                    {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
+                </a>
+            </div>
         {% endblock new_action %}
     {% endif %}
     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -37,6 +37,15 @@
 {% endblock %}
 
 {% block global_actions %}
+    {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
+        {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
+        {% block new_action %}
+            <a class="btn btn-primary {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
+                {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
+                {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
+            </a>
+        {% endblock new_action %}
+    {% endif %}
     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
         {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
 
@@ -56,16 +65,6 @@
                                 <i class="fa fa-search"></i>
                                 <span class="hidden-xs hidden-sm">{{ _action.label|default('action.search')|trans(_trans_parameters) }}</span>
                             </button>
-
-                            {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
-                                {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
-                                {% block new_action %}
-                                    <a class="btn btn-primary {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
-                                        {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                                        {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
-                                    </a>
-                                {% endblock new_action %}
-                            {% endif %}
                         </span>
                     </div>
                 </form>


### PR DESCRIPTION
This fixes #910.

First I tried to fix this with flexbox. It works perfectly on Chrome, almost right on Firefox and pretty bad on Safari. I can't imagine how it would look in browsers I cannot test (Android, Edge, etc.) So I settled for this solution based on plain-old CSS. It works as expected and the support is universal across every browser.
