### PR TITLE
Fix the default format used when changing the property type

### DIFF
--- a/Configuration/PropertyConfigPass.php
+++ b/Configuration/PropertyConfigPass.php
@@ -112,7 +112,6 @@ class PropertyConfigPass implements ConfigPassInterface
                         'property' => $propertyName,
                         'dataType' => $propertyMetadata['type'],
                         'fieldType' => $this->getFormTypeFromDoctrineType($propertyMetadata['type']),
-                        'format' => $this->getFieldFormat($propertyMetadata['type'], $backendConfig),
                     )
                 );
 


### PR DESCRIPTION
I've got an entity with this show action configuration:

``` yml
       show:
            fields:
                - { property: 'uuid' }
                - { property: 'email' }
                # [...]
                - { property: 'birthdate', type: date }
```

The `birthdate` field is a `\DateTime` in my entity, but i'd like it to be display as a date. 
So I switched the `type` to `date`. It works fine, the proper `date.html.twig` template is called, but unfortunately, the wrong format is used (it keeps the `datetime` one).

⚠️  I'm not sure this won't introduce any unexpected behavior, as I'm a bit lost in the metadata processing. 😕 
