### PR TITLE
Trigger jQuery event on item add/delete in CollectionType

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -27,7 +27,9 @@
             if (event.preventDefault) event.preventDefault(); else event.returnValue = false;
 
             var containerDiv = $('#{{ id }}').parents('.form-group:first');
+            var parentDiv = containerDiv.parents('[data-prototype]:first');
             containerDiv.remove();
+            parentDiv.trigger('easyadmin.collection.item-deleted');
             });
         {% endset %}
 
@@ -265,7 +267,7 @@
                     .replace(/{{ name }}\]\[__name__\]/g, '{{ name }}][' + numItems + ']')
                 ;
 
-                collection.append(newItem);
+                collection.append(newItem).trigger('easyadmin.collection.item-added');
             });
         {% endset %}
 


### PR DESCRIPTION
This pull request is to add the feature explained in #1046 

The events triggered are:

```
'easyadmin.collection.item-added': when item is added to collection.
'easyadmin.collection.item-deleted': when item is removed from collection.
```

The user can associate to jQuery events with something like this:
`$('.field-collection [data-prototype]').on('easyadmin.collection.item-added, easyadmin.collection.item-deleted', function() {...});`
