### PR TITLE
Allow to translate the "Are you sure?" message showed in forms

### DIFF
--- a/Resources/translations/EasyAdminBundle.en.xlf
+++ b/Resources/translations/EasyAdminBundle.en.xlf
@@ -139,6 +139,10 @@
                 <source>errors</source>
                 <target>Error|Errors</target>
             </trans-unit>
+            <trans-unit id="form.are_you_sure">
+                <source>form.are_you_sure</source>
+                <target>You haven't saved the changes made on this form.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/EasyAdminBundle.es.xlf
+++ b/Resources/translations/EasyAdminBundle.es.xlf
@@ -139,6 +139,10 @@
                 <source>errors</source>
                 <target>Error|Errores</target>
             </trans-unit>
+            <trans-unit id="form.are_you_sure">
+                <source>form.are_you_sure</source>
+                <target>No has guardado los cambios realizados en este formulario.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/EasyAdminBundle.eu.xlf
+++ b/Resources/translations/EasyAdminBundle.eu.xlf
@@ -135,6 +135,10 @@
                 <source>errors</source>
                 <target>Errore|Erroreak</target>
             </trans-unit>
+            <trans-unit id="form.are_you_sure">
+                <source>form.are_you_sure</source>
+                <target>Formularioen aldaketak ez dituzu gorde.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -47,7 +47,7 @@
 
     <script type="text/javascript">
         $(function() {
-            $('.edit-form').areYouSure({ 'message': 'You haven\'t saved the changes made on this form.' });
+            $('.edit-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans(_trans_parameters, 'EasyAdminBundle')|e('js') }}' });
 
             $('.form-actions').easyAdminSticky();
 

--- a/Resources/views/default/edit.html.twig
+++ b/Resources/views/default/edit.html.twig
@@ -47,7 +47,7 @@
 
     <script type="text/javascript">
         $(function() {
-            $('.edit-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans(_trans_parameters, 'EasyAdminBundle')|e('js') }}' });
+            $('.edit-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans({}, 'EasyAdminBundle')|e('js') }}' });
 
             $('.form-actions').easyAdminSticky();
 

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -36,7 +36,7 @@
 
     <script type="text/javascript">
         $(function() {
-            $('.new-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans(_trans_parameters, 'EasyAdminBundle')|e('js') }}' });
+            $('.new-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans({}, 'EasyAdminBundle')|e('js') }}' });
 
             $('.form-actions').easyAdminSticky();
 

--- a/Resources/views/default/new.html.twig
+++ b/Resources/views/default/new.html.twig
@@ -36,7 +36,7 @@
 
     <script type="text/javascript">
         $(function() {
-            $('.new-form').areYouSure({ 'message': 'You haven\'t saved the changes made on this form.' });
+            $('.new-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans(_trans_parameters, 'EasyAdminBundle')|e('js') }}' });
 
             $('.form-actions').easyAdminSticky();
 


### PR DESCRIPTION
This fixes #1053.
