### PR TITLE
Add a class to show.remaining_items's <li>

### DIFF
--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -16,7 +16,7 @@
 
                 {% set _remaining_items = value|length - easyadmin_config('show.max_results') %}
                 {% if _remaining_items > 0 %}
-                    <li>({{ 'show.remaining_items'|transchoice(count = _remaining_items, domain = 'EasyAdminBundle') }})</li>
+                    <li class="metainfo">({{ 'show.remaining_items'|transchoice(count = _remaining_items, domain = 'EasyAdminBundle') }})</li>
                 {% endif %}
             </ul>
         {% else %}

--- a/Resources/views/default/field_association.html.twig
+++ b/Resources/views/default/field_association.html.twig
@@ -16,7 +16,7 @@
 
                 {% set _remaining_items = value|length - easyadmin_config('show.max_results') %}
                 {% if _remaining_items > 0 %}
-                    <li class="metainfo">({{ 'show.remaining_items'|transchoice(count = _remaining_items, domain = 'EasyAdminBundle') }})</li>
+                    <li class="remaining-items">({{ 'show.remaining_items'|transchoice(count = _remaining_items, domain = 'EasyAdminBundle') }})</li>
                 {% endif %}
             </ul>
         {% else %}


### PR DESCRIPTION
to be able optionally style this item - for example, to disappear a bullet, make text smaller etc. The CSS class is named 'metainfo' because in future it could be reused in other places that deal with "information on data", not the field's data itself.
