### PR TITLE
Fixed missing translation "Delete"

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -698,7 +698,7 @@ class AdminController extends Controller
         ;
 
         $submitButtonType = $this->useLegacyFormComponent() ? 'submit' : 'Symfony\\Component\\Form\\Extension\\Core\\Type\\SubmitType';
-        $formBuilder->add('submit', $submitButtonType, array('label' => 'Delete'));
+        $formBuilder->add('submit', $submitButtonType, array('label' => 'delete_modal.action', 'translation_domain' => 'EasyAdminBundle'));
 
         return $formBuilder->getForm();
     }


### PR DESCRIPTION
Even though this button is hidden in the delete form, the debug bar is always reporting for missing translations and it's a bit annoying.
