### PR TITLE
Try to fix Travis CS-fixer

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,6 +1,6 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = Symfony\CS\Finder::create()
     ->in(__DIR__)
     ->ignoreDotFiles(true)
     ->ignoreVCS(true)
@@ -9,7 +9,7 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
     ->name('*.php')
 ;
 
-return Symfony\CS\Config\Config::create()
+return Symfony\CS\Config::create()
     ->setUsingCache(true)
     ->fixers(array('-unalign_double_arrow', '-phpdoc_short_description'))
     ->finder($finder)

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION="2.3.*"
     - php: 5.6
-      env: SYMFONY_VERSION="2.7.*"
-      # disabled temporarily to make test pass again
-      # env: CHECK_PHP_SYNTAX="yes"
+      env:
+        - SYMFONY_VERSION="2.7.*"
+        - CHECK_PHP_SYNTAX="yes"
     - php: 5.6
       env: SYMFONY_VERSION="2.8.*"
       env: ENABLE_CODE_COVERAGE="true"
@@ -64,13 +64,13 @@ before_install:
   - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
 
 install:
-  - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then curl http://get.sensiolabs.org/php-cs-fixer.phar -o php-cs-fixer; fi;
+  - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then composer require --dev --no-update friendsofphp/php-cs-fixer; fi;
   - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
   - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then composer require --dev satooshi/php-coveralls; fi
 
 script:
   - if [[ "$ENABLE_CODE_COVERAGE" == "true" ]]; then phpunit --coverage-text --coverage-clover build/logs/clover.xml; else phpunit; fi;
-  - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then php php-cs-fixer --no-interaction --dry-run --diff -v fix; fi;
+  - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then php vendor/bin/php-cs-fixer --no-interaction --dry-run --diff -v fix; fi;
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then mv ./.php_cs.cache $HOME/.app/cache/.php_cs.cache; fi;
 
 after_success: |


### PR DESCRIPTION
http://get.sensiolabs.org/php-cs-fixer.phar now provides the `2.0.0-beta` version of the php cs fixer, since it has been released some days ago (the RC has even been released some hours ago 😄).
~~Anyway, I think it's safer to rely on composer to install this dependency, and it also makes sense to have it as a dev dependency, ensuring everyone is working with the exact same version.~~ I'd like to require it in dev dependencies, but [this shows it'll not be possible because of the 2.3 build](https://travis-ci.org/ogizanagi/EasyAdminBundle/jobs/175404941#L205).

However, if you want to give a try to the 2.0 version, I can adapt the php-cs configuration, as I already use it on [some projects](https://github.com/Elao/PhpEnums/blob/master/.php_cs).