### PR TITLE
Allow to apply CSS classes to listing elements

### DIFF
--- a/Configuration/PropertyConfigPass.php
+++ b/Configuration/PropertyConfigPass.php
@@ -22,6 +22,8 @@ class PropertyConfigPass implements ConfigPassInterface
     private $defaultEntityFieldConfig = array(
         // CSS class or classes applied to form field
         'css_class' => '',
+        // CSS class or classes applied to form field's header
+        'header_css_class' => '',
         // date/time/datetime/number format applied to form field value
         'format' => null,
         // form field help message

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -133,7 +133,7 @@
                         {% set isSortingField = metadata.property == app.request.get('sortField') %}
                         {% set _column_label =  (metadata.label ?: field|humanize)|trans(_trans_parameters)  %}
 
-                        <td data-label="{{ _column_label }}" class="{{ isSortingField ? 'sorted' }} {{ metadata.dataType|lower }}">
+                        <td data-label="{{ _column_label }}" class="{{ isSortingField ? 'sorted' }} {{ metadata.dataType|lower }} {{ metadata.css_class }}">
                             {{ easyadmin_render_field_for_list_view(_entity_config.name, item, metadata) }}
                         </td>
                     {% endfor %}

--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -103,7 +103,7 @@
                     {% set _column_label = (metadata.label ?: field|humanize)|trans(_trans_parameters) %}
                     {% set _column_icon = isSortingField ? (nextSortDirection == 'DESC' ? 'fa-caret-up' : 'fa-caret-down') : 'fa-sort' %}
 
-                    <th data-property-name="{{ metadata.property }}" class="{{ isSortingField ? 'sorted' }} {{ metadata.virtual ? 'virtual' }} {{ metadata.dataType|lower }}">
+                    <th data-property-name="{{ metadata.property }}" class="{{ isSortingField ? 'sorted' }} {{ metadata.virtual ? 'virtual' }} {{ metadata.dataType|lower }} {{ metadata.header_css_class }}">
                         {% if metadata.sortable %}
                             <a href="{{ path('easyadmin', _request_parameters|merge({ sortField: metadata.property, sortDirection: nextSortDirection })) }}">
                                 <i class="fa {{ _column_icon }}"></i>


### PR DESCRIPTION
This fixes #1166.

Added `{{ metadata.css_class }}` to Resources/views/default/list.html.twig.
