### PR TITLE
Fixed the highlighting of menu subitems

### DIFF
--- a/Resources/views/default/menu.html.twig
+++ b/Resources/views/default/menu.html.twig
@@ -37,7 +37,7 @@
                 {% if item.children|default([]) is not empty %}
                     <ul class="treeview-menu">
                         {% for subitem in item.children %}
-                            <li class="{{ subitem.type == 'divider' ? 'header' }} {{ app.request.query.get('submenuIndex')|default(-1) == loop.index0 ? 'active' }}">
+                            <li class="{{ subitem.type == 'divider' ? 'header' }} {{ app.request.query.get('menuIndex')|default(-1) == loop.parent.loop.index0 and app.request.query.get('submenuIndex')|default(-1) == loop.index0 ? 'active' }}">
                                 {{ helper.render_menu_item(subitem) }}
                             </li>
                         {% endfor %}


### PR DESCRIPTION
If you selected an element of a submenu, every item at the same position in any submenu was highlighted too. This bug was discovered by @ktrzos in this comment: https://github.com/javiereguiluz/EasyAdminBundle/pull/1127#issuecomment-217631136
