### PR TITLE
Update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
 /.coveralls.yml   export-ignore
+/.github          export-ignore
 /.gitattributes   export-ignore
 /.gitignore       export-ignore
-/.php_cs.cache    export-ignore
+/.php_cs          export-ignore
 /.travis.yml      export-ignore
 /appveyor.yml     export-ignore
 /Tests            export-ignore
+/phpunit.xml.dist

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,4 @@
 /.travis.yml      export-ignore
 /appveyor.yml     export-ignore
 /Tests            export-ignore
-/phpunit.xml.dist
+/phpunit.xml.dist export-ignore


### PR DESCRIPTION
I guess it should rather ignore `.php_cs`. `.php_cs.cache` is already ignored by the `.gitignore` file anyway.
Github templates should probably not be exported neither, nor `phpunit.xml.dist`.