### PR TITLE
Fix "locale" container parameter

### DIFF
--- a/Configuration/ConfigManager.php
+++ b/Configuration/ConfigManager.php
@@ -183,9 +183,15 @@ class ConfigManager
      */
     private function doProcessConfig($backendConfig)
     {
+        if ($this->container->hasParameter('locale')) {
+            $locale = $this->container->getParameter('locale');
+        } else {
+            $locale = $this->container->getParameter('kernel.default_locale');
+        }
+
         $configPasses = array(
             new NormalizerConfigPass($this->container),
-            new DesignConfigPass($this->container->get('twig'), $this->container->getParameter('kernel.debug'), $this->container->getParameter('locale')),
+            new DesignConfigPass($this->container->get('twig'), $this->container->getParameter('kernel.debug'), $locale),
             new MenuConfigPass(),
             new ActionConfigPass(),
             new MetadataConfigPass($this->container->get('doctrine')),


### PR DESCRIPTION
The "locale" parameter is an artefact of the default configuration of Symfony Standard Edition, but there is no guarantee that it is defined. In case it's not defined, we should fallback to `kernel.default_locale` which is defined by FrameworkBundle.

