### PR TITLE
Always use VarDumper to dump contents

### DIFF
--- a/DataCollector/EasyAdminDataCollector.php
+++ b/DataCollector/EasyAdminDataCollector.php
@@ -95,17 +95,11 @@ class EasyAdminDataCollector extends DataCollector
      */
     public function dump($variable)
     {
-        if (class_exists('Symfony\Component\VarDumper\Dumper\HtmlDumper')) {
-            $cloner = new VarCloner();
-            $dumper = new HtmlDumper();
+        $cloner = new VarCloner();
+        $dumper = new HtmlDumper();
 
-            $dumper->dump($cloner->cloneVar($variable), $output = fopen('php://memory', 'r+b'));
-            $dumpedData = stream_get_contents($output, -1, 0);
-        } elseif (class_exists('Symfony\Component\Yaml\Yaml')) {
-            $dumpedData = sprintf('<pre class="sf-dump">%s</pre>', Yaml::dump((array) $variable, 1024));
-        } else {
-            $dumpedData = sprintf('<pre class="sf-dump">%s</pre>', var_export($variable, true));
-        }
+        $dumper->dump($cloner->cloneVar($variable), $output = fopen('php://memory', 'r+b'));
+        $dumpedData = stream_get_contents($output, -1, 0);
 
         return $dumpedData;
     }


### PR DESCRIPTION
After [this change](https://github.com/javiereguiluz/EasyAdminBundle/commit/1c0eca3b064150661b5f0b0185f5a5ac8336faaa) we now require VarDumper in `dev` environment. So I guess we can safely use it to dump contents.