### PR TITLE
Fixed the styles of the responsive tables

### DIFF
--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -706,6 +706,7 @@ body.list .global-actions .input-group-btn a.btn {
 
 /* Responsive tables
    ------------------------------------------------------------------------- */
+body.list .table-responsive,
 body.list table {
     background: transparent;
     border: 0;


### PR DESCRIPTION
This is a minor bug which improves how responsive tables look.
### Before

Chrome (left) and Firefox (right)

![before_tables](https://cloud.githubusercontent.com/assets/73419/13372417/77c091d4-dd42-11e5-8868-aacbcccb3166.png)
### After

![after_tables](https://cloud.githubusercontent.com/assets/73419/13372418/7ab0bf68-dd42-11e5-8860-aee3b6583180.png)
