### PR TITLE
Avoid the same index multiple times in collections

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -254,7 +254,8 @@
                 if (event.preventDefault) event.preventDefault(); else event.returnValue = false;
 
                 var collection = $('#{{ id }}');
-                var numItems = collection.children('div.form-group').length;
+                // Use a counter to avoid having the same index more than once
+                var numItems = collection.data('count') || collection.children('div.form-group').length;
 
                 collection.prev('.collection-empty').remove();
 
@@ -263,6 +264,9 @@
                     .replace(/_{{ name }}___name__/g, '_{{ name }}_' + numItems)
                     .replace(/{{ name }}\]\[__name__\]/g, '{{ name }}][' + numItems + ']')
                 ;
+
+                // Increment the counter and store it in the collection
+                collection.data('count', ++numItems);
 
                 collection.append(newItem).trigger('easyadmin.collection.item-added');
             });


### PR DESCRIPTION
This will allow the index of items never to appear more than once in a collection when an item is removed at some position and a new one is added then.
