### PR TITLE
Fixed the label of autocomplete fields

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -464,4 +464,4 @@
     })|raw })}) }}
 
     {{ form_errors(form.autocomplete) }}
-{% endblock easyadmin_autocomplete_widget %}
+{% endblock easyadmin_autocomplete_row %}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -455,11 +455,13 @@
 
 {# EasyAdminAutocomplete form type #}
 {% block easyadmin_autocomplete_widget %}
-    {# display the form row, but don't display its label #}
-    {{ form_row(form.autocomplete, { label: false, attr: attr|merge({ 'data-easyadmin-autocomplete-url' : path('easyadmin', {
+    {# display the form widget, but don't display its label #}
+    {{ form_widget(form.autocomplete, { attr: attr|merge({ 'data-easyadmin-autocomplete-url' : path('easyadmin', {
         action: 'autocomplete',
         entity: easyadmin.entity.name,
         property: easyadmin.field.fieldName,
         view: easyadmin.view
     })|raw })}) }}
+
+    {{ form_errors(form.autocomplete) }}
 {% endblock easyadmin_autocomplete_widget %}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -454,7 +454,7 @@
 {% endblock easyadmin_widget %}
 
 {# EasyAdminAutocomplete form type #}
-{% block easyadmin_autocomplete_widget %}
+{% block easyadmin_autocomplete_row %}
     {# display the form widget, but don't display its label #}
     {{ form_widget(form.autocomplete, { attr: attr|merge({ 'data-easyadmin-autocomplete-url' : path('easyadmin', {
         action: 'autocomplete',


### PR DESCRIPTION
This fixes #1129.

I've tried to solve this problem in a better way, but I can't. Somehow, our `label: false` setting is turned into `label: null` and I can't trace where this happens (more info here: https://github.com/javiereguiluz/EasyAdminBundle/issues/1129#issuecomment-217548679).
