### PR TITLE
Changed visibility of properties and methods from private to protected

### DIFF
--- a/Configuration/ActionConfigPass.php
+++ b/Configuration/ActionConfigPass.php
@@ -19,8 +19,8 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
  */
 class ActionConfigPass implements ConfigPassInterface
 {
-    private $views = array('edit', 'list', 'new', 'show');
-    private $defaultActionConfig = array(
+    protected $views = array('edit', 'list', 'new', 'show');
+    protected $defaultActionConfig = array(
         // either the name of a controller method or an application route (it depends on the 'type' option)
         'name' => null,
         // 'method' if the action is a controller method; 'route' if it's an application route
@@ -44,7 +44,7 @@ class ActionConfigPass implements ConfigPassInterface
         return $backendConfig;
     }
 
-    private function processDisabledActions(array $backendConfig)
+    protected function processDisabledActions(array $backendConfig)
     {
         $actionsDisabledByBackend = $backendConfig['disabled_actions'];
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
@@ -79,7 +79,7 @@ class ActionConfigPass implements ConfigPassInterface
      *
      * @return array
      */
-    private function normalizeActionsConfig(array $backendConfig)
+    protected function normalizeActionsConfig(array $backendConfig)
     {
         // first, normalize actions defined globally for the entire backend
         foreach ($this->views as $view) {
@@ -104,7 +104,7 @@ class ActionConfigPass implements ConfigPassInterface
         return $backendConfig;
     }
 
-    private function doNormalizeActionsConfig(array $actionsConfig, $errorOrigin = '')
+    protected function doNormalizeActionsConfig(array $actionsConfig, $errorOrigin = '')
     {
         $normalizedConfig = array();
 
@@ -149,7 +149,7 @@ class ActionConfigPass implements ConfigPassInterface
      *
      * @return array
      */
-    private function doNormalizeDefaultActionsConfig(array $actionsConfig, $view)
+    protected function doNormalizeDefaultActionsConfig(array $actionsConfig, $view)
     {
         $defaultActionsConfig = $this->getDefaultActionsConfig($view);
 
@@ -164,7 +164,7 @@ class ActionConfigPass implements ConfigPassInterface
         return $actionsConfig;
     }
 
-    private function resolveActionInheritance(array $backendConfig)
+    protected function resolveActionInheritance(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
             foreach ($this->views as $view) {
@@ -196,7 +196,7 @@ class ActionConfigPass implements ConfigPassInterface
      *
      * @return array
      */
-    private function filterRemovedActions(array $backendConfig)
+    protected function filterRemovedActions(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
             foreach ($this->views as $view) {
@@ -219,7 +219,7 @@ class ActionConfigPass implements ConfigPassInterface
         return $backendConfig;
     }
 
-    private function processActionsConfig(array $backendConfig)
+    protected function processActionsConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
             foreach ($this->views as $view) {
@@ -254,7 +254,7 @@ class ActionConfigPass implements ConfigPassInterface
      *
      * @return array
      */
-    private function getDefaultActionsConfig($view)
+    protected function getDefaultActionsConfig($view)
     {
         $actions = $this->doNormalizeActionsConfig(array(
             'delete' => array('name' => 'delete', 'label' => 'action.delete', 'icon' => 'trash-o', 'css_class' => 'btn btn-default'),
@@ -286,7 +286,7 @@ class ActionConfigPass implements ConfigPassInterface
      *
      * @return array
      */
-    private function getDefaultActions($view)
+    protected function getDefaultActions($view)
     {
         $defaultActions = array();
         $defaultActionsConfig = $this->getDefaultActionsConfig($view);
@@ -313,7 +313,7 @@ class ActionConfigPass implements ConfigPassInterface
      *
      * @return bool
      */
-    private function isValidMethodName($name)
+    protected function isValidMethodName($name)
     {
         return 0 !== preg_match('/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$/', $name);
     }
@@ -326,12 +326,12 @@ class ActionConfigPass implements ConfigPassInterface
      *
      * @return string
      */
-    private function humanizeString($content)
+    protected function humanizeString($content)
     {
         return ucfirst(trim(strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $content))));
     }
 
-    private function reorderArrayItems(array $originalArray, array $newKeyOrder)
+    protected function reorderArrayItems(array $originalArray, array $newKeyOrder)
     {
         $newArray = array();
         foreach ($newKeyOrder as $key) {

--- a/Configuration/ConfigManager.php
+++ b/Configuration/ConfigManager.php
@@ -22,9 +22,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ConfigManager
 {
-    private $backendConfig;
+    protected $backendConfig;
     /** @var ContainerInterface */
-    private $container;
+    protected $container;
 
     public function __construct(ContainerInterface $container)
     {
@@ -156,7 +156,7 @@ class ConfigManager
      *
      * @return array
      */
-    private function processConfig()
+    protected function processConfig()
     {
         $originalBackendConfig = $this->container->getParameter('easyadmin.config');
 
@@ -183,7 +183,7 @@ class ConfigManager
      *
      * @return array
      */
-    private function doProcessConfig($backendConfig)
+    protected function doProcessConfig($backendConfig)
     {
         $configPasses = array(
             new NormalizerConfigPass(),

--- a/Configuration/MenuConfigPass.php
+++ b/Configuration/MenuConfigPass.php
@@ -54,7 +54,7 @@ class MenuConfigPass implements ConfigPassInterface
      *
      * @return array
      */
-    private function normalizeMenuConfig(array $menuConfig, array $backendConfig, $parentItemIndex = -1)
+    protected function normalizeMenuConfig(array $menuConfig, array $backendConfig, $parentItemIndex = -1)
     {
         // if the backend doesn't define the menu configuration: create a default
         // menu configuration to display all its entities
@@ -111,7 +111,7 @@ class MenuConfigPass implements ConfigPassInterface
         return $menuConfig;
     }
 
-    private function processMenuConfig(array $menuConfig, array $backendConfig, $parentItemIndex = -1)
+    protected function processMenuConfig(array $menuConfig, array $backendConfig, $parentItemIndex = -1)
     {
         foreach ($menuConfig as $i => $itemConfig) {
             // these options are needed to find the active menu/submenu item in the template


### PR DESCRIPTION
I propose this set of changes as they greatly simplify the implementation of security in EasyAdmin. Namely, it eases switching on following features only if user has right to access it:
- left menu menuitems  
- action links
- links on associations
