### PR TITLE
Allow to define the default sorting of list/search views

### DIFF
--- a/Configuration/DefaultConfigPass.php
+++ b/Configuration/DefaultConfigPass.php
@@ -105,8 +105,18 @@ class DefaultConfigPass implements ConfigPassInterface
         // if no menu item has been set as "default", use the "list"
         // action of the first configured entity as the backend homepage
         if (null === $menuItemConfig = $backendConfig['default_menu_item']) {
+            $defaultEntityName = $backendConfig['default_entity_name'];
             $backendHomepage['route'] = 'easyadmin';
-            $backendHomepage['params'] = array('action' => 'list', 'entity' => $backendConfig['default_entity_name']);
+            $backendHomepage['params'] = array('action' => 'list', 'entity' => $defaultEntityName);
+
+            // if the default entity defines a custom sorting, use it
+            $defaultEntityConfig = $backendConfig['entities'][$defaultEntityName];
+            if (isset($defaultEntityConfig['list']['sort'])) {
+                $backendHomepage['params'] = array_merge($backendHomepage['params'], array(
+                    'sortField' => $defaultEntityConfig['list']['sort']['field'],
+                    'sortDirection' => $defaultEntityConfig['list']['sort']['direction'],
+                ));
+            }
         } else {
             $routeParams = array('menuIndex' => $menuItemConfig['menu_index'], 'submenuIndex' => $menuItemConfig['submenu_index']);
 

--- a/Configuration/DefaultConfigPass.php
+++ b/Configuration/DefaultConfigPass.php
@@ -110,7 +110,7 @@ class DefaultConfigPass implements ConfigPassInterface
             $backendHomepage['params'] = array('action' => 'list', 'entity' => $defaultEntityName);
 
             // if the default entity defines a custom sorting, use it
-            $defaultEntityConfig = $backendConfig['entities'][$defaultEntityName];
+            $defaultEntityConfig = isset($backendConfig['entities'][$defaultEntityName]) ? $backendConfig['entities'][$defaultEntityName] : array();
             if (isset($defaultEntityConfig['list']['sort'])) {
                 $backendHomepage['params'] = array_merge($backendHomepage['params'], array(
                     'sortField' => $defaultEntityConfig['list']['sort']['field'],

--- a/Configuration/ViewConfigPass.php
+++ b/Configuration/ViewConfigPass.php
@@ -114,7 +114,7 @@ class ViewConfigPass implements ConfigPassInterface
      * 'search' views can define to override the default (id, DESC) sorting
      * applied to their contents.
      *
-     * @param array  $backendConfig
+     * @param array $backendConfig
      *
      * @return array
      */

--- a/Configuration/ViewConfigPass.php
+++ b/Configuration/ViewConfigPass.php
@@ -134,10 +134,10 @@ class ViewConfigPass implements ConfigPassInterface
                 if (is_string($sortConfig)) {
                     $sortConfig = array('field' => $sortConfig, 'direction' => 'DESC');
                 } else {
-                    $sortConfig = array('field' => $sortConfig[0], 'direction' => $sortConfig[1]);
+                    $sortConfig = array('field' => $sortConfig[0], 'direction' => strtoupper($sortConfig[1]));
                 }
 
-                if (!in_array(strtoupper($sortConfig['direction']), array('ASC', 'DESC'))) {
+                if (!in_array($sortConfig['direction'], array('ASC', 'DESC'))) {
                     throw new \InvalidArgumentException(sprintf('If defined, the second value of the "sort" option of the "%s" view of the "%s" entity can only be "ASC" or "DESC".', $view, $entityName));
                 }
 

--- a/Configuration/ViewConfigPass.php
+++ b/Configuration/ViewConfigPass.php
@@ -138,15 +138,15 @@ class ViewConfigPass implements ConfigPassInterface
                 }
 
                 if (!in_array(strtoupper($sortConfig['direction']), array('ASC', 'DESC'))) {
-                    throw new \InvalidArgumentException(sprintf('The second value of the "sort" option of the "%s" view of the "%s" entity can only be "ASC" or "DESC".', $view, $entityName));
+                    throw new \InvalidArgumentException(sprintf('If defined, the second value of the "sort" option of the "%s" view of the "%s" entity can only be "ASC" or "DESC".', $view, $entityName));
                 }
 
-                if (!array_key_exists($sortConfig['field'], $entityConfig[$view]['fields'])) {
-                    throw new \InvalidArgumentException(sprintf('The "%s" field used in the "sort" option of the "%s" view of the "%s" entity is not defined as a valid field of that view and entity.', $sortConfig['field'], $view, $entityName));
+                if (isset($entityConfig[$view]['fields'][$sortConfig['field']]) && true === $entityConfig[$view]['fields'][$sortConfig['field']]['virtual']) {
+                    throw new \InvalidArgumentException(sprintf('The "%s" field cannot be used in the "sort" option of the "%s" view of the "%s" entity because it\'s a virtual property that is not persisted in the database.', $sortConfig['field'], $view, $entityName));
                 }
 
-                if (true === $entityConfig[$view]['fields'][$sortConfig['field']]['virtual']) {
-                    throw new \InvalidArgumentException(sprintf('The "%s" field cannot be used in the "sort" option of the "%s" view of the "%s" entity because it\'s a virtual field that is not defined as a real entity property.', $sortConfig['field'], $view, $entityName));
+                if (!array_key_exists($sortConfig['field'], $entityConfig['properties']) && !isset($entityConfig[$view]['fields'][$sortConfig['field']])) {
+                    throw new \InvalidArgumentException(sprintf('The "%s" field used in the "sort" option of the "%s" view of the "%s" entity does not exist neither as a property of that entity nor as a virtual field of that view.', $sortConfig['field'], $view, $entityName));
                 }
 
                 $backendConfig['entities'][$entityName][$view]['sort'] = $sortConfig;

--- a/Configuration/ViewConfigPass.php
+++ b/Configuration/ViewConfigPass.php
@@ -86,7 +86,6 @@ class ViewConfigPass implements ConfigPassInterface
         return $backendConfig;
     }
 
-
     /**
      * This method resolves the page title inheritance when some global view
      * (list, edit, etc.) defines a global title for all entities that can be

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -100,12 +100,14 @@ class AdminController extends Controller
 
         $this->entity = $this->get('easyadmin.config.manager')->getEntityConfiguration($entityName);
 
+        $action = $request->query->get('action', 'list');
         if (!$request->query->has('sortField')) {
-            $request->query->set('sortField', $this->entity['primary_key_field_name']);
+            $sortField = isset($this->entity[$action]['sort']['field']) ? $this->entity[$action]['sort']['field'] : $this->entity['primary_key_field_name'];
+            $request->query->set('sortField', $sortField);
         }
-
-        if (!$request->query->has('sortDirection') || !in_array(strtoupper($request->query->get('sortDirection')), array('ASC', 'DESC'))) {
-            $request->query->set('sortDirection', 'DESC');
+        if (!$request->query->has('sortDirection')) {
+            $sortDirection = isset($this->entity[$action]['sort']['direction']) ? $this->entity[$action]['sort']['direction'] : 'DESC';
+            $request->query->set('sortDirection', $sortDirection);
         }
 
         $this->em = $this->getDoctrine()->getManagerForClass($this->entity['class']);

--- a/Resources/doc/book/3-list-search-show-configuration.md
+++ b/Resources/doc/book/3-list-search-show-configuration.md
@@ -374,6 +374,27 @@ easy_admin:
 The main limitation of virtual properties is that you cannot sort listings
 using these fields.
 
+Sorting Entity Listings
+-----------------------
+
+By default the `list` and `search` views sort the rows in descending order
+according to the value of the primary key. You can sort by any other entity
+property using the `sort` configuration option:
+
+```yaml
+# app/config/config.yml
+easy_admin:
+    entities:
+        Product:
+            # ...
+            list:
+                # if the sort order is not specified, 'DESC' is used
+                sort: 'updatedAt'
+            search:
+                # use an array to also define the sorting direction
+                sort: ['updatedAt', 'ASC']
+```
+
 Filtering Entities
 ------------------
 

--- a/Resources/doc/book/3-list-search-show-configuration.md
+++ b/Resources/doc/book/3-list-search-show-configuration.md
@@ -395,6 +395,9 @@ easy_admin:
                 sort: ['updatedAt', 'ASC']
 ```
 
+The `sort` option of each entity overrides any other sorting configuration
+defined in the application, including the sorting defined by a custom menu.
+
 Filtering Entities
 ------------------
 

--- a/Resources/doc/book/3-list-search-show-configuration.md
+++ b/Resources/doc/book/3-list-search-show-configuration.md
@@ -395,8 +395,11 @@ easy_admin:
                 sort: ['updatedAt', 'ASC']
 ```
 
-The `sort` option of each entity overrides any other sorting configuration
-defined in the application, including the sorting defined by a custom menu.
+The `sort` option of each entity is only used as the default content sorting. If
+the query string includes the optional `sortField` and `sortDirection`
+parameters, their values override this `sort` option. This happens for example
+when defining a different sorting in a custom menu and when clicking on the
+listings columns to reorder the displayed contents.
 
 Filtering Entities
 ------------------

--- a/Tests/Configuration/fixtures/configurations/input/admin_146.yml
+++ b/Tests/Configuration/fixtures/configurations/input/admin_146.yml
@@ -1,0 +1,18 @@
+# TEST
+# the 'sort' config option (which can be a string or an array) is properly processed
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\FunctionalTests\Category
+            list:
+                sort: ['name', 'ASC']
+            search:
+                sort: id
+        Product:
+            class: AppTestBundle\Entity\FunctionalTests\Product
+            list:
+                sort: price
+            search:
+                sort: ['createdAt', 'desc']

--- a/Tests/Configuration/fixtures/configurations/input/admin_146.yml
+++ b/Tests/Configuration/fixtures/configurations/input/admin_146.yml
@@ -5,12 +5,16 @@
 easy_admin:
     entities:
         Category:
+            # although this is a unit test, it's correct to use the Category entity from
+            # the functional tests, because we need an entity with more than one 'id' property
             class: AppTestBundle\Entity\FunctionalTests\Category
             list:
                 sort: ['name', 'ASC']
             search:
                 sort: id
         Product:
+            # although this is a unit test, it's correct to use the Product entity from
+            # the functional tests, because we need an entity with more than one 'id' property
             class: AppTestBundle\Entity\FunctionalTests\Product
             list:
                 sort: price

--- a/Tests/Configuration/fixtures/configurations/output/config_146.yml
+++ b/Tests/Configuration/fixtures/configurations/output/config_146.yml
@@ -1,0 +1,12 @@
+easy_admin:
+    entities:
+        Category:
+            list:
+                sort: { field: 'name', direction: 'ASC' }
+            search:
+                sort: { field: 'id', direction: 'DESC' }
+        Product:
+            list:
+                sort: { field: 'price', direction: 'DESC' }
+            search:
+                sort: { field: 'createdAt', direction: 'DESC' }

--- a/Tests/Configuration/fixtures/exceptions/sort_invalid_direction.yml
+++ b/Tests/Configuration/fixtures/exceptions/sort_invalid_direction.yml
@@ -1,0 +1,15 @@
+# TEST
+# 'sort' config value can only use 'ASC' or 'DESC' as the sort direction
+
+# EXCEPTION
+expected_exception:
+    class: InvalidArgumentException
+    message_string: 'If defined, the second value of the "sort" option of the "list" view of the "Category" entity can only be "ASC" or "DESC".'
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                sort: ['id', 'this-direction-does-not-exist']

--- a/Tests/Configuration/fixtures/exceptions/sort_invalid_property.yml
+++ b/Tests/Configuration/fixtures/exceptions/sort_invalid_property.yml
@@ -1,0 +1,15 @@
+# TEST
+# 'sort' config value must refer to a valid entity property
+
+# EXCEPTION
+expected_exception:
+    class: InvalidArgumentException
+    message_string: 'The "this-does-not-exist" field used in the "sort" option of the "list" view of the "Category" entity does not exist neither as a property of that entity nor as a virtual field of that view.'
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                sort: 'this-does-not-exist'

--- a/Tests/Configuration/fixtures/exceptions/sort_invalid_value.yml
+++ b/Tests/Configuration/fixtures/exceptions/sort_invalid_value.yml
@@ -1,0 +1,15 @@
+# TEST
+# 'sort' config value can only be a string or an array
+
+# EXCEPTION
+expected_exception:
+    class: InvalidArgumentException
+    message_string: 'The "sort" option of the "list" view of the "Category" entity contains an invalid value (it can only be a string or an array).'
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                sort: 7

--- a/Tests/Configuration/fixtures/exceptions/sort_virtual_property.yml
+++ b/Tests/Configuration/fixtures/exceptions/sort_virtual_property.yml
@@ -1,0 +1,16 @@
+# TEST
+# 'sort' config value can't use virtual properties to sort contents
+
+# EXCEPTION
+expected_exception:
+    class: InvalidArgumentException
+    message_string: 'The "virtual_field" field cannot be used in the "sort" option of the "list" view of the "Category" entity because it's a virtual property that is not persisted in the database.'
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields: ['virtual_field']
+                sort: 'virtual_field'

--- a/Tests/Configuration/fixtures/exceptions/sort_virtual_property.yml
+++ b/Tests/Configuration/fixtures/exceptions/sort_virtual_property.yml
@@ -4,7 +4,7 @@
 # EXCEPTION
 expected_exception:
     class: InvalidArgumentException
-    message_string: 'The "virtual_field" field cannot be used in the "sort" option of the "list" view of the "Category" entity because it's a virtual property that is not persisted in the database.'
+    message_string: The "virtual_field" field cannot be used in the "sort" option of the "list" view of the "Category" entity because it's a virtual property that is not persisted in the database.
 
 # CONFIGURATION
 easy_admin:

--- a/Tests/Controller/EntitySortingTest.php
+++ b/Tests/Controller/EntitySortingTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Controller;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+
+class EntitySortingTest extends AbstractTestCase
+{
+    public function setUp()
+    {
+        // parent::setUp();
+
+        $this->initClient(array('environment' => 'entity_sorting'));
+    }
+
+    public function testMainMenuSorting()
+    {
+        $crawler = $this->requestListView('Product');
+
+        $this->assertContains('sortField=price', $crawler->filter('.sidebar-menu a:contains("Product 1")')->attr('href'));
+        $this->assertNotContains('sortDirection', $crawler->filter('.sidebar-menu a:contains("Product 1")')->attr('href'));
+        $this->assertContains('sortField=price', $crawler->filter('.sidebar-menu a:contains("Product 2")')->attr('href'));
+        $this->assertContains('sortDirection=ASC', $crawler->filter('.sidebar-menu a:contains("Product 2")')->attr('href'));
+        $this->assertContains('sortField=id', $crawler->filter('.sidebar-menu a:contains("Product 3")')->attr('href'));
+        $this->assertNotContains('sortDirection', $crawler->filter('.sidebar-menu a:contains("Product 3")')->attr('href'));
+
+        // click on any menu item to sort contents differently
+        $link = $crawler->filter('.sidebar-menu a:contains("Product 2")')->link();
+        $crawler = $this->client->click($link);
+        $this->assertNotContains('sorted', $crawler->filter('th[data-property-name="name"]')->attr('class'));
+        $this->assertContains('sorted', $crawler->filter('th[data-property-name="price"]')->attr('class'));
+        $this->assertContains('fa-caret-up', $crawler->filter('th[data-property-name="price"] i')->attr('class'));
+    }
+
+    public function testListViewSorting()
+    {
+        $crawler = $this->requestListView('Product');
+
+        // check the default sorting of the page
+        $this->assertContains('sorted', $crawler->filter('th[data-property-name="name"]')->attr('class'));
+        $this->assertContains('fa-caret-down', $crawler->filter('th[data-property-name="name"] i')->attr('class'));
+
+        // click on any other table column to sort contents differently
+        $link = $crawler->filter('th[data-property-name="price"] a')->link();
+        $crawler = $this->client->click($link);
+        $this->assertNotContains('sorted', $crawler->filter('th[data-property-name="name"]')->attr('class'));
+        $this->assertContains('sorted', $crawler->filter('th[data-property-name="price"]')->attr('class'));
+        $this->assertContains('fa-caret-down', $crawler->filter('th[data-property-name="price"] i')->attr('class'));
+    }
+
+    public function testSearchViewSorting()
+    {
+        $crawler = $this->requestSearchView('lorem', 'Product');
+
+        // check the default sorting of the page
+        $this->assertContains('sorted', $crawler->filter('th[data-property-name="createdAt"]')->attr('class'));
+        $this->assertContains('fa-caret-up', $crawler->filter('th[data-property-name="createdAt"] i')->attr('class'));
+
+        // click on any other table column to sort contents differently
+        $link = $crawler->filter('th[data-property-name="name"] a')->link();
+        $crawler = $this->client->click($link);
+        $this->assertNotContains('sorted', $crawler->filter('th[data-property-name="createdAt"]')->attr('class'));
+        $this->assertContains('sorted', $crawler->filter('th[data-property-name="name"]')->attr('class'));
+        $this->assertContains('fa-caret-down', $crawler->filter('th[data-property-name="name"] i')->attr('class'));
+    }
+}

--- a/Tests/Fixtures/App/config/config_entity_sorting.yml
+++ b/Tests/Fixtures/App/config/config_entity_sorting.yml
@@ -1,0 +1,16 @@
+imports:
+    - { resource: config.yml }
+
+easy_admin:
+    design:
+        menu:
+            - { label: 'Product 1', entity: 'Product', params: { sortField: 'price' } }
+            - { label: 'Product 2', entity: 'Product', params: { sortField: 'price', sortDirection: 'ASC' } }
+            - { label: 'Product 3', entity: 'Product', params: { sortField: 'id' } }
+    entities:
+        Product:
+            class: AppTestBundle\Entity\FunctionalTests\Product
+            list:
+                sort: name
+            search:
+                sort: [createdAt, ASC]


### PR DESCRIPTION
This fixes #1343

---

This PR adds a new `sort` config option to define the default sorting field and direction for the `list` and `search` views without the need to define a custom menu.
