### PR TITLE
Use Symfony mb_* polyfill for string functions

### DIFF
--- a/Configuration/ActionConfigPass.php
+++ b/Configuration/ActionConfigPass.php
@@ -332,7 +332,7 @@ class ActionConfigPass implements ConfigPassInterface
      */
     private function humanizeString($content)
     {
-        return ucfirst(trim(strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $content))));
+        return ucfirst(trim(mb_strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $content))));
     }
 
     private function reorderArrayItems(array $originalArray, array $newKeyOrder)

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -186,7 +186,7 @@ class AdminController extends Controller
         $entity = $easyadmin['item'];
 
         if ($this->request->isXmlHttpRequest() && $property = $this->request->query->get('property')) {
-            $newValue = 'true' === strtolower($this->request->query->get('newValue'));
+            $newValue = 'true' === mb_strtolower($this->request->query->get('newValue'));
             $fieldsMetadata = $this->entity['list']['fields'];
 
             if (!isset($fieldsMetadata[$property]) || 'toggle' !== $fieldsMetadata[$property]['dataType']) {
@@ -589,7 +589,7 @@ class AdminController extends Controller
 
         $formType = LegacyFormHelper::useLegacyFormComponent() ? 'easyadmin' : 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Form\\Type\\EasyAdminFormType';
 
-        return $this->get('form.factory')->createNamedBuilder(strtolower($this->entity['name']), $formType, $entity, $formOptions);
+        return $this->get('form.factory')->createNamedBuilder(mb_strtolower($this->entity['name']), $formType, $entity, $formOptions);
     }
 
     /**

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -164,7 +164,7 @@ class EasyAdminFormType extends AbstractType
     {
         return function (Options $options, $value) {
             return array_replace(array(
-                'id' => sprintf('%s-%s-form', $options['view'], strtolower($options['entity'])),
+                'id' => sprintf('%s-%s-form', $options['view'], mb_strtolower($options['entity'])),
             ), $value);
         };
     }

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -97,7 +97,7 @@ class QueryBuilder
                 $queryBuilder->orWhere(sprintf('entity.%s IN (:words_query)', $name));
                 $queryParameters['words_query'] = explode(' ', $searchQuery);
             } elseif ($isTextField) {
-                $searchQuery = strtolower($searchQuery);
+                $searchQuery = mb_strtolower($searchQuery);
 
                 $queryBuilder->orWhere(sprintf('LOWER(entity.%s) LIKE :fuzzy_query', $name));
                 $queryParameters['fuzzy_query'] = '%'.$searchQuery.'%';

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -287,31 +287,17 @@ class EasyAdminTwigExtension extends \Twig_Extension
             $value = '';
         }
 
-        if (function_exists('mb_get_info')) {
-            if (mb_strlen($value, $env->getCharset()) > $length) {
-                if ($preserve) {
-                    // If breakpoint is on the last word, return the value without separator.
-                    if (false === ($breakpoint = mb_strpos($value, ' ', $length, $env->getCharset()))) {
-                        return $value;
-                    }
-
-                    $length = $breakpoint;
-                }
-
-                return rtrim(mb_substr($value, 0, $length, $env->getCharset())).$separator;
-            }
-
-            return $value;
-        }
-
-        if (strlen($value) > $length) {
+        if (mb_strlen($value, $env->getCharset()) > $length) {
             if ($preserve) {
-                if (false !== ($breakpoint = strpos($value, ' ', $length))) {
-                    $length = $breakpoint;
+                // If breakpoint is on the last word, return the value without separator.
+                if (false === ($breakpoint = mb_strpos($value, ' ', $length, $env->getCharset()))) {
+                    return $value;
                 }
+
+                $length = $breakpoint;
             }
 
-            return rtrim(substr($value, 0, $length)).$separator;
+            return rtrim(mb_substr($value, 0, $length, $env->getCharset())).$separator;
         }
 
         return $value;

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/framework-bundle"      : "~2.3|~3.0",
         "symfony/http-foundation"       : "~2.3|~3.0",
         "symfony/http-kernel"           : "~2.3|~3.0",
-        "symfony/polyfill-mbstring"     : "~2.3|~3.0",
+        "symfony/polyfill-mbstring"     : "^1.0",
         "symfony/property-access"       : "~2.3|~3.0",
         "symfony/security-bundle"       : "~2.3|~3.0",
         "symfony/twig-bridge"           : "^2.3.4|~3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/framework-bundle"      : "~2.3|~3.0",
         "symfony/http-foundation"       : "~2.3|~3.0",
         "symfony/http-kernel"           : "~2.3|~3.0",
+        "symfony/polyfill-mbstring"     : "~2.3|~3.0",
         "symfony/property-access"       : "~2.3|~3.0",
         "symfony/security-bundle"       : "~2.3|~3.0",
         "symfony/twig-bridge"           : "^2.3.4|~3.0",


### PR DESCRIPTION
As pointed in #1434, we're using `strlen()`, `strlower()` etc. in some parts of the code and that's not friendly to languages such as Russian. Let's require the Symfony Polyfill to freely use `mb_*()` functions everywhere.