### PR TITLE
Allow to use FrameworkExtraBundle 2.3 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/orm"                  : "~2.3",
         "pagerfanta/pagerfanta"         : "~1.0,>=1.0.1",
         "sensio/distribution-bundle"    : "~2.3|~3.0|~4.0|~5.0",
-        "sensio/framework-extra-bundle" : "~3.0,>=3.0.2",
+        "sensio/framework-extra-bundle" : "~2.3|~3.0,>=3.0.2",
         "symfony/config"                : "~2.3|~3.0",
         "symfony/dependency-injection"  : "~2.3|~3.0",
         "symfony/doctrine-bridge"       : "~2.3|~3.0",


### PR DESCRIPTION
Let's try to be less restrictive in the allowed versions. This fixes #1258.
