### PR TITLE
Setting the toggle navigation cookie for root path

### DIFF
--- a/Resources/public/javascript/easyadmin.js
+++ b/Resources/public/javascript/easyadmin.js
@@ -42,10 +42,10 @@ function toggleNavigation(collapsed) {
 
 function createPersistentCookie(name, value)
 {
-    document.cookie = encodeURIComponent(name) + "=" + encodeURIComponent(value) + "; expires=Fri, 31 Dec 9999 23:59:59 GMT";
+    document.cookie = encodeURIComponent(name) + "=" + encodeURIComponent(value) + "; path=/; expires=Fri, 31 Dec 9999 23:59:59 GMT";
 }
 
 function deleteCookie(name)
 {
-    document.cookie = encodeURIComponent(name) + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    document.cookie = encodeURIComponent(name) + "=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 }


### PR DESCRIPTION
This issue happens when we create a [Custom Dashboard as the Index Page of the Backend](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/Resources/doc/tutorials/tips-and-tricks.md#use-a-custom-dashboard-as-the-index-page-of-the-backend).

> The cookie path attribute is used to specify the subset of URLs in a domain for which the cookie is valid. If a cookie has already passed domain matching, then the pathname component of the URL is compared with the path attribute, and if there is a match, the cookie is considered valid and is sent along with the URL request. The path `/foo` would match `/foobar` and `/foo/bar.html`. The path `/` is the most general path.

Currently, if dashboard path is `/dashboard` the cookie path would be `/dashboard`, so this cookie will not be valid for the root request path `/`.
