### PR TITLE
Fixed wrong translation key (label vs name)

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -1,5 +1,5 @@
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _trans_parameters = { '%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans } %}
+{% set _trans_parameters = { '%entity_name%': _entity_config.label|trans, '%entity_label%': _entity_config.label|trans } %}
 
 {% extends _entity_config.templates.layout %}
 


### PR DESCRIPTION
It's me again for another missing translation. I'm not using the default EasyAdmin translation strategy (entity name as default translation key) and i'm defining all my labels. This one is not translated correctly.
