### PR TITLE
FIX - #1505 - Testing UUID format for search or ommit the field

### DIFF
--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -110,7 +110,7 @@ class QueryBuilder
                 $validator = Validation::createValidator();
                 $uuidContraint = new UuidConstraint();
                 $errors = $validator->validate($searchQuery, $uuidContraint);
-                if (0 != count($errors)) {
+                if (0 !== count($errors)) {
                     continue;
                 }
                 // some databases don't support LOWER() on UUID fields

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -14,6 +14,8 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Search;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
+use Symfony\Component\Validator\Constraints\Uuid as UuidConstraint;
+use Symfony\Component\Validator\Validation;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -105,6 +107,13 @@ class QueryBuilder
                 // adding '0' turns the string into a numeric value
                 $queryParameters['exact_query'] = 0 + $searchQuery;
             } elseif ($isGuidField) {
+                $validator = Validation::createValidator();
+                $uuidContraint = new UuidConstraint();
+                $errors = $validator->validate($searchQuery, $uuidContraint);
+                if (0 != count($errors))
+                {
+                  continue;
+                }
                 // some databases don't support LOWER() on UUID fields
                 $queryBuilder->orWhere(sprintf('entity.%s IN (:words_query)', $name));
                 $queryParameters['words_query'] = explode(' ', $searchQuery);

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -110,8 +110,7 @@ class QueryBuilder
                 $validator = Validation::createValidator();
                 $uuidContraint = new UuidConstraint();
                 $errors = $validator->validate($searchQuery, $uuidContraint);
-                if (0 != count($errors))
-                {
+                if (0 != count($errors)) {
                   continue;
                 }
                 // some databases don't support LOWER() on UUID fields

--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -111,7 +111,7 @@ class QueryBuilder
                 $uuidContraint = new UuidConstraint();
                 $errors = $validator->validate($searchQuery, $uuidContraint);
                 if (0 != count($errors)) {
-                  continue;
+                    continue;
                 }
                 // some databases don't support LOWER() on UUID fields
                 $queryBuilder->orWhere(sprintf('entity.%s IN (:words_query)', $name));


### PR DESCRIPTION
Hello, I work on a project with EasyAdminBundle, I use PostgreSQL and I have an error with UUID representation when my search doesn't not a valid UUID.

This PR is linked with #1505 

<!-- Note: all your contributions adhere implicitly to the MIT license -->
