### PR TITLE
Updated the behavior of empty searches

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -356,7 +356,7 @@ class AdminController extends Controller
         $this->dispatch(EasyAdminEvents::PRE_SEARCH);
 
         // if the search query is empty, redirect to the 'list' action
-        if ('' === trim($this->request->query->get('query'))) {
+        if ('' === $this->request->query->get('query')) {
             $queryParameters = array_replace($this->request->query->all(), array('action' => 'list', 'query' => null));
             $queryParameters = array_filter($queryParameters);
 

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -506,27 +506,26 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertEquals('<strong>200</strong> results found', trim($crawler->filter('h1.title')->html()), 'The visible content contains HTML tags.');
     }
 
-    /**
-     * @dataProvider provideEmptyQueries
-     */
-    public function testSearchViewEmptyQuery($emptyQuery)
+    public function testSearchViewEmptyQuery()
     {
+        // empty queries redirect to "list" action
         $this->getBackendPage(array(
             'action' => 'search',
             'entity' => 'Category',
-            'query' => $emptyQuery,
+            'query' => '',
         ));
 
         $this->assertEquals(302, $this->client->getResponse()->getStatusCode());
         $this->assertEquals('/admin/?action=list&entity=Category&sortField=id&sortDirection=DESC', $this->client->getResponse()->headers->get('location'));
-    }
 
-    public function provideEmptyQueries()
-    {
-        return array(
-            array(''),
-            array('     '),
-        );
+        // pseudo-empty queries (e.g. strings which only contain white spaces) don't redirect to "list" action
+        $crawler = $this->getBackendPage(array(
+            'action' => 'search',
+            'entity' => 'Category',
+            'query' => '    ',
+        ));
+
+        $this->assertEquals('No results found', $crawler->filter('h1.title')->text());
     }
 
     public function testSearchViewTableIdColumn()


### PR DESCRIPTION
New behavior:
- If the query is really an empty string, redirect to "list"
- If the query is empty because it just contains white spaces, don't treat it in a special way (before we redirected it to "list" too)
