### PR TITLE
Fixed a problem where the search engine returned all entities

### DIFF
--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -12,7 +12,6 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Search;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
 
@@ -89,11 +88,6 @@ class QueryBuilder
                 // adding '0' turns the string into a numeric value
                 $queryParameters['exact_query'] = 0 + $searchQuery;
             } elseif ($isTextField) {
-                // PostgreSQL doesn't allow to search string values in non-string columns
-                if ($databaseIsPostgreSql) {
-                    continue;
-                }
-
                 $queryBuilder->orWhere(sprintf('entity.%s LIKE :fuzzy_query', $name));
                 $queryParameters['fuzzy_query'] = '%'.$searchQuery.'%';
 
@@ -111,21 +105,5 @@ class QueryBuilder
         }
 
         return $queryBuilder;
-    }
-
-    /**
-     * Returns true if the data of the given entity are stored in a database
-     * of type PostgreSQL.
-     *
-     * @param string $entityClass
-     *
-     * @return bool
-     */
-    private function isPostgreSqlPlatform($entityClass)
-    {
-        /** @var EntityManager */
-        $em = $this->doctrine->getManagerForClass($entityClass);
-
-        return $em->getConnection()->getDatabasePlatform() instanceof PostgreSqlPlatform;
     }
 }

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -76,8 +76,6 @@ class QueryBuilder
             ->from($entityConfig['class'], 'entity')
         ;
 
-        $databaseIsPostgreSql = $this->isPostgreSqlPlatform($entityConfig['class']);
-
         $queryParameters = array();
         foreach ($entityConfig['search']['fields'] as $name => $metadata) {
             $isNumericField = in_array($metadata['dataType'], array('integer', 'number', 'smallint', 'bigint', 'decimal', 'float'));

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -84,18 +84,18 @@ class QueryBuilder
             $isNumericField = in_array($metadata['dataType'], array('integer', 'number', 'smallint', 'bigint', 'decimal', 'float'));
             $isTextField = in_array($metadata['dataType'], array('string', 'text', 'guid'));
 
-            if (is_numeric($searchQuery) && $isNumericField) {
+            if ($isNumericField && is_numeric($searchQuery)) {
                 $queryBuilder->orWhere(sprintf('entity.%s = :exact_query', $name));
                 // adding '0' turns the string into a numeric value
                 $queryParameters['exact_query'] = 0 + $searchQuery;
             } elseif ($isTextField) {
-                $queryBuilder->orWhere(sprintf('entity.%s LIKE :fuzzy_query', $name));
-                $queryParameters['fuzzy_query'] = '%'.$searchQuery.'%';
-            } else {
                 // PostgreSQL doesn't allow to search string values in non-string columns
                 if ($databaseIsPostgreSql) {
                     continue;
                 }
+
+                $queryBuilder->orWhere(sprintf('entity.%s LIKE :fuzzy_query', $name));
+                $queryParameters['fuzzy_query'] = '%'.$searchQuery.'%';
 
                 $queryBuilder->orWhere(sprintf('entity.%s IN (:words_query)', $name));
                 $queryParameters['words_query'] = explode(' ', $searchQuery);


### PR DESCRIPTION
In some cases, search engine didn't work and returned all entities instead of the ones matching the search conditions. After debugging the queries performed in those cases, I found that it was related to using text-based queries with non-text based columns. The proposed fix worked for me (I've only tested it with MySQL and SQLite though).

Some people commented this problem too in some issue comment, but I lost the reference to it. I'm sorry.
