### PR TITLE
Change priority for processing config

### DIFF
--- a/Configuration/ConfigManager.php
+++ b/Configuration/ConfigManager.php
@@ -187,8 +187,8 @@ class ConfigManager
             new MenuConfigPass(),
             new ActionConfigPass(),
             new MetadataConfigPass($this->container->get('doctrine')),
-            new PropertyConfigPass(),
             new ViewConfigPass(),
+            new PropertyConfigPass(),
             new TemplateConfigPass($this->container->getParameter('kernel.root_dir').'/Resources/views'),
             new DefaultConfigPass(),
         );

--- a/Configuration/ViewConfigPass.php
+++ b/Configuration/ViewConfigPass.php
@@ -74,7 +74,7 @@ class ViewConfigPass implements ConfigPassInterface
                     // special case: if the field is called 'id' and doesn't define a custom
                     // label, use 'ID' as label. This improves the readability of the label
                     // of this important field, which is usually related to the primary key
-                    if ('id' === $fieldConfig['fieldName'] && !isset($fieldConfig['label'])) {
+                    if (isset($fieldConfig['fieldName']) && 'id' === $fieldConfig['fieldName'] && !isset($fieldConfig['label'])) {
                         $fieldConfig['label'] = 'ID';
                     }
 


### PR DESCRIPTION
By having a config like [this](https://github.com/javiereguiluz/easy-admin-demo/blob/master/app/config/admin/entities/purchase.yml) (without show fields) some defaults like format are not applied on the show page. So you see, as example, Delivery hour: January 1, 1970 08:00 instead of Delivery hour: 08:00:00

I don't know of this is the way to go..