### PR TITLE
Improved how the sticky form actions are displayed in "dev" environment

### DIFF
--- a/Configuration/DesignConfigPass.php
+++ b/Configuration/DesignConfigPass.php
@@ -21,9 +21,12 @@ class DesignConfigPass implements ConfigPassInterface
 {
     /** @var \Twig_Environment */
     private $twig;
+    private $kernelDebug;
 
-    public function __construct()
+    public function __construct($kernelDebug)
     {
+        $this->kernelDebug = $kernelDebug;
+
         // it's not possible to inject the 'twig' service because it's synthetic
         $loader = new \Twig_Loader_Filesystem(__DIR__.'/../Resources/views/css');
         $this->twig = new \Twig_Environment($loader);
@@ -41,6 +44,7 @@ class DesignConfigPass implements ConfigPassInterface
         $customCssContent = $this->twig->render('easyadmin.css.twig', array(
             'brand_color' => $backendConfig['design']['brand_color'],
             'color_scheme' => $backendConfig['design']['color_scheme'],
+            'kernel_debug' => $this->kernelDebug,
         ));
 
         // this avoids Symfony interpreting '%' used in CSS properties as container parameters

--- a/DependencyInjection/Compiler/EasyAdminConfigurationPass.php
+++ b/DependencyInjection/Compiler/EasyAdminConfigurationPass.php
@@ -37,7 +37,7 @@ class EasyAdminConfigurationPass implements CompilerPassInterface
 
         $configPasses = array(
             new NormalizerConfigPass(),
-            new DesignConfigPass(),
+            new DesignConfigPass($container->getParameter('kernel.debug')),
             new MenuConfigPass(),
             new ActionConfigPass(),
             new MetadataConfigPass($container->get('doctrine')),

--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -390,7 +390,7 @@ button.btn:active {
 {% endif %}
     height: 52px;
     padding-top: 10px;
-{% if app.environment|default('prod') == 'dev' %}
+{% if kernel_debug|default(false) %}
     height: 85px;
     padding-bottom: 45px;
 {% endif %}


### PR DESCRIPTION
This feature worked before, but the recent CSS management refactorization broke it.
