### PR TITLE
Run tests faster on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,9 @@ matrix:
   allow_failures:
     - php: nightly
     # code coverage is very slow; allow a failure to get the Travis result early
-    - env: ENABLE_CODE_COVERAGE="true"
+    - env:
+        - SYMFONY_VERSION="3.2.*"
+        - ENABLE_CODE_COVERAGE="true"
 
 before_install:
   - stty cols 120

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,22 +33,22 @@ matrix:
     # common (some popular version combinations)
     - php: 7.0
       env: SYMFONY_VERSION="3.1.*"
-    # common (some popular version combinations)
     - php: 5.6
-      env:
-        - SYMFONY_VERSION="2.8.*"
-        - ENABLE_CODE_COVERAGE="true"
+      env: SYMFONY_VERSION="2.8.*"
     # legacy (oldest supported versions)
     - php: 5.3
       env:
         - SYMFONY_VERSION="2.3.*"
         - COMPOSER_FLAGS="--prefer-lowest"
+    # code coverage (special job to process the code coverage)
+    - php: 7.1
+      env:
+        - SYMFONY_VERSION="3.2.*"
+        - ENABLE_CODE_COVERAGE="true"
   allow_failures:
     - php: nightly
     # code coverage is very slow; allow a failure to get the Travis result early
-    - env:
-        - SYMFONY_VERSION="2.8.*"
-        - ENABLE_CODE_COVERAGE="true"
+    - env: ENABLE_CODE_COVERAGE="true"
 
 before_install:
   - stty cols 120

--- a/Tests/Controller/DisabledActionsTest.php
+++ b/Tests/Controller/DisabledActionsTest.php
@@ -25,8 +25,8 @@ class DisabledActionsTest extends AbstractTestCase
 
     public function testAssociationLinksInListView()
     {
-        if (2 === Kernel::MAJOR_VERSION && in_array(Kernel::MINOR_VERSION, array(3, 7))) {
-            $this->markTestSkipped('This test is not compatible with Symfony 2.3 or 2.7.');
+        if (2 === Kernel::MAJOR_VERSION) {
+            $this->markTestSkipped('This test is not compatible with Symfony 2.x.');
         }
 
         $crawler = $this->requestListView('Purchase');
@@ -40,8 +40,8 @@ class DisabledActionsTest extends AbstractTestCase
 
     public function testAssociationLinksInShowView()
     {
-        if (2 === Kernel::MAJOR_VERSION && in_array(Kernel::MINOR_VERSION, array(3, 7))) {
-            $this->markTestSkipped('This test is not compatible with Symfony 2.3 or 2.7.');
+        if (2 === Kernel::MAJOR_VERSION) {
+            $this->markTestSkipped('This test is not compatible with Symfony 2.x.');
         }
 
         // 'Purchase' entity 'id' is generated randomly. In order to browse the


### PR DESCRIPTION
Processing the code coverage takes ~1 hour at the moment. Let's use faster PHP and Symfony versions to reduce this time.