### PR TITLE
Show 'empty_label' when all the elements of a collection are removed

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -27,6 +27,10 @@
             var parentDiv = containerDiv.parents('[data-prototype]:first');
             containerDiv.remove();
             parentDiv.trigger('easyadmin.collection.item-deleted');
+            
+            if (0 == parentDiv.children().length && 'undefined' !== parentDiv.attr('data-empty-collection')) {
+                $(parentDiv.attr('data-empty-collection')).insertBefore(parentDiv);
+            }
             });
         {% endset %}
 
@@ -330,13 +334,20 @@
 
 {%- block form_widget_compound -%}
     {% if value is empty %}
-        <div class="empty collection-empty">
-            <span class="label label-empty">{{ 'label.empty'|trans({}, 'EasyAdminBundle') }}</span>
-        </div>
+        {{ block('empty_collection') }}
+    {% endif %}
+    {% if value is empty or form.vars.prototype is defined %}
+        {% set attr = attr|merge({'data-empty-collection': block('empty_collection') }) %}
     {% endif %}
 
     {{ parent() }}
 {%- endblock form_widget_compound -%}
+
+{% block empty_collection %}
+    <div class="empty collection-empty">
+        <span class="label label-empty">{{ 'label.empty'|trans({}, 'EasyAdminBundle') }}</span>
+    </div>
+{% endblock empty_collection %}
 
 {% block vich_file_widget %}
 {% spaceless %}


### PR DESCRIPTION
Fix pull request #1049 
