### PR TITLE
don't access view for forms used in custom views

### DIFF
--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -54,7 +54,7 @@ class EasyAdminFormType extends AbstractType
         $entity = $options['entity'];
         $view = $options['view'];
         $entityConfig = $this->configManager->getEntityConfig($entity);
-        $entityProperties = $entityConfig[$view]['fields'];
+        $entityProperties = isset($entityConfig[$view]['fields']) ? $entityConfig[$view]['fields'] : array();
         $formGroups = array();
         $currentFormGroup = null;
 


### PR DESCRIPTION
When you create custom actions and use a form type based on the `EasyAdminFormType`, `$entityConfig[$view]` will not be set.

This is similar to the fix in #1393.