### PR TITLE
The layout should work when no _entity_config variable is defined

### DIFF
--- a/Resources/views/default/menu.html.twig
+++ b/Resources/views/default/menu.html.twig
@@ -34,13 +34,13 @@
     {% block main_menu %}
         {% for item in easyadmin_config('design.menu') %}
             <li class="{{ item.type == 'divider' ? 'header' }} {{ item.children is not empty ? 'treeview' }} {{ app.request.query.get('menuIndex')|default(-1) == loop.index0 ? 'active' }} {{ app.request.query.get('submenuIndex')|default(-1) != -1 ? 'submenu-active' }}">
-                {{ helper.render_menu_item(item, _entity_config.translation_domain) }}
+                {{ helper.render_menu_item(item, _entity_config.translation_domain|default('messages')) }}
 
                 {% if item.children|default([]) is not empty %}
                     <ul class="treeview-menu">
                         {% for subitem in item.children %}
                             <li class="{{ subitem.type == 'divider' ? 'header' }} {{ app.request.query.get('menuIndex')|default(-1) == loop.parent.loop.index0 and app.request.query.get('submenuIndex')|default(-1) == loop.index0 ? 'active' }}">
-                                {{ helper.render_menu_item(subitem, _entity_config.translation_domain) }}
+                                {{ helper.render_menu_item(subitem, _entity_config.translation_domain|default('messages')) }}
                             </li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
The `menu.html.twig` template is included via `layout.html.twig`. This layout not always defines the `_entity_config` variable because it can be used as the layout of custom pages. This error happened for instance in the login page of the EasyAdmin Demo App, which extends the layout but defines no entity.
