### PR TITLE
Improved the styles of the associations

### DIFF
--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -95,6 +95,14 @@ li {
     margin-bottom: 1em;
 }
 
+ul.inline {
+    list-style: none;
+    margin: 0;
+}
+ul.inline li {
+    margin: 0;
+}
+
 /* Flash messages
    ------------------------------------------------------------------------- */
 div.flash {

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -1,7 +1,7 @@
 {# a *-to-many collection of values #}
 {% if value is iterable %}
     {% if 'show' == view %}
-        <ul>
+        <ul class="{{ value|length < 2 ? 'inline' }}">
             {% for item in value %}
                 <li>
                     {% if link_parameters is defined %}


### PR DESCRIPTION
The way associations are displayed changed recently to display the list of related entities and some links:

![multiple_associations](https://cloud.githubusercontent.com/assets/73419/13372585/93edddce-dd49-11e5-82bd-18d992a0a9af.png)

The problem is that when there is only 1 associated entity, the styles are a bit awkward:

![before_association](https://cloud.githubusercontent.com/assets/73419/13372588/a5e1cc8e-dd49-11e5-93db-61d7a84f77ec.png)

Now we just display those "lists" inlined:

![after_association](https://cloud.githubusercontent.com/assets/73419/13372592/ae94412c-dd49-11e5-92cd-d36b5d7e11a5.png)
