### PR TITLE
Documented how to release new versions of this bundle

### DIFF
--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -2,18 +2,19 @@ How to release a new EasyAdmin version
 ======================================
 
 1. Update the value of the `EasyAdminBundle::VERSION` constant (in the
-   `EasyAdminBundle.php` file). Example: change `1.12.6-DEV` to `1.12.6`
+   `EasyAdminBundle.php` file) to remove the `-DEV` suffix and prepare the
+   stable release. Example: change `1.12.6-DEV` to `1.12.6`
 2. Update the version number in the `README.md` link that points to the stable
-   version documentation.
-3. Create the tag and sign it. Example: `git tag -s v1.12.6` (use the version
-   number without the leading `v` as the tag comment).
+   version documentation. Example: change `1.12.5` to `1.12.6`
+3. Create the tag and sign it. Example: `git tag -s v1.12.6` (the tag version is
+   always prefixed with `v`, but remove it for the tag comment: `1.12.6`).
 4. Push the tag to GitHub. Example: `git push origin v1.12.6`
 5. Prepare the changelog of the new version with the custom `changelog` Git
    command. Example: `git changelog v1.12.5` (the version passed to the command
-   is the previous version used as a reference to detect the changes).
+   is the previous version used as a reference to list the changes).
 6. Got to https://github.com/javiereguiluz/EasyAdminBundle/releases and click
-   on `Draft a new release`. Select the tag pushed before and paste the changelog
-   contents.
+   on `Draft a new release`. Select the tag pushed before and paste the
+   changelog contents.
 7. Update again the value of the `EasyAdminBundle::VERSION` constant to start
    the development of the next version. Example: change `1.12.6` to `1.12.7-DEV`
 

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -1,0 +1,24 @@
+How to release a new EasyAdmin version
+======================================
+
+1. Update the value of the `EasyAdminBundle::VERSION` constant (in the
+   `EasyAdminBundle.php` file).
+2. Update the version number in the `README.md` link that points to the stable
+   version documentation.
+3. Create the tag and sign it. Example: `git tag -s v1.12.6` (use the version
+   number without the leading `v` as the tag comment).
+4. Push the tag to GitHub. Example: `git push origin v1.12.6`
+5. Prepare the changelog of the new version with the custom `changelog` Git
+   command. Example: `git changelog v1.12.5` (the version passed to the command
+   is the previous version used as a reference to detect the changes).
+6. Got to https://github.com/javiereguiluz/EasyAdminBundle/releases and click
+   on `Draft a new release`. Select the tag pushed before and paste the changelog
+   contents.
+
+Resources
+---------
+
+The custom `changelog` Git command used to generate the version changelog can
+be defined as a global Git alias:
+
+    $ git config --global alias.changelog "!f() { git log $1...$2 --pretty=format:'[%h] %s' --reverse; } ; f"

--- a/.github/RELEASE_CHECKLIST.md
+++ b/.github/RELEASE_CHECKLIST.md
@@ -2,7 +2,7 @@ How to release a new EasyAdmin version
 ======================================
 
 1. Update the value of the `EasyAdminBundle::VERSION` constant (in the
-   `EasyAdminBundle.php` file).
+   `EasyAdminBundle.php` file). Example: change `1.12.6-DEV` to `1.12.6`
 2. Update the version number in the `README.md` link that points to the stable
    version documentation.
 3. Create the tag and sign it. Example: `git tag -s v1.12.6` (use the version
@@ -14,6 +14,8 @@ How to release a new EasyAdmin version
 6. Got to https://github.com/javiereguiluz/EasyAdminBundle/releases and click
    on `Draft a new release`. Select the tag pushed before and paste the changelog
    contents.
+7. Update again the value of the `EasyAdminBundle::VERSION` constant to start
+   the development of the next version. Example: change `1.12.6` to `1.12.7-DEV`
 
 Resources
 ---------


### PR DESCRIPTION
This is an internal document so I don't forget any step when releasing a new version of the bundle.

---

I decided to write this because the recent GPG key verification introduced by GitHub added a new step to the release process. By the way, starting from `1.12.6` version, all of them will be signed:

![github_verified](https://cloud.githubusercontent.com/assets/73419/14571733/252d0fcc-034b-11e6-9753-97d7b4111987.png)
