### PR TITLE
Allow using HTML code in the labels of the "show" view

### DIFF
--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -20,7 +20,7 @@
         {% for field, metadata in fields %}
             <div class="form-group field-{{ metadata.type|default('default')|lower }} {{ metadata.css_class|default('') }}">
                 <label class="col-sm-2 control-label">
-                    {{ (metadata.label ?: field|humanize)|trans(_trans_parameters) }}
+                    {{ (metadata.label ?: field|humanize)|trans(_trans_parameters)|raw }}
                 </label>
                 <div class="col-sm-10">
                     <div class="form-control">


### PR DESCRIPTION
I was checking #1192 and I realized that you can display icons in the table headers because HTML code is allowed:

![icon-list-view](https://cloud.githubusercontent.com/assets/73419/22175471/763e6cb2-dff5-11e6-87ba-edbe183f1051.png)

The same is not true for the "show" view. So let's add this minor change to support things like this:

![icon-show-view](https://cloud.githubusercontent.com/assets/73419/22175473/80ebc628-dff5-11e6-860a-954b1274c35e.png)
