### PR TITLE
Add missing dep on twig-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "symfony/http-foundation"       : "~2.3|~3.0",
         "symfony/http-kernel"           : "~2.3|~3.0",
         "symfony/property-access"       : "~2.3|~3.0",
-        "symfony/twig-bridge"           : "^2.3.4|~3.0",
+        "symfony/twig-bridge"           : "~2.3.4|~3.0",
+        "symfony/twig-bundle"           : "~2.3|~3.0",
         "twig/extensions"               : "~1.0",
         "twig/twig"                     : "~1.14,>=1.14.2|~2.0"
     },
@@ -49,7 +50,6 @@
         "symfony/finder"                    : "~2.3|~3.0",
         "symfony/phpunit-bridge"            : "^2.7",
         "symfony/security-bundle"           : "~2.3|~3.0",
-        "symfony/twig-bundle"               : "~2.3|~3.0",
         "symfony/validator"                 : "~2.3|~3.0",
         "symfony/yaml"                      : "~2.3|~3.0"
     },


### PR DESCRIPTION
On Symfony 3.2, `symfony/twig-bundle` is not installed by any of the listed dependencies. So, it should be added explicitly.
