### PR TITLE
Disable xdebug before running composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ matrix:
 before_install:
   - if [[ "SYMFONY_VERSION" == "2.8.*" || "SYMFONY_VERSION" == "3.0.*" ]]; then export SYMFONY_DEPRECATIONS_HELPER="strict"; fi;
   - if [[ "$ENABLE_CODE_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
-  - composer selfupdate
-  - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-  - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
+  - php -d memory_limit=-1 composer selfupdate
+  - if [[ "$SYMFONY_VERSION" != "" ]]; then php -d memory_limit=-1 composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [[ "$TWIG_VERSION" != "" ]]; then php -d memory_limit=-1 composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
 
 install:
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,10 @@ matrix:
 
 before_install:
   - if [[ "SYMFONY_VERSION" == "2.8.*" || "SYMFONY_VERSION" == "3.0.*" ]]; then export SYMFONY_DEPRECATIONS_HELPER="strict"; fi;
+  - if [[ "$ENABLE_CODE_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
   - composer selfupdate
   - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
-  - if [[ "$ENABLE_CODE_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
 
 install:
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,12 @@ matrix:
     - env: ENABLE_CODE_COVERAGE="true"
 
 before_install:
+  - echo 'memory_limit=-1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - if [[ "SYMFONY_VERSION" == "2.8.*" || "SYMFONY_VERSION" == "3.0.*" ]]; then export SYMFONY_DEPRECATIONS_HELPER="strict"; fi;
   - if [[ "$ENABLE_CODE_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != hhvm ]]; then phpenv config-rm xdebug.ini; fi;
-  - php -d memory_limit=-1 composer selfupdate
-  - if [[ "$SYMFONY_VERSION" != "" ]]; then php -d memory_limit=-1 composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
-  - if [[ "$TWIG_VERSION" != "" ]]; then php -d memory_limit=-1 composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
+  - composer selfupdate
+  - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+  - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
 
 install:
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;


### PR DESCRIPTION
A few days ago Travis started failing for PHP 5.3 because of "out of memory" errors when running Composer update. Let's disable Xdebug _before_ running Composer commands and see if this bug disappears.
