### PR TITLE
Fixed the styles of the global actions in the "list" view

### DIFF
--- a/Configuration/ActionConfigPass.php
+++ b/Configuration/ActionConfigPass.php
@@ -259,7 +259,7 @@ class ActionConfigPass implements ConfigPassInterface
         $actions = $this->doNormalizeActionsConfig(array(
             'delete' => array('name' => 'delete', 'label' => 'action.delete', 'icon' => 'trash-o', 'css_class' => 'btn btn-default'),
             'edit' => array('name' => 'edit', 'label' => 'action.edit', 'icon' => 'edit', 'css_class' => 'btn btn-primary'),
-            'new' => array('name' => 'new', 'label' => 'action.new'),
+            'new' => array('name' => 'new', 'label' => 'action.new', 'css_class' => 'btn btn-primary'),
             'search' => array('name' => 'search', 'label' => 'action.search'),
             'show' => array('name' => 'show', 'label' => 'action.show'),
             'list' => array('name' => 'list', 'label' => 'action.list', 'css_class' => 'btn btn-secondary'),

--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -706,20 +706,20 @@ body.list .global-actions {
     display: table;
     width: 100%;
 }
-body.list .global-actions .action-new {
+body.list .global-actions .button-action {
     display: table-cell;
     padding-left: 10px;
     vertical-align: middle;
     width: 120px;
 }
-body.list .global-actions .action-new a {
+body.list .global-actions .button-action a {
     float: right;
 }
-body.list .global-actions .action-search {
+body.list .global-actions .form-action {
     display: table-cell;
     width: 100%;
 }
-body.list .global-actions .action-search .input-group {
+body.list .global-actions .form-action .input-group {
     width: 100%;
 }
 

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -41,7 +41,7 @@
         {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
 
         {% block search_action %}
-            <div class="{{ _action.css_class|default('action-search') }}">
+            <div class="form-action {{ _action.css_class|default('') }}">
                 <form method="get" action="{{ path('easyadmin') }}">
                     <input type="hidden" name="action" value="search">
                     <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
@@ -66,8 +66,8 @@
     {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
         {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
         {% block new_action %}
-            <div class="{{ _action.css_class|default('action-new') }}">
-                <a class="btn btn-primary {{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
+            <div class="button-action">
+                <a class="{{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
                     {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
                     {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
                 </a>

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -59,10 +59,10 @@ class CustomizedBackendTest extends AbstractTestCase
     {
         $crawler = $this->requestListView();
 
-        $this->assertEquals('New Category', trim($crawler->filter('.global-actions a.btn')->text()));
-        $this->assertEquals('btn btn-primary custom_class_new action-new', $crawler->filter('.global-actions a.btn')->attr('class'));
-        $this->assertEquals('fa fa-plus-circle', $crawler->filter('.global-actions a.btn i')->attr('class'));
-        $this->assertStringStartsWith('/admin/?action=new&entity=Category&sortField=id&sortDirection=DESC&page=1', $crawler->filter('.global-actions a.btn')->attr('href'));
+        $this->assertEquals('New Category', trim($crawler->filter('.global-actions a.action-new')->text()));
+        $this->assertEquals('custom_class_new action-new', $crawler->filter('.global-actions a.action-new')->attr('class'));
+        $this->assertEquals('fa fa-plus-circle', $crawler->filter('.global-actions a.action-new i')->attr('class'));
+        $this->assertStringStartsWith('/admin/?action=new&entity=Category&sortField=id&sortDirection=DESC&page=1', $crawler->filter('.global-actions a.action-new')->attr('href'));
     }
 
     public function testListViewItemActions()

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_001.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_001.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_002.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_002.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_003.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_003.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_004.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_004.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_005.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_005.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_006.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_006.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_007.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_007.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_008.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_008.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_009.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_009.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_010.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_010.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_011.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_011.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_012.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_012.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_013.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_013.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_014.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_014.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_015.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_015.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_016.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_016.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_017.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_017.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_018.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_018.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_019.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_019.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_020.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_020.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_021.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_021.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_022.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_022.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_023.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_023.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_024.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_024.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_025.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_025.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_026.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_026.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_027.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_027.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_028.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_028.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_029.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_029.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_030.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_030.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_031.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_031.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_032.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_032.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_033.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_033.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_034.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_034.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_035.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_035.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_036.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_036.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_037.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_037.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_038.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_038.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_039.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_039.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_040.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_040.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_041.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_041.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_042.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_042.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_043.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_043.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_044.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_044.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_045.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_045.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_046.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_046.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_047.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_047.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_048.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_048.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_049.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_049.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_050.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_050.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_051.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_051.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_052.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_052.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_053.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_053.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_054.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_054.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_055.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_055.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_056.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_056.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_057.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_057.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_058.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_058.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_059.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_059.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_060.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_060.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_061.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_061.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_062.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_062.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_063.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_063.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_064.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_064.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_065.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_065.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_066.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_066.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_067.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_067.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_068.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_068.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_069.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_069.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_070.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_070.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_071.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_071.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_072.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_072.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_073.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_073.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_074.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_074.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_075.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_075.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_076.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_076.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_077.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_077.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_078.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_078.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_079.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_079.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_080.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_080.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_081.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_081.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_082.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_082.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_083.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_083.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_084.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_084.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_085.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_085.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_086.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_086.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_087.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_087.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_088.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_088.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_089.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_089.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_090.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_090.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_091.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_091.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_092.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_092.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_093.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_093.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_094.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_094.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_095.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_095.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_096.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_096.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_097.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_097.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_098.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_098.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_099.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_099.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_100.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_100.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_101.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_101.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_102.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_102.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_103.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_103.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_104.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_104.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_105.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_105.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_106.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_106.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_107.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_107.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_108.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_108.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_109.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_109.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_110.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_110.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_111.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_111.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_112.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_112.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_113.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_113.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_114.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_114.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_115.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_115.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_116.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_116.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_117.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_117.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_118.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_118.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_119.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_119.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_120.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_120.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_121.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_121.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_122.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_122.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_123.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_123.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_124.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_124.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_125.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_125.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_126.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_126.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_127.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_127.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_128.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_128.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_129.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_129.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_130.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_130.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_131.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_131.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_132.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/configurations/output/config_132.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_001.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_001.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_002.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_002.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_003.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_003.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_004.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_004.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_005.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_005.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_006.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_006.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_007.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_007.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_008.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_008.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_009.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_009.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_010.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_010.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_011.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_011.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_012.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/deprecations/output/config_012.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_001.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_001.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_002.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_002.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_003.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_003.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_004.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_004.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_005.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_application/output/config_005.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_001.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_001.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_002.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_002.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_003.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_003.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_004.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_004.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:

--- a/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_005.yml
+++ b/Tests/DependencyInjection/Compiler/fixtures/templates/overridden_by_entity/output/config_005.yml
@@ -238,17 +238,17 @@ easy_admin:
                         label: action.delete
                         css_class: 'text-danger action-delete'
                         icon: null
+                    new:
+                        name: new
+                        type: method
+                        label: action.new
+                        css_class: 'btn btn-primary action-new'
+                        icon: null
                     search:
                         name: search
                         type: method
                         label: action.search
                         css_class: ' action-search'
-                        icon: null
-                    new:
-                        name: new
-                        type: method
-                        label: action.new
-                        css_class: ' action-new'
                         icon: null
             new:
                 fields:


### PR DESCRIPTION
The current `list.html.twig` template is the only one which still hardcoded some CSS classes. This changes make it work as expected in any case (removing any action, adding CSS classes to any action, etc.)
