### PR TITLE
Update EasyAdminBundle.pl.xlf

### DIFF
--- a/Resources/translations/EasyAdminBundle.pl.xlf
+++ b/Resources/translations/EasyAdminBundle.pl.xlf
@@ -107,6 +107,10 @@
             </trans-unit>
             
             <!-- misc. elements -->
+            <trans-unit id="toggle_navigation">
+                <source>toggle_navigation</source>
+                <target>Przełącz nawigację</target>
+            </trans-unit>
             <trans-unit id="delete_modal.title">
                 <source>delete_modal.title</source>
                 <target>Czy na pewno chcesz usunąć ten element?</target>
@@ -135,9 +139,13 @@
                 <source>errors</source>
                 <target>Błąd|Błędy</target>
             </trans-unit>
-            <trans-unit id="toggle_navigation">
-                <source>toggle_navigation</source>
-                <target>Przełącz nawigację</target>
+            <trans-unit id="form.are_you_sure">
+                <source>form.are_you_sure</source>
+                <target>Nie zapisano zmian wprowadzonych w tym formularzu.</target>
+            </trans-unit>
+            <trans-unit id="show.remaining_items">
+                <source>show.remaining_items</source>
+                <target><![CDATA[{1} pozostała jedna pozycja nie wyświetlona na tym listingu|{2,3,4} pozostały %count% pozycje nie wyświetlone na tym listingu|{5,21} pozostało %count% pozycji nie wyświetlonych na tym listingu|{22,Inf} liczba pozycji nie wyświetlonych na tym listingu: %count%]]></target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Added 2 missing translation units in Polish translation.

Please check correctness of show.remaining_items - either I did it incorrectly or there is mistake in English version:

```
<trans-unit id="show.remaining_items">
                <source>show.remaining_items</source>
                <target><![CDATA[{1} there is another item not displayed in this listing|]1,Inf] %count% other items are not displayed in this listing]]></target>
</trans-unit>
```

See that `]1,Inf]` - shouldn't it be: `{2,Inf}`?

Note that the Polish translation is hard as we have such declination:
- {1} pozycja
- {2,3,4} pozycje
- {5-21} pozycji
- {22-24} pozycje
- {25-31} pozycji
- {32-34} pozycje
  ...

So I decided to just specify the count after a colon for `%count% > 21`
