### PR TITLE
Improved the styles of the checkbox in vertical forms

### DIFF
--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -396,6 +396,12 @@ button.btn:active {
 {% endif %}
 }
 
+/* Field: checkbox
+   ------------------------------------------------------------------------- */
+form:not(.form-horizontal) .field-checkbox label {
+    padding-top: 23px;
+}
+
 /* Field: collection
    ------------------------------------------------------------------------- */
 .field-collection .collection-empty {


### PR DESCRIPTION
When using the `vertical` form styles, checkboxes look unaligned vertically because they don't have a label like the other fields (see `Published` form field):

![before_checkbox](https://cloud.githubusercontent.com/assets/73419/14046754/a73dccc6-f2a3-11e5-9b81-c96d3f154b8f.png)

This PR adds a top padding to align everything as expected:

![adter_checkbox](https://cloud.githubusercontent.com/assets/73419/14046765/b37be766-f2a3-11e5-825d-f62019e05534.png)

---

A question for Symfony wizards: the CSS selector is `form:not(.form-horizontal)` instead of `.form-vertical` because I don't know how to make horizontal forms include `.form-horizontal` class and vertical forms include `.form-vertical` (there is an inheritance between horizontal and vertical form themes).
