### PR TITLE
Compile commonly used classes

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -42,10 +42,22 @@ class EasyAdminExtension extends Extension
         $loader->load('services.xml');
         $loader->load('form.xml');
 
-        // Don't register our exception listener if debug is enabled
+        // don't register our exception listener if debug is enabled
         if ($container->getParameter('kernel.debug')) {
             $container->removeDefinition('easyadmin.listener.exception');
         }
+
+        // compile commonly used classes
+        $this->addClassesToCompile(array(
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\EasyAdminBundle',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Controller\\AdminController',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Event\\EasyAdminEvents',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Configuration\\Configurator',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\EventListener\\RequestPostInitializeListener',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Form\\Extension\EasyAdminExtension',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Twig\\EasyAdminTwigExtension',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\EventListener\\ExceptionListener',
+        ));
 
         $this->ensureBackwardCompatibility($container);
     }


### PR DESCRIPTION
This fixes #997.

In this PR I've only added the 8 classes that are loaded in all EasyAdmin pages. In new/form there are more classes loaded.

---

Performance profiling for the `list` view shows that indeed less classes are loaded:

![metrics](https://cloud.githubusercontent.com/assets/73419/13825715/2e2578ca-ebb4-11e5-89e7-1040864a52ad.png)

But EasyAdmin is already quite fast, so users won't perceive any real difference:

![difference](https://cloud.githubusercontent.com/assets/73419/13825744/582d481e-ebb4-11e5-8b62-6d656fb4fd28.png)

---

Should we include this change or it's better to forget about this "improvement"?
