### PR TITLE
Removed some deprecations

### DIFF
--- a/DataCollector/EasyAdminDataCollector.php
+++ b/DataCollector/EasyAdminDataCollector.php
@@ -36,15 +36,15 @@ class EasyAdminDataCollector extends DataCollector
 
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
-        $backendConfiguration = $this->configurator->getBackendConfig();
+        $backendConfig = $this->configurator->getBackendConfig();
         $entityName = $request->query->get('entity', null);
-        $currentEntityConfiguration = array_key_exists($entityName, $backendConfiguration['entities']) ? $backendConfiguration['entities'][$entityName] : array();
+        $currentEntityConfig = array_key_exists($entityName, $backendConfig['entities']) ? $backendConfig['entities'][$entityName] : array();
 
         $this->data = array(
-            'num_entities' => count($backendConfiguration['entities']),
+            'num_entities' => count($backendConfig['entities']),
             'request_parameters' => $this->getEasyAdminParameters($request),
-            'current_entity_configuration' => $currentEntityConfiguration,
-            'backend_configuration' => $backendConfiguration,
+            'current_entity_configuration' => $currentEntityConfig,
+            'backend_configuration' => $backendConfig,
         );
     }
 
@@ -74,12 +74,12 @@ class EasyAdminDataCollector extends DataCollector
         return $this->data['request_parameters'];
     }
 
-    public function getCurrentEntityConfiguration()
+    public function getCurrentEntityConfig()
     {
         return $this->data['current_entity_configuration'];
     }
 
-    public function getBackendConfiguration()
+    public function getBackendConfig()
     {
         return $this->data['backend_configuration'];
     }

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -34,8 +34,8 @@ class EasyAdminExtension extends Extension
     {
         // process bundle's configuration parameters
         $configs = $this->processConfigFiles($configs);
-        $backendConfiguration = $this->processConfiguration(new Configuration(), $configs);
-        $container->setParameter('easyadmin.config', $backendConfiguration);
+        $backendConfig = $this->processConfiguration(new Configuration(), $configs);
+        $container->setParameter('easyadmin.config', $backendConfig);
 
         // load bundle's services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -50,7 +50,7 @@ class EasyAdminFormType extends AbstractType
     {
         $entity = $options['entity'];
         $view = $options['view'];
-        $entityConfig = $this->configurator->getEntityConfiguration($entity);
+        $entityConfig = $this->configurator->getEntityConfig($entity);
         $entityProperties = $entityConfig[$view]['fields'];
 
         foreach ($entityProperties as $name => $metadata) {
@@ -80,7 +80,7 @@ class EasyAdminFormType extends AbstractType
                 'allow_extra_fields' => true,
                 'data_class' => function (Options $options) use ($configurator) {
                     $entity = $options['entity'];
-                    $entityConfig = $configurator->getEntityConfiguration($entity);
+                    $entityConfig = $configurator->getEntityConfig($entity);
 
                     return $entityConfig['class'];
                 },

--- a/Tests/Configuration/ConfiguratorTest.php
+++ b/Tests/Configuration/ConfiguratorTest.php
@@ -33,7 +33,7 @@ class ConfiguratorTest extends \PHPUnit_Framework_TestCase
     {
         $backendConfig = array('easy_admin' => null);
         $configurator = new Configurator($backendConfig, new PropertyAccessor());
-        $configurator->getEntityConfiguration('TestEntity');
+        $configurator->getEntityConfig('TestEntity');
     }
 
     /**
@@ -44,7 +44,7 @@ class ConfiguratorTest extends \PHPUnit_Framework_TestCase
     {
         $backendConfig = array('easy_admin' => array('entities' => array('AppBundle\\Entity\\TestEntity')));
         $configurator = new Configurator($backendConfig, new PropertyAccessor());
-        $configurator->getEntityConfiguration('UnmanagedEntity');
+        $configurator->getEntityConfig('UnmanagedEntity');
     }
 }
 

--- a/Tests/DataCollector/EasyAdminDataCollectorTest.php
+++ b/Tests/DataCollector/EasyAdminDataCollectorTest.php
@@ -48,11 +48,11 @@ class EasyAdminDataCollectorTest extends AbstractTestCase
         );
         $this->assertEquals($parameters, $collector->getRequestParameters());
 
-        $currentConfiguration = $collector->getCurrentEntityConfiguration();
+        $currentConfiguration = $collector->getCurrentEntityConfig();
         $this->assertEquals('Category', $currentConfiguration['name']);
 
-        $backendConfiguration = $collector->getBackendConfiguration();
-        $this->assertCount(5, $backendConfiguration['entities']);
+        $backendConfig = $collector->getBackendConfig();
+        $this->assertCount(5, $backendConfig['entities']);
     }
 
     public function testCollectorInformationForEditView()
@@ -72,11 +72,11 @@ class EasyAdminDataCollectorTest extends AbstractTestCase
         );
         $this->assertEquals($parameters, $collector->getRequestParameters());
 
-        $currentConfiguration = $collector->getCurrentEntityConfiguration();
+        $currentConfiguration = $collector->getCurrentEntityConfig();
         $this->assertEquals('Category', $currentConfiguration['name']);
 
-        $backendConfiguration = $collector->getBackendConfiguration();
-        $this->assertCount(5, $backendConfiguration['entities']);
+        $backendConfig = $collector->getBackendConfig();
+        $this->assertCount(5, $backendConfig['entities']);
     }
 
     /**

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -79,7 +79,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
     public function getEntityConfiguration($entityName)
     {
         return null !== $this->getBackendConfiguration('entities.'.$entityName)
-            ? $this->configurator->getEntityConfiguration($entityName)
+            ? $this->configurator->getEntityConfig($entityName)
             : null;
     }
 
@@ -98,7 +98,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
      */
     public function renderEntityField(\Twig_Environment $twig, $view, $entityName, $item, array $fieldMetadata)
     {
-        $entityConfiguration = $this->configurator->getEntityConfiguration($entityName);
+        $entityConfiguration = $this->configurator->getEntityConfig($entityName);
         $fieldName = $fieldMetadata['property'];
 
         try {


### PR DESCRIPTION
This is a minor change.
- Configurator::getEntityConfiguration() is deprecated by Configurator::getEntityConfig()
- Changed some variables called `$xxxConfiguration` to `$xxxConfig` (we did this in
  most of the code before, but there were some occurrences left)
