### PR TITLE
Fix route params in custom actions tutorial

### DIFF
--- a/Resources/doc/tutorials/custom-actions.md
+++ b/Resources/doc/tutorials/custom-actions.md
@@ -71,13 +71,13 @@ class AdminController extends BaseAdminController
 
         // redirect to the 'list' view of the given entity
         return $this->redirectToRoute('easyadmin', array(
-            'view' => 'list',
+            'action' => 'list',
             'entity' => $this->request->query->get('entity'),
         ));
 
         // redirect to the 'edit' view of the given entity item
         return $this->redirectToRoute('easyadmin', array(
-            'view' => 'edit',
+            'action' => 'edit',
             'id' => $id,
             'entity' => $this->request->query->get('entity'),
         ));
@@ -170,13 +170,13 @@ class ProductController extends Controller
 
         // redirect to the 'list' view of the given entity
         return $this->redirectToRoute('easyadmin', array(
-            'view' => 'list',
+            'action' => 'list',
             'entity' => $this->request->query->get('entity'),
         ));
 
         // redirect to the 'edit' view of the given entity item
         return $this->redirectToRoute('easyadmin', array(
-            'view' => 'edit',
+            'action' => 'edit',
             'id' => $id,
             'entity' => $this->request->query->get('entity'),
         ));


### PR DESCRIPTION
The route param is not called `view` but `action`, as defined in [AdminController](https://github.com/javiereguiluz/EasyAdminBundle/blob/master/Controller/AdminController.php#L67).
