### PR TITLE
Do not exclude more recent Doctrine Cache versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php"                           : ">=5.3.0",
-        "doctrine/cache"                : "1.5.x",
+        "doctrine/cache"                : "~1.5",
         "doctrine/common"               : "^2.4.0",
         "doctrine/doctrine-bundle"      : "~1.2",
         "doctrine/orm"                  : "~2.3",


### PR DESCRIPTION
Let Composer decide which version of the Doctrine Cache is the one
fitting the user's requirements.

This fixes #1144.
