### PR TITLE
Improved the behavior of the search engine when the query is empty

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -355,6 +355,14 @@ class AdminController extends Controller
     {
         $this->dispatch(EasyAdminEvents::PRE_SEARCH);
 
+        // if the search query is empty, redirect to the 'list' action
+        if ('' === trim($this->request->query->get('query'))) {
+            $queryParameters = array_replace($this->request->query->all(), array('action' => 'list', 'query' => null));
+            $queryParameters = array_filter($queryParameters);
+
+            return $this->redirect($this->get('router')->generate('easyadmin', $queryParameters));
+        }
+
         $searchableFields = $this->entity['search']['fields'];
         $paginator = $this->findBy($this->entity['class'], $this->request->query->get('query'), $searchableFields, $this->request->query->get('page', 1), $this->config['list']['max_results'], $this->request->query->get('sortField'), $this->request->query->get('sortDirection'));
         $fields = $this->entity['list']['fields'];

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -506,6 +506,29 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertEquals('<strong>200</strong> results found', trim($crawler->filter('h1.title')->html()), 'The visible content contains HTML tags.');
     }
 
+    /**
+     * @dataProvider provideEmptyQueries
+     */
+    public function testSearchViewEmptyQuery($emptyQuery)
+    {
+        $this->getBackendPage(array(
+            'action' => 'search',
+            'entity' => 'Category',
+            'query' => $emptyQuery,
+        ));
+
+        $this->assertEquals(302, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('/admin/?action=list&entity=Category&sortField=id&sortDirection=DESC', $this->client->getResponse()->headers->get('location'));
+    }
+
+    public function provideEmptyQueries()
+    {
+        return array(
+            array(''),
+            array('     '),
+        );
+    }
+
     public function testSearchViewTableIdColumn()
     {
         $crawler = $this->requestSearchView();


### PR DESCRIPTION
This fixes #612. When the search query is empty, redirect to the `list` action.
