### PR TITLE
Added Twig 2.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,8 @@ matrix:
       sudo: required
       dist: trusty
       group: edge
-    - php: 5.6
+    - php: 7.0
+      env: SYMFONY_VERSION="3.2.*"
       env: TWIG_VERSION="2.x-dev"
   allow_failures:
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
     - php: 7.1
       env:
         - SYMFONY_VERSION="3.2.*"
+        - TWIG_VERSION="2.x-dev"
         - CHECK_PHP_SYNTAX="yes"
     - php: 7.0
       env: SYMFONY_VERSION="3.1.*"
@@ -46,9 +47,6 @@ matrix:
       sudo: required
       dist: trusty
       group: edge
-    - php: 7.0
-      env: SYMFONY_VERSION="3.2.*"
-      env: TWIG_VERSION="2.x-dev"
   allow_failures:
     - php: nightly
     - php: hhvm-stable


### PR DESCRIPTION
Twig 2.x will be released next week. Let's make sure this bundle will work with it.

---

The first change will be to start testing Twig 2.x with PHP 7 and Symfony 3.2.
