### PR TITLE
Fix an issue with twig extension for virtual fields

### DIFF
--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -136,10 +136,6 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 return $twig->render($entityConfiguration['templates']['label_null'], $templateParameters);
             }
 
-            if (true === $fieldMetadata['virtual']) {
-                return $this->renderVirtualField($templateParameters);
-            }
-
             if ('image' === $fieldType) {
                 return $this->renderImageField($templateParameters);
             }
@@ -150,6 +146,10 @@ class EasyAdminTwigExtension extends \Twig_Extension
 
             if ('association' === $fieldType) {
                 return $this->renderAssociationField($templateParameters);
+            }
+
+            if (true === $fieldMetadata['virtual']) {
+                return $this->renderVirtualField($templateParameters);
             }
 
             return $twig->render($fieldMetadata['template'], $templateParameters);


### PR DESCRIPTION
### The issue

I had a big issue after updating to 1.16.5 from 1.16.3:

![image](https://cloud.githubusercontent.com/assets/3369266/22304388/82702210-e337-11e6-8fc4-29be6312d638.png)

The twig extension refactoring broke my backend because I have a virtual property which generates an image path based on another property.

Here's the configuration:

```yml
easy_admin:
    entities:
        MyEntity:
            class: AppBundle\Entity\MyEntity
            list:
                fields: [ id, name, { property: webIcon, type: image } ]
```

`webIcon` just corresponds to the `getWebIcon()` method from the entity itself.

The problem came from the order of the different methods. As the `virtual` value is managed _before_ the `image` one, my property was considered virtual _before_ considered as an image.

### The fix

This fix only moves the method that evaluates a property as virtual **at the end** of all other evaluations.

This allows `fieldType` to be evaluated as a priority, and `virtual` as "fallback".

**BUT** I could also fix the issue by adding `virtual: false` to my yaml configuration, but I don't find this as a solution. This is why I made this PR.
