### PR TITLE
do not compile the bundle class

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -49,7 +49,6 @@ class EasyAdminExtension extends Extension
 
         // compile commonly used classes
         $this->addClassesToCompile(array(
-            'JavierEguiluz\\Bundle\\EasyAdminBundle\\EasyAdminBundle',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\Controller\\AdminController',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\Event\\EasyAdminEvents',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\Configuration\\Configurator',


### PR DESCRIPTION
Adding the bundle class to the list of compiled classes breaks locating bundle resources (due to how the `getPath()` method is implemented in the base `Bundle` class in the HttpKernel component: https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Bundle/Bundle.php#L119-L127).

This fixes #1027.
