### PR TITLE
Prevent error messages when installing an app and the DB doesn't exist

### DIFF
--- a/Cache/ConfigWarmer.php
+++ b/Cache/ConfigWarmer.php
@@ -29,8 +29,14 @@ class ConfigWarmer implements CacheWarmerInterface
 
     public function warmUp($cacheDir)
     {
-        // this forces the full processing of the backend configuration
-        $this->configManager->getBackendConfig();
+        try {
+            // this forces the full processing of the backend configuration
+            $this->configManager->getBackendConfig();
+        } catch (\PDOException $e) {
+            // this occurs for example when the database doesn't exist yet and the
+            // project is being installed ('composer install' clears the cache at the end)
+            // ignore this error at this point and display an error message later
+        }
     }
 
     public function isOptional()


### PR DESCRIPTION
This fixes #1326 in a very naive way. Maybe it's better to `try ... catch` other exceptions inside our `MetadataConfigPass` class?
