### PR TITLE
Reorganise docs about third-party bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,15 @@ read before using EasyAdmin.
   * [How to translate the backend](Resources/doc/tutorials/i18n.md)
   * [How to define custom actions](Resources/doc/tutorials/custom-actions.md)
   * [How to define custom options for entity properties](Resources/doc/tutorials/custom-property-options.md)
-  * [How to integrate FOSUserBundle to manage users](Resources/doc/tutorials/fosuserbundle-integration.md)
-  * [How to use a WYSIWYG editor](Resources/doc/tutorials/wysiwyg-editor.md)
-  * [How to upload files and images](Resources/doc/tutorials/upload-files-and-images.md)
-  * [How To integrate FOSRestBundle and EasyAdmin](Resources/doc/tutorials/fosrestbundle-integration.md)
   * [How to manage configuration for complex backends](Resources/doc/tutorials/complex-backend-config.md)
   * [Tips and tricks](Resources/doc/tutorials/tips-and-tricks.md)
+
+#### Third-party bundles/services integrations
+
+  * [How to upload files and images with VichUploaderBundle](Resources/doc/tutorials/upload-files-and-images.md)
+  * [How to integrate FOSUserBundle to manage users](Resources/doc/tutorials/fosuserbundle-integration.md)
+  * [How to use a WYSIWYG editor with IvoryCKEditorBundle](Resources/doc/tutorials/wysiwyg-editor.md)
+  * [How To integrate FOSRestBundle and EasyAdmin](Resources/doc/tutorials/fosrestbundle-integration.md)
 
 > **❮ NOTE ❯** you are reading the documentation of the bundle's **development**
 > version. You can also [read the documentation of the latest stable version ➜]


### PR DESCRIPTION
Hey guys, I've been so busy that I had no time to see the awesome features you added :+1: (especially removing the css route :+1: ).

I was wondering (again, I think it's the 10th time :stuck_out_tongue_winking_eye: ) about reordering some links in the documentation.

As some of these tutorials are mostly about other bundles, I propose a specific category for them, adding the name of the bundle when it's not specified (for CKEditor and file upload).

What do you think?
