### PR TITLE
Removed the _easyadmin_render_css route

### DIFF
--- a/Configuration/DesignConfigPass.php
+++ b/Configuration/DesignConfigPass.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
+
+/**
+ * Processes the custom CSS styles applied to the backend design based on the
+ * value of the design configuration options.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class DesignConfigPass implements ConfigPassInterface
+{
+    /** @var \Twig_Environment */
+    private $twig;
+
+    public function __construct()
+    {
+        // it's not possible to inject the 'twig' service because it's synthetic
+        $loader = new \Twig_Loader_Filesystem(__DIR__.'/../Resources/views/css');
+        $this->twig = new \Twig_Environment($loader);
+    }
+
+    public function process(array $backendConfig)
+    {
+        $backendConfig = $this->processCustomCss($backendConfig);
+
+        return $backendConfig;
+    }
+
+    private function processCustomCss(array $backendConfig)
+    {
+        $customCssContent = $this->twig->render('easyadmin.css.twig', array(
+            'brand_color' => $backendConfig['design']['brand_color'],
+            'color_scheme' => $backendConfig['design']['color_scheme'],
+        ));
+
+        // this avoids Symfony interpreting '%' used in CSS properties as container parameters
+        $escapedCustomCssContent = str_replace('%', '%%', $customCssContent);
+
+        $backendConfig['_internal']['custom_css'] = $escapedCustomCssContent;
+
+        return $backendConfig;
+    }
+}

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -72,30 +72,6 @@ class AdminController extends Controller
     }
 
     /**
-     * It renders the main CSS applied to the backend design. This controller
-     * allows to generate dynamic CSS files that use variables without the need
-     * to set up a CSS preprocessing toolchain.
-     *
-     * @Route("/_css/easyadmin.css", name="_easyadmin_render_css")
-     *
-     * @return Response
-     */
-    public function renderCssAction()
-    {
-        $config = $this->container->getParameter('easyadmin.config');
-
-        $cssContent = $this->renderView('@EasyAdmin/css/easyadmin.css.twig', array(
-            'brand_color' => $config['design']['brand_color'],
-            'color_scheme' => $config['design']['color_scheme'],
-        ));
-
-        return Response::create($cssContent, 200, array('Content-Type' => 'text/css'))
-            ->setPublic()
-            ->setSharedMaxAge(600)
-            ;
-    }
-
-    /**
      * Utility method which initializes the configuration of the entity on which
      * the user is performing the action.
      *
@@ -731,5 +707,17 @@ class AdminController extends Controller
             : $this->get('router')->generate($homepageConfig['route'], $homepageConfig['params']);
 
         return $this->redirect($url);
+    }
+
+    /**
+     * It renders the main CSS applied to the backend design. This controller
+     * allows to generate dynamic CSS files that use variables without the need
+     * to set up a CSS preprocessing toolchain.
+     *
+     * @return null
+     * @deprecated The CSS styles are no longer rendered at runtime but preprocessed during container compilation. Use the $container['easyadmin.config']['_internal']['custom_css'] variable instead.
+     */
+    public function renderCssAction()
+    {
     }
 }

--- a/DependencyInjection/Compiler/EasyAdminConfigurationPass.php
+++ b/DependencyInjection/Compiler/EasyAdminConfigurationPass.php
@@ -13,6 +13,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\DependencyInjection\Compiler;
 
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ActionConfigPass;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\DefaultConfigPass;
+use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\DesignConfigPass;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\MenuConfigPass;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\MetadataConfigPass;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\NormalizerConfigPass;
@@ -36,6 +37,7 @@ class EasyAdminConfigurationPass implements CompilerPassInterface
 
         $configPasses = array(
             new NormalizerConfigPass(),
+            new DesignConfigPass(),
             new MenuConfigPass(),
             new ActionConfigPass(),
             new MetadataConfigPass($container->get('doctrine')),

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -13,7 +13,9 @@
             <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/font-awesome.min.css') }}">
             <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/adminlte.min.css') }}">
             <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/featherlight.min.css') }}">
-            <link rel="stylesheet" href="{{ path('_easyadmin_render_css') }}">
+            <style>
+                {{ easyadmin_config('_internal.custom_css')|raw }}
+            </style>
         {% endblock %}
 
         {% for css_asset in easyadmin_config('design.assets.css') %}

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -49,7 +49,6 @@ class DefaultBackendTest extends AbstractTestCase
             '/bundles/easyadmin/stylesheet/font-awesome.min.css',
             '/bundles/easyadmin/stylesheet/adminlte.min.css',
             '/bundles/easyadmin/stylesheet/featherlight.min.css',
-            '/admin/_css/easyadmin.css',
         );
 
         $crawler = $this->getBackendHomepage();
@@ -89,11 +88,10 @@ class DefaultBackendTest extends AbstractTestCase
         }
     }
 
-    public function testAdminCssFile()
+    public function testCustomCssFile()
     {
-        $this->client->request('GET', '/admin/_css/easyadmin.css');
+        $this->getBackendHomepage();
 
-        $this->assertEquals('text/css; charset=UTF-8', $this->client->getResponse()->headers->get('Content-Type'));
         $this->assertEquals(13, substr_count($this->client->getResponse()->getContent(), '#205081'), 'The admin.css file uses the default brand color.');
         // #222222 color is only used by the "dark" color scheme, not the "light" one
         $this->assertEquals(7, substr_count($this->client->getResponse()->getContent(), '#222222'), 'The admin.css file uses the dark color scheme.');

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -97,6 +97,16 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertEquals(7, substr_count($this->client->getResponse()->getContent(), '#222222'), 'The admin.css file uses the dark color scheme.');
     }
 
+    public function testCustomCssProperty()
+    {
+        $this->getBackendHomepage();
+        $customCssContent = $this->client->getContainer()->getParameter('easyadmin.config');
+
+        $this->assertEquals(13, substr_count($customCssContent['_internal']['custom_css'], '#205081'), 'The generated custom CSS uses the default brand color.');
+        // #222222 color is only used by the "dark" color scheme, not the "light" one
+        $this->assertEquals(7, substr_count($customCssContent['_internal']['custom_css'], '#222222'), 'The generated custom CSS uses the dark color scheme.');
+    }
+
     public function testListViewTitle()
     {
         $crawler = $this->requestListView();

--- a/Tests/DependencyInjection/Compiler/EasyAdminConfigurationPassTest.php
+++ b/Tests/DependencyInjection/Compiler/EasyAdminConfigurationPassTest.php
@@ -37,7 +37,9 @@ class EasyAdminConfigurationPassTest extends \PHPUnit_Framework_TestCase
         $expectedConfiguration = Yaml::parse(file_get_contents($expectedConfigFile));
         $actualConfiguration = $container->getParameter('easyadmin.config');
 
-        $this->assertEquals($expectedConfiguration['easy_admin'], $actualConfiguration);
+        // 'assertEquals()' is not used because storing the full processed backend
+        // configuration would make fixtures too big
+        $this->assertArraySubset($expectedConfiguration['easy_admin'], $actualConfiguration);
     }
 
     public function provideConfigurationFiles()

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,8 +15,17 @@ Upgrade to 2.0.0 (XX/XXX/2016)
    In order to upgrade, you just need to replace `admin` by `easyadmin` in all
    `path()`, `generateUrl()` and `redirectToRoute()` calls.
 
-Upgrade to 1.11.6 (XX/XXX/2016)
+Upgrade to 1.12.5 (XX/XXX/2016)
 -------------------------------
+
+ * The `renderCssAction()` method of the AdminController has been deprecated and
+   its associated route `@Route("/_css/easyadmin.css", name="_easyadmin_render_css")`
+   has been removed. The custom CSS now is preprocessed during container compilation
+   and the result is stored in the `_internal.custom_css` option of the processed
+   backend configuration.
+
+Upgrade to 1.11.6 (26/February/2016)
+------------------------------------
 
  * `findBy()` and `createSearchQueryBuilder()` methods now receive two new
    parameters called `$sortField` and `$sortDirection` to allow sorting the


### PR DESCRIPTION
### Problem
- I'm very worried because some people have reported in #998 some horrible errors related to CSS.
- I can't debug that error in any way and the information provided by those users is not enough for me.
### Solution
- Let's remove the route that serves the custom CSS contents and let's rethink everything.
- Custom CSS never changes, so generating it for every request is absurd.
- Let's process those contents during container compilation and save them for later reuse.
- The custom CSS is now saved in the `custom_css` property under the special `_internal` property of the backend config. the `_internal` name clearly shows that this is something internal for the bundle and you should never touch that.
