### PR TITLE
Use `%entity_label` instead of `%entity_name%` in doc examples

### DIFF
--- a/Resources/doc/book/3-list-search-show-configuration.md
+++ b/Resources/doc/book/3-list-search-show-configuration.md
@@ -74,7 +74,7 @@ The `title` value can include the following special variables:
 >             class: AppBundle\Entity\Customer
 >             label: 'Customers'
 >             list:
->                 title: '%%entity_name%% listing'
+>                 title: '%%entity_label%% listing'
 >         # ...
 > ```
 

--- a/Resources/doc/book/4-edit-new-configuration.md
+++ b/Resources/doc/book/4-edit-new-configuration.md
@@ -121,7 +121,7 @@ The `title` option can include the following special variables:
 >             class: AppBundle\Entity\Customer
 >             label: 'Customers'
 >             form:
->                 title: '%%entity_name%% listing'
+>                 title: '%%entity_label%% listing'
 >         # ...
 > ```
 


### PR DESCRIPTION
Which is probably more appropriate :)

> - `%entity_label%`, resolves to the value defined in the `label` option of
>   the entity. If you haven't defined it, this value will be equal to the
>   entity name. In the example above, this value would be `Customers`.
