### PR TITLE
Fix missing birthday form type nullable handling

### DIFF
--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -31,7 +31,7 @@
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}
 
-            {% if _field_type in ['datetime', 'datetimetz', 'date', 'time'] and easyadmin.field.nullable|default(false) %}
+            {% if _field_type in ['datetime', 'date', 'time', 'birthday'] and easyadmin.field.nullable|default(false) %}
                 <div class="nullable-control">
                     <label>
                         <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -228,7 +228,7 @@
         {{- form_label(form, _field_label, { translation_domain: 'messages' }) -}}
         {{- form_widget(form) -}}
 
-        {% if _field_type in ['datetime', 'datetimetz', 'date', 'time'] and easyadmin.field.nullable|default(false) %}
+        {% if _field_type in ['datetime', 'date', 'time', 'birthday'] and easyadmin.field.nullable|default(false) %}
             <div class="nullable-control">
                 <label>
                     <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>


### PR DESCRIPTION
Symfony's birthday type was not handled by the nullable feature. 
Also, removed `datetimez`, which is a doctrine type. Here, `_field_type` is the form type.
