### PR TITLE
Allow to translate field labels

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -1,5 +1,8 @@
 {% use "form_div_layout.html.twig" %}
 
+{# needed to force translation of labels #}
+{% set translation_domain = 'messages' %}
+
 {% block form_start -%}
     {% if 'easyadmin' == block_prefixes|slice(-2)|first %}
         {% set attr = attr|merge({
@@ -172,6 +175,8 @@
 {# Labels #}
 
 {% block form_label -%}
+    {# needed to force translation of labels #}
+    {% set translation_domain = 'messages' %}
     {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' control-label')|trim}) -%}
     {{- parent() -}}
 {%- endblock form_label %}
@@ -191,6 +196,9 @@
 {%- endblock radio_label %}
 
 {% block checkbox_radio_label %}
+    {# needed to force translation of labels #}
+    {% set translation_domain = 'messages' %}
+
     {# Do no display the label if widget is not defined in order to prevent double label rendering #}
     {% if widget is defined %}
         {% if required %}


### PR DESCRIPTION
This fixes the new bug reported in #933.

I've also updated the "EasyAdmin Demo Application" to show how we recommend to translate backends easily: https://github.com/javiereguiluz/easy-admin-demo/commit/3a07f064d7b6ceb145ec3552aa904dd89fed5a53

---

Every "missing translation" error is gone ... except for two weird errors:

![missing_translations](https://cloud.githubusercontent.com/assets/73419/13406837/dfeeb486-df25-11e5-9c2a-eec5d8516c32.png)

If I understand this right, an empty message is translated 9 times and there is no translation for it. And the second one is for the collection prototype.

**I don't know how to solve this. Any clues? Thanks!**
