### PR TITLE
Search and ajax autocomplete for related entities are now case insensitive

### DIFF
--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -82,14 +82,16 @@ class QueryBuilder
             $isTextField = in_array($metadata['dataType'], array('string', 'text', 'guid'));
 
             if ($isNumericField && is_numeric($searchQuery)) {
-                $queryBuilder->orWhere(sprintf('entity.%s = :exact_query', $name));
+                $queryBuilder->orWhere(sprintf('LOWER(entity.%s) = :exact_query', $name));
                 // adding '0' turns the string into a numeric value
                 $queryParameters['exact_query'] = 0 + $searchQuery;
             } elseif ($isTextField) {
-                $queryBuilder->orWhere(sprintf('entity.%s LIKE :fuzzy_query', $name));
+                $searchQuery = strtolower($searchQuery);
+                
+                $queryBuilder->orWhere(sprintf('LOWER(entity.%s) LIKE :fuzzy_query', $name));
                 $queryParameters['fuzzy_query'] = '%'.$searchQuery.'%';
 
-                $queryBuilder->orWhere(sprintf('entity.%s IN (:words_query)', $name));
+                $queryBuilder->orWhere(sprintf('LOWER(entity.%s) IN (:words_query)', $name));
                 $queryParameters['words_query'] = explode(' ', $searchQuery);
             }
         }

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -82,12 +82,12 @@ class QueryBuilder
             $isTextField = in_array($metadata['dataType'], array('string', 'text', 'guid'));
 
             if ($isNumericField && is_numeric($searchQuery)) {
-                $queryBuilder->orWhere(sprintf('LOWER(entity.%s) = :exact_query', $name));
+                $queryBuilder->orWhere(sprintf('entity.%s = :exact_query', $name));
                 // adding '0' turns the string into a numeric value
                 $queryParameters['exact_query'] = 0 + $searchQuery;
             } elseif ($isTextField) {
                 $searchQuery = strtolower($searchQuery);
-                
+
                 $queryBuilder->orWhere(sprintf('LOWER(entity.%s) LIKE :fuzzy_query', $name));
                 $queryParameters['fuzzy_query'] = '%'.$searchQuery.'%';
 


### PR DESCRIPTION
I modified the search query builder to make it case insensitive. When case sensitive, the search and autocomplete features are almost unusable.

Your thoughts about it ?
