### PR TITLE
Fixed Autocomplete feature in embedded forms

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -139,8 +139,6 @@ class AdminController extends Controller
     {
         $results = $this->get('easyadmin.autocomplete')->find(
             $this->request->query->get('entity'),
-            $this->request->query->get('property'),
-            $this->request->query->get('view'),
             $this->request->query->get('query'),
             $this->request->query->get('page', 1)
         );

--- a/Form/EventListener/EasyAdminAutocompleteSubscriber.php
+++ b/Form/EventListener/EasyAdminAutocompleteSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Form\EventListener;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+class EasyAdminAutocompleteSubscriber implements EventSubscriberInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SET_DATA => 'preSetData',
+            FormEvents::PRE_SUBMIT => 'preSubmit',
+        );
+    }
+
+    public function preSetData(FormEvent $event)
+    {
+        $form = $event->getForm();
+        $data = $event->getData() ?: array();
+
+        $options = $form->getConfig()->getOptions();
+        $options['compound'] = false;
+        $options['choices'] = is_array($data) || $data instanceof \Traversable ? $data : array($data);
+
+        $form->add('autocomplete', LegacyFormHelper::getType('entity'), $options);
+    }
+
+    public function preSubmit(FormEvent $event)
+    {
+        $form = $event->getForm();
+
+        if (null === $data = $event->getData()) {
+            $data = array('autocomplete' => array());
+            $event->setData($data);
+        }
+
+        $options = $form->get('autocomplete')->getConfig()->getOptions();
+        $options['choices'] = $options['em']->getRepository($options['class'])->findBy(array(
+            $options['id_reader']->getIdField() => $data['autocomplete'],
+        ));
+
+        if (isset($options['choice_list'])) {
+            // clear choice list for SF < 3.0
+            $options['choice_list'] = null;
+        }
+
+        $form->add('autocomplete', LegacyFormHelper::getType('entity'), $options);
+    }
+}

--- a/Form/Type/EasyAdminAutocompleteType.php
+++ b/Form/Type/EasyAdminAutocompleteType.php
@@ -2,6 +2,8 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Form\Type;
 
+use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ConfigManager;
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use JavierEguiluz\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
@@ -20,6 +22,13 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class EasyAdminAutocompleteType extends AbstractType
 {
+    private $configManager;
+
+    public function __construct(ConfigManager $configManager)
+    {
+        $this->configManager = $configManager;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -81,6 +90,12 @@ class EasyAdminAutocompleteType extends AbstractType
      */
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
+        if (null === $config = $this->configManager->getEntityConfigByClass($options['class'])) {
+            throw new UndefinedEntityException(array('entity_name' => $options['class']));
+        }
+
+        $view->vars['autocomplete_entity_name'] = $config['name'];
+
         // Add a custom block prefix to inner field to ease theming:
         array_splice($view['autocomplete']->vars['block_prefixes'], -1, 0, 'easyadmin_autocomplete_inner');
     }

--- a/Form/Type/EasyAdminAutocompleteType.php
+++ b/Form/Type/EasyAdminAutocompleteType.php
@@ -3,7 +3,6 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Form\Type;
 
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ConfigManager;
-use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use JavierEguiluz\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
@@ -91,7 +90,7 @@ class EasyAdminAutocompleteType extends AbstractType
     public function finishView(FormView $view, FormInterface $form, array $options)
     {
         if (null === $config = $this->configManager->getEntityConfigByClass($options['class'])) {
-            throw new UndefinedEntityException(array('entity_name' => $options['class']));
+            throw new \InvalidArgumentException(sprintf('The configuration of the "%s" entity is not available (this entity is used as the target of the "%s" autocomplete field).', $options['class'], $form->getName()));
         }
 
         $view->vars['autocomplete_entity_name'] = $config['name'];

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -11,6 +11,7 @@
         </service>
 
         <service id="easyadmin.form.type.autocomplete" class="JavierEguiluz\Bundle\EasyAdminBundle\Form\Type\EasyAdminAutocompleteType">
+            <argument type="service" id="easyadmin.config.manager"/>
             <tag name="form.type" alias="easyadmin_autocomplete" />
         </service>
 

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -501,9 +501,7 @@
             'data-easyadmin-autocomplete-max-results': easyadmin_config('show.max_results'),
             'data-easyadmin-autocomplete-url' : path('easyadmin', {
                 action: 'autocomplete',
-                entity: easyadmin.entity.name,
-                property: easyadmin.field.fieldName,
-                view: easyadmin.view
+                entity: autocomplete_entity_name,
             })|raw })
         })
     }}

--- a/Search/Autocomplete.php
+++ b/Search/Autocomplete.php
@@ -19,6 +19,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
  * the autocomplete field types.
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
 class Autocomplete
 {

--- a/Tests/Controller/AutocompleteTest.php
+++ b/Tests/Controller/AutocompleteTest.php
@@ -25,13 +25,11 @@ class AutocompleteTest extends AbstractTestCase
     /**
      * @dataProvider provideMissingParameters
      */
-    public function testAutocompleteWithMissingParameters($property, $view, $query)
+    public function testAutocompleteWithMissingParameters($query)
     {
         $queryParameters = array(
             'action' => 'autocomplete',
             'entity' => 'Category',
-            'property' => $property,
-            'view' => $view,
             'query' => $query,
         );
 
@@ -51,8 +49,6 @@ class AutocompleteTest extends AbstractTestCase
         $this->getBackendPage(array(
             'action' => 'autocomplete',
             'entity' => 'Category',
-            'property' => 'parent',
-            'view' => 'edit',
             'query' => 'Parent Categ',
         ));
 
@@ -69,8 +65,6 @@ class AutocompleteTest extends AbstractTestCase
         $this->getBackendPage(array(
             'action' => 'autocomplete',
             'entity' => 'Category',
-            'property' => 'parent',
-            'view' => 'edit',
             'query' => 21,
         ));
 
@@ -87,13 +81,9 @@ class AutocompleteTest extends AbstractTestCase
     public function provideMissingParameters()
     {
         return array(
-            // property, view, query
-            array('', 'edit', 'Categ'),
-            array('parent', '', 'Categ'),
-            array('parent', 'edit', ''),
-            array(null, 'edit', 'Categ'),
-            array('parent', null, 'Categ'),
-            array('parent', 'edit', null),
+            // query
+            array(''),
+            array(null),
         );
     }
 }

--- a/Tests/Search/AutocompleteTest.php
+++ b/Tests/Search/AutocompleteTest.php
@@ -25,13 +25,13 @@ class AutocompleteTest extends AbstractTestCase
     /**
      * @dataProvider provideMissingParameters
      */
-    public function testAutocompleteWithMissingParameters($entity, $property, $view, $query)
+    public function testAutocompleteWithMissingParameters($entity, $query)
     {
         $this->getBackendHomepage();
 
         $this->assertSame(
             array('results' => array()),
-            $this->client->getContainer()->get('easyadmin.autocomplete')->find($entity, $property, $view, $query),
+            $this->client->getContainer()->get('easyadmin.autocomplete')->find($entity, $query),
             'Some of the parameters required for autocomplete are missing.'
         );
     }
@@ -43,34 +43,14 @@ class AutocompleteTest extends AbstractTestCase
     public function testAutocompleteWrongEntity()
     {
         $this->getBackendHomepage();
-        $this->client->getContainer()->get('easyadmin.autocomplete')->find('ThisEntityDoesNotExist', 'name', 'edit', 'John Doe');
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The "property" argument must contain the name of a property configured in the "edit" view of the "Product" entity ("ThisPropertyDoesNotExist" given).
-     */
-    public function testAutocompleteWrongProperty()
-    {
-        $this->getBackendHomepage();
-        $this->client->getContainer()->get('easyadmin.autocomplete')->find('Product', 'ThisPropertyDoesNotExist', 'edit', 'John Doe');
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The "name" property configured in the "edit" view of the "Product" entity can't be of type "easyadmin_autocomplete" because it's not related to another entity.
-     */
-    public function testAutocompleteWrongTargetEntity()
-    {
-        $this->getBackendHomepage();
-        $this->client->getContainer()->get('easyadmin.autocomplete')->find('Product', 'name', 'edit', 'John Doe');
+        $this->client->getContainer()->get('easyadmin.autocomplete')->find('ThisEntityDoesNotExist', 'John Doe');
     }
 
     public function testAutocompleteText()
     {
         $this->getBackendHomepage();
         // the query is 'Parent Categ' instead of 'Parent Category' to better test the autocomplete
-        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'parent', 'edit', 'Parent Categ');
+        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'Parent Categ');
 
         // the results are the first batch of 10 parent categories
         foreach (range(1, 10) as $i => $n) {
@@ -82,7 +62,7 @@ class AutocompleteTest extends AbstractTestCase
     public function testAutocompleteNumbers()
     {
         $this->getBackendHomepage();
-        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'parent', 'edit', 21);
+        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 21);
 
         $this->assertSame(
             array(
@@ -97,7 +77,7 @@ class AutocompleteTest extends AbstractTestCase
     {
         $this->getBackendHomepage();
         // testing page 2
-        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'parent', 'edit', 'Parent Categ', 2);
+        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'Parent Categ', 2);
 
         // the results are the second batch of 10 parent categories
         foreach (range(11, 20) as $i => $n) {
@@ -109,14 +89,10 @@ class AutocompleteTest extends AbstractTestCase
     public function provideMissingParameters()
     {
         return array(
-            array('', 'parent', 'edit', 'Categ'),
-            array('Category', '', 'edit', 'Categ'),
-            array('Category', 'parent', '', 'Categ'),
-            array('Category', 'parent', 'edit', ''),
-            array(null, 'parent', 'edit', 'Categ'),
-            array('Category', null, 'edit', 'Categ'),
-            array('Category', 'parent', null, 'Categ'),
-            array('Category', 'parent', 'edit', null),
+            array('', 'Categ'),
+            array(null, 'Categ'),
+            array('Category', ''),
+            array('Category', null),
         );
     }
 }


### PR DESCRIPTION
Fixed #1313

This PR doesn't change the way to use `EasyAdminAutocompleteType` but expands its reach. Now is possible to use in embedded forms:

```
$builder->add('category', EasyAdminAutocompleteType::class, array('class' => Category::class));
```
- Where `Category::class` must be an entity class managed by EasyAdmin. (**it doesn't new**)
- Otherwise `InvalidArgumentException` is thrown. (**it doesn't new**, just was moved to form type)

ping @CruzyCruz, please test it.

---

**`@internal`**

After this PR, autocomplete requests require `entity` name and `query` parameters only, `property` and `view` has been removed, because `entity` name is already the target entity where to look for.
