### PR TITLE
Allow user to set class for form_group_class

### DIFF
--- a/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -92,4 +92,4 @@
 {% endspaceless %}
 {% endblock reset_row %}
 
-{% block form_group_class 'col-sm-10' %}
+{% block form_group_class easyadmin.field.class|default('col-sm-10') %}


### PR DESCRIPTION
To customise form_group_class block, new parameter named **class** has been used. for ex.

``` yaml
- property: 'name'
  label: 'My name'
  class: 'col-sm-8'
  type: 'text'
  css_class: 'col-sm-4'
  type_options: { attr: {'class': 'col-sm-3 ', 'style': 'background-color:#f9f4d1'}, required: false }
```

will generate html like: 

``` html
<div class="col-xs-12 col-sm-4">
    <div class="form-group field-input">
        <label class="col-sm-4 control-label" for="name">My name</label>
        <div class="col-sm-8">
            <input type="text" style="background-color:#f9f4d1" id="name" name="name" class="form-control col-sm-3">
        </div>
    </div>
</div>
```

I have tried to resolve this issue Ref: [https://github.com/javiereguiluz/EasyAdminBundle/issues/1336](https://github.com/javiereguiluz/EasyAdminBundle/issues/1336)
