### PR TITLE
List action title bug

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -78,7 +78,7 @@
     {% endif %}
 {% endset %}
 
-{% block page_title %}{{ _content_title }}{% endblock %}
+{% block page_title %}{{ _content_title|striptags }}{% endblock %}
 
 {% block content_header %}
     <div class="row">


### PR DESCRIPTION
**List action(search) html output:**

```
<title><strong>1</strong> sonuç bulundu</title>
```
