### PR TITLE
Fixed #1231 - Typos in translation

### DIFF
--- a/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/Resources/translations/EasyAdminBundle.fr.xlf
@@ -141,7 +141,7 @@
             </trans-unit>
             <trans-unit id="form.are_you_sure">
                 <source>form.are_you_sure</source>
-                <target>Vous n'avez pas sauvegardé vor modification.</target>
+                <target>Vous n'avez pas sauvegardé vos modifications.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Translations created here d1f4e57dca7cf32794cd8aa3cc632aecc2a63bb5 is wrong.
