### PR TITLE
Add a new `search_form` block in list

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -45,21 +45,23 @@
         {% block search_action %}
             <div class="form-action {{ _action.css_class|default('') }}">
                 <form method="get" action="{{ path('easyadmin') }}">
-                    <input type="hidden" name="action" value="search">
-                    <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
-                    <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
-                    <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
-                    <input type="hidden" name="menuIndex" value="{{ _request_parameters.menuIndex }}">
-                    <input type="hidden" name="submenuIndex" value="{{ _request_parameters.submenuIndex }}">
-                    <div class="input-group">
-                        <input class="form-control" type="search" name="query" value="{{ app.request.get('query')|default('') }}">
-                        <span class="input-group-btn">
-                            <button class="btn" type="submit">
-                                <i class="fa fa-search"></i>
-                                <span class="hidden-xs hidden-sm">{{ _action.label|default('action.search')|trans(_trans_parameters) }}</span>
-                            </button>
-                        </span>
-                    </div>
+                    {% block search_form %}
+                        <input type="hidden" name="action" value="search">
+                        <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
+                        <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
+                        <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
+                        <input type="hidden" name="menuIndex" value="{{ _request_parameters.menuIndex }}">
+                        <input type="hidden" name="submenuIndex" value="{{ _request_parameters.submenuIndex }}">
+                        <div class="input-group">
+                            <input class="form-control" type="search" name="query" value="{{ app.request.get('query')|default('') }}">
+                            <span class="input-group-btn">
+                                <button class="btn" type="submit">
+                                    <i class="fa fa-search"></i>
+                                    <span class="hidden-xs hidden-sm">{{ _action.label|default('action.search')|trans(_trans_parameters) }}</span>
+                                </button>
+                            </span>
+                        </div>
+                    {% endblock %}
                 </form>
             </div>
         {% endblock search_action %}


### PR DESCRIPTION
I wish there were a block like this because now if we need to customize the `search` action by adding custom form inputs (like a simple date range or related-entity search), we have to copy/paste the whole form.

As I find copy/pasting to be wrong, adding a simple block here allows things like this:

``` twig
{% block search_form %}
    <div class="input-group">
        <select name="category">
            <option value="">-- Filter by category --</option>
            {% for category in categories %}<option value="{{ category.id }}">{{ category }}</option>{% endfor %}
        </select>
    </div>
{% endblock %}
```

And add the `categories` collection in the `searchAction` manually, or with a twig extension.

What do you think?
