### PR TITLE
Display an error message when an entity doesn't define a __toString() method

### DIFF
--- a/Configuration/ConfigManager.php
+++ b/Configuration/ConfigManager.php
@@ -196,6 +196,7 @@ class ConfigManager
             new ViewConfigPass(),
             new TemplateConfigPass($this->container->getParameter('kernel.root_dir').'/Resources/views'),
             new DefaultConfigPass(),
+            new ValidationConfigPass(),
         );
 
         foreach ($configPasses as $configPass) {

--- a/Configuration/ValidationConfigPass.php
+++ b/Configuration/ValidationConfigPass.php
@@ -37,11 +37,23 @@ class ValidationConfigPass implements ConfigPassInterface
     private function processAssociationsConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('edit', 'list', 'new', 'search', 'show') as $view) {
+            foreach (array('list', 'search', 'show') as $view) {
                 foreach ($entityConfig[$view]['fields'] as $fieldName => $fieldConfig) {
-                    if ('association' === $fieldConfig['dataType']) {
+                    // Doctrine associations that don't define a custom template must define a __toString() method
+                    if ('association' === $fieldConfig['dataType'] && 0 === strpos($fieldConfig['template'], '@EasyAdmin/default/')) {
                         if (!method_exists($fieldConfig['targetEntity'], '__toString')) {
-                            throw new \InvalidArgumentException(sprintf('The "%s" class must define a "__toString()" method because it is used in the "%s" field of the "%s" view in the "%s" entity.', $fieldConfig['targetEntity'], $fieldName, $view, $entityName));
+                            throw new \InvalidArgumentException(sprintf('The "%s" class must define a "__toString()" method because it is used as the "%s" field in the "%s" view of the "%s" entity.', $fieldConfig['targetEntity'], $fieldName, $view, $entityName));
+                        }
+                    }
+                }
+            }
+
+            foreach (array('edit', 'new') as $view) {
+                foreach ($entityConfig[$view]['fields'] as $fieldName => $fieldConfig) {
+                    // fields used in autocomplete form types must define a __toString() method
+                    if ('easyadmin_autocomplete' === $fieldConfig['fieldType']) {
+                        if (!method_exists($fieldConfig['targetEntity'], '__toString')) {
+                            throw new \InvalidArgumentException(sprintf('The "%s" class must define a "__toString()" method because it is used as the "%s" autocomplete field in the "%s" view of the "%s" entity.', $fieldConfig['targetEntity'], $fieldName, $view, $entityName));
                         }
                     }
                 }

--- a/Configuration/ValidationConfigPass.php
+++ b/Configuration/ValidationConfigPass.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
+
+/**
+ * Performs the last validations on the processed backend configuration before
+ * executing the application.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class ValidationConfigPass implements ConfigPassInterface
+{
+    public function process(array $backendConfig)
+    {
+        $backendConfig = $this->processAssociationsConfig($backendConfig);
+
+        return $backendConfig;
+    }
+
+    /**
+     * It checks that the entity classes used in associations define a __toString()
+     * method to avoid the usual error "Object of class ... could not be converted to string".
+     *
+     * @param array $backendConfig
+     *
+     * @return array
+     */
+    private function processAssociationsConfig(array $backendConfig)
+    {
+        foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
+            foreach (array('edit', 'list', 'new', 'search', 'show') as $view) {
+                foreach ($entityConfig[$view]['fields'] as $fieldName => $fieldConfig) {
+                    if ('association' === $fieldConfig['dataType']) {
+                        if (!method_exists($fieldConfig['targetEntity'], '__toString')) {
+                            throw new \InvalidArgumentException(sprintf('The "%s" class must define a "__toString()" method because it is used in the "%s" field of the "%s" view in the "%s" entity.', $fieldConfig['targetEntity'], $fieldName, $view, $entityName));
+                        }
+                    }
+                }
+            }
+        }
+
+        return $backendConfig;
+    }
+}

--- a/Tests/Configuration/fixtures/exceptions/association_without_tostring.yml
+++ b/Tests/Configuration/fixtures/exceptions/association_without_tostring.yml
@@ -4,8 +4,7 @@
 # EXCEPTION
 expected_exception:
     class: InvalidArgumentException
-    # the message refers to the 'edit' view because that's the first view processed
-    message_string: 'The "AppTestBundle\Entity\UnitTests\Exceptions\CategoryWithoutToString" class must define a "__toString()" method because it is used in the "parent" field of the "edit" view in the "Category" entity.'
+    message_string: 'The "AppTestBundle\Entity\UnitTests\Exceptions\CategoryWithoutToString" class must define a "__toString()" method because it is used as the "parent" field in the "list" view of the "Category" entity.'
 
 # CONFIGURATION
 easy_admin:

--- a/Tests/Configuration/fixtures/exceptions/association_without_tostring.yml
+++ b/Tests/Configuration/fixtures/exceptions/association_without_tostring.yml
@@ -1,0 +1,14 @@
+# TEST
+# the entity classes used in associations must define a __toString() method
+
+# EXCEPTION
+expected_exception:
+    class: InvalidArgumentException
+    # the message refers to the 'edit' view because that's the first view processed
+    message_string: 'The "AppTestBundle\Entity\UnitTests\Exceptions\CategoryWithoutToString" class must define a "__toString()" method because it is used in the "parent" field of the "edit" view in the "Category" entity.'
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Exceptions\CategoryWithoutToString

--- a/Tests/Configuration/fixtures/exceptions/autocomplete_without_tostring.yml
+++ b/Tests/Configuration/fixtures/exceptions/autocomplete_without_tostring.yml
@@ -1,0 +1,22 @@
+# TEST
+# the entity classes used in autocomplete types must define a __toString() method
+
+# EXCEPTION
+expected_exception:
+    class: InvalidArgumentException
+    message_string: 'The "AppTestBundle\Entity\UnitTests\Exceptions\CategoryWithoutToString" class must define a "__toString()" method because it is used as the "parent" autocomplete field in the "edit" view of the "Category" entity.'
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Exceptions\CategoryWithoutToString
+            # don't include the 'parent' field in the 'list' and 'show' views to avoid
+            # exceptions that would prevent to test the exception thrown in the 'form' view
+            list:
+                fields: ['id']
+            show:
+                fields: ['id']
+            form:
+                fields:
+                    - { property: parent, type: easyadmin_autocomplete }

--- a/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Category.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Category.php
@@ -66,7 +66,6 @@ class Category
         $this->products = new ArrayCollection();
     }
 
-    /** {@inheritdoc} */
     public function __toString()
     {
         return $this->getName();

--- a/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Image.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Image.php
@@ -45,6 +45,11 @@ class Image
      */
     protected $thumbnail;
 
+    public function __toString()
+    {
+        return 'Image #'.$this->id();
+    }
+
     /**
      * Set the content of the full size image.
      *

--- a/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Product.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Product.php
@@ -403,9 +403,6 @@ class Product
         return $this->id;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function __toString()
     {
         return $this->getName();

--- a/Tests/Fixtures/AppTestBundle/Entity/UnitTests/Exceptions/CategoryWithoutToString.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/UnitTests/Exceptions/CategoryWithoutToString.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace AppTestBundle\Entity\UnitTests\Exceptions;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * This entity doesn't contain a __toString() method to force an exception
+ * in some tests.
+ *
+ * @ORM\Entity
+ */
+class CategoryWithoutToString
+{
+    /**
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\OneToOne(targetEntity="CategoryWithoutToString")
+     * @ORM\JoinColumn(name="parent_id", referencedColumnName="id", nullable=true)
+     */
+    protected $parent;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent()
+    {
+        return $this->parent;
+    }
+}


### PR DESCRIPTION
Sadly, it's common to forget adding the `__toString()` method in entities used as part of Doctrine associations. We now display a useful error message in those cases:

![tostring_error_message](https://cloud.githubusercontent.com/assets/73419/20029565/7340bad4-a34f-11e6-9614-b4fd55c7820a.png)
