### PR TITLE
Insert empty label when all elements in collection are removed

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -344,6 +344,8 @@
 {%- block form_widget_compound -%}
     {% if value is empty %}
         {{ block('empty_collection') }}
+    {% endif %}
+    {% if value is empty or form.vars.prototype is defined %}
         {% set attr = attr|merge({'data-empty-collection': block('empty_collection') }) %}
     {% endif %}
 

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -28,6 +28,10 @@
 
             var containerDiv = $('#{{ id }}').parents('.form-group:first');
             containerDiv.remove();
+            
+            if (0 == parentDiv.children().length && 'undefined' !== parentDiv.attr('data-empty-collection')) {
+                $(parentDiv.attr('data-empty-collection')).insertBefore(parentDiv);
+            }
             });
         {% endset %}
 
@@ -339,13 +343,18 @@
 
 {%- block form_widget_compound -%}
     {% if value is empty %}
-        <div class="empty collection-empty">
-            <span class="label label-empty">{{ 'label.empty'|trans({}, 'EasyAdminBundle') }}</span>
-        </div>
+        {{ block('empty_collection') }}
+        {% set attr = attr|merge({'data-empty-collection': block('empty_collection') }) %}
     {% endif %}
 
     {{ parent() }}
 {%- endblock form_widget_compound -%}
+
+{% block empty_collection %}
+    <div class="empty collection-empty">
+        <span class="label label-empty">{{ 'label.empty'|trans({}, 'EasyAdminBundle') }}</span>
+    </div>
+{% endblock empty_collection %}
 
 {% block vich_file_widget %}
 {% spaceless %}


### PR DESCRIPTION
Actually when all items are removed from a collection the 'empty label' disappears:
![before](https://cloud.githubusercontent.com/assets/4667395/14121141/7e891b2c-f5f6-11e5-968e-24e456234255.gif)

in this pull request I defined the 'empty_label' as a block, render it as before and set as data-attribute in collection. The remove javascript function check if there is no children in collection and data-attribute is defined and if is true, insert it:
![after](https://cloud.githubusercontent.com/assets/4667395/14121362/6f2187d6-f5f7-11e5-8085-617777598f1c.gif)
