### PR TITLE
Updated some translation id

### DIFF
--- a/Form/Type/Configurator/EntityTypeConfigurator.php
+++ b/Form/Type/Configurator/EntityTypeConfigurator.php
@@ -59,7 +59,7 @@ class EntityTypeConfigurator implements TypeConfiguratorInterface
             && !isset($options[$placeHolderOptionName = $this->getPlaceholderOptionName()])
             && isset($options['required']) && false === $options['required']
         ) {
-            $options[$placeHolderOptionName] = 'form.label.empty_value';
+            $options[$placeHolderOptionName] = 'label.form.empty_value';
         }
 
         return $options;

--- a/Resources/translations/EasyAdminBundle.ca.xlf
+++ b/Resources/translations/EasyAdminBundle.ca.xlf
@@ -107,6 +107,10 @@
                 <source>delete_modal.content</source>
                 <target>Aquesta acció no es pot desfer.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Borrar</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Afegir un element</target>

--- a/Resources/translations/EasyAdminBundle.cs.xlf
+++ b/Resources/translations/EasyAdminBundle.cs.xlf
@@ -119,6 +119,10 @@
                 <source>delete_modal.content</source>
                 <target>Není možné se vrátit zpět.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Smazat</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Vložit položku</target>

--- a/Resources/translations/EasyAdminBundle.de.xlf
+++ b/Resources/translations/EasyAdminBundle.de.xlf
@@ -107,6 +107,10 @@
                 <source>delete_modal.content</source>
                 <target>Aktion kann nicht rückgängig gemacht werden.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Löschen</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Ein neues Element hinzufügen</target>

--- a/Resources/translations/EasyAdminBundle.en.xlf
+++ b/Resources/translations/EasyAdminBundle.en.xlf
@@ -119,6 +119,10 @@
                 <source>delete_modal.content</source>
                 <target>There is no undo for this operation.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Delete</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Add a new item</target>

--- a/Resources/translations/EasyAdminBundle.es.xlf
+++ b/Resources/translations/EasyAdminBundle.es.xlf
@@ -119,6 +119,10 @@
                 <source>delete_modal.content</source>
                 <target>Esta acción no se puede deshacer.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Borrar</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Añadir un elemento</target>

--- a/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/Resources/translations/EasyAdminBundle.fr.xlf
@@ -107,6 +107,10 @@
                 <source>delete_modal.content</source>
                 <target>Cette action est irréversible.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Supprimer</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Ajouter un nouvel élément</target>

--- a/Resources/translations/EasyAdminBundle.it.xlf
+++ b/Resources/translations/EasyAdminBundle.it.xlf
@@ -107,6 +107,10 @@
                 <source>delete_modal.content</source>
                 <target>Questa azione è irreversibile.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Cancella</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Aggiungi un nuovo elemento</target>

--- a/Resources/translations/EasyAdminBundle.pl.xlf
+++ b/Resources/translations/EasyAdminBundle.pl.xlf
@@ -107,6 +107,10 @@
                 <source>delete_modal.content</source>
                 <target>Tej operacji nie można anulować.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Usuń</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Dodaj nową pozycję</target>

--- a/Resources/translations/EasyAdminBundle.ro.xlf
+++ b/Resources/translations/EasyAdminBundle.ro.xlf
@@ -107,6 +107,10 @@
                 <source>delete_modal.content</source>
                 <target>Nu există posibilitatea de a reveni asupra acestei decizii.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Șterge</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Adaugă un item nou</target>

--- a/Resources/translations/EasyAdminBundle.ru.xlf
+++ b/Resources/translations/EasyAdminBundle.ru.xlf
@@ -119,6 +119,10 @@
                 <source>delete_modal.content</source>
                 <target>Эту операцию нельзя будет отменить.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Удалить</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Добавить новый элемент</target>

--- a/Resources/translations/EasyAdminBundle.sl.xlf
+++ b/Resources/translations/EasyAdminBundle.sl.xlf
@@ -107,6 +107,10 @@
                 <source>delete_modal.content</source>
                 <target>Razveljavitev za to operacijo ne obstaja.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Izbrišite</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Dodajte nov element</target>

--- a/Resources/translations/EasyAdminBundle.tr.xlf
+++ b/Resources/translations/EasyAdminBundle.tr.xlf
@@ -115,6 +115,10 @@
                 <source>delete_modal.content</source>
                 <target>Bu işlem geri alınamaz.</target>
             </trans-unit>
+            <trans-unit id="delete_modal.action">
+                <source>delete_modal.action</source>
+                <target>Sil</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Yeni öğe ekle</target>

--- a/Resources/translations/messages.ca.xlf
+++ b/Resources/translations/messages.ca.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Tornar al llistat</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Ningú</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Borrar</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.cs.xlf
+++ b/Resources/translations/messages.cs.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Zpět na výpis</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Prázdné</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Smazat</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.de.xlf
+++ b/Resources/translations/messages.de.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Zurück zur Übersicht</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>kein Wert</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Löschen</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.en.xlf
+++ b/Resources/translations/messages.en.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Back to listing</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>None</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Delete</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.es.xlf
+++ b/Resources/translations/messages.es.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Volver al listado</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Ninguno</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Borrar</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.fr.xlf
+++ b/Resources/translations/messages.fr.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Retour à la liste</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Aucun(e)</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Supprimer</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.it.xlf
+++ b/Resources/translations/messages.it.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Torna alla lista</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Nessun valore</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Cancella</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.pl.xlf
+++ b/Resources/translations/messages.pl.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Wróć do listy</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Pusta wartość</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Usuń</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.ro.xlf
+++ b/Resources/translations/messages.ro.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Înapoi la listă</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Gol</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Șterge</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.ru.xlf
+++ b/Resources/translations/messages.ru.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Вернуться к списку</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Пусто</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Удалить</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.sl.xlf
+++ b/Resources/translations/messages.sl.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Nazaj na seznam</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Noben</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Izbrišite</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.tr.xlf
+++ b/Resources/translations/messages.tr.xlf
@@ -35,13 +35,9 @@
                 <source>action.list</source>
                 <target>Listeye Dön</target>
             </trans-unit>
-            <trans-unit id="form.label.empty_value">
-                <source>form.label.empty_value</source>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
                 <target>Boş</target>
-            </trans-unit>
-            <trans-unit id="modal.action.delete">
-                <source>modal.action.delete</source>
-                <target>Sil</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/views/default/includes/_delete_form.html.twig
+++ b/Resources/views/default/includes/_delete_form.html.twig
@@ -22,7 +22,7 @@
                     {% set _delete_action = easyadmin_get_action(view, 'delete', _entity_config.name) %}
                     <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button">
                         {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
-                        {{ 'modal.action.delete'|trans(_trans_parameters) }}
+                        {{ 'delete_modal.action'|trans(_trans_parameters, 'EasyAdminBundle') }}
                     </button>
                 {% endif %}
             </div>


### PR DESCRIPTION
All the built-in translations should be defined in `EasyAdminBundle` domain ... unless defining them in `messages` domain is easier or simplifies the work of the users (for instance, defining `label.form.empty_value` under `EasyAdminBundle` would be very complex for us because we would need to inject the translator service in `EntityTypeConfigurator` to translate it).
