### PR TITLE
List: Changed the _global_actions var to a block

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -33,48 +33,6 @@
 {% endspaceless %}
 {% endset %}
 
-{% set _global_actions %}
-    {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
-        {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
-
-        {% block search_action %}
-            <div class="form-action {{ _action.css_class|default('') }}">
-                <form method="get" action="{{ path('easyadmin') }}">
-                    {% block search_form %}
-                        <input type="hidden" name="action" value="search">
-                        <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
-                        <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
-                        <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
-                        <input type="hidden" name="menuIndex" value="{{ _request_parameters.menuIndex }}">
-                        <input type="hidden" name="submenuIndex" value="{{ _request_parameters.submenuIndex }}">
-                        <div class="input-group">
-                            <input class="form-control" type="search" name="query" value="{{ app.request.get('query')|default('') }}">
-                            <span class="input-group-btn">
-                                <button class="btn" type="submit">
-                                    <i class="fa fa-search"></i>
-                                    <span class="hidden-xs hidden-sm">{{ _action.label|default('action.search')|trans(_trans_parameters) }}</span>
-                                </button>
-                            </span>
-                        </div>
-                    {% endblock %}
-                </form>
-            </div>
-        {% endblock search_action %}
-    {% endif %}
-
-    {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
-        {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
-        {% block new_action %}
-            <div class="button-action">
-                <a class="{{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
-                    {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
-                    {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
-                </a>
-            </div>
-        {% endblock new_action %}
-    {% endif %}
-{% endset %}
-
 {% block page_title %}{{ _content_title|striptags }}{% endblock %}
 
 {% block content_header %}
@@ -85,11 +43,51 @@
 
         <div class="col-sm-7">
             <div class="global-actions">
-                {{ _global_actions }}
+                {% block global_actions %}
+                    {% if easyadmin_action_is_enabled_for_list_view('search', _entity_config.name) %}
+                        {% set _action = easyadmin_get_action_for_list_view('search', _entity_config.name) %}
+
+                        {% block search_action %}
+                            <div class="form-action {{ _action.css_class|default('') }}">
+                                <form method="get" action="{{ path('easyadmin') }}">
+                                    {% block search_form %}
+                                        <input type="hidden" name="action" value="search">
+                                        <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
+                                        <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
+                                        <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
+                                        <input type="hidden" name="menuIndex" value="{{ _request_parameters.menuIndex }}">
+                                        <input type="hidden" name="submenuIndex" value="{{ _request_parameters.submenuIndex }}">
+                                        <div class="input-group">
+                                            <input class="form-control" type="search" name="query" value="{{ app.request.get('query')|default('') }}">
+                                            <span class="input-group-btn">
+                                                <button class="btn" type="submit">
+                                                    <i class="fa fa-search"></i>
+                                                    <span class="hidden-xs hidden-sm">{{ _action.label|default('action.search')|trans(_trans_parameters) }}</span>
+                                                </button>
+                                            </span>
+                                        </div>
+                                    {% endblock %}
+                                </form>
+                            </div>
+                        {% endblock search_action %}
+                    {% endif %}
+
+                    {% if easyadmin_action_is_enabled_for_list_view('new', _entity_config.name) %}
+                        {% set _action = easyadmin_get_action_for_list_view('new', _entity_config.name) %}
+                        {% block new_action %}
+                            <div class="button-action">
+                                <a class="{{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}">
+                                    {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
+                                    {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
+                                </a>
+                            </div>
+                        {% endblock new_action %}
+                    {% endif %}
+                {% endblock global_actions %}
             </div>
         </div>
     </div>
-{% endblock %}
+{% endblock content_header %}
 
 {% block main %}
     {% set _list_item_actions = easyadmin_get_actions_for_list_item(_entity_config.name) %}


### PR DESCRIPTION
Actually this var was quite problematic to one of my backends, and I clearly don't understand why it wasn't transformed to a block earlier... @javiereguiluz any idea about why it was a variable instead of a block?

By the way, if you want to simplify your code review, I just copy/pasted the `set` tag and replaced it with a `block` tag (and added some tag names in the `endblock` tags to simplify template readability).

Plus, it adds much more override flexibility because one now can override all blocks AND this block, so one could absolutely refactor the whole list view just with this new block.

What do you think?
