### PR TITLE
Added option to sort joined entities

### DIFF
--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -54,7 +54,18 @@ class QueryBuilder
         }
 
         if (null !== $sortField) {
-            $queryBuilder->orderBy('entity.'.$sortField, $sortDirection);
+            if (isset($entityConfig['list']['fields'][$sortField]['entitySort'])) {
+                $sortConfig = $entityConfig['list']['fields'][$sortField]['entitySort'];
+
+                $queryBuilder->join(
+                    $sortConfig['targetEntity'],
+                    'entity_joined',
+                    'WITH',
+                    'entity_joined = entity.' . $sortField
+                )->orderBy('entity_joined.' . $sortConfig['targetProperty'], $sortDirection);
+            } else {
+                $queryBuilder->orderBy('entity.'.$sortField, $sortDirection);
+            }
         }
 
         return $queryBuilder;

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -57,7 +57,7 @@ class QueryBuilder
             if (isset($entityConfig['list']['fields'][$sortField]['entitySort'])) {
                 $sortConfig = $entityConfig['list']['fields'][$sortField]['entitySort'];
 
-                $queryBuilder->join(
+                $queryBuilder->leftJoin(
                     $sortConfig['targetEntity'],
                     'entity_joined',
                     'WITH',


### PR DESCRIPTION
This PR adds the option to order by the property of a related entity when sorting through the EasyAdminBundle list view. This addresses #1337 

Currently, joined entities are sorted by ID but that's not what you always want. The alternative, via queryBuilder by overriding `createCustomer<EntityName>ListQueryBuilder` is also not optimal. 

This PR aims to address that.

All that's needed is this configuration on a field with the new "entitySort" configuration and the rest will be taken care of.

    # Sample configuration
    fields:
      - property: customer
        entitySort: 
	      targetEntity: AppBundle\Entity\Customer
	      targetProperty: name

This could have been done also automagically via Doctrine annotation reader since the relationships are already declared but i figured this would be more lightweight and also would get the conversation started on this topic. Perhaps if the annotations are parsed elsewhere on EasyAdmin we could use that code for this issue aswell. 

Thoughts on PR? Also thoughts on YAML vs Doctrine Annotation reader use and how would I go about testing this?
