### PR TITLE
Added the new @Event annotation

### DIFF
--- a/Event/EasyAdminEvents.php
+++ b/Event/EasyAdminEvents.php
@@ -17,32 +17,54 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Event;
 final class EasyAdminEvents
 {
     // Events related to initialization
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_INITIALIZE = 'easy_admin.pre_initialize';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_INITIALIZE = 'easy_admin.post_initialize';
 
     // Events related to backend views
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_DELETE = 'easy_admin.pre_delete';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_DELETE = 'easy_admin.post_delete';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_EDIT = 'easy_admin.pre_edit';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_EDIT = 'easy_admin.post_edit';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_LIST = 'easy_admin.pre_list';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_LIST = 'easy_admin.post_list';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_NEW = 'easy_admin.pre_new';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_NEW = 'easy_admin.post_new';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_SEARCH = 'easy_admin.pre_search';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_SEARCH = 'easy_admin.post_search';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_SHOW = 'easy_admin.pre_show';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_SHOW = 'easy_admin.post_show';
 
     // Events related to Doctrine entities
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_PERSIST = 'easy_admin.pre_persist';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_PERSIST = 'easy_admin.post_persist';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_UPDATE = 'easy_admin.pre_update';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_UPDATE = 'easy_admin.post_update';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const PRE_REMOVE = 'easy_admin.pre_remove';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_REMOVE = 'easy_admin.post_remove';
 
     // Events related to Doctrine Query Builder usage
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_LIST_QUERY_BUILDER = 'easy_admin.post_list_query_builder';
+    /** @Event("Symfony\Component\EventDispatcher\GenericEvent") */
     const POST_SEARCH_QUERY_BUILDER = 'easy_admin.post_search_query_builder';
 }


### PR DESCRIPTION
@Haehnchen, the author of the PHPStorm Symfony plugin, has introduced a new `@Event` annotation in Symfony code (https://github.com/symfony/symfony/pull/18685) He's also updating some bundles (e.g. https://github.com/liip/LiipImagineBundle/pull/732) so we could do the same.

In our case this info is not critical because we always use the same generic event object, but still it's a little nice addition.
