### PR TITLE
Simplify integration with FOSRestBundle

### DIFF
--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -58,6 +58,8 @@ class RequestPostInitializeListener
             return;
         }
 
+        $this->request->setRequestFormat('html');
+
         $this->request->attributes->set('easyadmin', array(
             'entity' => $entity = $event->getArgument('entity'),
             'view' => $this->request->query->get('action', 'list'),


### PR DESCRIPTION
I've an scenario in which our Symfony app works only as an API and it only returns json. I'm using the FOSRestBundle, which is forced to return `json` only.

I have two exceptions, the NelmioAPIDoc paths, which works well out of the box, and the AdminBundle paths, which don't. This is because the FOSRestBundle forces the response content type **unless** is specified before.

I thought it would make sense to define the request format as html, since as far as I know the bundle always returns html. 

I don't know for sure if this can break something, let me know if this is ok.
