### PR TITLE
Remove Distribution bundle from requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "doctrine/doctrine-bundle"      : "~1.2",
         "doctrine/orm"                  : "~2.3",
         "pagerfanta/pagerfanta"         : "~1.0,>=1.0.1",
-        "sensio/distribution-bundle"    : "~2.3|~3.0|~4.0|~5.0",
         "sensio/framework-extra-bundle" : "~2.3|~3.0,>=3.0.2",
         "symfony/config"                : "~2.3|~3.0",
         "symfony/dependency-injection"  : "~2.3|~3.0",


### PR DESCRIPTION
I don't understand why this is a requirement of this bundle. Can be removed I think.