### PR TITLE
Display a proper error message when a database item cannot be removed

### DIFF
--- a/Exception/EntityRemoveException.php
+++ b/Exception/EntityRemoveException.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class EntityRemoveException extends BaseException
+{
+    public function __construct(array $parameters = array())
+    {
+        $errorMessage = sprintf('You can\'t delete this "%s" item because other items depend on it in the database.', $parameters['entity']);
+        $proposedSolution = "Don't delete this item or change the database configuration to allow deleting it.";
+
+        parent::__construct($errorMessage, $proposedSolution, 404);
+    }
+}


### PR DESCRIPTION
This fixes #747.

---

When you try to remove an entity which doesn't have a `cascade: remove` option, Symfony/Doctrine display the following error message in production:

![error_before](https://cloud.githubusercontent.com/assets/73419/20457012/b296a5a8-ae81-11e6-8f98-9b16808676d7.png)

Now, thanks to this new exception, we can display a human-friendly message for this common error:

![error_after](https://cloud.githubusercontent.com/assets/73419/20457018/c0fe9736-ae81-11e6-91d1-384d0497c746.png)
