### PR TITLE
Add support for objects as the value of entity primary keys

### DIFF
--- a/Resources/views/default/list.html.twig
+++ b/Resources/views/default/list.html.twig
@@ -130,7 +130,8 @@
         <tbody>
         {% block table_body %}
             {% for item in paginator.currentPageResults %}
-                {% set _item_id = attribute(item, _entity_config.primary_key_field_name) %}
+                {# the empty string concatenation is needed when the primary key is an object (e.g. an Uuid object) #}
+                {% set _item_id = '' ~ attribute(item, _entity_config.primary_key_field_name) %}
                 <tr data-id="{{ _item_id }}">
                     {% for field, metadata in fields %}
                         {% set isSortingField = metadata.property == app.request.get('sortField') %}

--- a/Resources/views/default/show.html.twig
+++ b/Resources/views/default/show.html.twig
@@ -1,5 +1,6 @@
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
-{% set _entity_id = attribute(entity, _entity_config.primary_key_field_name) %}
+{# the empty string concatenation is needed when the primary key is an object (e.g. an Uuid object) #}
+{% set _entity_id = '' ~ attribute(entity, _entity_config.primary_key_field_name) %}
 {% trans_default_domain _entity_config.translation_domain %}
 {% set _trans_parameters = { '%entity_name%': _entity_config.name|trans, '%entity_label%': _entity_config.label|trans, '%entity_id%': _entity_id } %}
 


### PR DESCRIPTION
This fixes #1507.

@timonf instead of applying a Twig format, I wonder if concatenating an empty string would do the trick. This is something that I've used sometimes in PHP, so it's easier to understand to me. Let's see if it works.