### PR TITLE
Improve page titles for non-list views

### DIFF
--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -10,8 +10,10 @@
 {% block body_class 'edit edit-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
+{% spaceless %}
     {% set _default_title = 'edit.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
     {{ _entity_config.edit.title is defined ? _entity_config.edit.title|trans(_trans_parameters) : _default_title }}
+{% endspaceless %}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -91,17 +91,7 @@
 
                 <section class="content-header">
                 {% block content_header %}
-                    <div class="row">
-                        <div class="col-sm-5">
-                            <h1 class="title">{% block content_title %}{% endblock %}</h1>
-                        </div>
-
-                        <div class="col-sm-7">
-                            <div class="global-actions">
-                                {% block global_actions %}{% endblock %}
-                            </div>
-                        </div>
-                    </div>
+                    <h1 class="title">{% block content_title %}{% endblock %}</h1>
                 {% endblock content_header %}
                 </section>
 

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -28,14 +28,14 @@
 {% endblock %}
 
 {% set _content_title %}
-    {% spaceless %}
-        {% if 'search' == app.request.get('action') %}
-            {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
-        {% else %}
-            {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-            {{ _entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title }}
-        {% endif %}
-    {% endspaceless %}
+{% spaceless %}
+    {% if 'search' == app.request.get('action') %}
+        {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
+    {% else %}
+        {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+        {{ _entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title }}
+    {% endif %}
+{% endspaceless %}
 {% endset %}
 
 {% set _global_actions %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -93,7 +93,6 @@
     </div>
 {% endblock %}
 
-
 {% block main %}
     {% set _list_item_actions = easyadmin_get_actions_for_list_item(_entity_config.name) %}
 

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -27,6 +27,16 @@
     <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/bootstrap-toggle.min.css') }}">
 {% endblock %}
 
+{% set _content_title %}
+    {% spaceless %}
+        {% if 'search' == app.request.get('action') %}
+            {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
+        {% else %}
+            {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+            {{ _entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title }}
+        {% endif %}
+    {% endspaceless %}
+{% endset %}
 
 {% set _global_actions %}
     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
@@ -68,16 +78,7 @@
     {% endif %}
 {% endset %}
 
-{% set _content_title %}
-{% spaceless %}
-    {% if 'search' == app.request.get('action') %}
-        {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
-    {% else %}
-        {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-        {{ _entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title }}
-    {% endif %}
-{% endspaceless %}
-{% endset %}
+{% block page_title %}{{ _content_title }}{% endblock %}
 
 {% block content_header %}
     <div class="row">

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -27,16 +27,8 @@
     <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/bootstrap-toggle.min.css') }}">
 {% endblock %}
 
-{% block content_title %}
-    {% if 'search' == app.request.get('action') %}
-        {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
-    {% else %}
-        {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-        {{ _entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title }}
-    {% endif %}
-{% endblock %}
 
-{% block global_actions %}
+{% set _global_actions %}
     {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
         {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
 
@@ -74,7 +66,33 @@
             </div>
         {% endblock new_action %}
     {% endif %}
+{% endset %}
+
+{% set _content_title %}
+{% spaceless %}
+    {% if 'search' == app.request.get('action') %}
+        {{ 'search.page_title'|transchoice(count = paginator.nbResults, domain = 'EasyAdminBundle')|raw }}
+    {% else %}
+        {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+        {{ _entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title }}
+    {% endif %}
+{% endspaceless %}
+{% endset %}
+
+{% block content_header %}
+    <div class="row">
+        <div class="col-sm-5">
+            <h1 class="title">{{ _content_title }}</h1>
+        </div>
+
+        <div class="col-sm-7">
+            <div class="global-actions">
+                {{ _global_actions }}
+            </div>
+        </div>
+    </div>
 {% endblock %}
+
 
 {% block main %}
     {% set _list_item_actions = easyadmin_get_actions_for_list_item(_entity_config.name) %}

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -9,8 +9,10 @@
 {% block body_class 'new new-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
+{% spaceless %}
     {% set _default_title = 'new.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
     {{ _entity_config.new.title is defined ? _entity_config.new.title|trans(_trans_parameters) : _default_title }}
+{% endspaceless %}
 {% endblock %}
 
 {% block main %}

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -8,8 +8,10 @@
 {% block body_class 'show show-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
+{% spaceless %}
     {% set _default_title = 'show.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
     {{ _entity_config.show.title is defined ? _entity_config.show.title|trans(_trans_parameters) : _default_title }}
+{% endspaceless %}
 {% endblock %}
 
 {% block main %}


### PR DESCRIPTION
### Problem

The current layout treats all views in the same way, so it reserves a big part of the header section for "global actions", which are present in `list` view but no the other ones. This means for example that long titles look wrong in `edit`, `show` and `new` views:

![before_title](https://cloud.githubusercontent.com/assets/73419/13647905/83be4678-e636-11e5-9839-6e5718e33e0d.png)
### Solution

Let's reserve that "global actions" space just for the `list` view:

![after_title](https://cloud.githubusercontent.com/assets/73419/13647916/90f309fa-e636-11e5-9d47-ca5c8c3a642e.png)
