### PR TITLE
Fix var-dumper deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "symfony/finder"                    : "~2.3|~3.0",
         "symfony/phpunit-bridge"            : "^2.7",
         "symfony/validator"                 : "~2.3|~3.0",
-        "symfony/yaml"                      : "~2.3|~3.0"
+        "symfony/yaml"                      : "~2.3|~3.0",
+        "symfony/var-dumper"                : "~2.3|~3.0"
     },
     "autoload": {
         "psr-4": { "JavierEguiluz\\Bundle\\EasyAdminBundle\\": "" },


### PR DESCRIPTION
Using the Symfony\Component\HttpKernel\DataCollector\DataCollector::cloneVar() method without the VarDumper component is deprecated since version 3.2 and won't be supported in 4.0. Install symfony/var-dumper version 3.2 or above: 490x

Using the Symfony\Component\Form\Extension\DataCollector\FormDataCollector::cloneVar() method without the VarDumper component is deprecated since version 3.2 and won't be supported in 4.0. Install symfony/var-dumper version 3.2 or above: 171x