### PR TITLE
	Initialize the database fixtures for every test

### DIFF
--- a/Tests/Fixtures/AbstractTestCase.php
+++ b/Tests/Fixtures/AbstractTestCase.php
@@ -28,6 +28,7 @@ abstract class AbstractTestCase extends WebTestCase
     protected function setUp()
     {
         $this->initClient();
+        $this->initDatabase();
     }
 
     protected function tearDown()
@@ -38,6 +39,17 @@ abstract class AbstractTestCase extends WebTestCase
     protected function initClient(array $options = array())
     {
         $this->client = static::createClient($options);
+    }
+
+    /**
+     * It ensures that the database contains the original fixtures of the
+     * application. This way tests can modify its contents safely without
+     * interfering with subsequent tests.
+     */
+    protected function initDatabase()
+    {
+        $buildDir = __DIR__.'/../../build';
+        copy($buildDir.'/original_test.db', $buildDir.'/test.db');
     }
 
     /**

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -30,7 +30,8 @@ AnnotationRegistry::registerLoader(function ($class) use ($autoload) {
     return class_exists($class, false);
 });
 
-// Test Setup: remove files in the build/ directory
+// Test Setup: remove all the contents in the build/ directory
+// (PHP doesn't allow to delete direcctories unless they are empty)
 if (is_dir($buildDir = __DIR__.'/../build')) {
     $files = new RecursiveIteratorIterator(
         new RecursiveDirectoryIterator($buildDir, RecursiveDirectoryIterator::SKIP_DOTS),
@@ -59,5 +60,8 @@ $application->run($input, new NullOutput());
 // Load fixtures of the AppTestBundle
 $input = new ArrayInput(array('command' => 'doctrine:fixtures:load', '--no-interaction' => true, '--append' => true));
 $application->run($input, new NullOutput());
+
+// Make a copy of the original SQLite database to use a clean db in every test
+copy($buildDir.'/test.db', $buildDir.'/original_test.db');
 
 unset($input, $application);


### PR DESCRIPTION
To avoid side-effects such as the one suffered in #985, we now initialize the database fixtures for every test. This is very easy because we use SQLite and we just need to copy + overwrite a file.
