### PR TITLE
Fixed the styles of the header and menu in responsive mode

### DIFF
--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -482,6 +482,9 @@ button.btn:active {
 .content-wrapper {
     background: {{ colors.page_background }};
 }
+.fixed .content-wrapper {
+    padding-top: 50px;
+}
 
 /* Header
    ------------------------------------------------------------------------- */
@@ -493,6 +496,7 @@ button.btn:active {
     color: {{ colors.white }};
     font-family: Helvetica, "Helvetica Neue", Arial, sans-serif; /* needed to override AdminLTE styles */
     font-weight: bold;
+    height: 40px;
 }
 .main-header .logo-lg {
     overflow: hidden;
@@ -576,7 +580,7 @@ button.btn:active {
 {% endif %}
 }
 .main-sidebar {
-    padding-top: 90px;
+    padding-top: 40px;
 }
 
 .sidebar-menu > li.header {
@@ -931,6 +935,7 @@ body.error .error-message {
     }
     .main-header .logo {
         text-align: left;
+        height: 50px;
     }
     .main-header .logo img {
         max-height: 48px;


### PR DESCRIPTION
This has been on my TODO list for too long. Let's fix it.
### Before

(left: Chrome; right: Firefox)

![before_header](https://cloud.githubusercontent.com/assets/73419/13372469/321ec068-dd44-11e5-9744-44f888038475.png)
### After

![after_header](https://cloud.githubusercontent.com/assets/73419/13372470/358d6be6-dd44-11e5-888c-50fcd582ef81.png)
