### PR TITLE
Translatable exception messages

### DIFF
--- a/Configuration/ConfigManager.php
+++ b/Configuration/ConfigManager.php
@@ -11,6 +11,7 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
 
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -84,7 +85,7 @@ class ConfigManager
     {
         $backendConfig = $this->getBackendConfig();
         if (!isset($backendConfig['entities'][$entityName])) {
-            throw new \InvalidArgumentException(sprintf('Entity "%s" is not managed by EasyAdmin.', $entityName));
+            throw new UndefinedEntityException(array('entity_name' => $entityName));
         }
 
         return $backendConfig['entities'][$entityName];

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -69,7 +69,7 @@ class AdminController extends Controller
 
         $action = $request->query->get('action', 'list');
         if (!$this->isActionAllowed($action)) {
-            throw new ForbiddenActionException(array('action' => $action, 'entity' => $this->entity['name']));
+            throw new ForbiddenActionException(array('action' => $action, 'entity_name' => $this->entity['name']));
         }
 
         return $this->executeDynamicMethod($action.'<EntityName>Action');

--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -338,7 +338,7 @@ class AdminController extends Controller
                 $this->em->remove($entity);
                 $this->em->flush();
             } catch (ForeignKeyConstraintViolationException $e) {
-                throw new EntityRemoveException(array('entity' => $this->entity['name']));
+                throw new EntityRemoveException(array('entity_name' => $this->entity['name']));
             }
 
             $this->dispatch(EasyAdminEvents::POST_REMOVE, array('entity' => $entity));

--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -83,7 +83,7 @@ class RequestPostInitializeListener
     {
         $manager = $this->doctrine->getManagerForClass($entityConfig['class']);
         if (null === $entity = $manager->getRepository($entityConfig['class'])->find($itemId)) {
-            throw new EntityNotFoundException(array('entity' => $entityConfig, 'entity_id' => $itemId));
+            throw new EntityNotFoundException(array('entity_name' => $entityConfig['name'], 'entity_id_name' => $entityConfig['primary_key_field_name'], 'entity_id_value' => $itemId));
         }
 
         return $entity;

--- a/Exception/BaseException.php
+++ b/Exception/BaseException.php
@@ -16,32 +16,40 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
  */
 class BaseException extends \RuntimeException
 {
-    // the HTTP status code of the Response created for the exception
     protected $message;
-    // this is the error message that can be safely displayed to end users
-    private $safeMessage;
-    // this is the full error message displayed only in 'dev' environment and logs
-    private $statusCode;
+    private $context;
 
     /**
-     * @param string $errorMessage
-     * @param string $proposedSolution
-     * @param int    $statusCode
+     * @param ExceptionContext $exceptionContext
      */
-    public function __construct($errorMessage, $proposedSolution = '', $statusCode = 500)
+    public function __construct(ExceptionContext $context)
     {
-        $this->safeMessage = $errorMessage;
-        $this->message = sprintf('Error: %s Solution: %s', $errorMessage, $proposedSolution);
-        $this->statusCode = $statusCode;
+        $this->message = $context->getDebugMessage();
+        $this->context = $context;
     }
 
-    public function getSafeMessage()
+    public function getContext()
     {
-        return $this->safeMessage;
+        return $this->context;
+    }
+
+    public function getPublicMessage()
+    {
+        return $this->context->getPublicMessage();
+    }
+
+    public function getDebugMessage()
+    {
+        return $this->context->getDebugMessage();
+    }
+
+    public function getParameters()
+    {
+        return $this->context->getParameters();
     }
 
     public function getStatusCode()
     {
-        return $this->statusCode;
+        return $this->context->getStatusCode();
     }
 }

--- a/Exception/BaseException.php
+++ b/Exception/BaseException.php
@@ -20,7 +20,7 @@ class BaseException extends \RuntimeException
     private $context;
 
     /**
-     * @param ExceptionContext $exceptionContext
+     * @param ExceptionContext $context
      */
     public function __construct(ExceptionContext $context)
     {

--- a/Exception/EntityNotFoundException.php
+++ b/Exception/EntityNotFoundException.php
@@ -18,9 +18,13 @@ class EntityNotFoundException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $errorMessage = sprintf('The "%s" entity with "%s = %s" does not exist in the database.', $parameters['entity']['name'], $parameters['entity']['primary_key_field_name'], $parameters['entity_id']);
-        $proposedSolution = sprintf('Check that the mentioned entity hasn\'t been deleted by mistake.');
+        $exceptionContext = new ExceptionContext(
+            'exception.entity_not_found',
+            sprintf('The "%s" entity with "%s = %s" does not exist in the database. The entity may have been deleted by mistake or by a "cascade={"remove"}" operation executed by Doctrine.', $parameters['entity_name'], $parameters['entity_id_name'], $parameters['entity_id_value']),
+            $parameters,
+            404
+        );
 
-        parent::__construct($errorMessage, $proposedSolution, 404);
+        parent::__construct($exceptionContext);
     }
 }

--- a/Exception/EntityRemoveException.php
+++ b/Exception/EntityRemoveException.php
@@ -18,9 +18,13 @@ class EntityRemoveException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $errorMessage = sprintf('You can\'t delete this "%s" item because other items depend on it in the database.', $parameters['entity']);
-        $proposedSolution = "Don't delete this item or change the database configuration to allow deleting it.";
+        $exceptionContext = new ExceptionContext(
+            'exception.entity_remove',
+            sprintf('There is a ForeignKeyConstraintViolationException for the Doctrine entity associated with "%s". Solution: disable the "delete" action for this entity or configure the "cascade={"remove"}" attribute for the related property in the Doctrine entity.', $parameters['entity_name']),
+            $parameters,
+            404
+        );
 
-        parent::__construct($errorMessage, $proposedSolution, 404);
+        parent::__construct($exceptionContext);
     }
 }

--- a/Exception/ExceptionContext.php
+++ b/Exception/ExceptionContext.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class ExceptionContext
+{
+    private $publicMessage;
+    private $debugMessage;
+    private $parameters;
+    private $statusCode;
+
+    public function __construct($publicMessage, $debugMessage = '', $parameters = array(), $statusCode = 500) {
+        $this->publicMessage = $publicMessage;
+        $this->debugMessage = $debugMessage;
+        $this->parameters = $this->transformIntoTranslationParameters($parameters);
+        $this->statusCode = $statusCode;
+    }
+
+    public function getPublicMessage()
+    {
+        return $this->publicMessage;
+    }
+
+    public function getDebugMessage()
+    {
+        return $this->debugMessage;
+    }
+
+    public function getParameters()
+    {
+        return $this->parameters;
+    }
+
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+
+    private function transformIntoTranslationParameters(array $parameters)
+    {
+        $newParameters = array();
+        foreach ($parameters as $key => $value) {
+            if ('%' !== $key[0]) {
+                $key = '%'.$key;
+            }
+            if ('%' !== substr($key, -1)) {
+                $key = $key.'%';
+            }
+
+            $newParameters[$key] = $value;
+        }
+
+        return $newParameters;
+    }
+}

--- a/Exception/ExceptionContext.php
+++ b/Exception/ExceptionContext.php
@@ -24,7 +24,7 @@ class ExceptionContext
     public function __construct($publicMessage, $debugMessage = '', $parameters = array(), $statusCode = 500) {
         $this->publicMessage = $publicMessage;
         $this->debugMessage = $debugMessage;
-        $this->parameters = $this->transformIntoTranslationParameters($parameters);
+        $this->parameters = $parameters;
         $this->statusCode = $statusCode;
     }
 
@@ -43,14 +43,19 @@ class ExceptionContext
         return $this->parameters;
     }
 
+    public function getTranslationParameters()
+    {
+        return $this->transformIntoTranslationPlaceholders($this->parameters);
+    }
+
     public function getStatusCode()
     {
         return $this->statusCode;
     }
 
-    private function transformIntoTranslationParameters(array $parameters)
+    private function transformIntoTranslationPlaceholders(array $parameters)
     {
-        $newParameters = array();
+        $placeholders = array();
         foreach ($parameters as $key => $value) {
             if ('%' !== $key[0]) {
                 $key = '%'.$key;
@@ -59,9 +64,9 @@ class ExceptionContext
                 $key = $key.'%';
             }
 
-            $newParameters[$key] = $value;
+            $placeholders[$key] = $value;
         }
 
-        return $newParameters;
+        return $placeholders;
     }
 }

--- a/Exception/ExceptionContext.php
+++ b/Exception/ExceptionContext.php
@@ -21,7 +21,8 @@ class ExceptionContext
     private $parameters;
     private $statusCode;
 
-    public function __construct($publicMessage, $debugMessage = '', $parameters = array(), $statusCode = 500) {
+    public function __construct($publicMessage, $debugMessage = '', $parameters = array(), $statusCode = 500)
+    {
         $this->publicMessage = $publicMessage;
         $this->debugMessage = $debugMessage;
         $this->parameters = $parameters;

--- a/Exception/FlattenException.php
+++ b/Exception/FlattenException.php
@@ -18,8 +18,8 @@ use Symfony\Component\Debug\Exception\FlattenException as BaseFlattenException;
  */
 class FlattenException extends BaseFlattenException
 {
-    /** @var string */
-    private $safeMessage;
+    /** @var ExceptionContext */
+    private $context;
 
     public static function create(\Exception $exception, $statusCode = null, array $headers = array())
     {
@@ -29,25 +29,28 @@ class FlattenException extends BaseFlattenException
 
         /** @var FlattenException $e */
         $e = parent::create($exception, $statusCode, $headers);
-        $e->setStatusCode($exception->getStatusCode());
-        $e->setSafeMessage($exception->getSafeMessage());
+        $e->context = $exception->getContext();
 
         return $e;
     }
 
-    /**
-     * @return string
-     */
-    public function getSafeMessage()
+    public function getPublicMessage()
     {
-        return $this->safeMessage;
+        return $this->context->getPublicMessage();
     }
 
-    /**
-     * @param string $safeMessage
-     */
-    public function setSafeMessage($safeMessage)
+    public function getDebugMessage()
     {
-        $this->safeMessage = $safeMessage;
+        return $this->context->getDebugMessage();
+    }
+
+    public function getParameters()
+    {
+        return $this->context->getParameters();
+    }
+
+    public function getStatusCode()
+    {
+        return $this->context->getStatusCode();
     }
 }

--- a/Exception/FlattenException.php
+++ b/Exception/FlattenException.php
@@ -49,6 +49,11 @@ class FlattenException extends BaseFlattenException
         return $this->context->getParameters();
     }
 
+    public function getTranslationParameters()
+    {
+        return $this->context->getTranslationParameters();
+    }
+
     public function getStatusCode()
     {
         return $this->context->getStatusCode();

--- a/Exception/ForbiddenActionException.php
+++ b/Exception/ForbiddenActionException.php
@@ -18,9 +18,13 @@ class ForbiddenActionException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $errorMessage = sprintf('The requested "%s" action is not allowed for the "%s" entity.', $parameters['action'], $parameters['entity']);
-        $proposedSolution = sprintf('Remove the "%s" action from the "disabled_actions" option, which can be configured globally for the entire backend or locally for the "%s" entity.', $parameters['action'], $parameters['entity']);
+        $exceptionContext = new ExceptionContext(
+            'exception.forbidden_action',
+            sprintf('The requested "%s" action is not allowed for the "%s" entity. Solution: remove the "%s" action from the "disabled_actions" option, which can be configured globally for the entire backend or locally for the "%s" entity.', $parameters['action'], $parameters['entity_name'], $parameters['action'], $parameters['entity_name']),
+            $parameters,
+            403
+        );
 
-        parent::__construct($errorMessage, $proposedSolution, 403);
+        parent::__construct($exceptionContext);
     }
 }

--- a/Exception/NoEntitiesConfiguredException.php
+++ b/Exception/NoEntitiesConfiguredException.php
@@ -18,9 +18,13 @@ class NoEntitiesConfiguredException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $errorMessage = 'Your backend is empty because you haven\'t configured any Doctrine entity to manage.';
-        $proposedSolution = 'Open your "app/config/config.yml" file and configure the backend under the "easy_admin" key.';
+        $exceptionContext = new ExceptionContext(
+            'exception.no_entities_configured',
+            'The backend is empty because you haven\'t configured any Doctrine entity to manage. Solution: open your "app/config/config.yml" file and configure the backend under the "easy_admin" key.',
+            $parameters,
+            500
+        );
 
-        parent::__construct($errorMessage, $proposedSolution);
+        parent::__construct($exceptionContext);
     }
 }

--- a/Exception/UndefinedEntityException.php
+++ b/Exception/UndefinedEntityException.php
@@ -18,9 +18,13 @@ class UndefinedEntityException extends BaseException
 {
     public function __construct(array $parameters = array())
     {
-        $errorMessage = sprintf('The "%s" entity is not defined in the configuration of your backend.', $parameters['entity_name']);
-        $proposedSolution = sprintf('Open your "app/config/config.yml" file and add the "%s" entity to the list of entities managed by EasyAdmin. NOTE: If your project worked before, this error may be caused by a change introduced by EasyAdmin 1.12.0 version. Check out https://github.com/javiereguiluz/EasyAdminBundle/releases/tag/v1.12.0 for more details.', $parameters['entity_name']);
+        $exceptionContext = new ExceptionContext(
+            'exception.undefined_entity',
+            sprintf('The "%s" entity is not defined in the configuration of your backend. Solution: open your "app/config/config.yml" file and add the "%s" entity to the list of entities managed by EasyAdmin.', $parameters['entity_name'], $parameters['entity_name']),
+            $parameters,
+            404
+        );
 
-        parent::__construct($errorMessage, $proposedSolution);
+        parent::__construct($exceptionContext);
     }
 }

--- a/Resources/translations/EasyAdminBundle.en.xlf
+++ b/Resources/translations/EasyAdminBundle.en.xlf
@@ -135,6 +135,10 @@
                 <source>action.remove_item</source>
                 <target>Remove the item</target>
             </trans-unit>
+            <trans-unit id="error">
+                <source>error</source>
+                <target>Error</target>
+            </trans-unit>
             <trans-unit id="errors">
                 <source>errors</source>
                 <target>Error|Errors</target>
@@ -146,6 +150,12 @@
             <trans-unit id="show.remaining_items">
                 <source>show.remaining_items</source>
                 <target><![CDATA[{1} there is another item not displayed in this listing|]1,Inf] %count% other items are not displayed in this listing]]></target>
+            </trans-unit>
+
+            <!-- Exceptions -->
+            <trans-unit id="exception.entity_remove">
+                <source>exception.entity_remove</source>
+                <target>You can't delete this "%entity_name%" item because other items depend on it in the database.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/EasyAdminBundle.en.xlf
+++ b/Resources/translations/EasyAdminBundle.en.xlf
@@ -135,10 +135,6 @@
                 <source>action.remove_item</source>
                 <target>Remove the item</target>
             </trans-unit>
-            <trans-unit id="error">
-                <source>error</source>
-                <target>Error</target>
-            </trans-unit>
             <trans-unit id="errors">
                 <source>errors</source>
                 <target>Error|Errors</target>
@@ -153,9 +149,25 @@
             </trans-unit>
 
             <!-- Exceptions -->
+            <trans-unit id="exception.entity_not_found">
+                <source>exception.entity_not_found</source>
+                <target>This item is no longer available.</target>
+            </trans-unit>
             <trans-unit id="exception.entity_remove">
                 <source>exception.entity_remove</source>
-                <target>You can't delete this "%entity_name%" item because other items depend on it in the database.</target>
+                <target>This item can't be deleted because other items depend on it.</target>
+            </trans-unit>
+            <trans-unit id="exception.forbidden_action">
+                <source>exception.forbidden_action</source>
+                <target>The requested action can't be performed on this item.</target>
+            </trans-unit>
+            <trans-unit id="exception.no_entities_configured">
+                <source>exception.no_entities_configured</source>
+                <target>The application is not properly configured.</target>
+            </trans-unit>
+            <trans-unit id="exception.undefined_entity">
+                <source>exception.undefined_entity</source>
+                <target>The application is not properly configured for this kind of items.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/Resources/translations/EasyAdminBundle.fr.xlf
@@ -135,10 +135,6 @@
                 <source>action.remove_item</source>
                 <target>Supprimer l'élément</target>
             </trans-unit>
-            <trans-unit id="error">
-                <source>error</source>
-                <target>Erreur</target>
-            </trans-unit>
             <trans-unit id="errors">
                 <source>errors</source>
                 <target>Erreur|Erreurs</target>
@@ -150,12 +146,6 @@
             <trans-unit id="show.remaining_items">
                 <source>show.remaining_items</source>
                 <target><![CDATA[{1} il y a un autre élément qui n'est pas affiché dans cette liste|]1,Inf] %count% autres éléments ne sont pas affichés dans cette liste]]></target>
-            </trans-unit>
-
-            <!-- Exceptions -->
-            <trans-unit id="exception.entity_remove">
-                <source>exception.entity_remove</source>
-                <target>Vous ne pouvez pas supprimer ce contenu de type "%entity_name%" car il possède des dépendances à d'autres contenus.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/Resources/translations/EasyAdminBundle.fr.xlf
@@ -135,6 +135,10 @@
                 <source>action.remove_item</source>
                 <target>Supprimer l'élément</target>
             </trans-unit>
+            <trans-unit id="error">
+                <source>error</source>
+                <target>Erreur</target>
+            </trans-unit>
             <trans-unit id="errors">
                 <source>errors</source>
                 <target>Erreur|Erreurs</target>
@@ -146,6 +150,12 @@
             <trans-unit id="show.remaining_items">
                 <source>show.remaining_items</source>
                 <target><![CDATA[{1} il y a un autre élément qui n'est pas affiché dans cette liste|]1,Inf] %count% autres éléments ne sont pas affichés dans cette liste]]></target>
+            </trans-unit>
+
+            <!-- Exceptions -->
+            <trans-unit id="exception.entity_remove">
+                <source>exception.entity_remove</source>
+                <target>Vous ne pouvez pas supprimer ce contenu de type "%entity_name%" car il possède des dépendances à d'autres contenus.</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -1096,13 +1096,15 @@ body.show .form-control.text {
 {# -------------------------------------------------------------------------
    ERROR PAGES
    ------------------------------------------------------------------------- #}
+body.error .content-wrapper {
+    align-items: center;
+    display: flex;
+}
 body.error .error-description {
     background: {{ colors.white }};
     border: 1px solid {{ colors.gray_lighter }};
     box-shadow: 0 0 3px {{ colors.gray_light }};
-    margin: 2em auto 2em;
-    max-width: 90%;
-    min-height: 150px;
+    max-width: 96%;
     padding: 0;
 }
 body.error .error-description h1 {
@@ -1110,13 +1112,14 @@ body.error .error-description h1 {
     color: {{ colors.white }};
     font-size: 18px;
     font-weight: bold;
-    margin-top: 0;
+    margin: 0;
     padding: 10px;
     text-transform: uppercase;
 }
 body.error .error-message {
     font-size: 16px;
-    padding: 15px;
+    padding: 45px 30px;
+    text-align: center;
 }
 
 {# =========================================================================
@@ -1287,7 +1290,7 @@ body.error .error-message {
     }
 
     body.error .error-description {
-        max-width: 70%;
+        max-width: 550px;
     }
 
     .pagination > li > a,

--- a/Resources/views/default/exception.html.twig
+++ b/Resources/views/default/exception.html.twig
@@ -6,15 +6,15 @@
 ] %}
 
 {% block body_class 'error' %}
-{% block page_title 'ERROR' %}
+{% block page_title %}{{ 'error'|trans({}, 'EasyAdminBundle') }}{% endblock %}
 
 {% block content %}
     <section id="main" class="content">
         <div class="error-description">
-            <h1>Error</h1>
+            <h1>{{ block('page_title') }}</h1>
 
             <div class="error-message">
-                <p>{{ exception.safeMessage }}</p>
+                <p>{{ exception.publicMessage|trans(exception.parameters, 'EasyAdminBundle') }}</p>
             </div>
         </div>
     </section>

--- a/Resources/views/default/exception.html.twig
+++ b/Resources/views/default/exception.html.twig
@@ -11,10 +11,10 @@
 {% block content %}
     <section id="main" class="content">
         <div class="error-description">
-            <h1>{{ block('page_title') }}</h1>
+            <h1><i class="fa fa-exclamation-circle"></i> {{ block('page_title') }}</h1>
 
             <div class="error-message">
-                <p>{{ exception.publicMessage|trans(exception.translationParameters, 'EasyAdminBundle') }}</p>
+                {{ exception.publicMessage|trans(exception.translationParameters, 'EasyAdminBundle') }}
             </div>
         </div>
     </section>

--- a/Resources/views/default/exception.html.twig
+++ b/Resources/views/default/exception.html.twig
@@ -6,7 +6,7 @@
 ] %}
 
 {% block body_class 'error' %}
-{% block page_title %}{{ 'error'|trans({}, 'EasyAdminBundle') }}{% endblock %}
+{% block page_title %}{{ 'errors'|transchoice(1, {}, 'EasyAdminBundle') }}{% endblock %}
 
 {% block content %}
     <section id="main" class="content">
@@ -14,7 +14,7 @@
             <h1>{{ block('page_title') }}</h1>
 
             <div class="error-message">
-                <p>{{ exception.publicMessage|trans(exception.parameters, 'EasyAdminBundle') }}</p>
+                <p>{{ exception.publicMessage|trans(exception.translationParameters, 'EasyAdminBundle') }}</p>
             </div>
         </div>
     </section>

--- a/Tests/Controller/BackendErrorsTest.php
+++ b/Tests/Controller/BackendErrorsTest.php
@@ -30,6 +30,6 @@ class BackendErrorsTest extends AbstractTestCase
         ));
 
         $this->assertSame(500, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('Entity "InexistentEntity" is not managed by EasyAdmin.', $crawler->filter('head title')->text());
+        $this->assertContains('The "InexistentEntity" entity is not defined in the configuration of your backend.', $crawler->filter('head title')->text());
     }
 }

--- a/Tests/Controller/DisabledActionsTest.php
+++ b/Tests/Controller/DisabledActionsTest.php
@@ -63,7 +63,7 @@ class DisabledActionsTest extends AbstractTestCase
         $crawler = $this->requestShowView('User', 1);
 
         $this->assertContains(
-            'Error: The requested &quot;show&quot; action is not allowed for the &quot;User&quot; entity.',
+            'The requested &quot;show&quot; action is not allowed for the &quot;User&quot; entity.',
             $this->client->getResponse()->getContent()
         );
     }

--- a/Tests/Controller/ReadOnlyBackendTest.php
+++ b/Tests/Controller/ReadOnlyBackendTest.php
@@ -51,7 +51,7 @@ class ReadOnlyBackendTest extends AbstractTestCase
         $this->requestEditView();
 
         $this->assertSame(500, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('Error: The requested &quot;edit&quot; action is not allowed for the &quot;Category&quot; entity. Solution: Remove the &quot;edit&quot; action from the &quot;disabled_actions&quot; option, which can be configured globally for the entire backend or locally for the &quot;Category&quot; entity.', $this->client->getResponse()->getContent());
+        $this->assertContains('The requested &quot;edit&quot; action is not allowed for the &quot;Category&quot; entity. Solution: remove the &quot;edit&quot; action from the &quot;disabled_actions&quot; option, which can be configured globally for the entire backend or locally for the &quot;Category&quot; entity.', $this->client->getResponse()->getContent());
     }
 
     public function testNewActionIsDisabled()
@@ -59,6 +59,6 @@ class ReadOnlyBackendTest extends AbstractTestCase
         $this->requestNewView();
 
         $this->assertSame(500, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('Error: The requested &quot;new&quot; action is not allowed for the &quot;Category&quot; entity. Solution: Remove the &quot;new&quot; action from the &quot;disabled_actions&quot; option, which can be configured globally for the entire backend or locally for the &quot;Category&quot; entity.', $this->client->getResponse()->getContent());
+        $this->assertContains('The requested &quot;new&quot; action is not allowed for the &quot;Category&quot; entity. Solution: remove the &quot;new&quot; action from the &quot;disabled_actions&quot; option, which can be configured globally for the entire backend or locally for the &quot;Category&quot; entity.', $this->client->getResponse()->getContent());
     }
 }

--- a/Tests/EventListener/ExceptionListenerTest.php
+++ b/Tests/EventListener/ExceptionListenerTest.php
@@ -46,11 +46,9 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
     public function testCatchBaseExceptions()
     {
         $exception = new EasyEntityNotFoundException(array(
-            'entity' => array(
-                'name' => 'Test',
-                'primary_key_field_name' => 'Test key',
-            ),
-            'entity_id' => 2,
+            'entity_name' => 'Test',
+            'entity_id_name' => 'Test key',
+            'entity_id_value' => 2,
         ));
         $event = $this->getEventExceptionThatShouldBeCalledOnce($exception);
         $templating = $this->getTemplating();

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,7 +15,15 @@ Upgrade to 2.0.0 (XX/XXX/201X)
    In order to upgrade, you just need to replace `admin` by `easyadmin` in all
    `path()`, `generateUrl()` and `redirectToRoute()` calls.
 
-Upgrade to 1.15.X (XX/October/2016)
+Upgrade to 1.16.4 (XX/January/2017)
+-----------------------------------
+
+* The `BaseException` class has changed the signature of its constructor. It now
+  receives a single argument of type `ExceptionContext` (this class was also added
+  in this new version). Your applications should not be affected because it's
+  highly uncommon to use these built-in exceptions directly.
+
+Upgrade to 1.15.2 (9/October/2016)
 -----------------------------------
 
 * The template fragments used to render each property value (e.g.


### PR DESCRIPTION
I was working on #1424 when I realized that the proposed solution was too complicated. The problem was that we can't translate exceptions inside the templates (the natural place) because we don't store the translation parameters anywhere.

So, I propose to create a new `ExceptionContext` class to store all the related information about exceptions. The idea would be to add in the translation files the public message displayed to the end-user. In contrast, the debug message stored in the log file (and displayed in the `dev` environment) would always be in English.

In this example, a French user would see this in the browser:

![exception-public](https://cloud.githubusercontent.com/assets/73419/22000123/ca158084-dc3d-11e6-9109-700f2c8aa4c8.png)

...and this message in the log file:

![exception-private](https://cloud.githubusercontent.com/assets/73419/22000129/d0d2c648-dc3d-11e6-9b1b-fdacabb9e55e.png)

---

This PR is still WIP but ... what do you think? Thanks!