### PR TITLE
Updated the list of classes to compile

### DIFF
--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -49,7 +49,6 @@ class EasyAdminExtension extends Extension
 
         // compile commonly used classes
         $this->addClassesToCompile(array(
-            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Controller\\AdminController',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\Event\\EasyAdminEvents',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\Configuration\\Configurator',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\EventListener\\RequestPostInitializeListener',

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -49,12 +49,14 @@ class EasyAdminExtension extends Extension
 
         // compile commonly used classes
         $this->addClassesToCompile(array(
-            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Event\\EasyAdminEvents',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\Configuration\\Configurator',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Event\\EasyAdminEvents',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\EventListener\\ExceptionListener',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\EventListener\\RequestPostInitializeListener',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\Form\\Extension\EasyAdminExtension',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Search\\Paginator',
+            'JavierEguiluz\\Bundle\\EasyAdminBundle\\Search\\QueryBuilder',
             'JavierEguiluz\\Bundle\\EasyAdminBundle\\Twig\\EasyAdminTwigExtension',
-            'JavierEguiluz\\Bundle\\EasyAdminBundle\\EventListener\\ExceptionListener',
         ));
 
         $this->ensureBackwardCompatibility($container);


### PR DESCRIPTION
- Removed `AdminController` class because it contains annotations (and `addClassesToCompile()` doesn't work for annotations).
- Added the two newly introduced classes related to Search
