### PR TITLE
Fixed missing "class" option in docs

### DIFF
--- a/Resources/doc/tutorials/fosuserbundle-integration.md
+++ b/Resources/doc/tutorials/fosuserbundle-integration.md
@@ -61,6 +61,7 @@ the same way you manage any property of any other entity:
 easy_admin:
     entities:
         User:
+            class: AppBundle\Entity\User
             form:
                 fields: ['enabled', 'username', 'email', 'roles', 'lastLogin']
 ```


### PR DESCRIPTION
Fixed missing "class" option in the FOSUser bundle tutorial.
