### PR TITLE
Initialize dynamic autocomplete fields based on jQuery selectors

### DIFF
--- a/Resources/public/javascript/easyadmin.js
+++ b/Resources/public/javascript/easyadmin.js
@@ -51,13 +51,18 @@ function deleteCookie(name)
     document.cookie = encodeURIComponent(name) + "=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 }
 
-function createAutoCompleteFields() {
-    var autocompleteFields = $('[data-easyadmin-autocomplete-url]');
+function createAutoCompleteFields(fields) {
+    var $autocompleteFields = fields ? $(fields) : $('select[data-easyadmin-autocomplete-url]');
 
-    autocompleteFields.each(function () {
+    $autocompleteFields.each(function () {
         var $this = $(this),
             url = $this.data('easyadmin-autocomplete-url'),
             max_results = $this.data('easyadmin-autocomplete-max-results');
+
+        if ('SELECT' !== this.tagName || !url) {
+            console.log(this, 'Cannot initialize the autocomplete field! It is not a valid SELECT element or the required [data-easyadmin-autocomplete-url] attribute is missing.');
+            return;
+        }
 
         $this.select2({
             theme: 'bootstrap',


### PR DESCRIPTION
### Use cases
 * Initialize all available autocomplete fields on page (default):
```
createAutoCompleteFields();
```
 * Initialize dynamic autocomplete fields based on jQuery selector:
```   
createAutoCompleteFields('.container select[data-easyadmin-autocomplete-url]');
```
 * EasyAdmin & Symfony Collection forms (Related to https://github.com/javiereguiluz/EasyAdminBundle/issues/1518)
```   
$('.field-collection').on('easyadmin.collection.item-added', function() {
    var $fields = $(this).find('select[data-easyadmin-autocomplete-url]');
    if ($fields.length) {
        createAutoCompleteFields($fields);
    }
});
```

### TODO
- [ ] Update `easyadmin-all.min.js`
- [ ] Document this feature
