### PR TITLE
Documented the "sortable" config option

### DIFF
--- a/Resources/doc/book/3-list-search-show-configuration.md
+++ b/Resources/doc/book/3-list-search-show-configuration.md
@@ -176,6 +176,13 @@ These are the options that you can define for each field:
     * Any of the custom EasyAdmin types: `image`, `toggle`, `raw` (they are
       explained later in this chapter).
 
+The fields of the `list` and `search` views define another option:
+
+  * `sortable` (optional): if `true` the backend allows to sort results by this
+    property. All properties are *sortable* by default except virtual properties
+    (explained later in this chapter) and those related with associations of any
+    type (one-to-*, *-to-one, *-to-many).
+
 The fields of the `show` view define another two options:
 
   * `help` (optional): the help message displayed below the field contents.

--- a/Resources/doc/book/3-list-search-show-configuration.md
+++ b/Resources/doc/book/3-list-search-show-configuration.md
@@ -179,9 +179,9 @@ These are the options that you can define for each field:
 The fields of the `list` and `search` views define another option:
 
   * `sortable` (optional): if `true` the backend allows to sort results by this
-    property. All properties are *sortable* by default except virtual properties
-    (explained later in this chapter) and those related with associations of any
-    type (one-to-*, *-to-one, *-to-many).
+    property. Set it to `false` to disable sorting. All properties are *sortable*
+    by default except virtual properties (explained later in this chapter) and
+    those related with associations of any type (one-to-*, *-to-one, *-to-many).
 
 The fields of the `show` view define another two options:
 

--- a/Resources/doc/book/3-list-search-show-configuration.md
+++ b/Resources/doc/book/3-list-search-show-configuration.md
@@ -179,9 +179,9 @@ These are the options that you can define for each field:
 The fields of the `list` and `search` views define another option:
 
   * `sortable` (optional): if `true` the backend allows to sort results by this
-    property. Set it to `false` to disable sorting. All properties are *sortable*
+    property; set it to `false` to disable sorting. All properties are *sortable*
     by default except virtual properties (explained later in this chapter) and
-    those related with associations of any type (one-to-*, *-to-one, *-to-many).
+    those related with Doctrine associations of any type.
 
 The fields of the `show` view define another two options:
 


### PR DESCRIPTION
The other day I was trying to help someone on StackOverflow: http://stackoverflow.com/q/36985324/2804294  I failed doing that ... but the guy who asked the question provided a clever answer related to the `sortable` config option. It wasn't documented because it was sort of "private" config option ... but let's make it a regular config option.
