### PR TITLE
Issue #1409 FIX

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -667,6 +667,7 @@ class AdminController extends Controller
 
         $submitButtonType = LegacyFormHelper::useLegacyFormComponent() ? 'submit' : 'Symfony\\Component\\Form\\Extension\\Core\\Type\\SubmitType';
         $formBuilder->add('submit', $submitButtonType, array('label' => 'delete_modal.action', 'translation_domain' => 'EasyAdminBundle'));
+        $formBuilder->add('deleteFlag', LegacyFormHelper::useLegacyFormComponent() ? 'submit' : 'Symfony\\Component\\Form\\Extension\\Core\\Type\\HiddenType', array('data' => '1'));
 
         return $formBuilder->getForm();
     }

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -667,6 +667,7 @@ class AdminController extends Controller
 
         $submitButtonType = LegacyFormHelper::useLegacyFormComponent() ? 'submit' : 'Symfony\\Component\\Form\\Extension\\Core\\Type\\SubmitType';
         $formBuilder->add('submit', $submitButtonType, array('label' => 'delete_modal.action', 'translation_domain' => 'EasyAdminBundle'));
+        $formBuilder->add('deleteFlag', LegacyFormHelper::useLegacyFormComponent() ? 'hidden' : 'Symfony\\Component\\Form\\Extension\\Core\\Type\\HiddenType', array('data' => '1'));
 
         return $formBuilder->getForm();
     }


### PR DESCRIPTION
https://github.com/javiereguiluz/EasyAdminBundle/issues/1409

Delete form with disabled CSRF form fixed by adding hidden field to form.
Modification is preventing empty DELETE request from being sent (therefore form is not being submitted if CSRF is disabled).