### PR TITLE
Doctrine associations should check 'disabled actions' config too

### DIFF
--- a/Configuration/ConfigManager.php
+++ b/Configuration/ConfigManager.php
@@ -139,14 +139,14 @@ class ConfigManager
      */
     public function isActionEnabled($entityName, $view, $action)
     {
-        if ($view === $action) {
-            return true;
+        $entityConfig = $this->getEntityConfig($entityName);
+        if (in_array($action, $entityConfig['disabled_actions'])) {
+            return false;
         }
 
-        $entityConfig = $this->getEntityConfig($entityName);
-
-        return !in_array($action, $entityConfig['disabled_actions'])
-            && array_key_exists($action, $entityConfig[$view]['actions']);
+        // the '$view === $action' check is needed when checking if an action is
+        // accessible for a related Doctrine association
+        return $view === $action || array_key_exists($action, $entityConfig[$view]['actions']);
     }
 
     /**

--- a/Configuration/ConfigManager.php
+++ b/Configuration/ConfigManager.php
@@ -140,13 +140,8 @@ class ConfigManager
     public function isActionEnabled($entityName, $view, $action)
     {
         $entityConfig = $this->getEntityConfig($entityName);
-        if (in_array($action, $entityConfig['disabled_actions'])) {
-            return false;
-        }
 
-        // the '$view === $action' check is needed when checking if an action is
-        // accessible for a related Doctrine association
-        return $view === $action || array_key_exists($action, $entityConfig[$view]['actions']);
+        return !in_array($action, $entityConfig['disabled_actions']) && array_key_exists($action, $entityConfig[$view]['actions']);
     }
 
     /**

--- a/Tests/Controller/DisabledActionsTest.php
+++ b/Tests/Controller/DisabledActionsTest.php
@@ -35,9 +35,9 @@ class DisabledActionsTest extends AbstractTestCase
 
     public function testAssociationLinksInShowView()
     {
-        // the 'id' of 'Purchase' entity is generated randomly: to get the
-        // 'show' view of the first 'Purchase', browse the 'list' view and
-        // get its 'id' from the forst row of the listing
+        // 'Purchase' entity 'id' is generated randomly. In order to browse the
+        // 'show' view of the first 'Purchase' entity, browse the 'list' view
+        // and get the 'id' from the first row of the listing
         $crawler = $this->requestListView('Purchase');
         $firstPurchaseId = trim($crawler->filter('td[data-label="ID"]')->first()->text());
         $crawler = $this->requestShowView('Purchase', $firstPurchaseId);

--- a/Tests/Controller/DisabledActionsTest.php
+++ b/Tests/Controller/DisabledActionsTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Controller;
+
+use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+
+class DisabledActionsTest extends AbstractTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initClient(array('environment' => 'disabled_actions'));
+    }
+
+    public function testAssociationLinksInListView()
+    {
+        $crawler = $this->requestListView('Purchase');
+
+        $this->assertSame(
+            'user11',
+            trim($crawler->filter('td[data-label="Buyer"]')->html()),
+            'The "buyer" field in the "list" view of the "Purchase" item does not contain a link because the "show" action is disabled for the "User" entity.'
+        );
+    }
+
+    public function testAssociationLinksInShowView()
+    {
+        // the 'id' of 'Purchase' entity is generated randomly: to get the
+        // 'show' view of the first 'Purchase', browse the 'list' view and
+        // get its 'id' from the forst row of the listing
+        $crawler = $this->requestListView('Purchase');
+        $firstPurchaseId = trim($crawler->filter('td[data-label="ID"]')->first()->text());
+        $crawler = $this->requestShowView('Purchase', $firstPurchaseId);
+
+        $this->assertSame(
+            'user11',
+            trim($crawler->filter('.field-association:contains("Buyer") .form-control')->html()),
+            'The "buyer" field in the "show" view of the "Purchase" item does not contain a link because the "show" action is disabled for the "User" entity.'
+        );
+    }
+
+    public function testAccessingDisabledActions()
+    {
+        $crawler = $this->requestShowView('User', 1);
+
+        $this->assertContains(
+            'Error: The requested &quot;show&quot; action is not allowed for the &quot;User&quot; entity.',
+            $this->client->getResponse()->getContent()
+        );
+    }
+}

--- a/Tests/Fixtures/App/config/config_disabled_actions.yml
+++ b/Tests/Fixtures/App/config/config_disabled_actions.yml
@@ -1,0 +1,14 @@
+imports:
+    - { resource: config.yml }
+
+easy_admin:
+    entities:
+        Purchase:
+            class: AppTestBundle\Entity\FunctionalTests\Purchase
+            list:
+                fields: ['id', 'buyer']
+        User:
+            class: AppTestBundle\Entity\FunctionalTests\User
+            # the 'show' action is disabled so the 'buyer' field is not linked
+            # in the 'list' view of the 'Purchase' entity
+            disabled_actions: ['show']

--- a/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadCategories.php
+++ b/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadCategories.php
@@ -18,13 +18,18 @@ use AppTestBundle\Entity\FunctionalTests\Category;
 
 class LoadCategories extends AbstractFixture implements OrderedFixtureInterface
 {
+    public function getOrder()
+    {
+        return 20;
+    }
+
     public function load(ObjectManager $manager)
     {
         foreach (range(1, 100) as $i) {
             $category = new Category();
             $category->setName('Parent Category #'.$i);
 
-            $this->addReference('parent-category-'.$i, $category);
+            $this->addReference('category-'.$i, $category);
             $manager->persist($category);
         }
 
@@ -33,17 +38,12 @@ class LoadCategories extends AbstractFixture implements OrderedFixtureInterface
         foreach (range(1, 100) as $i) {
             $category = new Category();
             $category->setName('Category #'.$i);
-            $category->setParent($this->getReference('parent-category-'.$i));
+            $category->setParent($this->getReference('category-'.$i));
 
-            $this->addReference('category-'.$i, $category);
+            $this->addReference('category-'.(100+$i), $category);
             $manager->persist($category);
         }
 
         $manager->flush();
-    }
-
-    public function getOrder()
-    {
-        return 10;
     }
 }

--- a/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadProducts.php
+++ b/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadProducts.php
@@ -38,6 +38,11 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
         'Pellentesque et sapien pulvinar, consectetur eros ac, vehicula odio.',
     );
 
+    public function getOrder()
+    {
+        return 100;
+    }
+
     public function load(ObjectManager $manager)
     {
         foreach (range(1, 100) as $i) {
@@ -47,6 +52,7 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
             $product->setPrice($this->getRandomPrice());
             $product->setTags($this->getRandomTags());
             $product->setEan($this->getRandomEan());
+            $product->setCategories($this->getRandomCategories());
             $product->setDescription($this->getRandomDescription());
             $product->setHtmlFeatures($this->getRandomHtmlFeatures());
 
@@ -55,11 +61,6 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
         }
 
         $manager->flush();
-    }
-
-    public function getOrder()
-    {
-        return 100;
     }
 
     public function getRandomTags()
@@ -126,6 +127,19 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
         $cents = array('00', '29', '39', '49', '99');
 
         return (float) mt_rand(2, 79).'.'.$cents[array_rand($cents)];
+    }
+
+    private function getRandomCategories()
+    {
+        $categories = array();
+        $numCategories = rand(1, 4);
+        $allCategoryIds = range(1, 100);
+
+        for ($i = 0; $i < $numCategories; $i++) {
+            $categories[] = $this->getReference('category-'.mt_rand(1, 100));
+        }
+
+        return $categories;
     }
 
     public function getRandomDescription()

--- a/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadPurchases.php
+++ b/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadPurchases.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use AppTestBundle\Entity\FunctionalTests\Purchase;
+use AppTestBundle\Entity\FunctionalTests\PurchaseItem;
+use AppTestBundle\Entity\FunctionalTests\User;
+
+class LoadPurchases extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function getOrder()
+    {
+        return 200;
+    }
+
+    public function load(ObjectManager $manager)
+    {
+        foreach (range(1, 30) as $i) {
+            $purchase = new Purchase();
+            $purchase->setGuid($this->generateGuid());
+            $purchase->setDeliveryDate(new \DateTime("+$i days"));
+            $purchase->setCreatedAt(new \DateTime("now +$i seconds"));
+            $purchase->setShipping(new \StdClass());
+            $purchase->setDeliveryHour($this->getRandomHour());
+            $purchase->setBillingAddress(json_encode(array(
+                'line1' => '1234 Main Street',
+                'line2' => 'Big City, XX 23456',
+            )));
+            $purchase->setBuyer($this->getReference('user-'.($i % 20 + 1)));
+
+            $this->addReference('purchase-'.$i, $purchase);
+            $manager->persist($purchase);
+            $manager->flush();
+
+            $numItemsPurchased = rand(1, 5);
+            foreach (range(1, $numItemsPurchased) as $j) {
+                $item = new PurchaseItem();
+                $item->setQuantity(rand(1, 3));
+                $item->setProduct($this->getRandomProduct());
+                $item->setTaxRate(0.21);
+                $item->setPurchase($this->getReference('purchase-'.$i));
+
+                $manager->persist($item);
+            }
+        }
+
+        $manager->flush();
+    }
+
+    private function generateGuid()
+    {
+        return sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+          mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+          mt_rand(0, 0xffff),
+          mt_rand(0, 0x0fff) | 0x4000,
+          mt_rand(0, 0x3fff) | 0x8000,
+          mt_rand(0, 0xffff), mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+        );
+    }
+
+    private function getRandomHour()
+    {
+        $date = new \DateTime();
+
+        return $date->setTime(rand(0, 23), 0);
+    }
+
+    private function getRandomProduct()
+    {
+        $productId = rand(1, 100);
+
+        return $this->getReference('product-'.$productId);
+    }
+}

--- a/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadUsers.php
+++ b/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadUsers.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use AppTestBundle\Entity\FunctionalTests\User;
+
+class LoadUsers extends AbstractFixture implements OrderedFixtureInterface
+{
+    public function getOrder()
+    {
+        return 10;
+    }
+
+    public function load(ObjectManager $manager)
+    {
+        foreach (range(1, 20) as $i) {
+            $user = new User();
+            $user->setUsername('user'.$i);
+            $user->setEmail('user'.$i.'@example.com');
+
+            $this->addReference('user-'.$i, $user);
+            $manager->persist($user);
+        }
+
+        $manager->flush();
+    }
+}

--- a/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Purchase.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Purchase.php
@@ -24,12 +24,11 @@ class Purchase
     /**
      * The purchase increment id. This identifier will be use in all communication between the customer and the store.
      *
-     * @var int
-     * @ORM\Column(type="integer", name="id", nullable=false)
+     * @var string
+     * @ORM\Column(type="string", name="id", nullable=false)
      * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
      */
-    public $id;
+    protected $id = null;
 
     /**
      * The Unique id of the purchase.
@@ -37,23 +36,23 @@ class Purchase
      * @var string
      * @ORM\Column(type="guid")
      */
-    public $guid;
+    protected $guid = null;
 
     /**
-     * The day of the delivery.
+     * The date of the delivery (it doesn't include the time).
      *
      * @var \DateTime
      * @ORM\Column(type="date")
      */
-    public $deliverySelected;
+    protected $deliveryDate = null;
 
     /**
-     * The purchase date in the customer timezone.
+     * The purchase datetime in the customer timezone.
      *
      * @var \DateTime
      * @ORM\Column(type="datetimetz")
      */
-    public $purchaseAt;
+    protected $createdAt = null;
 
     /**
      * The shipping information.
@@ -61,15 +60,15 @@ class Purchase
      * @var Shipment
      * @ORM\Column(type="object")
      */
-    public $shipping;
+    protected $shipping = null;
 
     /**
      * The customer preferred time of the day for the delivery.
      *
-     * @var \DateTime
-     * @ORM\Column(type="time")
+     * @var \DateTime|null
+     * @ORM\Column(type="time", nullable=true)
      */
-    public $preferredDeliveryHour;
+    protected $deliveryHour = null;
 
     /**
      * The customer billing address.
@@ -77,19 +76,23 @@ class Purchase
      * @var array
      * @ORM\Column(type="json_array")
      */
-    public $billingAddress = array();
+    protected $billingAddress = array();
+
+    /**
+     * The user who made the purchase.
+     *
+     * @var User
+     * @ORM\ManyToOne(targetEntity="User", inversedBy="purchases")
+     */
+    protected $buyer;
 
     /**
      * Items that have been purchased.
      *
-     * @var ArrayCollection
-     * @ORM\ManyToMany(targetEntity="PurchaseItem")
-     * @ORM\JoinTable(name="purchase_purchase_item",
-     *                  joinColumns={@ORM\JoinColumn(name="purchase_id", referencedColumnName="id")},
-     *                  inverseJoinColumns={@ORM\JoinColumn(name="item_id", referencedColumnName="id", unique=true)}
-     *                  )
+     * @var PurchaseItem[]
+     * @ORM\OneToMany(targetEntity="PurchaseItem", mappedBy="purchase", cascade={"remove"})
      */
-    public $purchasedItems;
+    protected $purchasedItems;
 
     /**
      * Constructor of the Purchase class.
@@ -97,11 +100,11 @@ class Purchase
      */
     public function __construct()
     {
+        $this->id = $this->generateId();
         $this->purchasedItems = new ArrayCollection();
-        $this->purchaseAt = new \DateTime();
-        $this->deliverySelected = new \DateTime('+2 days');
-        $this->preferredDeliveryHour = new \DateTime('14:00');
-        $this->id = $this->generateIncrementId();
+        $this->createdAt = new \DateTime();
+        $this->deliveryDate = new \DateTime('+2 days');
+        $this->deliveryHour = new \DateTime('14:00');
     }
 
     /**
@@ -115,8 +118,6 @@ class Purchase
     }
 
     /**
-     * Get the customer billing address.
-     *
      * @return array
      */
     public function getBillingAddress()
@@ -125,39 +126,39 @@ class Purchase
     }
 
     /**
-     * Set the day of delivery.
-     *
-     * @param \DateTime $deliverySelected
+     * @param User $buyer
      */
-    public function setDeliverySelected($deliverySelected)
+    public function setBuyer($buyer)
     {
-        $this->deliverySelected = $deliverySelected;
+        $this->buyer = $buyer;
     }
 
     /**
-     * Get the day when the customer want to be deliver.
-     *
+     * @return User
+     */
+    public function getBuyer()
+    {
+        return $this->buyer;
+    }
+
+    /**
+     * @param \DateTime $deliveryDate
+     */
+    public function setDeliveryDate($deliveryDate)
+    {
+        $this->deliveryDate = $deliveryDate;
+    }
+
+    /**
      * @return \DateTime
      */
-    public function getDeliverySelected()
+    public function getDeliveryDate()
     {
-        return $this->deliverySelected;
+        return $this->deliveryDate;
     }
 
     /**
-     * Get the purchase id.
-     *
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
-     * Set all items ordered.
-     *
-     * @param ArrayCollection $purchasedItems
+     * @param PurchaseItem[] $purchasedItems
      */
     public function setPurchasedItems($purchasedItems)
     {
@@ -165,9 +166,7 @@ class Purchase
     }
 
     /**
-     * Get all ordered items.
-     *
-     * @return ArrayCollection
+     * @return PurchaseItem[]
      */
     public function getPurchasedItems()
     {
@@ -175,48 +174,38 @@ class Purchase
     }
 
     /**
-     * Set the delivery hour.
-     *
-     * @param \DateTime $preferredDeliveryHour
+     * @param \DateTime $deliveryHour
      */
-    public function setPreferredDeliveryHour($preferredDeliveryHour)
+    public function setDeliveryHour($deliveryHour)
     {
-        $this->preferredDeliveryHour = $preferredDeliveryHour;
+        $this->deliveryHour = $deliveryHour;
     }
 
     /**
-     * Get the delivery hour.
-     *
+     * @return \DateTime|null
+     */
+    public function getDeliveryHour()
+    {
+        return $this->deliveryHour;
+    }
+
+    /**
+     * @param \DateTime $createdAt
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
      * @return \DateTime
      */
-    public function getPreferredDeliveryHour()
+    public function getCreatedAt()
     {
-        return $this->preferredDeliveryHour;
+        return $this->createdAt;
     }
 
     /**
-     * Set the date when the order have been created.
-     *
-     * @param \DateTime $purchaseAt
-     */
-    public function setPurchaseAt($purchaseAt)
-    {
-        $this->purchaseAt = $purchaseAt;
-    }
-
-    /**
-     * Get the date of the order.
-     *
-     * @return \DateTime
-     */
-    public function getPurchaseAt()
-    {
-        return $this->purchaseAt;
-    }
-
-    /**
-     * Set the shipping information.
-     *
      * @param Shipment $shipping
      */
     public function setShipping($shipping)
@@ -225,8 +214,6 @@ class Purchase
     }
 
     /**
-     * Get the shipping information.
-     *
      * @return Shipment
      */
     public function getShipping()
@@ -235,22 +222,69 @@ class Purchase
     }
 
     /**
-     * Generate an increment id base on the store id and teh current date.
-     *
      * @param int $storeId
      *
-     * @return int
+     * @return string
      */
-    public function generateIncrementId($storeId = 1)
+    public function generateId($storeId = 1)
     {
-        $uid = date('YmdHi');
-
-        return (int) sprintf('%d%013d', $storeId, $uid);
+        return preg_replace('/[^0-9]/i', '', sprintf('%d%d%03d%s', $storeId, date('Y'), date('z'), microtime()));
     }
 
     /** {@inheritdoc} */
     public function __toString()
     {
         return 'Purchase #'.$this->getId();
+    }
+
+    /**
+     * @return string
+     */
+    public function getGuid()
+    {
+        return $this->guid;
+    }
+
+    /**
+     * @param string $guid
+     *
+     * @return Purchase
+     */
+    public function setGuid($guid)
+    {
+        $this->guid = $guid;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return Purchase
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getTotal()
+    {
+        $total = 0.0;
+
+        foreach ($this->getPurchasedItems() as $item) {
+            $total += $item->getTotalPrice();
+        }
+
+        return $total;
     }
 }

--- a/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/PurchaseItem.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/PurchaseItem.php
@@ -20,14 +20,12 @@ use Doctrine\ORM\Mapping as ORM;
 class PurchaseItem
 {
     /**
-     * The identifier of the image.
-     *
      * @var int
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      */
-    protected $id;
+    protected $id = null;
 
     /**
      * The ordered quantity.
@@ -49,10 +47,16 @@ class PurchaseItem
      * The ordered product.
      *
      * @var Product
-     * @ORM\ManyToOne(targetEntity="Product")
+     * @ORM\ManyToOne(targetEntity="Product", inversedBy="purchasedItems")
      * @ORM\JoinColumn(name="product_id", referencedColumnName="id")
-     **/
+     */
     protected $product;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Purchase", inversedBy="purchasedItems")
+     * @ORM\JoinColumn(name="purchase_id", referencedColumnName="id")
+     */
+    protected $purchase;
 
     /**
      * @param Product $product
@@ -68,6 +72,22 @@ class PurchaseItem
     public function getProduct()
     {
         return $this->product;
+    }
+
+    /**
+     * @param Purchase $purchase
+     */
+    public function setPurchase($purchase)
+    {
+        $this->purchase = $purchase;
+    }
+
+    /**
+     * @return Purchase
+     */
+    public function getPurchase()
+    {
+        return $this->purchase;
     }
 
     /**

--- a/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/User.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/User.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace AppTestBundle\Entity\FunctionalTests;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ */
+class User
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=64)
+     */
+    protected $username;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=255)
+     */
+    protected $email;
+
+    /**
+     * @var Purchase[]
+     *
+     * @ORM\OneToMany(targetEntity="Purchase", mappedBy="buyer", cascade={"remove"})
+     */
+    private $purchases;
+
+    public function __toString()
+    {
+        return $this->username;
+    }
+
+    public function __construct()
+    {
+        $this->purchases = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param string $email
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param Purchase[] $purchases
+     */
+    public function setPurchases($purchases)
+    {
+        $this->purchases = $purchases;
+    }
+
+    /**
+     * @return Purchase[]
+     */
+    public function getPurchases()
+    {
+        return $this->purchases;
+    }
+}

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -57,7 +57,7 @@ $input = new ArrayInput(array('command' => 'doctrine:schema:create'));
 $application->run($input, new NullOutput());
 
 // Load fixtures of the AppTestBundle
-$input = new ArrayInput(array('command' => 'doctrine:fixtures:load', '--no-interaction' => true, '--append' => true));
+$input = new ArrayInput(array('command' => 'doctrine:fixtures:load', '--no-interaction' => true, '--append' => false));
 $application->run($input, new NullOutput());
 
 // Make a copy of the original SQLite database to use the same unmodified database in every test

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -164,8 +164,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
                     return $twig->render($fieldMetadata['template'], $templateParameters);
                 }
 
-                // the repeated 'show' value is correct (and needed)
-                $isShowActionAllowed = $this->isActionEnabled('show', 'show', $targetEntityConfig['name']);
+                $isShowActionAllowed = !in_array('show', $targetEntityConfig['disabled_actions']);
             }
 
             if ('association' === $fieldType && ($fieldMetadata['associationType'] & ClassMetadata::TO_ONE)) {

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -164,7 +164,8 @@ class EasyAdminTwigExtension extends \Twig_Extension
                     return $twig->render($fieldMetadata['template'], $templateParameters);
                 }
 
-                $isShowActionAllowed = $this->isActionEnabled($view, 'show', $targetEntityConfig['name']);
+                // the repeated 'show' value is correct (and needed)
+                $isShowActionAllowed = $this->isActionEnabled('show', 'show', $targetEntityConfig['name']);
             }
 
             if ('association' === $fieldType && ($fieldMetadata['associationType'] & ClassMetadata::TO_ONE)) {


### PR DESCRIPTION
This fixes #1275

---

This PR fixes the "step 4" of this use case:

1. If Product and Category define a Doctrine relation ...
2. ... and you display Category in the Product listing ...
3. ... Category displays a link that points to the 'show' action of that Category ...
4. ... except when Category has disabled the 'show' action with 'disabled_actions' config option


This PR is a bit complex because it contains changes to fixtures to keep them in sync with the EasyAdmin demo app.