### PR TITLE
Prevent errors when the security bundle is not enabled

### DIFF
--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -74,7 +74,7 @@
                                 {% block user_menu %}
                                     <span class="sr-only">{{ 'user.logged_in_as'|trans(domain = 'EasyAdminBundle') }}</span>
                                     <i class="hidden-xs fa fa-user"></i>
-                                    {% if app.user %}
+                                    {% if app.user|default %}
                                         {{ app.user.username|default('user.unnamed'|trans(domain = 'EasyAdminBundle')) }}
                                     {% else %}
                                         {{ 'user.anonymous'|trans(domain = 'EasyAdminBundle') }}


### PR DESCRIPTION
As Fabien pointed in #1333, this could fail. The solution uses the trick proposed by @lsmith77 in [this tweet](https://twitter.com/lsmith/status/786902739603316736).
