### PR TITLE
Security is a requirement for an admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "symfony/http-foundation"       : "~2.3|~3.0",
         "symfony/http-kernel"           : "~2.3|~3.0",
         "symfony/property-access"       : "~2.3|~3.0",
+        "symfony/security-bundle"       : "~2.3|~3.0",
         "symfony/twig-bridge"           : "~2.3.4|~3.0",
         "symfony/twig-bundle"           : "~2.3|~3.0",
         "twig/extensions"               : "~1.0",
@@ -49,7 +50,6 @@
         "symfony/dom-crawler"               : "~2.3|~3.0",
         "symfony/finder"                    : "~2.3|~3.0",
         "symfony/phpunit-bridge"            : "^2.7",
-        "symfony/security-bundle"           : "~2.3|~3.0",
         "symfony/validator"                 : "~2.3|~3.0",
         "symfony/yaml"                      : "~2.3|~3.0"
     },


### PR DESCRIPTION
Not sure about this one. But without the security bundle, the admin does not work as the layout uses `app.user`, which is only available when the security bundle is available.

Two possible ways to fix it: trying to make usage of `app.user` optional, or add security bundle as a requirement. I think the second option, which is what this PR do, seems legitimate as not-securing an admin does not seem like a use case we should support.
