### PR TITLE
Avoid missing template errors for compound widgets

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -353,7 +353,7 @@
 
 {% block empty_collection %}
     <div class="empty collection-empty">
-        {{ include(easyadmin.entity.templates.label_empty) }}
+        {{ include([easyadmin.entity.templates.label_empty, '@EasyAdmin/default/label_empty.html.twig']) }}
     </div>
 {% endblock empty_collection %}
 


### PR DESCRIPTION
This fixes #1368.

