### PR TITLE
Use array syntax short

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -15,7 +15,7 @@ return PhpCsFixer\Config::create()
     ->setFinder($finder)
     ->setRules(array(
         '@Symfony' => true,
-        'array_syntax' => array('syntax' => 'long'),
+        'array_syntax' => ['syntax' => 'short'],
         'binary_operator_spaces' => array(
             'align_double_arrow' => false,
         ),

--- a/.php_cs
+++ b/.php_cs
@@ -4,7 +4,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->ignoreDotFiles(true)
     ->ignoreVCS(true)
-    ->exclude(array('build', 'vendor'))
+    ->exclude(['build', 'vendor'])
     ->files()
     ->name('*.php')
 ;
@@ -13,12 +13,12 @@ return PhpCsFixer\Config::create()
     ->setUsingCache(true)
     ->setRiskyAllowed(true)
     ->setFinder($finder)
-    ->setRules(array(
+    ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
-        'binary_operator_spaces' => array(
+        'binary_operator_spaces' => [
             'align_double_arrow' => false,
-        ),
+        ],
         'combine_consecutive_unsets' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
@@ -26,5 +26,5 @@ return PhpCsFixer\Config::create()
         'php_unit_strict' => true,
         'phpdoc_summary' => false,
         'strict_comparison' => true,
-    ))
+    ])
 ;

--- a/Configuration/ActionConfigPass.php
+++ b/Configuration/ActionConfigPass.php
@@ -19,8 +19,8 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
  */
 class ActionConfigPass implements ConfigPassInterface
 {
-    private $views = array('edit', 'list', 'new', 'show');
-    private $defaultActionConfig = array(
+    private $views = ['edit', 'list', 'new', 'show'];
+    private $defaultActionConfig = [
         // either the name of a controller method or an application route (it depends on the 'type' option)
         'name' => null,
         // 'method' if the action is a controller method; 'route' if it's an application route
@@ -33,7 +33,7 @@ class ActionConfigPass implements ConfigPassInterface
         'icon' => null,
         // the value of the HTML 'target' attribute add to the links of the actions (e.g. '_blank')
         'target' => '_self',
-    );
+    ];
 
     public function process(array $backendConfig)
     {
@@ -50,7 +50,7 @@ class ActionConfigPass implements ConfigPassInterface
     {
         $actionsDisabledByBackend = $backendConfig['disabled_actions'];
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            $actionsDisabledByEntity = isset($entityConfig['disabled_actions']) ? $entityConfig['disabled_actions'] : array();
+            $actionsDisabledByEntity = isset($entityConfig['disabled_actions']) ? $entityConfig['disabled_actions'] : [];
             $disabledActions = array_unique(array_merge($actionsDisabledByBackend, $actionsDisabledByEntity));
 
             $backendConfig['entities'][$entityName]['disabled_actions'] = $disabledActions;
@@ -108,7 +108,7 @@ class ActionConfigPass implements ConfigPassInterface
 
     private function doNormalizeActionsConfig(array $actionsConfig, $errorOrigin = '')
     {
-        $normalizedConfig = array();
+        $normalizedConfig = [];
 
         foreach ($actionsConfig as $i => $actionConfig) {
             if (!is_string($actionConfig) && !is_array($actionConfig)) {
@@ -117,7 +117,7 @@ class ActionConfigPass implements ConfigPassInterface
 
             // config format #1
             if (is_string($actionConfig)) {
-                $actionConfig = array('name' => $actionConfig);
+                $actionConfig = ['name' => $actionConfig];
             }
 
             $actionConfig = array_merge($this->defaultActionConfig, $actionConfig);
@@ -260,14 +260,14 @@ class ActionConfigPass implements ConfigPassInterface
      */
     private function getDefaultActionsConfig($view)
     {
-        $actions = $this->doNormalizeActionsConfig(array(
-            'delete' => array('name' => 'delete', 'label' => 'action.delete', 'icon' => 'trash-o', 'css_class' => 'btn btn-default'),
-            'edit' => array('name' => 'edit', 'label' => 'action.edit', 'icon' => 'edit', 'css_class' => 'btn btn-primary'),
-            'new' => array('name' => 'new', 'label' => 'action.new', 'css_class' => 'btn btn-primary'),
-            'search' => array('name' => 'search', 'label' => 'action.search'),
-            'show' => array('name' => 'show', 'label' => 'action.show'),
-            'list' => array('name' => 'list', 'label' => 'action.list', 'css_class' => 'btn btn-secondary'),
-        ));
+        $actions = $this->doNormalizeActionsConfig([
+            'delete' => ['name' => 'delete', 'label' => 'action.delete', 'icon' => 'trash-o', 'css_class' => 'btn btn-default'],
+            'edit' => ['name' => 'edit', 'label' => 'action.edit', 'icon' => 'edit', 'css_class' => 'btn btn-primary'],
+            'new' => ['name' => 'new', 'label' => 'action.new', 'css_class' => 'btn btn-primary'],
+            'search' => ['name' => 'search', 'label' => 'action.search'],
+            'show' => ['name' => 'show', 'label' => 'action.show'],
+            'list' => ['name' => 'list', 'label' => 'action.list', 'css_class' => 'btn btn-secondary'],
+        ]);
 
         // minor tweaks for some action + view combinations
         if ('list' === $view) {
@@ -292,16 +292,16 @@ class ActionConfigPass implements ConfigPassInterface
      */
     private function getDefaultActions($view)
     {
-        $defaultActions = array();
+        $defaultActions = [];
         $defaultActionsConfig = $this->getDefaultActionsConfig($view);
 
         // actions are displayed in the same order as defined in this array
-        $actionsEnabledByView = array(
-            'edit' => array('delete', 'list'),
-            'list' => array('edit', 'delete', 'new', 'search'),
-            'new' => array('list'),
-            'show' => array('edit', 'delete', 'list'),
-        );
+        $actionsEnabledByView = [
+            'edit' => ['delete', 'list'],
+            'list' => ['edit', 'delete', 'new', 'search'],
+            'new' => ['list'],
+            'show' => ['edit', 'delete', 'list'],
+        ];
 
         foreach ($actionsEnabledByView[$view] as $actionName) {
             $defaultActions[$actionName] = $defaultActionsConfig[$actionName];
@@ -332,12 +332,12 @@ class ActionConfigPass implements ConfigPassInterface
      */
     private function humanizeString($content)
     {
-        return ucfirst(trim(mb_strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $content))));
+        return ucfirst(trim(mb_strtolower(preg_replace(['/([A-Z])/', '/[_\s]+/'], ['_$1', ' '], $content))));
     }
 
     private function reorderArrayItems(array $originalArray, array $newKeyOrder)
     {
-        $newArray = array();
+        $newArray = [];
         foreach ($newKeyOrder as $key) {
             if (isset($originalArray[$key])) {
                 $newArray[$key] = $originalArray[$key];

--- a/Configuration/ConfigManager.php
+++ b/Configuration/ConfigManager.php
@@ -121,10 +121,10 @@ class ConfigManager
         try {
             $entityConfig = $this->getEntityConfig($entityName);
         } catch (\Exception $e) {
-            $entityConfig = array();
+            $entityConfig = [];
         }
 
-        return isset($entityConfig[$view]['actions'][$action]) ? $entityConfig[$view]['actions'][$action] : array();
+        return isset($entityConfig[$view]['actions'][$action]) ? $entityConfig[$view]['actions'][$action] : [];
     }
 
     /**
@@ -181,7 +181,7 @@ class ConfigManager
      */
     private function doProcessConfig($backendConfig)
     {
-        $configPasses = array(
+        $configPasses = [
             new NormalizerConfigPass($this->container),
             new DesignConfigPass($this->container->get('twig'), $this->container->getParameter('kernel.debug'), $this->container->getParameter('locale')),
             new MenuConfigPass(),
@@ -191,7 +191,7 @@ class ConfigManager
             new ViewConfigPass(),
             new TemplateConfigPass($this->container->getParameter('kernel.root_dir').'/Resources/views'),
             new DefaultConfigPass(),
-        );
+        ];
 
         foreach ($configPasses as $configPass) {
             $backendConfig = $configPass->process($backendConfig);

--- a/Configuration/DefaultConfigPass.php
+++ b/Configuration/DefaultConfigPass.php
@@ -100,29 +100,29 @@ class DefaultConfigPass implements ConfigPassInterface
      */
     private function processDefaultHomepage(array $backendConfig)
     {
-        $backendHomepage = array();
+        $backendHomepage = [];
 
         // if no menu item has been set as "default", use the "list"
         // action of the first configured entity as the backend homepage
         if (null === $menuItemConfig = $backendConfig['default_menu_item']) {
             $defaultEntityName = $backendConfig['default_entity_name'];
             $backendHomepage['route'] = 'easyadmin';
-            $backendHomepage['params'] = array('action' => 'list', 'entity' => $defaultEntityName);
+            $backendHomepage['params'] = ['action' => 'list', 'entity' => $defaultEntityName];
 
             // if the default entity defines a custom sorting, use it
-            $defaultEntityConfig = isset($backendConfig['entities'][$defaultEntityName]) ? $backendConfig['entities'][$defaultEntityName] : array();
+            $defaultEntityConfig = isset($backendConfig['entities'][$defaultEntityName]) ? $backendConfig['entities'][$defaultEntityName] : [];
             if (isset($defaultEntityConfig['list']['sort'])) {
-                $backendHomepage['params'] = array_merge($backendHomepage['params'], array(
+                $backendHomepage['params'] = array_merge($backendHomepage['params'], [
                     'sortField' => $defaultEntityConfig['list']['sort']['field'],
                     'sortDirection' => $defaultEntityConfig['list']['sort']['direction'],
-                ));
+                ]);
             }
         } else {
-            $routeParams = array('menuIndex' => $menuItemConfig['menu_index'], 'submenuIndex' => $menuItemConfig['submenu_index']);
+            $routeParams = ['menuIndex' => $menuItemConfig['menu_index'], 'submenuIndex' => $menuItemConfig['submenu_index']];
 
             if ('entity' === $menuItemConfig['type']) {
                 $backendHomepage['route'] = 'easyadmin';
-                $backendHomepage['params'] = array_merge(array('action' => 'list', 'entity' => $menuItemConfig['entity']), $routeParams, $menuItemConfig['params']);
+                $backendHomepage['params'] = array_merge(['action' => 'list', 'entity' => $menuItemConfig['entity']], $routeParams, $menuItemConfig['params']);
             } elseif ('route' === $menuItemConfig['type']) {
                 $backendHomepage['route'] = $menuItemConfig['route'];
                 $backendHomepage['params'] = array_merge($routeParams, $menuItemConfig['params']);

--- a/Configuration/DesignConfigPass.php
+++ b/Configuration/DesignConfigPass.php
@@ -42,7 +42,7 @@ class DesignConfigPass implements ConfigPassInterface
     {
         if (!isset($backendConfig['design']['rtl'])) {
             // ar = Arabic, fa = Persian, he = Hebrew
-            if (in_array(substr($this->locale, 0, 2), array('ar', 'fa', 'he'))) {
+            if (in_array(substr($this->locale, 0, 2), ['ar', 'fa', 'he'])) {
                 $backendConfig['design']['rtl'] = true;
             } else {
                 $backendConfig['design']['rtl'] = false;
@@ -54,13 +54,13 @@ class DesignConfigPass implements ConfigPassInterface
 
     private function processCustomCss(array $backendConfig)
     {
-        $customCssContent = $this->twig->render('@EasyAdmin/css/easyadmin.css.twig', array(
+        $customCssContent = $this->twig->render('@EasyAdmin/css/easyadmin.css.twig', [
             'brand_color' => $backendConfig['design']['brand_color'],
             'color_scheme' => $backendConfig['design']['color_scheme'],
             'kernel_debug' => $this->kernelDebug,
-        ));
+        ]);
 
-        $minifiedCss = preg_replace(array('/\n/', '/\s{2,}/'), ' ', $customCssContent);
+        $minifiedCss = preg_replace(['/\n/', '/\s{2,}/'], ' ', $customCssContent);
         $backendConfig['_internal']['custom_css'] = $minifiedCss;
 
         return $backendConfig;

--- a/Configuration/MenuConfigPass.php
+++ b/Configuration/MenuConfigPass.php
@@ -60,7 +60,7 @@ class MenuConfigPass implements ConfigPassInterface
         // menu configuration to display all its entities
         if (empty($menuConfig)) {
             foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-                $menuConfig[] = array('entity' => $entityName, 'label' => $entityConfig['label']);
+                $menuConfig[] = ['entity' => $entityName, 'label' => $entityConfig['label']];
             }
         }
 
@@ -70,7 +70,7 @@ class MenuConfigPass implements ConfigPassInterface
         //   design.menu: [{ entity: 'Product' }, { entity: 'User' }]
         foreach ($menuConfig as $i => $itemConfig) {
             if (is_string($itemConfig)) {
-                $itemConfig = array('entity' => $itemConfig);
+                $itemConfig = ['entity' => $itemConfig];
             }
 
             $menuConfig[$i] = $itemConfig;
@@ -88,7 +88,7 @@ class MenuConfigPass implements ConfigPassInterface
 
             // normalize submenu configuration (only for main menu items)
             if (!isset($itemConfig['children']) && $parentItemIndex === -1) {
-                $itemConfig['children'] = array();
+                $itemConfig['children'] = [];
             }
 
             // normalize 'default' option, which sets the menu item used as the backend index
@@ -132,7 +132,7 @@ class MenuConfigPass implements ConfigPassInterface
                 }
 
                 if (!isset($itemConfig['params'])) {
-                    $itemConfig['params'] = array();
+                    $itemConfig['params'] = [];
                 }
             }
 
@@ -154,7 +154,7 @@ class MenuConfigPass implements ConfigPassInterface
                 }
 
                 if (!isset($itemConfig['params'])) {
-                    $itemConfig['params'] = array();
+                    $itemConfig['params'] = [];
                 }
             }
 

--- a/Configuration/MetadataConfigPass.php
+++ b/Configuration/MetadataConfigPass.php
@@ -66,7 +66,7 @@ class MetadataConfigPass implements ConfigPassInterface
      */
     private function processEntityPropertiesMetadata(ClassMetadata $entityMetadata)
     {
-        $entityPropertiesMetadata = array();
+        $entityPropertiesMetadata = [];
 
         if ($entityMetadata->isIdentifierComposite) {
             throw new \RuntimeException(sprintf("The '%s' entity isn't valid because it contains a composite primary key.", $entityMetadata->name));
@@ -79,10 +79,10 @@ class MetadataConfigPass implements ConfigPassInterface
 
         // introspect fields for entity associations
         foreach ($entityMetadata->associationMappings as $fieldName => $associationMetadata) {
-            $entityPropertiesMetadata[$fieldName] = array_merge($associationMetadata, array(
+            $entityPropertiesMetadata[$fieldName] = array_merge($associationMetadata, [
                 'type' => 'association',
                 'associationType' => $associationMetadata['type'],
-            ));
+            ]);
 
             // associations different from *-to-one cannot be sorted
             if ($associationMetadata['type'] & ClassMetadata::TO_MANY) {

--- a/Configuration/NormalizerConfigPass.php
+++ b/Configuration/NormalizerConfigPass.php
@@ -21,31 +21,31 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class NormalizerConfigPass implements ConfigPassInterface
 {
-    private $defaultViewConfig = array(
-        'list' => array(
+    private $defaultViewConfig = [
+        'list' => [
             'dql_filter' => null,
-            'fields' => array(),
-        ),
-        'search' => array(
+            'fields' => [],
+        ],
+        'search' => [
             'dql_filter' => null,
-            'fields' => array(),
-        ),
-        'show' => array(
-            'fields' => array(),
-        ),
-        'form' => array(
-            'fields' => array(),
-            'form_options' => array(),
-        ),
-        'edit' => array(
-            'fields' => array(),
-            'form_options' => array(),
-        ),
-        'new' => array(
-            'fields' => array(),
-            'form_options' => array(),
-        ),
-    );
+            'fields' => [],
+        ],
+        'show' => [
+            'fields' => [],
+        ],
+        'form' => [
+            'fields' => [],
+            'form_options' => [],
+        ],
+        'edit' => [
+            'fields' => [],
+            'form_options' => [],
+        ],
+        'new' => [
+            'fields' => [],
+            'form_options' => [],
+        ],
+    ];
 
     /** @var ContainerInterface */
     private $container;
@@ -132,10 +132,10 @@ class NormalizerConfigPass implements ConfigPassInterface
                 $entityConfig['search']['dql_filter'] = isset($entityConfig['list']['dql_filter']) ? $entityConfig['list']['dql_filter'] : null;
             }
 
-            foreach (array('edit', 'form', 'list', 'new', 'search', 'show') as $view) {
+            foreach (['edit', 'form', 'list', 'new', 'search', 'show'] as $view) {
                 $entityConfig[$view] = array_replace_recursive(
                     $this->defaultViewConfig[$view],
-                    isset($entityConfig[$view]) ? $entityConfig[$view] : array()
+                    isset($entityConfig[$view]) ? $entityConfig[$view] : []
                 );
             }
 
@@ -172,8 +172,8 @@ class NormalizerConfigPass implements ConfigPassInterface
     private function normalizePropertyConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('form', 'edit', 'list', 'new', 'search', 'show') as $view) {
-                $fields = array();
+            foreach (['form', 'edit', 'list', 'new', 'search', 'show'] as $view) {
+                $fields = [];
                 foreach ($entityConfig[$view]['fields'] as $i => $field) {
                     if (!is_string($field) && !is_array($field)) {
                         throw new \RuntimeException(sprintf('The values of the "fields" option for the "%s" view of the "%s" entity can only be strings or arrays.', $view, $entityConfig['class']));
@@ -181,7 +181,7 @@ class NormalizerConfigPass implements ConfigPassInterface
 
                     if (is_string($field)) {
                         // Config format #1: field is just a string representing the entity property
-                        $fieldConfig = array('property' => $field);
+                        $fieldConfig = ['property' => $field];
                     } else {
                         // Config format #1: field is an array that defines one or more
                         // options. Check that either 'property' or 'type' option is set
@@ -226,7 +226,7 @@ class NormalizerConfigPass implements ConfigPassInterface
         // all the previous form fields are "ungrouped". To avoid design issues,
         // insert an empty 'group' type (no label, no icon) as the first form element.
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('form', 'edit', 'new') as $view) {
+            foreach (['form', 'edit', 'new'] as $view) {
                 $fieldNumber = 0;
                 $isTheFirstGroupElement = true;
 
@@ -235,7 +235,7 @@ class NormalizerConfigPass implements ConfigPassInterface
                     if (!isset($fieldConfig['property']) && isset($fieldConfig['type']) && 'group' === $fieldConfig['type']) {
                         if ($isTheFirstGroupElement && $fieldNumber > 1) {
                             $backendConfig['entities'][$entityName][$view]['fields'] = array_merge(
-                                array('_easyadmin_form_design_element_forced_first_group' => array('type' => 'group')),
+                                ['_easyadmin_form_design_element_forced_first_group' => ['type' => 'group']],
                                 $backendConfig['entities'][$entityName][$view]['fields']
                             );
 
@@ -249,11 +249,11 @@ class NormalizerConfigPass implements ConfigPassInterface
         }
 
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('form', 'edit', 'new') as $view) {
+            foreach (['form', 'edit', 'new'] as $view) {
                 foreach ($entityConfig[$view]['fields'] as $fieldName => $fieldConfig) {
                     // this is a form design element instead of a regular property
                     $isFormDesignElement = !isset($fieldConfig['property']) && isset($fieldConfig['type']);
-                    if ($isFormDesignElement && in_array($fieldConfig['type'], array('divider', 'group', 'section'))) {
+                    if ($isFormDesignElement && in_array($fieldConfig['type'], ['divider', 'group', 'section'])) {
                         // assign them a property name to add them later as unmapped form fields
                         $fieldConfig['property'] = $fieldName;
 
@@ -271,11 +271,11 @@ class NormalizerConfigPass implements ConfigPassInterface
 
     private function normalizeActionConfig(array $backendConfig)
     {
-        $views = array('edit', 'list', 'new', 'show', 'form');
+        $views = ['edit', 'list', 'new', 'show', 'form'];
 
         foreach ($views as $view) {
             if (!isset($backendConfig[$view]['actions'])) {
-                $backendConfig[$view]['actions'] = array();
+                $backendConfig[$view]['actions'] = [];
             }
 
             // there is no need to check if the "actions" option for the global
@@ -285,7 +285,7 @@ class NormalizerConfigPass implements ConfigPassInterface
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
             foreach ($views as $view) {
                 if (!isset($entityConfig[$view]['actions'])) {
-                    $backendConfig['entities'][$entityName][$view]['actions'] = array();
+                    $backendConfig['entities'][$entityName][$view]['actions'] = [];
                 }
 
                 if (!is_array($backendConfig['entities'][$entityName][$view]['actions'])) {
@@ -354,15 +354,15 @@ class NormalizerConfigPass implements ConfigPassInterface
     private function mergeFormConfig(array $parentConfig, array $childConfig)
     {
         // save the fields config for later processing
-        $parentFields = isset($parentConfig['fields']) ? $parentConfig['fields'] : array();
-        $childFields = isset($childConfig['fields']) ? $childConfig['fields'] : array();
+        $parentFields = isset($parentConfig['fields']) ? $parentConfig['fields'] : [];
+        $childFields = isset($childConfig['fields']) ? $childConfig['fields'] : [];
         $removedFieldNames = $this->getRemovedFieldNames($childFields);
 
         // first, perform a recursive replace to merge both configs
         $mergedConfig = array_replace_recursive($parentConfig, $childConfig);
 
         // merge the config of each field individually
-        $mergedFields = array();
+        $mergedFields = [];
         foreach ($parentFields as $parentFieldName => $parentFieldConfig) {
             if (isset($parentFieldConfig['property']) && in_array($parentFieldConfig['property'], $removedFieldNames)) {
                 continue;
@@ -374,7 +374,7 @@ class NormalizerConfigPass implements ConfigPassInterface
                 continue;
             }
 
-            $childFieldConfig = $this->findFieldConfigByProperty($childFields, $parentFieldConfig['property']) ?: array();
+            $childFieldConfig = $this->findFieldConfigByProperty($childFields, $parentFieldConfig['property']) ?: [];
             $mergedFields[$parentFieldName] = array_replace_recursive($parentFieldConfig, $childFieldConfig);
         }
 
@@ -406,7 +406,7 @@ class NormalizerConfigPass implements ConfigPassInterface
      */
     private function getRemovedFieldNames(array $fieldsConfig)
     {
-        $removedFieldNames = array();
+        $removedFieldNames = [];
         foreach ($fieldsConfig as $fieldConfig) {
             if (isset($fieldConfig['property']) && '-' === substr($fieldConfig['property'], 0, 1)) {
                 $removedFieldNames[] = substr($fieldConfig['property'], 1);

--- a/Configuration/PropertyConfigPass.php
+++ b/Configuration/PropertyConfigPass.php
@@ -19,7 +19,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
  */
 class PropertyConfigPass implements ConfigPassInterface
 {
-    private $defaultEntityFieldConfig = array(
+    private $defaultEntityFieldConfig = [
         // CSS class or classes applied to form field or list/show property
         'css_class' => '',
         // date/time/datetime/number format applied to form field value
@@ -41,12 +41,12 @@ class PropertyConfigPass implements ConfigPassInterface
         // the path of the template used to render the field in 'show' and 'list' views
         'template' => null,
         // the options passed to the Symfony Form type used to render the form field
-        'type_options' => array(),
+        'type_options' => [],
         // the name of the group where this form field is displayed (used only for complex form layouts)
         'form_group' => null,
-    );
+    ];
 
-    private $defaultVirtualFieldMetadata = array(
+    private $defaultVirtualFieldMetadata = [
         'columnName' => 'virtual',
         'fieldName' => 'virtual',
         'id' => false,
@@ -58,9 +58,9 @@ class PropertyConfigPass implements ConfigPassInterface
         'type' => 'text',
         'unique' => false,
         'virtual' => true,
-    );
+    ];
 
-    private $doctrineTypeToFormTypeMap = array(
+    private $doctrineTypeToFormTypeMap = [
         'array' => 'collection',
         'association' => 'entity',
         'bigint' => 'text',
@@ -80,7 +80,7 @@ class PropertyConfigPass implements ConfigPassInterface
         'string' => 'text',
         'text' => 'textarea',
         'time' => 'time',
-    );
+    ];
 
     public function process(array $backendConfig)
     {
@@ -103,16 +103,16 @@ class PropertyConfigPass implements ConfigPassInterface
     private function processMetadataConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            $properties = array();
+            $properties = [];
             foreach ($entityConfig['properties'] as $propertyName => $propertyMetadata) {
                 $properties[$propertyName] = array_replace(
                     $this->defaultEntityFieldConfig,
                     $propertyMetadata,
-                    array(
+                    [
                         'property' => $propertyName,
                         'dataType' => $propertyMetadata['type'],
                         'fieldType' => $this->getFormTypeFromDoctrineType($propertyMetadata['type']),
-                    )
+                    ]
                 );
 
                 // 'boolean' properties are displayed by default as toggleable
@@ -139,7 +139,7 @@ class PropertyConfigPass implements ConfigPassInterface
     private function processFieldConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('edit', 'list', 'new', 'search', 'show') as $view) {
+            foreach (['edit', 'list', 'new', 'search', 'show'] as $view) {
                 $originalViewConfig = $backendConfig['entities'][$entityName][$view];
                 foreach ($entityConfig[$view]['fields'] as $fieldName => $fieldConfig) {
                     $originalFieldConfig = isset($originalViewConfig['fields'][$fieldName]) ? $originalViewConfig['fields'][$fieldName] : null;
@@ -147,14 +147,14 @@ class PropertyConfigPass implements ConfigPassInterface
                     if (array_key_exists($fieldName, $entityConfig['properties'])) {
                         $fieldMetadata = array_merge(
                             $entityConfig['properties'][$fieldName],
-                            array('virtual' => false)
+                            ['virtual' => false]
                         );
                     } else {
                         // this is a virtual field which doesn't exist as a property of
                         // the related entity. That's why Doctrine can't provide metadata for it
                         $fieldMetadata = array_merge(
                             $this->defaultVirtualFieldMetadata,
-                            array('columnName' => $fieldName, 'fieldName' => $fieldName)
+                            ['columnName' => $fieldName, 'fieldName' => $fieldName]
                         );
                     }
 
@@ -167,14 +167,14 @@ class PropertyConfigPass implements ConfigPassInterface
                     // 'list', 'search' and 'show' views: use the value of the 'type' option
                     // as the 'dataType' option because the previous code has already
                     // prioritized end-user preferences over Doctrine and default values
-                    if (in_array($view, array('list', 'search', 'show'))) {
+                    if (in_array($view, ['list', 'search', 'show'])) {
                         $normalizedConfig['dataType'] = $normalizedConfig['type'];
                     }
 
                     // 'new' and 'edit' views: if the user has defined the 'type' option
                     // for the field, use it as 'fieldType'. Otherwise, infer the best field
                     // type using the property data type.
-                    if (in_array($view, array('edit', 'new'))) {
+                    if (in_array($view, ['edit', 'new'])) {
                         $normalizedConfig['fieldType'] = isset($originalFieldConfig['type'])
                             ? $originalFieldConfig['type']
                             : $this->getFormTypeFromDoctrineType($normalizedConfig['type']);
@@ -229,14 +229,14 @@ class PropertyConfigPass implements ConfigPassInterface
      */
     private function getFieldFormat($fieldType, array $backendConfig)
     {
-        if (in_array($fieldType, array('date', 'time', 'datetime', 'datetimetz'))) {
+        if (in_array($fieldType, ['date', 'time', 'datetime', 'datetimetz'])) {
             // make 'datetimetz' use the same format as 'datetime'
             $fieldType = ('datetimetz' === $fieldType) ? 'datetime' : $fieldType;
 
             return $backendConfig['formats'][$fieldType];
         }
 
-        if (in_array($fieldType, array('bigint', 'integer', 'smallint', 'decimal', 'float'))) {
+        if (in_array($fieldType, ['bigint', 'integer', 'smallint', 'decimal', 'float'])) {
             return isset($backendConfig['formats']['number']) ? $backendConfig['formats']['number'] : null;
         }
     }

--- a/Configuration/TemplateConfigPass.php
+++ b/Configuration/TemplateConfigPass.php
@@ -22,7 +22,7 @@ class TemplateConfigPass implements ConfigPassInterface
 {
     private $templatesDir;
 
-    private $defaultBackendTemplates = array(
+    private $defaultBackendTemplates = [
         'layout' => '@EasyAdmin/default/layout.html.twig',
         'menu' => '@EasyAdmin/default/menu.html.twig',
         'edit' => '@EasyAdmin/default/edit.html.twig',
@@ -61,7 +61,7 @@ class TemplateConfigPass implements ConfigPassInterface
         'label_inaccessible' => '@EasyAdmin/default/label_inaccessible.html.twig',
         'label_null' => '@EasyAdmin/default/label_null.html.twig',
         'label_undefined' => '@EasyAdmin/default/label_undefined.html.twig',
-    );
+    ];
 
     public function __construct($templatesDir)
     {
@@ -116,7 +116,7 @@ class TemplateConfigPass implements ConfigPassInterface
 
         // second, walk through all entity fields to determine their specific template
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('list', 'show') as $view) {
+            foreach (['list', 'show'] as $view) {
                 foreach ($entityConfig[$view]['fields'] as $fieldName => $fieldMetadata) {
                     // if the field defines its own template, resolve its location
                     if (isset($fieldMetadata['template'])) {
@@ -197,7 +197,7 @@ class TemplateConfigPass implements ConfigPassInterface
     private function processFieldTemplates(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('list', 'show') as $view) {
+            foreach (['list', 'show'] as $view) {
                 foreach ($entityConfig[$view]['fields'] as $fieldName => $fieldMetadata) {
                     if (null !== $fieldMetadata['template']) {
                         continue;

--- a/Configuration/ViewConfigPass.php
+++ b/Configuration/ViewConfigPass.php
@@ -34,7 +34,7 @@ class ViewConfigPass implements ConfigPassInterface
     {
         // process the 'help' message that each view can define to display it under the page title
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('edit', 'list', 'new', 'search', 'show') as $view) {
+            foreach (['edit', 'list', 'new', 'search', 'show'] as $view) {
                 // isset() cannot be used because the value can be 'null' (used to remove the inherited help message)
                 if (array_key_exists('help', $backendConfig['entities'][$entityName][$view])) {
                     continue;
@@ -59,7 +59,7 @@ class ViewConfigPass implements ConfigPassInterface
     private function processDefaultFieldsConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('edit', 'list', 'new', 'search', 'show') as $view) {
+            foreach (['edit', 'list', 'new', 'search', 'show'] as $view) {
                 if (0 === count($entityConfig[$view]['fields'])) {
                     $fieldsConfig = $this->filterFieldList(
                         $entityConfig['properties'],
@@ -87,7 +87,7 @@ class ViewConfigPass implements ConfigPassInterface
     private function processFieldConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('edit', 'list', 'new', 'search', 'show') as $view) {
+            foreach (['edit', 'list', 'new', 'search', 'show'] as $view) {
                 foreach ($entityConfig[$view]['fields'] as $fieldName => $fieldConfig) {
                     // special case: if the field is called 'id' and doesn't define a custom
                     // label, use 'ID' as label. This improves the readability of the label
@@ -116,7 +116,7 @@ class ViewConfigPass implements ConfigPassInterface
     private function processPageTitleConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('edit', 'list', 'new', 'show') as $view) {
+            foreach (['edit', 'list', 'new', 'show'] as $view) {
                 if (!isset($entityConfig[$view]['title']) && isset($backendConfig[$view]['title'])) {
                     $backendConfig['entities'][$entityName][$view]['title'] = $backendConfig[$view]['title'];
                 }
@@ -138,7 +138,7 @@ class ViewConfigPass implements ConfigPassInterface
     private function processSortingConfig(array $backendConfig)
     {
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            foreach (array('list', 'search') as $view) {
+            foreach (['list', 'search'] as $view) {
                 if (!isset($entityConfig[$view]['sort'])) {
                     continue;
                 }
@@ -149,12 +149,12 @@ class ViewConfigPass implements ConfigPassInterface
                 }
 
                 if (is_string($sortConfig)) {
-                    $sortConfig = array('field' => $sortConfig, 'direction' => 'DESC');
+                    $sortConfig = ['field' => $sortConfig, 'direction' => 'DESC'];
                 } else {
-                    $sortConfig = array('field' => $sortConfig[0], 'direction' => strtoupper($sortConfig[1]));
+                    $sortConfig = ['field' => $sortConfig[0], 'direction' => strtoupper($sortConfig[1])];
                 }
 
-                if (!in_array($sortConfig['direction'], array('ASC', 'DESC'))) {
+                if (!in_array($sortConfig['direction'], ['ASC', 'DESC'])) {
                     throw new \InvalidArgumentException(sprintf('If defined, the second value of the "sort" option of the "%s" view of the "%s" entity can only be "ASC" or "DESC".', $view, $entityName));
                 }
 
@@ -183,15 +183,15 @@ class ViewConfigPass implements ConfigPassInterface
      */
     private function getExcludedFieldNames($view, array $entityConfig)
     {
-        $excludedFieldNames = array(
-            'edit' => array($entityConfig['primary_key_field_name']),
-            'list' => array('password', 'salt', 'slug', 'updatedAt', 'uuid'),
-            'new' => array($entityConfig['primary_key_field_name']),
-            'search' => array('password', 'salt'),
-            'show' => array(),
-        );
+        $excludedFieldNames = [
+            'edit' => [$entityConfig['primary_key_field_name']],
+            'list' => ['password', 'salt', 'slug', 'updatedAt', 'uuid'],
+            'new' => [$entityConfig['primary_key_field_name']],
+            'search' => ['password', 'salt'],
+            'show' => [],
+        ];
 
-        return isset($excludedFieldNames[$view]) ? $excludedFieldNames[$view] : array();
+        return isset($excludedFieldNames[$view]) ? $excludedFieldNames[$view] : [];
     }
 
     /**
@@ -203,15 +203,15 @@ class ViewConfigPass implements ConfigPassInterface
      */
     private function getExcludedFieldTypes($view)
     {
-        $excludedFieldTypes = array(
-            'edit' => array('binary', 'blob', 'json_array', 'object'),
-            'list' => array('array', 'binary', 'blob', 'guid', 'json_array', 'object', 'simple_array', 'text'),
-            'new' => array('binary', 'blob', 'json_array', 'object'),
-            'search' => array('association', 'binary', 'boolean', 'blob', 'date', 'datetime', 'datetimetz', 'time', 'object'),
-            'show' => array(),
-        );
+        $excludedFieldTypes = [
+            'edit' => ['binary', 'blob', 'json_array', 'object'],
+            'list' => ['array', 'binary', 'blob', 'guid', 'json_array', 'object', 'simple_array', 'text'],
+            'new' => ['binary', 'blob', 'json_array', 'object'],
+            'search' => ['association', 'binary', 'boolean', 'blob', 'date', 'datetime', 'datetimetz', 'time', 'object'],
+            'show' => [],
+        ];
 
-        return isset($excludedFieldTypes[$view]) ? $excludedFieldTypes[$view] : array();
+        return isset($excludedFieldTypes[$view]) ? $excludedFieldTypes[$view] : [];
     }
 
     /**
@@ -224,9 +224,9 @@ class ViewConfigPass implements ConfigPassInterface
      */
     private function getMaxNumberFields($view)
     {
-        $maxNumberFields = array(
+        $maxNumberFields = [
             'list' => 7,
-        );
+        ];
 
         return isset($maxNumberFields[$view]) ? $maxNumberFields[$view] : PHP_INT_MAX;
     }
@@ -243,7 +243,7 @@ class ViewConfigPass implements ConfigPassInterface
      */
     private function filterFieldList(array $fields, array $excludedFieldNames, array $excludedFieldTypes, $maxNumFields)
     {
-        $filteredFields = array();
+        $filteredFields = [];
 
         foreach ($fields as $name => $metadata) {
             if (!in_array($name, $excludedFieldNames) && !in_array($metadata['type'], $excludedFieldTypes)) {

--- a/DataCollector/EasyAdminDataCollector.php
+++ b/DataCollector/EasyAdminDataCollector.php
@@ -38,30 +38,30 @@ class EasyAdminDataCollector extends DataCollector
     {
         $backendConfig = $this->configManager->getBackendConfig();
         $entityName = $request->query->get('entity', null);
-        $currentEntityConfig = array_key_exists($entityName, $backendConfig['entities']) ? $backendConfig['entities'][$entityName] : array();
+        $currentEntityConfig = array_key_exists($entityName, $backendConfig['entities']) ? $backendConfig['entities'][$entityName] : [];
 
-        $this->data = array(
+        $this->data = [
             'num_entities' => count($backendConfig['entities']),
             'request_parameters' => $this->getEasyAdminParameters($request),
             'current_entity_configuration' => $currentEntityConfig,
             'backend_configuration' => $backendConfig,
-        );
+        ];
     }
 
     private function getEasyAdminParameters(Request $request)
     {
         // 'admin' is the deprecated route name that will be removed in version 2.0.
-        if (!in_array($request->attributes->get('_route'), array('easyadmin', 'admin'))) {
+        if (!in_array($request->attributes->get('_route'), ['easyadmin', 'admin'])) {
             return;
         }
 
-        return array(
+        return [
             'action' => $request->query->get('action'),
             'entity' => $request->query->get('entity'),
             'id' => $request->query->get('id'),
             'sort_field' => $request->query->get('sortField'),
             'sort_direction' => $request->query->get('sortDirection'),
-        );
+        ];
     }
 
     public function getNumEntities()

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -47,7 +47,7 @@ class Configuration implements ConfigurationInterface
                 })
                 ->then(function ($v) {
                     if (!isset($v['list'])) {
-                        $v['list'] = array();
+                        $v['list'] = [];
                     }
 
                     // if the new option is defined, don't override it with the legacy option
@@ -85,7 +85,7 @@ class Configuration implements ConfigurationInterface
                 ->always()
                 ->then(function ($v) {
                     if (!isset($v['design'])) {
-                        $v['design'] = array('assets' => array());
+                        $v['design'] = ['assets' => []];
                     }
 
                     return $v;
@@ -200,7 +200,7 @@ class Configuration implements ConfigurationInterface
 
                 ->variableNode('disabled_actions')
                     ->info('The names of the actions disabled for all backend entities.')
-                    ->defaultValue(array())
+                    ->defaultValue([])
                     ->validate()
                         ->ifTrue(function ($v) {
                             return false === is_array($v);
@@ -230,13 +230,13 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue('default')
                             ->info('The theme used to render the backend pages. For now this value can only be "default".')
                             ->validate()
-                                ->ifNotInArray(array('default'))
+                                ->ifNotInArray(['default'])
                                 ->thenInvalid('The theme name can only be "default".')
                             ->end()
                         ->end()
 
                         ->enumNode('color_scheme')
-                            ->values(array('dark', 'light'))
+                            ->values(['dark', 'light'])
                             ->info('The color scheme applied to the backend design (values: "dark" or "light").')
                             ->defaultValue('dark')
                             ->treatNullLike('dark')
@@ -262,12 +262,12 @@ class Configuration implements ConfigurationInterface
                         ->end()
 
                         ->variableNode('form_theme')
-                            ->defaultValue(array('@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'))
-                            ->treatNullLike(array('@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'))
+                            ->defaultValue(['@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'])
+                            ->treatNullLike(['@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'])
                             ->info('The form theme applied to backend forms. Allowed values: "horizontal", "vertical", any valid form theme path or an array of theme paths.')
                             ->validate()
                                 ->ifString()->then(function ($v) {
-                                    return array($v);
+                                    return [$v];
                                 })
                             ->end()
                             ->validate()
@@ -306,15 +306,15 @@ class Configuration implements ConfigurationInterface
                                     ->beforeNormalization()
                                         ->always(function ($v) {
                                             if (is_string($v)) {
-                                                $v = array('path' => $v);
+                                                $v = ['path' => $v];
                                             }
-                                            $mimeTypes = array(
+                                            $mimeTypes = [
                                                 'ico' => 'image/x-icon',
                                                 'png' => 'image/png',
                                                 'gif' => 'image/gif',
                                                 'jpg' => 'image/jpeg',
                                                 'jpeg' => 'image/jpeg',
-                                            );
+                                            ];
                                             if (!isset($v['mime_type']) && isset($mimeTypes[$ext = pathinfo($v['path'], PATHINFO_EXTENSION)])) {
                                                 $v['mime_type'] = $mimeTypes[$ext];
                                             } elseif (!isset($v['mime_type'])) {
@@ -377,7 +377,7 @@ class Configuration implements ConfigurationInterface
 
                         ->arrayNode('menu')
                             ->normalizeKeys(false)
-                            ->defaultValue(array())
+                            ->defaultValue([])
                             ->info('The items to display in the main menu.')
                             ->prototype('variable')
                         ->end()
@@ -461,7 +461,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('entities')
                     ->normalizeKeys(false)
                     ->useAttributeAsKey('name', false)
-                    ->defaultValue(array())
+                    ->defaultValue([])
                     ->info('The list of entities to manage in the administration zone.')
                     ->prototype('variable')
                 ->end()

--- a/DependencyInjection/EasyAdminExtension.php
+++ b/DependencyInjection/EasyAdminExtension.php
@@ -51,7 +51,7 @@ class EasyAdminExtension extends Extension
 
         // compile commonly used classes on PHP < 7.0
         if (PHP_VERSION_ID < 70000) {
-            $this->addClassesToCompile(array(
+            $this->addClassesToCompile([
                 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Configuration\\ConfigManager',
                 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Event\\EasyAdminEvents',
                 'JavierEguiluz\\Bundle\\EasyAdminBundle\\EventListener\\ExceptionListener',
@@ -60,7 +60,7 @@ class EasyAdminExtension extends Extension
                 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Search\\Paginator',
                 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Search\\QueryBuilder',
                 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Twig\\EasyAdminTwigExtension',
-            ));
+            ]);
         }
 
         $this->ensureBackwardCompatibility($container);
@@ -77,13 +77,13 @@ class EasyAdminExtension extends Extension
         // BC for Symfony 2.3 and Request Stack
         $isRequestStackAvailable = class_exists('Symfony\\Component\\HttpFoundation\\RequestStack');
         if (!$isRequestStackAvailable) {
-            $needsSetRequestMethodCall = array('easyadmin.listener.request_post_initialize', 'easyadmin.form.type.extension');
+            $needsSetRequestMethodCall = ['easyadmin.listener.request_post_initialize', 'easyadmin.form.type.extension'];
             foreach ($needsSetRequestMethodCall as $serviceId) {
                 $container
                     ->getDefinition($serviceId)
-                    ->addMethodCall('setRequest', array(
+                    ->addMethodCall('setRequest', [
                         new Reference('request', ContainerInterface::NULL_ON_INVALID_REFERENCE, false),
-                    ))
+                    ])
                 ;
             }
         }
@@ -100,11 +100,11 @@ class EasyAdminExtension extends Extension
 
     private function processConfigFiles(array $configs)
     {
-        $existingEntityNames = array();
+        $existingEntityNames = [];
 
         foreach ($configs as $i => $config) {
             if (array_key_exists('entities', $config)) {
-                $processedConfig = array();
+                $processedConfig = [];
 
                 foreach ($config['entities'] as $key => $value) {
                     $entityConfig = $this->normalizeEntityConfig($key, $value);
@@ -159,7 +159,7 @@ class EasyAdminExtension extends Extension
     {
         // normalize config formats #1 and #2 to use the 'class' option as config format #3
         if (!is_array($entityConfig)) {
-            $entityConfig = array('class' => $entityConfig);
+            $entityConfig = ['class' => $entityConfig];
         }
 
         // if config format #3 is used, ensure that it defines the 'class' option

--- a/EventListener/ExceptionListener.php
+++ b/EventListener/ExceptionListener.php
@@ -77,7 +77,7 @@ class ExceptionListener extends BaseExceptionListener
 
         return $this->templating->renderResponse(
             $exceptionTemplatePath,
-            array('exception' => $exception),
+            ['exception' => $exception],
             Response::create()->setStatusCode($exception->getStatusCode())
         );
     }
@@ -95,9 +95,9 @@ class ExceptionListener extends BaseExceptionListener
 
         if (null !== $this->logger) {
             if ($exception->getStatusCode() >= 500) {
-                $this->logger->critical($message, array('exception' => $exception));
+                $this->logger->critical($message, ['exception' => $exception]);
             } else {
-                $this->logger->error($message, array('exception' => $exception));
+                $this->logger->error($message, ['exception' => $exception]);
             }
         }
     }
@@ -167,11 +167,11 @@ class ExceptionListener extends BaseExceptionListener
      */
     private function legacyDuplicateRequest(Request $request)
     {
-        $attributes = array(
+        $attributes = [
             '_controller' => $this->controller,
             'logger' => $this->logger instanceof DebugLoggerInterface ? $this->logger : null,
             'format' => $request->getRequestFormat(),
-        );
+        ];
         $request = $request->duplicate(null, null, $attributes);
         $request->setMethod('GET');
 

--- a/EventListener/RequestPostInitializeListener.php
+++ b/EventListener/RequestPostInitializeListener.php
@@ -62,11 +62,11 @@ class RequestPostInitializeListener
             return;
         }
 
-        $this->request->attributes->set('easyadmin', array(
+        $this->request->attributes->set('easyadmin', [
             'entity' => $entity = $event->getArgument('entity'),
             'view' => $this->request->query->get('action', 'list'),
             'item' => ($id = $this->request->query->get('id')) ? $this->findCurrentItem($entity, $id) : null,
-        ));
+        ]);
     }
 
     /**
@@ -83,7 +83,7 @@ class RequestPostInitializeListener
     {
         $manager = $this->doctrine->getManagerForClass($entityConfig['class']);
         if (null === $entity = $manager->getRepository($entityConfig['class'])->find($itemId)) {
-            throw new EntityNotFoundException(array('entity' => $entityConfig, 'entity_id' => $itemId));
+            throw new EntityNotFoundException(['entity' => $entityConfig, 'entity_id' => $itemId]);
         }
 
         return $entity;

--- a/Exception/EntityNotFoundException.php
+++ b/Exception/EntityNotFoundException.php
@@ -16,7 +16,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
  */
 class EntityNotFoundException extends BaseException
 {
-    public function __construct(array $parameters = array())
+    public function __construct(array $parameters = [])
     {
         $errorMessage = sprintf('The "%s" entity with "%s = %s" does not exist in the database.', $parameters['entity']['name'], $parameters['entity']['primary_key_field_name'], $parameters['entity_id']);
         $proposedSolution = sprintf('Check that the mentioned entity hasn\'t been deleted by mistake.');

--- a/Exception/EntityRemoveException.php
+++ b/Exception/EntityRemoveException.php
@@ -16,7 +16,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
  */
 class EntityRemoveException extends BaseException
 {
-    public function __construct(array $parameters = array())
+    public function __construct(array $parameters = [])
     {
         $errorMessage = sprintf('You can\'t delete this "%s" item because other items depend on it in the database.', $parameters['entity']);
         $proposedSolution = "Don't delete this item or change the database configuration to allow deleting it.";

--- a/Exception/FlattenException.php
+++ b/Exception/FlattenException.php
@@ -21,7 +21,7 @@ class FlattenException extends BaseFlattenException
     /** @var string */
     private $safeMessage;
 
-    public static function create(\Exception $exception, $statusCode = null, array $headers = array())
+    public static function create(\Exception $exception, $statusCode = null, array $headers = [])
     {
         if (!$exception instanceof BaseException) {
             throw new \RuntimeException(sprintf('You should only try to create an instance of "%s" with a "JavierEguiluz\Bundle\EasyAdminBundle\Exception\BaseException" instance, or subclass. "%s" given.', __CLASS__, get_class($exception)));

--- a/Exception/ForbiddenActionException.php
+++ b/Exception/ForbiddenActionException.php
@@ -16,7 +16,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
  */
 class ForbiddenActionException extends BaseException
 {
-    public function __construct(array $parameters = array())
+    public function __construct(array $parameters = [])
     {
         $errorMessage = sprintf('The requested "%s" action is not allowed for the "%s" entity.', $parameters['action'], $parameters['entity']);
         $proposedSolution = sprintf('Remove the "%s" action from the "disabled_actions" option, which can be configured globally for the entire backend or locally for the "%s" entity.', $parameters['action'], $parameters['entity']);

--- a/Exception/NoEntitiesConfiguredException.php
+++ b/Exception/NoEntitiesConfiguredException.php
@@ -16,7 +16,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
  */
 class NoEntitiesConfiguredException extends BaseException
 {
-    public function __construct(array $parameters = array())
+    public function __construct(array $parameters = [])
     {
         $errorMessage = 'Your backend is empty because you haven\'t configured any Doctrine entity to manage.';
         $proposedSolution = 'Open your "app/config/config.yml" file and configure the backend under the "easy_admin" key.';

--- a/Exception/UndefinedEntityException.php
+++ b/Exception/UndefinedEntityException.php
@@ -16,7 +16,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Exception;
  */
 class UndefinedEntityException extends BaseException
 {
-    public function __construct(array $parameters = array())
+    public function __construct(array $parameters = [])
     {
         $errorMessage = sprintf('The "%s" entity is not defined in the configuration of your backend.', $parameters['entity_name']);
         $proposedSolution = sprintf('Open your "app/config/config.yml" file and add the "%s" entity to the list of entities managed by EasyAdmin. NOTE: If your project worked before, this error may be caused by a change introduced by EasyAdmin 1.12.0 version. Check out https://github.com/javiereguiluz/EasyAdminBundle/releases/tag/v1.12.0 for more details.', $parameters['entity_name']);

--- a/Form/EventListener/EasyAdminAutocompleteSubscriber.php
+++ b/Form/EventListener/EasyAdminAutocompleteSubscriber.php
@@ -26,20 +26,20 @@ class EasyAdminAutocompleteSubscriber implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
+        return [
             FormEvents::PRE_SET_DATA => 'preSetData',
             FormEvents::PRE_SUBMIT => 'preSubmit',
-        );
+        ];
     }
 
     public function preSetData(FormEvent $event)
     {
         $form = $event->getForm();
-        $data = $event->getData() ?: array();
+        $data = $event->getData() ?: [];
 
         $options = $form->getConfig()->getOptions();
         $options['compound'] = false;
-        $options['choices'] = is_array($data) || $data instanceof \Traversable ? $data : array($data);
+        $options['choices'] = is_array($data) || $data instanceof \Traversable ? $data : [$data];
 
         $form->add('autocomplete', LegacyFormHelper::getType('entity'), $options);
     }
@@ -49,14 +49,14 @@ class EasyAdminAutocompleteSubscriber implements EventSubscriberInterface
         $form = $event->getForm();
 
         if (null === $data = $event->getData()) {
-            $data = array('autocomplete' => array());
+            $data = ['autocomplete' => []];
             $event->setData($data);
         }
 
         $options = $form->get('autocomplete')->getConfig()->getOptions();
-        $options['choices'] = $options['em']->getRepository($options['class'])->findBy(array(
+        $options['choices'] = $options['em']->getRepository($options['class'])->findBy([
             $options['id_reader']->getIdField() => $data['autocomplete'],
-        ));
+        ]);
 
         if (isset($options['choice_list'])) {
             // clear choice list for SF < 3.0

--- a/Form/Extension/EasyAdminExtension.php
+++ b/Form/Extension/EasyAdminExtension.php
@@ -57,14 +57,14 @@ class EasyAdminExtension extends AbstractTypeExtension
             $easyadmin = $this->request->attributes->get('easyadmin');
             $entity = $easyadmin['entity'];
             $action = $easyadmin['view'];
-            $fields = isset($entity[$action]['fields']) ? $entity[$action]['fields'] : array();
-            $view->vars['easyadmin'] = array(
+            $fields = isset($entity[$action]['fields']) ? $entity[$action]['fields'] : [];
+            $view->vars['easyadmin'] = [
                 'entity' => $entity,
                 'view' => $action,
                 'item' => $easyadmin['item'],
                 'field' => isset($fields[$view->vars['name']]) ? $fields[$view->vars['name']] : null,
                 'form_group' => $form->getConfig()->getAttribute('easyadmin_form_group'),
-            );
+            ];
         }
     }
 

--- a/Form/Type/Configurator/IvoryCKEditorTypeConfigurator.php
+++ b/Form/Type/Configurator/IvoryCKEditorTypeConfigurator.php
@@ -28,12 +28,12 @@ class IvoryCKEditorTypeConfigurator implements TypeConfiguratorInterface
     public function configure($name, array $options, array $metadata, FormConfigInterface $parentConfig)
     {
         // when the IvoryCKEditor doesn't define the toolbar to use, EasyAdmin uses a simple toolbar
-        $options['config']['toolbar'] = array(
-            array('name' => 'styles', 'items' => array('Bold', 'Italic', 'Strike', 'Link')),
-            array('name' => 'lists', 'items' => array('BulletedList', 'NumberedList', '-', 'Outdent', 'Indent')),
-            array('name' => 'clipboard', 'items' => array('Copy', 'Paste', 'PasteFromWord', '-', 'Undo', 'Redo')),
-            array('name' => 'advanced', 'items' => array('Source')),
-        );
+        $options['config']['toolbar'] = [
+            ['name' => 'styles', 'items' => ['Bold', 'Italic', 'Strike', 'Link']],
+            ['name' => 'lists', 'items' => ['BulletedList', 'NumberedList', '-', 'Outdent', 'Indent']],
+            ['name' => 'clipboard', 'items' => ['Copy', 'Paste', 'PasteFromWord', '-', 'Undo', 'Redo']],
+            ['name' => 'advanced', 'items' => ['Source']],
+        ];
 
         return $options;
     }
@@ -43,7 +43,7 @@ class IvoryCKEditorTypeConfigurator implements TypeConfiguratorInterface
      */
     public function supports($type, array $options, array $metadata)
     {
-        $isCkeditorField = in_array($type, array('ckeditor', 'Ivory\\CKEditorBundle\\Form\\Type\\CKEditorType'));
+        $isCkeditorField = in_array($type, ['ckeditor', 'Ivory\\CKEditorBundle\\Form\\Type\\CKEditorType']);
 
         return $isCkeditorField && !isset($options['config']['toolbar']) && !isset($options['config_name']);
     }

--- a/Form/Type/EasyAdminAutocompleteType.php
+++ b/Form/Type/EasyAdminAutocompleteType.php
@@ -71,13 +71,13 @@ class EasyAdminAutocompleteType extends AbstractType implements DataMapperInterf
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
+        $resolver->setDefaults([
             'multiple' => false,
             // force display errors on this form field
             'error_bubbling' => false,
-        ));
+        ]);
 
-        $resolver->setRequired(array('class'));
+        $resolver->setRequired(['class']);
     }
 
     // BC for SF < 2.7

--- a/Form/Type/EasyAdminFormType.php
+++ b/Form/Type/EasyAdminFormType.php
@@ -40,7 +40,7 @@ class EasyAdminFormType extends AbstractType
      * @param ConfigManager               $configManager
      * @param TypeConfiguratorInterface[] $configurators
      */
-    public function __construct(ConfigManager $configManager, array $configurators = array())
+    public function __construct(ConfigManager $configManager, array $configurators = [])
     {
         $this->configManager = $configManager;
         $this->configurators = $configurators;
@@ -54,8 +54,8 @@ class EasyAdminFormType extends AbstractType
         $entity = $options['entity'];
         $view = $options['view'];
         $entityConfig = $this->configManager->getEntityConfig($entity);
-        $entityProperties = isset($entityConfig[$view]['fields']) ? $entityConfig[$view]['fields'] : array();
-        $formGroups = array();
+        $entityProperties = isset($entityConfig[$view]['fields']) ? $entityConfig[$view]['fields'] : [];
+        $formGroups = [];
         $currentFormGroup = null;
 
         foreach ($entityProperties as $name => $metadata) {
@@ -74,7 +74,7 @@ class EasyAdminFormType extends AbstractType
             // to the form. Instead, consider it the current form group (this is
             // applied to the form fields defined after it) and store its details
             // in a property to get them in form template
-            if (in_array($formFieldType, array('easyadmin_group', 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Form\\Type\\EasyAdminGroupType'))) {
+            if (in_array($formFieldType, ['easyadmin_group', 'JavierEguiluz\\Bundle\\EasyAdminBundle\\Form\\Type\\EasyAdminGroupType'])) {
                 $currentFormGroup = $metadata['fieldName'];
                 $formGroups[$currentFormGroup] = $metadata;
 
@@ -113,7 +113,7 @@ class EasyAdminFormType extends AbstractType
         $configManager = $this->configManager;
 
         $resolver
-            ->setDefaults(array(
+            ->setDefaults([
                 'allow_extra_fields' => true,
                 'data_class' => function (Options $options) use ($configManager) {
                     $entity = $options['entity'];
@@ -121,15 +121,15 @@ class EasyAdminFormType extends AbstractType
 
                     return $entityConfig['class'];
                 },
-            ))
-            ->setRequired(array('entity', 'view'));
+            ])
+            ->setRequired(['entity', 'view']);
 
         // setNormalizer() is available since Symfony 2.6
         if (method_exists($resolver, 'setNormalizer')) {
             $resolver->setNormalizer('attr', $this->getAttributesNormalizer());
         } else {
             // BC for Symfony < 2.6
-            $resolver->setNormalizers(array('attr' => $this->getAttributesNormalizer()));
+            $resolver->setNormalizers(['attr' => $this->getAttributesNormalizer()]);
         }
     }
 
@@ -163,9 +163,9 @@ class EasyAdminFormType extends AbstractType
     private function getAttributesNormalizer()
     {
         return function (Options $options, $value) {
-            return array_replace(array(
+            return array_replace([
                 'id' => sprintf('%s-%s-form', $options['view'], mb_strtolower($options['entity'])),
-            ), $value);
+            ], $value);
         };
     }
 }

--- a/Form/Util/LegacyFormHelper.php
+++ b/Form/Util/LegacyFormHelper.php
@@ -20,7 +20,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Form\Util;
  */
 final class LegacyFormHelper
 {
-    private static $supportedTypes = array(
+    private static $supportedTypes = [
         // Symfony's built-in types
         'birthday' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\BirthdayType',
         'button' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\ButtonType',
@@ -64,7 +64,7 @@ final class LegacyFormHelper
         'ckeditor' => 'Ivory\\CKEditorBundle\\Form\\Type\\CKEditorType',
         'vich_file' => 'Vich\\UploaderBundle\\Form\\Type\\VichFileType',
         'vich_image' => 'Vich\\UploaderBundle\\Form\\Type\\VichImageType',
-    );
+    ];
 
     /**
      * It returns the FQCN of the given short type name if not use legacy form

--- a/Search/Autocomplete.php
+++ b/Search/Autocomplete.php
@@ -49,7 +49,7 @@ class Autocomplete
     public function find($entity, $query, $page = 1)
     {
         if (empty($entity) || empty($query)) {
-            return array('results' => array());
+            return ['results' => []];
         }
 
         $backendConfig = $this->configManager->getBackendConfig();
@@ -59,18 +59,18 @@ class Autocomplete
 
         $paginator = $this->finder->findByAllProperties($backendConfig['entities'][$entity], $query, $page, $backendConfig['show']['max_results']);
 
-        return array('results' => $this->processResults($paginator->getCurrentPageResults(), $backendConfig['entities'][$entity]));
+        return ['results' => $this->processResults($paginator->getCurrentPageResults(), $backendConfig['entities'][$entity])];
     }
 
     private function processResults($entities, $targetEntityConfig)
     {
-        $results = array();
+        $results = [];
 
         foreach ($entities as $entity) {
-            $results[] = array(
+            $results[] = [
                 'id' => $this->propertyAccessor->getValue($entity, $targetEntityConfig['primary_key_field_name']),
                 'text' => (string) $entity,
-            );
+            ];
         }
 
         return $results;

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -82,10 +82,10 @@ class QueryBuilder
             ->from($entityConfig['class'], 'entity')
         ;
 
-        $queryParameters = array();
+        $queryParameters = [];
         foreach ($entityConfig['search']['fields'] as $name => $metadata) {
-            $isNumericField = in_array($metadata['dataType'], array('integer', 'number', 'smallint', 'bigint', 'decimal', 'float'));
-            $isTextField = in_array($metadata['dataType'], array('string', 'text', 'guid'));
+            $isNumericField = in_array($metadata['dataType'], ['integer', 'number', 'smallint', 'bigint', 'decimal', 'float']);
+            $isTextField = in_array($metadata['dataType'], ['string', 'text', 'guid']);
             $isGuidField = 'guid' === $metadata['dataType'];
 
             if ($isNumericField && is_numeric($searchQuery)) {

--- a/Tests/Configuration/ActionConfigPassTest.php
+++ b/Tests/Configuration/ActionConfigPassTest.php
@@ -32,10 +32,10 @@ class ActionConfigPassTest extends \PHPUnit_Framework_TestCase
 
     public function getWrongActionConfigs()
     {
-        return array(
-            array(array(7)),
-            array(array(true)),
-            array(array(null)),
-        );
+        return [
+            [[7]],
+            [[true]],
+            [[null]],
+        ];
     }
 }

--- a/Tests/Configuration/ConfigManagerTest.php
+++ b/Tests/Configuration/ConfigManagerTest.php
@@ -76,7 +76,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
         // glob() returns an array of strings and fixtures require an array of arrays
         return array_map(
             function ($filePath) {
-                return array($filePath);
+                return [$filePath];
             },
             glob(__DIR__.'/fixtures/exceptions/*.yml')
         );
@@ -92,7 +92,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
 
         // these tests are not compatible with Symfony 2.3 because the YAML
         // component of that version does not ignore duplicate keys
-        $incompatibleTests = array(
+        $incompatibleTests = [
             'configurations/input/admin_007.yml',
             'configurations/input/admin_008.yml',
             'configurations/input/admin_013.yml',
@@ -101,7 +101,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
             'configurations/input/admin_020.yml',
             'configurations/input/admin_021.yml',
             'configurations/input/admin_026.yml',
-        );
+        ];
 
         return !in_array(substr($filePath, -34), $incompatibleTests);
     }

--- a/Tests/Configuration/NormalizerConfigPassTest.php
+++ b/Tests/Configuration/NormalizerConfigPassTest.php
@@ -21,14 +21,14 @@ class NormalizerConfigPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testFieldsMustBeStringsOrArrays()
     {
-        $backendConfig = array('entities' => array(
-            'TestEntity' => array(
+        $backendConfig = ['entities' => [
+            'TestEntity' => [
                 'class' => 'AppBundle\Entity\TestEntity',
-                'edit' => array(
-                    'fields' => array(20),
-                ),
-            ),
-        ));
+                'edit' => [
+                    'fields' => [20],
+                ],
+            ],
+        ]];
 
         $configPass = new NormalizerConfigPass($this->getServiceContainer());
         $configPass->process($backendConfig);
@@ -40,16 +40,16 @@ class NormalizerConfigPassTest extends \PHPUnit_Framework_TestCase
      */
     public function testFieldsMustDefinePropertyOption()
     {
-        $backendConfig = array('entities' => array(
-            'TestEntity' => array(
+        $backendConfig = ['entities' => [
+            'TestEntity' => [
                 'class' => 'AppBundle\Entity\TestEntity',
-                'edit' => array(
-                    'fields' => array(
-                        array('label' => 'Field without "property" option'),
-                    ),
-                ),
-            ),
-        ));
+                'edit' => [
+                    'fields' => [
+                        ['label' => 'Field without "property" option'],
+                    ],
+                ],
+            ],
+        ]];
 
         $configPass = new NormalizerConfigPass($this->getServiceContainer());
         $configPass->process($backendConfig);

--- a/Tests/Controller/ActionTargetTest.php
+++ b/Tests/Controller/ActionTargetTest.php
@@ -19,7 +19,7 @@ class ActionTargetTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'action_target'));
+        $this->initClient(['environment' => 'action_target']);
     }
 
     public function testListViewActions()

--- a/Tests/Controller/AdvancedFormLayoutTest.php
+++ b/Tests/Controller/AdvancedFormLayoutTest.php
@@ -19,7 +19,7 @@ class AdvancedFormLayoutTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'advanced_form_layout'));
+        $this->initClient(['environment' => 'advanced_form_layout']);
     }
 
     /**
@@ -30,10 +30,10 @@ class AdvancedFormLayoutTest extends AbstractTestCase
     public function testFormLayout()
     {
         // a dataProvider can't be used because it can't create the Crawlers
-        foreach (array('edit', 'new') as $view) {
+        foreach (['edit', 'new'] as $view) {
             $queryParams = array_merge(
-                array('action' => $view, 'entity' => 'Product'),
-                'edit' === $view ? array('id' => 1) : array()
+                ['action' => $view, 'entity' => 'Product'],
+                'edit' === $view ? ['id' => 1] : []
             );
             $crawler = $this->getBackendPage($queryParams);
 

--- a/Tests/Controller/AutocompleteTest.php
+++ b/Tests/Controller/AutocompleteTest.php
@@ -19,7 +19,7 @@ class AutocompleteTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'autocomplete'));
+        $this->initClient(['environment' => 'autocomplete']);
     }
 
     /**
@@ -27,11 +27,11 @@ class AutocompleteTest extends AbstractTestCase
      */
     public function testAutocompleteWithMissingParameters($query)
     {
-        $queryParameters = array(
+        $queryParameters = [
             'action' => 'autocomplete',
             'entity' => 'Category',
             'query' => $query,
-        );
+        ];
 
         // remove empty parameters to force the autocomplete error
         $queryParameters = array_filter($queryParameters);
@@ -39,18 +39,18 @@ class AutocompleteTest extends AbstractTestCase
         $this->getBackendPage($queryParameters);
 
         $this->assertSame(
-            array('results' => array()),
+            ['results' => []],
             json_decode($this->client->getResponse()->getContent(), true)
         );
     }
 
     public function testAutocompleteText()
     {
-        $this->getBackendPage(array(
+        $this->getBackendPage([
             'action' => 'autocomplete',
             'entity' => 'Category',
             'query' => 'Parent Categ',
-        ));
+        ]);
 
         // the results are the first 10 parent categories
         $response = json_decode($this->client->getResponse()->getContent(), true);
@@ -62,28 +62,28 @@ class AutocompleteTest extends AbstractTestCase
 
     public function testAutocompleteNumber()
     {
-        $this->getBackendPage(array(
+        $this->getBackendPage([
             'action' => 'autocomplete',
             'entity' => 'Category',
             'query' => 21,
-        ));
+        ]);
 
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertSame(
-            array(
-                array('id' => 21, 'text' => 'Parent Category #21'),
-                array('id' => 121, 'text' => 'Category #21'),
-            ),
+            [
+                ['id' => 21, 'text' => 'Parent Category #21'],
+                ['id' => 121, 'text' => 'Category #21'],
+            ],
             $response['results']
         );
     }
 
     public function provideMissingParameters()
     {
-        return array(
+        return [
             // query
-            array(''),
-            array(null),
-        );
+            [''],
+            [null],
+        ];
     }
 }

--- a/Tests/Controller/BackendErrorsTest.php
+++ b/Tests/Controller/BackendErrorsTest.php
@@ -19,15 +19,15 @@ class BackendErrorsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'default_backend'));
+        $this->initClient(['environment' => 'default_backend']);
     }
 
     public function testUndefinedEntityError()
     {
-        $crawler = $this->getBackendPage(array(
+        $crawler = $this->getBackendPage([
             'entity' => 'InexistentEntity',
             'view' => 'list',
-        ));
+        ]);
 
         $this->assertSame(500, $this->client->getResponse()->getStatusCode());
         $this->assertContains('Entity "InexistentEntity" is not managed by EasyAdmin.', $crawler->filter('head title')->text());

--- a/Tests/Controller/CustomEntityControllerAsServiceTest.php
+++ b/Tests/Controller/CustomEntityControllerAsServiceTest.php
@@ -19,7 +19,7 @@ class CustomEntityControllerAsServiceTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'custom_entity_controller_service'));
+        $this->initClient(['environment' => 'custom_entity_controller_service']);
     }
 
     public function testListAction()

--- a/Tests/Controller/CustomEntityControllerTest.php
+++ b/Tests/Controller/CustomEntityControllerTest.php
@@ -19,7 +19,7 @@ class CustomEntityControllerTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'custom_entity_controller'));
+        $this->initClient(['environment' => 'custom_entity_controller']);
     }
 
     public function testListAction()

--- a/Tests/Controller/CustomFieldTemplateTest.php
+++ b/Tests/Controller/CustomFieldTemplateTest.php
@@ -19,7 +19,7 @@ class CustomFieldTemplateTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'custom_field_template'));
+        $this->initClient(['environment' => 'custom_field_template']);
     }
 
     public function testListViewCustomFieldTemplate()

--- a/Tests/Controller/CustomMenuTest.php
+++ b/Tests/Controller/CustomMenuTest.php
@@ -20,7 +20,7 @@ class CustomMenuTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'custom_menu'));
+        $this->initClient(['environment' => 'custom_menu']);
     }
 
     public function testCustomBackendHomepage()
@@ -50,10 +50,10 @@ class CustomMenuTest extends AbstractTestCase
         $this->getBackendHomepage();
         $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
-        $this->assertArraySubset(array(
+        $this->assertArraySubset([
             'route' => 'easyadmin',
-            'params' => array('action' => 'list', 'entity' => 'Category'),
-        ), $backendConfig['homepage']);
+            'params' => ['action' => 'list', 'entity' => 'Category'],
+        ], $backendConfig['homepage']);
     }
 
     public function testDefaultMenuItem()
@@ -61,11 +61,11 @@ class CustomMenuTest extends AbstractTestCase
         $this->getBackendHomepage();
         $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
-        $this->assertArraySubset(array(
+        $this->assertArraySubset([
             'label' => 'Categories',
             'entity' => 'Category',
             'type' => 'entity',
-        ), $backendConfig['default_menu_item']);
+        ], $backendConfig['default_menu_item']);
     }
 
     public function testMenuDividers()
@@ -175,8 +175,8 @@ class CustomMenuTest extends AbstractTestCase
 
     public function testMenuItemTypes()
     {
-        $expectedTypesMainMenu = array('empty', 'entity', 'entity', 'divider', 'link', 'link', 'link', 'divider', 'route', 'route');
-        $expectedTypesSubMenu = array('entity', 'entity', 'divider', 'entity', 'link');
+        $expectedTypesMainMenu = ['empty', 'entity', 'entity', 'divider', 'link', 'link', 'link', 'divider', 'route', 'route'];
+        $expectedTypesSubMenu = ['entity', 'entity', 'divider', 'entity', 'link'];
 
         $this->getBackendHomepage();
         $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();

--- a/Tests/Controller/CustomTranslationDomainTest.php
+++ b/Tests/Controller/CustomTranslationDomainTest.php
@@ -19,7 +19,7 @@ class CustomTranslationDomainTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'custom_translation_domain'));
+        $this->initClient(['environment' => 'custom_translation_domain']);
     }
 
     public function testListView()

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -19,7 +19,7 @@ class CustomizedBackendTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'customized_backend'));
+        $this->initClient(['environment' => 'customized_backend']);
     }
 
     public function testListViewPageTitle()
@@ -41,12 +41,12 @@ class CustomizedBackendTest extends AbstractTestCase
     {
         $crawler = $this->requestListView();
 
-        $hiddenParameters = array(
+        $hiddenParameters = [
             'action' => 'search',
             'entity' => 'Category',
             'sortField' => 'id',
             'sortDirection' => 'DESC',
-        );
+        ];
 
         $this->assertSame('Look for Categories', trim($crawler->filter('.action-search button[type=submit]')->text()));
         $this->assertContains('custom_class_search', $crawler->filter('.action-search')->attr('class'));
@@ -91,7 +91,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testListViewTableColumnLabels()
     {
         $crawler = $this->requestListView();
-        $columnLabels = array('ID', 'Label', 'Parent category', 'Actions');
+        $columnLabels = ['ID', 'Label', 'Parent category', 'Actions'];
 
         foreach ($columnLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('.table thead th')->eq($i)->text()));
@@ -101,7 +101,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testListViewTableColumnAttributes()
     {
         $crawler = $this->requestListView();
-        $columnAttributes = array('id', 'name', 'parent');
+        $columnAttributes = ['id', 'name', 'parent'];
 
         foreach ($columnAttributes as $i => $attribute) {
             $this->assertSame($attribute, trim($crawler->filter('.table thead th')->eq($i)->attr('data-property-name')));
@@ -127,7 +127,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testListViewTableRowAttributes()
     {
         $crawler = $this->requestListView();
-        $columnAttributes = array('ID', 'Label', 'Parent category');
+        $columnAttributes = ['ID', 'Label', 'Parent category'];
 
         foreach ($columnAttributes as $i => $attribute) {
             $this->assertSame($attribute, trim($crawler->filter('.table tbody tr td')->eq($i)->attr('data-label')));
@@ -173,7 +173,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testShowViewFieldLabels()
     {
         $crawler = $this->requestShowView();
-        $fieldLabels = array('#', 'Label', 'Parent category');
+        $fieldLabels = ['#', 'Label', 'Parent category'];
 
         foreach ($fieldLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('#main .form-group label')->eq($i)->text()));
@@ -183,7 +183,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testShowViewFieldClasses()
     {
         $crawler = $this->requestShowView();
-        $fieldClasses = array('integer', 'string', 'association');
+        $fieldClasses = ['integer', 'string', 'association'];
 
         foreach ($fieldClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
@@ -206,13 +206,13 @@ class CustomizedBackendTest extends AbstractTestCase
 
     public function testShowViewListActionReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'list',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
-        );
+        ];
 
         // 1. visit a specific 'list' view page
         $crawler = $this->getBackendPage($parameters);
@@ -237,13 +237,13 @@ class CustomizedBackendTest extends AbstractTestCase
      */
     public function testChainedReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'list',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
-        );
+        ];
 
         // 1. visit a specific 'list' view page
         $crawler = $this->getBackendPage($parameters);
@@ -292,7 +292,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testEditViewFieldLabels()
     {
         $crawler = $this->requestEditView();
-        $fieldLabels = array('ID', 'Label', 'Parent Category Label');
+        $fieldLabels = ['ID', 'Label', 'Parent Category Label'];
 
         foreach ($fieldLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('#main .form-group label')->eq($i)->text()));
@@ -302,8 +302,8 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testEditViewFieldClasses()
     {
         $crawler = $this->requestEditView();
-        $fieldDefaultClasses = array('integer', 'text', 'entity');
-        $fieldCustomClasses = array('integer', 'text', 'entity');
+        $fieldDefaultClasses = ['integer', 'text', 'entity'];
+        $fieldCustomClasses = ['integer', 'text', 'entity'];
 
         foreach ($fieldDefaultClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
@@ -330,13 +330,13 @@ class CustomizedBackendTest extends AbstractTestCase
 
     public function testEditViewListActionReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'list',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
-        );
+        ];
 
         // 1. visit a specific 'list' view page
         $crawler = $this->getBackendPage($parameters);
@@ -395,7 +395,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testNewViewFieldLabels()
     {
         $crawler = $this->requestNewView();
-        $fieldLabels = array('ID', 'Label', 'Parent Category Label');
+        $fieldLabels = ['ID', 'Label', 'Parent Category Label'];
 
         foreach ($fieldLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('#main .form-group label')->eq($i)->text()));
@@ -405,7 +405,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testNewViewFieldClasses()
     {
         $crawler = $this->requestNewView();
-        $fieldClasses = array('integer', 'text', 'entity');
+        $fieldClasses = ['integer', 'text', 'entity'];
 
         foreach ($fieldClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
@@ -425,13 +425,13 @@ class CustomizedBackendTest extends AbstractTestCase
 
     public function testNewViewListActionReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'list',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
-        );
+        ];
 
         // 1. visit a specific 'list' view page
         $crawler = $this->getBackendPage($parameters);
@@ -503,7 +503,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testSearchViewTableColumnLabels()
     {
         $crawler = $this->requestSearchView();
-        $columnLabels = array('ID', 'Label', 'Parent category', 'Actions');
+        $columnLabels = ['ID', 'Label', 'Parent category', 'Actions'];
 
         foreach ($columnLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('.table thead th')->eq($i)->text()));
@@ -513,7 +513,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testSearchViewTableColumnAttributes()
     {
         $crawler = $this->requestSearchView();
-        $columnAttributes = array('id', 'name', 'parent');
+        $columnAttributes = ['id', 'name', 'parent'];
 
         foreach ($columnAttributes as $i => $attribute) {
             $this->assertSame($attribute, trim($crawler->filter('.table thead th')->eq($i)->attr('data-property-name')));
@@ -539,7 +539,7 @@ class CustomizedBackendTest extends AbstractTestCase
     public function testSearchViewTableRowAttributes()
     {
         $crawler = $this->requestSearchView();
-        $columnAttributes = array('ID', 'Label', 'Parent category');
+        $columnAttributes = ['ID', 'Label', 'Parent category'];
 
         foreach ($columnAttributes as $i => $attribute) {
             $this->assertSame($attribute, trim($crawler->filter('.table tbody tr td')->eq($i)->attr('data-label')));
@@ -570,14 +570,14 @@ class CustomizedBackendTest extends AbstractTestCase
 
     public function testSearchViewShowActionReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'search',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
             'query' => 'cat',
-        );
+        ];
 
         // 1. visit a specific 'search' view page
         $crawler = $this->getBackendPage($parameters);

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -20,7 +20,7 @@ class DefaultBackendTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'default_backend'));
+        $this->initClient(['environment' => 'default_backend']);
     }
 
     public function testBackendHomepageRedirection()
@@ -83,13 +83,13 @@ class DefaultBackendTest extends AbstractTestCase
 
     public function testMainMenuItems()
     {
-        $menuItems = array(
+        $menuItems = [
             'Category' => '/admin/?entity=Category&action=list&menuIndex=0&submenuIndex=-1',
             'Image' => '/admin/?entity=Image&action=list&menuIndex=1&submenuIndex=-1',
             'Purchase' => '/admin/?entity=Purchase&action=list&menuIndex=2&submenuIndex=-1',
             'PurchaseItem' => '/admin/?entity=PurchaseItem&action=list&menuIndex=3&submenuIndex=-1',
             'Product' => '/admin/?entity=Product&action=list&menuIndex=4&submenuIndex=-1',
-        );
+        ];
 
         $crawler = $this->getBackendHomepage();
 
@@ -133,12 +133,12 @@ class DefaultBackendTest extends AbstractTestCase
     {
         $crawler = $this->requestListView();
 
-        $hiddenParameters = array(
+        $hiddenParameters = [
             'action' => 'search',
             'entity' => 'Category',
             'sortField' => 'id',
             'sortDirection' => 'DESC',
-        );
+        ];
 
         $this->assertSame('Search', trim($crawler->filter('.action-search button[type=submit]')->text()));
         $this->assertContains('action-search', $crawler->filter('.global-actions > div')->first()->attr('class'));
@@ -186,7 +186,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testListViewTableColumnLabels()
     {
         $crawler = $this->requestListView();
-        $columnLabels = array('ID', 'Name', 'Products', 'Parent', 'Actions');
+        $columnLabels = ['ID', 'Name', 'Products', 'Parent', 'Actions'];
 
         foreach ($columnLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('.table thead th')->eq($i)->text()));
@@ -196,7 +196,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testListViewTableColumnAttributes()
     {
         $crawler = $this->requestListView();
-        $columnAttributes = array('id', 'name', 'products', 'parent');
+        $columnAttributes = ['id', 'name', 'products', 'parent'];
 
         foreach ($columnAttributes as $i => $attribute) {
             $this->assertSame($attribute, trim($crawler->filter('.table thead th')->eq($i)->attr('data-property-name')));
@@ -222,7 +222,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testListViewTableRowAttributes()
     {
         $crawler = $this->requestListView();
-        $columnAttributes = array('ID', 'Name', 'Products', 'Parent');
+        $columnAttributes = ['ID', 'Name', 'Products', 'Parent'];
 
         foreach ($columnAttributes as $i => $attribute) {
             $this->assertSame($attribute, trim($crawler->filter('.table tbody tr td')->eq($i)->attr('data-label')));
@@ -253,7 +253,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testShowViewFieldLabels()
     {
         $crawler = $this->requestShowView();
-        $fieldLabels = array('ID', 'Name', 'Products', 'Parent');
+        $fieldLabels = ['ID', 'Name', 'Products', 'Parent'];
 
         foreach ($fieldLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('#main .form-group label')->eq($i)->text()));
@@ -263,7 +263,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testShowViewFieldClasses()
     {
         $crawler = $this->requestShowView();
-        $fieldClasses = array('integer', 'string', 'association');
+        $fieldClasses = ['integer', 'string', 'association'];
 
         foreach ($fieldClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
@@ -291,13 +291,13 @@ class DefaultBackendTest extends AbstractTestCase
 
     public function testShowViewReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'list',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
-        );
+        ];
 
         // 1. visit a specific 'list' view page
         $crawler = $this->getBackendPage($parameters);
@@ -335,7 +335,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testEditViewFieldLabels()
     {
         $crawler = $this->requestEditView();
-        $fieldLabels = array('Name', 'Products', 'Parent');
+        $fieldLabels = ['Name', 'Products', 'Parent'];
 
         foreach ($fieldLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('#main .form-group label')->eq($i)->text()));
@@ -345,7 +345,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testEditViewFieldClasses()
     {
         $crawler = $this->requestEditView();
-        $fieldClasses = array('text', 'entity');
+        $fieldClasses = ['text', 'entity'];
 
         foreach ($fieldClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
@@ -371,13 +371,13 @@ class DefaultBackendTest extends AbstractTestCase
 
     public function testEditViewReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'list',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
-        );
+        ];
 
         // 1. visit a specific 'list' view page
         $crawler = $this->getBackendPage($parameters);
@@ -400,9 +400,9 @@ class DefaultBackendTest extends AbstractTestCase
         $this->client->followRedirects();
 
         $categoryName = sprintf('Modified Category %s', md5(mt_rand()));
-        $form = $crawler->selectButton('Save changes')->form(array(
+        $form = $crawler->selectButton('Save changes')->form([
             'category[name]' => $categoryName,
-        ));
+        ]);
         $crawler = $this->client->submit($form);
 
         $this->assertContains(
@@ -419,8 +419,8 @@ class DefaultBackendTest extends AbstractTestCase
         $product = $em->getRepository('AppTestBundle\Entity\FunctionalTests\Product')->find(1);
         $this->assertTrue($product->isEnabled(), 'Initially the product is enabled.');
 
-        $queryParameters = array('action' => 'edit', 'view' => 'list', 'entity' => 'Product', 'id' => '1', 'property' => 'enabled', 'newValue' => 'false');
-        $this->client->request('GET', '/admin/?'.http_build_query($queryParameters), array(), array(), array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
+        $queryParameters = ['action' => 'edit', 'view' => 'list', 'entity' => 'Product', 'id' => '1', 'property' => 'enabled', 'newValue' => 'false'];
+        $this->client->request('GET', '/admin/?'.http_build_query($queryParameters), [], [], ['HTTP_X-Requested-With' => 'XMLHttpRequest']);
 
         $product = $em->getRepository('AppTestBundle\Entity\FunctionalTests\Product')->find(1);
         $this->assertFalse($product->isEnabled(), 'After editing it via Ajax, the product is not enabled.');
@@ -428,8 +428,8 @@ class DefaultBackendTest extends AbstractTestCase
 
     public function testWrongEntityModificationViaAjax()
     {
-        $queryParameters = array('action' => 'edit', 'view' => 'list', 'entity' => 'Product', 'id' => '1', 'property' => 'this_property_does_not_exist', 'newValue' => 'false');
-        $this->client->request('GET', '/admin/?'.http_build_query($queryParameters), array(), array(), array('HTTP_X-Requested-With' => 'XMLHttpRequest'));
+        $queryParameters = ['action' => 'edit', 'view' => 'list', 'entity' => 'Product', 'id' => '1', 'property' => 'this_property_does_not_exist', 'newValue' => 'false'];
+        $this->client->request('GET', '/admin/?'.http_build_query($queryParameters), [], [], ['HTTP_X-Requested-With' => 'XMLHttpRequest']);
 
         $this->assertSame(500, $this->client->getResponse()->getStatusCode(), 'Trying to modify a non-existent property via Ajax returns a 500 error');
         $this->assertContains('The type of the &quot;this_property_does_not_exist&quot; property is not &quot;toggle&quot;', $this->client->getResponse()->getContent());
@@ -456,7 +456,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testNewViewFieldLabels()
     {
         $crawler = $this->requestNewView();
-        $fieldLabels = array('Name', 'Products', 'Parent');
+        $fieldLabels = ['Name', 'Products', 'Parent'];
 
         foreach ($fieldLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('#main .form-group label')->eq($i)->text()));
@@ -466,7 +466,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testNewViewFieldClasses()
     {
         $crawler = $this->requestNewView();
-        $fieldClasses = array('text', 'entity');
+        $fieldClasses = ['text', 'entity'];
 
         foreach ($fieldClasses as $i => $cssClass) {
             $this->assertContains('field-'.$cssClass, trim($crawler->filter('#main .form-group')->eq($i)->attr('class')));
@@ -488,13 +488,13 @@ class DefaultBackendTest extends AbstractTestCase
 
     public function testNewViewReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'list',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
-        );
+        ];
 
         // 1. visit a specific 'list' view page
         $crawler = $this->getBackendPage($parameters);
@@ -517,9 +517,9 @@ class DefaultBackendTest extends AbstractTestCase
         $this->client->followRedirects();
 
         $categoryName = sprintf('The New Category %s', md5(mt_rand()));
-        $form = $crawler->selectButton('Save changes')->form(array(
+        $form = $crawler->selectButton('Save changes')->form([
             'category[name]' => $categoryName,
-        ));
+        ]);
         $crawler = $this->client->submit($form);
 
         $this->assertContains($categoryName, $crawler->filter('#main table tr')->eq(1)->text(), 'The newly created category is displayed in the first data row of the "list" table.');
@@ -536,21 +536,21 @@ class DefaultBackendTest extends AbstractTestCase
     public function testSearchViewEmptyQuery()
     {
         // empty queries redirect to "list" action
-        $this->getBackendPage(array(
+        $this->getBackendPage([
             'action' => 'search',
             'entity' => 'Category',
             'query' => '',
-        ));
+        ]);
 
         $this->assertSame(302, $this->client->getResponse()->getStatusCode());
         $this->assertSame('/admin/?action=list&entity=Category&sortField=id&sortDirection=DESC', $this->client->getResponse()->headers->get('location'));
 
         // pseudo-empty queries (e.g. strings which only contain white spaces) don't redirect to "list" action
-        $crawler = $this->getBackendPage(array(
+        $crawler = $this->getBackendPage([
             'action' => 'search',
             'entity' => 'Category',
             'query' => '    ',
-        ));
+        ]);
 
         $this->assertSame('No results found', $crawler->filter('h1.title')->text());
     }
@@ -567,7 +567,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testSearchViewTableColumnLabels()
     {
         $crawler = $this->requestSearchView();
-        $columnLabels = array('ID', 'Name', 'Products', 'Parent', 'Actions');
+        $columnLabels = ['ID', 'Name', 'Products', 'Parent', 'Actions'];
 
         foreach ($columnLabels as $i => $label) {
             $this->assertSame($label, trim($crawler->filter('.table thead th')->eq($i)->text()));
@@ -577,7 +577,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testSearchViewTableColumnAttributes()
     {
         $crawler = $this->requestSearchView();
-        $columnAttributes = array('id', 'name', 'products', 'parent');
+        $columnAttributes = ['id', 'name', 'products', 'parent'];
 
         foreach ($columnAttributes as $i => $attribute) {
             $this->assertSame($attribute, trim($crawler->filter('.table thead th')->eq($i)->attr('data-property-name')));
@@ -603,7 +603,7 @@ class DefaultBackendTest extends AbstractTestCase
     public function testSearchViewTableRowAttributes()
     {
         $crawler = $this->requestSearchView();
-        $columnAttributes = array('ID', 'Name', 'Products', 'Parent');
+        $columnAttributes = ['ID', 'Name', 'Products', 'Parent'];
 
         foreach ($columnAttributes as $i => $attribute) {
             $this->assertSame($attribute, trim($crawler->filter('.table tbody tr td')->eq($i)->attr('data-label')));
@@ -634,14 +634,14 @@ class DefaultBackendTest extends AbstractTestCase
 
     public function testSearchViewShowActionReferer()
     {
-        $parameters = array(
+        $parameters = [
             'action' => 'search',
             'entity' => 'Category',
             'sortField' => 'name',
             'sortDirection' => 'ASC',
             'page' => '2',
             'query' => 'cat',
-        );
+        ];
 
         // 1. visit a specific 'search' view page
         $crawler = $this->getBackendPage($parameters);
@@ -680,7 +680,7 @@ class DefaultBackendTest extends AbstractTestCase
 
     public function testEntityDeletionRequiresCsrfToken()
     {
-        $queryParameters = array('action' => 'delete', 'entity' => 'Product', 'id' => '1');
+        $queryParameters = ['action' => 'delete', 'entity' => 'Product', 'id' => '1'];
         // Sending a 'DELETE' HTTP request is not enough (the delete form includes a CSRF token)
         $this->client->request('DELETE', '/admin/?'.http_build_query($queryParameters));
 
@@ -690,7 +690,7 @@ class DefaultBackendTest extends AbstractTestCase
 
     public function testEntityDeletionRequiresDeleteHttpMethod()
     {
-        $queryParameters = array('action' => 'delete', 'entity' => 'Product', 'id' => '1');
+        $queryParameters = ['action' => 'delete', 'entity' => 'Product', 'id' => '1'];
         // 'POST' HTTP method is wrong for deleting entities ('DELETE' method is required)
         $this->client->request('POST', '/admin/?'.http_build_query($queryParameters));
 

--- a/Tests/Controller/DefaultMenuTest.php
+++ b/Tests/Controller/DefaultMenuTest.php
@@ -19,7 +19,7 @@ class DefaultMenuTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'default_menu'));
+        $this->initClient(['environment' => 'default_menu']);
     }
 
     public function testCustomBackendHomepage()
@@ -46,13 +46,13 @@ class DefaultMenuTest extends AbstractTestCase
     {
         $crawler = $this->getBackendHomepage();
 
-        $urls = array(
+        $urls = [
             '/admin/?entity=Category&action=list&menuIndex=0&submenuIndex=-1',
             '/admin/?entity=Image&action=list&menuIndex=1&submenuIndex=-1',
             '/admin/?entity=Purchase&action=list&menuIndex=2&submenuIndex=-1',
             '/admin/?entity=PurchaseItem&action=list&menuIndex=3&submenuIndex=-1',
             '/admin/?entity=Product&action=list&menuIndex=4&submenuIndex=-1',
-        );
+        ];
 
         foreach ($urls as $i => $url) {
             $this->assertSame($url, $crawler->filter('.sidebar-menu li a')->eq($i)->attr('href'));

--- a/Tests/Controller/DisabledActionsTest.php
+++ b/Tests/Controller/DisabledActionsTest.php
@@ -20,7 +20,7 @@ class DisabledActionsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'disabled_actions'));
+        $this->initClient(['environment' => 'disabled_actions']);
     }
 
     public function testAssociationLinksInListView()

--- a/Tests/Controller/DqlFilterTest.php
+++ b/Tests/Controller/DqlFilterTest.php
@@ -19,7 +19,7 @@ class DqlFilterTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'dql_filter'));
+        $this->initClient(['environment' => 'dql_filter']);
     }
 
     public function testListDqlFilter()
@@ -28,7 +28,7 @@ class DqlFilterTest extends AbstractTestCase
 
         $this->assertCount(4, $crawler->filter('#main .table tbody tr'));
         $this->assertSame(
-            array('54', '53', '52', '51'),
+            ['54', '53', '52', '51'],
             $crawler->filter('#main .table tbody tr')->extract('data-id')
         );
     }
@@ -39,7 +39,7 @@ class DqlFilterTest extends AbstractTestCase
 
         $this->assertCount(11, $crawler->filter('#main .table tbody tr'));
         $this->assertSame(
-            array('29', '28', '27', '26', '25', '24', '23', '22', '21', '20', '2'),
+            ['29', '28', '27', '26', '25', '24', '23', '22', '21', '20', '2'],
             $crawler->filter('#main .table tbody tr')->extract('data-id')
         );
     }

--- a/Tests/Controller/EmptyActionLabelsTest.php
+++ b/Tests/Controller/EmptyActionLabelsTest.php
@@ -19,7 +19,7 @@ class EmptyActionLabelsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'empty_action_labels'));
+        $this->initClient(['environment' => 'empty_action_labels']);
     }
 
     public function testBuiltInActionLabels()

--- a/Tests/Controller/EmptyBackendTest.php
+++ b/Tests/Controller/EmptyBackendTest.php
@@ -17,7 +17,7 @@ class EmptyBackendTest extends AbstractTestCase
 {
     public function testNoEntityHasBeenConfigured()
     {
-        $this->initClient(array('environment' => 'empty_backend'));
+        $this->initClient(['environment' => 'empty_backend']);
         $this->client->request('GET', '/admin/');
 
         $this->assertSame(500, $this->client->getResponse()->getStatusCode());

--- a/Tests/Controller/EntitySortingTest.php
+++ b/Tests/Controller/EntitySortingTest.php
@@ -19,7 +19,7 @@ class EntitySortingTest extends AbstractTestCase
     {
         // parent::setUp();
 
-        $this->initClient(array('environment' => 'entity_sorting'));
+        $this->initClient(['environment' => 'entity_sorting']);
     }
 
     public function testMainMenuSorting()

--- a/Tests/Controller/FormViewTest.php
+++ b/Tests/Controller/FormViewTest.php
@@ -19,7 +19,7 @@ class FormViewTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'form_view'));
+        $this->initClient(['environment' => 'form_view']);
     }
 
     public function testNewView()

--- a/Tests/Controller/InternationalizationTest.php
+++ b/Tests/Controller/InternationalizationTest.php
@@ -19,7 +19,7 @@ class InternationalizationTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'internationalization'));
+        $this->initClient(['environment' => 'internationalization']);
     }
 
     public function testLanguageDefinedByLayout()

--- a/Tests/Controller/MultipleConfigSyntaxTest.php
+++ b/Tests/Controller/MultipleConfigSyntaxTest.php
@@ -17,12 +17,12 @@ class MultipleConfigSyntaxTest extends AbstractTestCase
 {
     public function testConfigurationInDifferentFiles()
     {
-        $this->initClient(array('environment' => 'multiple_config_syntax'));
+        $this->initClient(['environment' => 'multiple_config_syntax']);
         $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
-        $expectedEntityNames = array(
+        $expectedEntityNames = [
             'Product', 'Product2', 'Product3', 'Product4', 'Inventory', 'Product22', 'Product5', 'Inventory2',
-        );
+        ];
 
         $i = 0;
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {

--- a/Tests/Controller/OverrideEasyAdminTemplateTest.php
+++ b/Tests/Controller/OverrideEasyAdminTemplateTest.php
@@ -19,7 +19,7 @@ class OverrideEasyAdminTemplateTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'override_templates'));
+        $this->initClient(['environment' => 'override_templates']);
     }
 
     public function testLayoutIsOverridden()

--- a/Tests/Controller/RawFieldTest.php
+++ b/Tests/Controller/RawFieldTest.php
@@ -19,7 +19,7 @@ class RawFieldTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'raw_field'));
+        $this->initClient(['environment' => 'raw_field']);
     }
 
     public function testListViewRawField()

--- a/Tests/Controller/ReadOnlyBackendTest.php
+++ b/Tests/Controller/ReadOnlyBackendTest.php
@@ -19,7 +19,7 @@ class ReadOnlyBackendTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'read_only_backend'));
+        $this->initClient(['environment' => 'read_only_backend']);
     }
 
     public function testListViewContainsNoDisabledActions()

--- a/Tests/Controller/RtlTest.php
+++ b/Tests/Controller/RtlTest.php
@@ -19,7 +19,7 @@ class RtlTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'rtl'));
+        $this->initClient(['environment' => 'rtl']);
     }
 
     public function testRtlAutodetection()

--- a/Tests/Controller/SplitConfigurationTest.php
+++ b/Tests/Controller/SplitConfigurationTest.php
@@ -17,10 +17,10 @@ class SplitConfigurationTest extends AbstractTestCase
 {
     public function testConfigurationInDifferentFiles()
     {
-        $this->initClient(array('environment' => 'split_configuration'));
+        $this->initClient(['environment' => 'split_configuration']);
         $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
-        $this->assertSame(array('Category', 'Product'), array_keys($backendConfig['entities']));
+        $this->assertSame(['Category', 'Product'], array_keys($backendConfig['entities']));
 
         $this->assertSame('Categories', $backendConfig['entities']['Category']['label']);
 
@@ -35,6 +35,6 @@ class SplitConfigurationTest extends AbstractTestCase
             'The value "wrong_value" is not allowed for path "easy_admin.design.color_scheme". Permissible values: "dark", "light"'
         );
 
-        $this->initClient(array('environment' => 'split_configuration_error'));
+        $this->initClient(['environment' => 'split_configuration_error']);
     }
 }

--- a/Tests/Controller/TypeOptionsTest.php
+++ b/Tests/Controller/TypeOptionsTest.php
@@ -19,7 +19,7 @@ class TypeOptionsTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'type_options'));
+        $this->initClient(['environment' => 'type_options']);
     }
 
     public function testNewViewTypeOptions()

--- a/Tests/DataCollector/EasyAdminDataCollectorTest.php
+++ b/Tests/DataCollector/EasyAdminDataCollectorTest.php
@@ -19,7 +19,7 @@ class EasyAdminDataCollectorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'default_backend'));
+        $this->initClient(['environment' => 'default_backend']);
     }
 
     public function testCollectorIsEnabled()
@@ -38,13 +38,13 @@ class EasyAdminDataCollectorTest extends AbstractTestCase
 
         $this->assertSame(5, $collector->getNumEntities());
 
-        $parameters = array(
+        $parameters = [
             'action' => 'list',
             'entity' => 'Category',
             'id' => null,
             'sort_field' => 'id',
             'sort_direction' => 'DESC',
-        );
+        ];
         $this->assertSame($parameters, $collector->getRequestParameters());
 
         $currentConfiguration = $collector->getCurrentEntityConfig();
@@ -62,13 +62,13 @@ class EasyAdminDataCollectorTest extends AbstractTestCase
 
         $this->assertSame(5, $collector->getNumEntities());
 
-        $parameters = array(
+        $parameters = [
             'action' => 'edit',
             'entity' => 'Category',
             'id' => '200',
             'sort_field' => 'id',
             'sort_direction' => 'DESC',
-        );
+        ];
         $this->assertSame($parameters, $collector->getRequestParameters());
 
         $currentConfiguration = $collector->getCurrentEntityConfig();

--- a/Tests/EventListener/ExceptionListenerTest.php
+++ b/Tests/EventListener/ExceptionListenerTest.php
@@ -45,17 +45,17 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testCatchBaseExceptions()
     {
-        $exception = new EasyEntityNotFoundException(array(
-            'entity' => array(
+        $exception = new EasyEntityNotFoundException([
+            'entity' => [
                 'name' => 'Test',
                 'primary_key_field_name' => 'Test key',
-            ),
+            ],
             'entity_id' => 2,
-        ));
+        ]);
         $event = $this->getEventExceptionThatShouldBeCalledOnce($exception);
         $templating = $this->getTemplating();
 
-        $listener = new ExceptionListener($templating, array(), 'easyadmin.listener.exception:showExceptionPageAction');
+        $listener = new ExceptionListener($templating, [], 'easyadmin.listener.exception:showExceptionPageAction');
         $listener->onKernelException($event);
     }
 
@@ -77,7 +77,7 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
         $event = $this->getEventExceptionThatShouldNotBeCalled($exception);
         $templating = $this->getTemplating();
 
-        $listener = new ExceptionListener($templating, array(), 'easyadmin.listener.exception:showExceptionPageAction');
+        $listener = new ExceptionListener($templating, [], 'easyadmin.listener.exception:showExceptionPageAction');
         $listener->onKernelException($event);
     }
 }

--- a/Tests/Fixtures/AbstractTestCase.php
+++ b/Tests/Fixtures/AbstractTestCase.php
@@ -36,7 +36,7 @@ abstract class AbstractTestCase extends WebTestCase
         $this->client = null;
     }
 
-    protected function initClient(array $options = array())
+    protected function initClient(array $options = [])
     {
         $this->client = static::createClient($options);
     }
@@ -67,7 +67,7 @@ abstract class AbstractTestCase extends WebTestCase
      */
     protected function getBackendHomepage()
     {
-        return $this->getBackendPage(array('entity' => 'Category', 'view' => 'list'));
+        return $this->getBackendPage(['entity' => 'Category', 'view' => 'list']);
     }
 
     /**
@@ -75,11 +75,11 @@ abstract class AbstractTestCase extends WebTestCase
      */
     protected function requestListView($entityName = 'Category')
     {
-        return $this->getBackendPage(array(
+        return $this->getBackendPage([
             'action' => 'list',
             'entity' => $entityName,
             'view' => 'list',
-        ));
+        ]);
     }
 
     /**
@@ -87,11 +87,11 @@ abstract class AbstractTestCase extends WebTestCase
      */
     protected function requestShowView($entityName = 'Category', $entityId = 200)
     {
-        return $this->getBackendPage(array(
+        return $this->getBackendPage([
             'action' => 'show',
             'entity' => $entityName,
             'id' => $entityId,
-        ));
+        ]);
     }
 
     /**
@@ -99,11 +99,11 @@ abstract class AbstractTestCase extends WebTestCase
      */
     protected function requestSearchView($searchQuery = 'cat', $entityName = 'Category')
     {
-        return $this->getBackendPage(array(
+        return $this->getBackendPage([
             'action' => 'search',
             'entity' => $entityName,
             'query' => $searchQuery,
-        ));
+        ]);
     }
 
     /**
@@ -111,10 +111,10 @@ abstract class AbstractTestCase extends WebTestCase
      */
     protected function requestNewView($entityName = 'Category')
     {
-        return $this->getBackendPage(array(
+        return $this->getBackendPage([
             'action' => 'new',
             'entity' => $entityName,
-        ));
+        ]);
     }
 
     /**
@@ -122,10 +122,10 @@ abstract class AbstractTestCase extends WebTestCase
      */
     protected function requestEditView($entityName = 'Category', $entityId = '200')
     {
-        return $this->getBackendPage(array(
+        return $this->getBackendPage([
             'action' => 'edit',
             'entity' => $entityName,
             'id' => $entityId,
-        ));
+        ]);
     }
 }

--- a/Tests/Fixtures/App/AppKernel.php
+++ b/Tests/Fixtures/App/AppKernel.php
@@ -20,7 +20,7 @@ class AppKernel extends Kernel
 {
     public function registerBundles()
     {
-        return array(
+        return [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
@@ -29,7 +29,7 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
             new JavierEguiluz\Bundle\EasyAdminBundle\EasyAdminBundle(),
             new JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\AppTestBundle(),
-        );
+        ];
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)
@@ -38,9 +38,9 @@ class AppKernel extends Kernel
 
         if ($this->isSymfony3()) {
             $loader->load(function (ContainerBuilder $container) {
-                $container->loadFromExtension('framework', array(
+                $container->loadFromExtension('framework', [
                     'assets' => null,
-                ));
+                ]);
             });
         }
     }

--- a/Tests/Fixtures/AppTestBundle/Admin/CustomCategoryControllerAsService.php
+++ b/Tests/Fixtures/AppTestBundle/Admin/CustomCategoryControllerAsService.php
@@ -31,7 +31,7 @@ class CustomCategoryControllerAsService
     public function indexAction()
     {
         $actionName = $this->container->get('request_stack')->getMasterRequest()->query->get('action', 'list');
-        $actionMethod = is_callable(array($this, $actionName.'CategoryAction')) ? $actionName.'CategoryAction' : $actionName.'Action';
+        $actionMethod = is_callable([$this, $actionName.'CategoryAction']) ? $actionName.'CategoryAction' : $actionName.'Action';
 
         return $this->{$actionMethod}();
     }

--- a/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadProducts.php
+++ b/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadProducts.php
@@ -18,7 +18,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 
 class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
 {
-    private $phrases = array(
+    private $phrases = [
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
         'Pellentesque vitae velit ex.',
         'Mauris dapibus, risus quis suscipit vulputate, eros diam egestas libero, eu vulputate eros eros eu risus.',
@@ -36,7 +36,7 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
         'Sed varius a risus eget aliquam.',
         'Nunc viverra elit ac laoreet suscipit.',
         'Pellentesque et sapien pulvinar, consectetur eros ac, vehicula odio.',
-    );
+    ];
 
     public function getOrder()
     {
@@ -65,7 +65,7 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
 
     public function getRandomTags()
     {
-        $tags = array(
+        $tags = [
             'books',
             'electronics',
             'GPS',
@@ -81,7 +81,7 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
             'TV & video',
             'videogames',
             'wearables',
-        );
+        ];
 
         $numTags = mt_rand(2, 4);
         shuffle($tags);
@@ -109,12 +109,12 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
 
     public function getRandomName()
     {
-        $words = array(
+        $words = [
             'Lorem', 'Ipsum', 'Sit', 'Amet', 'Adipiscing', 'Elit',
             'Vitae', 'Velit', 'Mauris', 'Dapibus', 'Suscipit', 'Vulputate',
             'Eros', 'Diam', 'Egestas', 'Libero', 'Platea', 'Dictumst',
             'Tempus', 'Commodo', 'Mattis', 'Donec', 'Posuere', 'Eleifend',
-        );
+        ];
 
         $numWords = 2;
         shuffle($words);
@@ -124,14 +124,14 @@ class LoadProducts extends AbstractFixture implements OrderedFixtureInterface
 
     public function getRandomPrice()
     {
-        $cents = array('00', '29', '39', '49', '99');
+        $cents = ['00', '29', '39', '49', '99'];
 
         return (float) mt_rand(2, 79).'.'.$cents[array_rand($cents)];
     }
 
     private function getRandomCategories()
     {
-        $categories = array();
+        $categories = [];
         $numCategories = rand(1, 4);
         $allCategoryIds = range(1, 100);
 

--- a/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadPurchases.php
+++ b/Tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadPurchases.php
@@ -25,10 +25,10 @@ class LoadPurchases extends AbstractFixture implements OrderedFixtureInterface
             $purchase->setCreatedAt(new \DateTime("now +$i seconds"));
             $purchase->setShipping(new \StdClass());
             $purchase->setDeliveryHour($this->getRandomHour());
-            $purchase->setBillingAddress(json_encode(array(
+            $purchase->setBillingAddress(json_encode([
                 'line1' => '1234 Main Street',
                 'line2' => 'Big City, XX 23456',
-            )));
+            ]));
             $purchase->setBuyer($this->getReference('user-'.($i % 20 + 1)));
 
             $this->addReference('purchase-'.$i, $purchase);

--- a/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Product.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Product.php
@@ -44,7 +44,7 @@ class Product
      * @var string[]
      * @ORM\Column(type="simple_array")
      */
-    protected $tags = array();
+    protected $tags = [];
 
     /**
      * The EAN 13 of the product. (type set to string in PHP due to 32 bit limitation).
@@ -73,7 +73,7 @@ class Product
      * @var array
      * @ORM\Column(type="array")
      */
-    protected $features = array();
+    protected $features = [];
 
     /**
      * Features of the product as a formatted HTML content.

--- a/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Purchase.php
+++ b/Tests/Fixtures/AppTestBundle/Entity/FunctionalTests/Purchase.php
@@ -76,7 +76,7 @@ class Purchase
      * @var array
      * @ORM\Column(type="json_array")
      */
-    protected $billingAddress = array();
+    protected $billingAddress = [];
 
     /**
      * The user who made the purchase.

--- a/Tests/Form/Util/LegacyFormHelperTest.php
+++ b/Tests/Form/Util/LegacyFormHelperTest.php
@@ -17,13 +17,13 @@ class LegacyFormHelperTest extends \PHPUnit_Framework_TestCase
 {
     public function shortTypesToFqcnProvider()
     {
-        return array(
-            'Symfony Type (regular name)' => array('integer', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\IntegerType'),
-            'Symfony Type (irregular name)' => array('datetime', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType'),
-            'Doctrine Bridge Type' => array('entity', 'Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType'),
-            'Custom Type (short name)' => array('foo', 'foo'),
-            'Custom Type (FQCN)' => array('Foo\Bar', 'Foo\Bar'),
-        );
+        return [
+            'Symfony Type (regular name)' => ['integer', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\IntegerType'],
+            'Symfony Type (irregular name)' => ['datetime', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType'],
+            'Doctrine Bridge Type' => ['entity', 'Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType'],
+            'Custom Type (short name)' => ['foo', 'foo'],
+            'Custom Type (FQCN)' => ['Foo\Bar', 'Foo\Bar'],
+        ];
     }
 
     /**

--- a/Tests/Search/AutocompleteTest.php
+++ b/Tests/Search/AutocompleteTest.php
@@ -19,7 +19,7 @@ class AutocompleteTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(array('environment' => 'autocomplete'));
+        $this->initClient(['environment' => 'autocomplete']);
     }
 
     /**
@@ -30,7 +30,7 @@ class AutocompleteTest extends AbstractTestCase
         $this->getBackendHomepage();
 
         $this->assertSame(
-            array('results' => array()),
+            ['results' => []],
             $this->client->getContainer()->get('easyadmin.autocomplete')->find($entity, $query),
             'Some of the parameters required for autocomplete are missing.'
         );
@@ -65,10 +65,10 @@ class AutocompleteTest extends AbstractTestCase
         $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 21);
 
         $this->assertSame(
-            array(
-                array('id' => 21, 'text' => 'Parent Category #21'),
-                array('id' => 121, 'text' => 'Category #21'),
-            ),
+            [
+                ['id' => 21, 'text' => 'Parent Category #21'],
+                ['id' => 121, 'text' => 'Category #21'],
+            ],
             $autocomplete['results']
         );
     }
@@ -88,11 +88,11 @@ class AutocompleteTest extends AbstractTestCase
 
     public function provideMissingParameters()
     {
-        return array(
-            array('', 'Categ'),
-            array(null, 'Categ'),
-            array('Category', ''),
-            array('Category', null),
-        );
+        return [
+            ['', 'Categ'],
+            [null, 'Categ'],
+            ['Category', ''],
+            ['Category', null],
+        ];
     }
 }

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -49,15 +49,15 @@ $application = new Application(new AppKernel('default_backend', true));
 $application->setAutoExit(false);
 
 // Create database
-$input = new ArrayInput(array('command' => 'doctrine:database:create'));
+$input = new ArrayInput(['command' => 'doctrine:database:create']);
 $application->run($input, new NullOutput());
 
 // Create database schema
-$input = new ArrayInput(array('command' => 'doctrine:schema:create'));
+$input = new ArrayInput(['command' => 'doctrine:schema:create']);
 $application->run($input, new NullOutput());
 
 // Load fixtures of the AppTestBundle
-$input = new ArrayInput(array('command' => 'doctrine:fixtures:load', '--no-interaction' => true, '--append' => false));
+$input = new ArrayInput(['command' => 'doctrine:fixtures:load', '--no-interaction' => true, '--append' => false]);
 $application->run($input, new NullOutput());
 
 // Make a copy of the original SQLite database to use the same unmodified database in every test

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -35,24 +35,24 @@ class EasyAdminTwigExtension extends \Twig_Extension
 
     public function getFunctions()
     {
-        return array(
-            new \Twig_SimpleFunction('easyadmin_render_field_for_*_view', array($this, 'renderEntityField'), array('is_safe' => array('html'), 'needs_environment' => true)),
-            new \Twig_SimpleFunction('easyadmin_config', array($this, 'getBackendConfiguration')),
-            new \Twig_SimpleFunction('easyadmin_entity', array($this, 'getEntityConfiguration')),
-            new \Twig_SimpleFunction('easyadmin_action_is_enabled', array($this, 'isActionEnabled')),
-            new \Twig_SimpleFunction('easyadmin_action_is_enabled_for_*_view', array($this, 'isActionEnabled')),
-            new \Twig_SimpleFunction('easyadmin_get_action', array($this, 'getActionConfiguration')),
-            new \Twig_SimpleFunction('easyadmin_get_action_for_*_view', array($this, 'getActionConfiguration')),
-            new \Twig_SimpleFunction('easyadmin_get_actions_for_*_item', array($this, 'getActionsForItem')),
-        );
+        return [
+            new \Twig_SimpleFunction('easyadmin_render_field_for_*_view', [$this, 'renderEntityField'], ['is_safe' => ['html'], 'needs_environment' => true]),
+            new \Twig_SimpleFunction('easyadmin_config', [$this, 'getBackendConfiguration']),
+            new \Twig_SimpleFunction('easyadmin_entity', [$this, 'getEntityConfiguration']),
+            new \Twig_SimpleFunction('easyadmin_action_is_enabled', [$this, 'isActionEnabled']),
+            new \Twig_SimpleFunction('easyadmin_action_is_enabled_for_*_view', [$this, 'isActionEnabled']),
+            new \Twig_SimpleFunction('easyadmin_get_action', [$this, 'getActionConfiguration']),
+            new \Twig_SimpleFunction('easyadmin_get_action_for_*_view', [$this, 'getActionConfiguration']),
+            new \Twig_SimpleFunction('easyadmin_get_actions_for_*_item', [$this, 'getActionsForItem']),
+        ];
     }
 
     public function getFilters()
     {
-        return array(
-            new \Twig_SimpleFilter('easyadmin_truncate', array($this, 'truncateText'), array('needs_environment' => true)),
+        return [
+            new \Twig_SimpleFilter('easyadmin_truncate', [$this, 'truncateText'], ['needs_environment' => true]),
             new \Twig_SimpleFilter('easyadmin_urldecode', 'urldecode'),
-        );
+        ];
     }
 
     /**
@@ -107,23 +107,23 @@ class EasyAdminTwigExtension extends \Twig_Extension
         try {
             $value = $this->propertyAccessor->getValue($item, $fieldName);
         } catch (\Exception $e) {
-            return $twig->render($entityConfiguration['templates']['label_inaccessible'], array(
+            return $twig->render($entityConfiguration['templates']['label_inaccessible'], [
                 'view' => $view,
                 'backend_config' => $this->getBackendConfiguration(),
                 'entity_config' => $entityConfiguration,
-            ));
+            ]);
         }
 
         try {
             $fieldType = $fieldMetadata['dataType'];
-            $templateParameters = array(
+            $templateParameters = [
                 'field_options' => $fieldMetadata,
                 'item' => $item,
                 'value' => $value,
                 'view' => $view,
                 'backend_config' => $this->getBackendConfiguration(),
                 'entity_config' => $entityConfiguration,
-            );
+            ];
 
             if (null === $value) {
                 return $twig->render($entityConfiguration['templates']['label_null'], $templateParameters);
@@ -153,7 +153,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 $templateParameters['uuid'] = md5($imageUrl);
             }
 
-            if (in_array($fieldType, array('array', 'simple_array')) && empty($value)) {
+            if (in_array($fieldType, ['array', 'simple_array']) && empty($value)) {
                 return $twig->render($entityConfiguration['templates']['label_empty'], $templateParameters);
             }
 
@@ -188,7 +188,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 // if the associated entity is managed by EasyAdmin, and the "show"
                 // action is enabled for the associated entity, display a link to it
                 if (null !== $targetEntityConfig && null !== $primaryKeyValue && $isShowActionAllowed) {
-                    $templateParameters['link_parameters'] = array('entity' => $targetEntityConfig['name'], 'action' => 'show', 'id' => $primaryKeyValue);
+                    $templateParameters['link_parameters'] = ['entity' => $targetEntityConfig['name'], 'action' => 'show', 'id' => $primaryKeyValue];
                 }
             }
 
@@ -196,7 +196,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 // if the associated entity is managed by EasyAdmin, and the "show"
                 // action is enabled for the associated entity, display a link to it
                 if (null !== $targetEntityConfig && $isShowActionAllowed) {
-                    $templateParameters['link_parameters'] = array('entity' => $targetEntityConfig['name'], 'action' => 'show', 'primary_key_name' => $targetEntityConfig['primary_key_field_name']);
+                    $templateParameters['link_parameters'] = ['entity' => $targetEntityConfig['name'], 'action' => 'show', 'primary_key_name' => $targetEntityConfig['primary_key_field_name']];
                 }
             }
 
@@ -206,7 +206,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 throw $e;
             }
 
-            return $twig->render($entityConfiguration['templates']['label_undefined'], array('view' => $view));
+            return $twig->render($entityConfiguration['templates']['label_undefined'], ['view' => $view]);
         }
     }
 
@@ -253,18 +253,18 @@ class EasyAdminTwigExtension extends \Twig_Extension
         try {
             $entityConfig = $this->configManager->getEntityConfig($entityName);
         } catch (\Exception $e) {
-            return array();
+            return [];
         }
 
         $disabledActions = $entityConfig['disabled_actions'];
         $viewActions = $entityConfig[$view]['actions'];
 
-        $actionsExcludedForItems = array(
-            'list' => array('new', 'search'),
-            'edit' => array(),
-            'new' => array(),
-            'show' => array(),
-        );
+        $actionsExcludedForItems = [
+            'list' => ['new', 'search'],
+            'edit' => [],
+            'new' => [],
+            'show' => [],
+        ];
         $excludedActions = $actionsExcludedForItems[$view];
 
         return array_filter($viewActions, function ($action) use ($excludedActions, $disabledActions) {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php"                           : ">=5.3.0",
+        "php"                           : ">=5.4.0",
         "doctrine/cache"                : "~1.5",
         "doctrine/common"               : "^2.4.0",
         "doctrine/doctrine-bundle"      : "~1.2",


### PR DESCRIPTION
Using php cs fixer to change the [array syntax to short value](https://wiki.php.net/rfc/shortsyntaxforarrays) (instead long).

This PR is stylish mainly, but it has enough sense to me and I think to the community since:

- The project should support 5.4 or upper (it is supporting only >=5.3.0) which should get rid [since is EOL](http://php.net/eol.php) and php community should aims to use upper versions. At least consider this for future versions of EasyBundle.
- More easily readability since this project has a heavy use of configurations (parameter lists) and arrays for define data, the files and code will be more easy readable.
