### PR TITLE
Show the "sign out" link in the user menu

### DIFF
--- a/Resources/translations/EasyAdminBundle.bg.xlf
+++ b/Resources/translations/EasyAdminBundle.bg.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Анонимен потребител</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Изход</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.ca.xlf
+++ b/Resources/translations/EasyAdminBundle.ca.xlf
@@ -97,6 +97,10 @@
                 <source>user.logged_in_as</source>
                 <target>Connectat com a</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Tanca la sessió</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="delete_modal.title">

--- a/Resources/translations/EasyAdminBundle.cs.xlf
+++ b/Resources/translations/EasyAdminBundle.cs.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Anonymní uživatel</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Odhlásit se</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.de.xlf
+++ b/Resources/translations/EasyAdminBundle.de.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Anonymer Benutzer</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Abmelden</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.en.xlf
+++ b/Resources/translations/EasyAdminBundle.en.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Anonymous User</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Sign out</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.es.xlf
+++ b/Resources/translations/EasyAdminBundle.es.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Usuario anónimo</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Cerrar sesión</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.eu.xlf
+++ b/Resources/translations/EasyAdminBundle.eu.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Erabiltzaile anonimoa</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Amaitu saioa</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.fi.xlf
+++ b/Resources/translations/EasyAdminBundle.fi.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Tuntematon käyttäjä</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Ulos</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/Resources/translations/EasyAdminBundle.fr.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Utilisateur anonyme</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Déconnexion</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.it.xlf
+++ b/Resources/translations/EasyAdminBundle.it.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Utente anonimo</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Esci</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.nl.xlf
+++ b/Resources/translations/EasyAdminBundle.nl.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Anonieme gebruiker</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Uitloggen</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.pl.xlf
+++ b/Resources/translations/EasyAdminBundle.pl.xlf
@@ -105,7 +105,11 @@
                 <source>user.anonymous</source>
                 <target>Anonimowy użytkownik</target>
             </trans-unit>
-            
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Wyloguj</target>
+            </trans-unit>
+
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">
                 <source>toggle_navigation</source>

--- a/Resources/translations/EasyAdminBundle.pt.xlf
+++ b/Resources/translations/EasyAdminBundle.pt.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Usuário anônimo</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Sair</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.ro.xlf
+++ b/Resources/translations/EasyAdminBundle.ro.xlf
@@ -97,6 +97,10 @@
                 <source>user.logged_in_as</source>
                 <target>Înregistrat ca</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Deconectați-vă</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="delete_modal.title">

--- a/Resources/translations/EasyAdminBundle.ru.xlf
+++ b/Resources/translations/EasyAdminBundle.ru.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Анонимный пользователь</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Выход</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.sl.xlf
+++ b/Resources/translations/EasyAdminBundle.sl.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Anonimni uporabnik</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Odjava</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/translations/EasyAdminBundle.sv.xlf
+++ b/Resources/translations/EasyAdminBundle.sv.xlf
@@ -63,6 +63,10 @@
                 <source>user.logged_in_as</source>
                 <target>Inloggad som</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Logga ut</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="delete_modal.title">

--- a/Resources/translations/EasyAdminBundle.tr.xlf
+++ b/Resources/translations/EasyAdminBundle.tr.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Anonim Kullanıcı</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Çıkış</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">
@@ -147,7 +151,7 @@
                 <source>show.remaining_items</source>
                 <target>Diğer %count% öğe bu listede görüntülenemiyor</target>
             </trans-unit>
-            
+
             <!-- Exceptions -->
             <trans-unit id="exception.entity_not_found">
                 <source>exception.entity_not_found</source>

--- a/Resources/translations/EasyAdminBundle.uk.xlf
+++ b/Resources/translations/EasyAdminBundle.uk.xlf
@@ -105,6 +105,10 @@
                 <source>user.anonymous</source>
                 <target>Анонімний користувач</target>
             </trans-unit>
+            <trans-unit id="user.signout">
+                <source>user.signout</source>
+                <target>Вихід</target>
+            </trans-unit>
 
             <!-- misc. elements -->
             <trans-unit id="toggle_navigation">

--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -699,7 +699,7 @@ button.btn:active {
 }
 
 .main-header .navbar .user-menu .btn {
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.05);
     border-color: transparent;
     color: #fff;
 }
@@ -710,7 +710,7 @@ button.btn:active {
     padding: 6px 8px;
 }
 .main-header .navbar .user-menu .btn-group:hover .btn {
-    background: rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.1);
 }
 .main-header .navbar .user-menu .btn-group {
     height: 35px;
@@ -1223,6 +1223,13 @@ body.error .error-message {
     }
     .navbar-custom-menu .user-menu i {
         padding-right: 4px;
+    }
+
+    .main-header .navbar .user-menu .btn {
+        background: rgba(255, 255, 255, 0.1);
+    }
+    .main-header .navbar .user-menu .btn-group:hover .btn {
+        background: rgba(255, 255, 255, 0.2);
     }
 
     .main-sidebar {

--- a/Resources/views/css/easyadmin.css.twig
+++ b/Resources/views/css/easyadmin.css.twig
@@ -698,6 +698,41 @@ button.btn:active {
     width: 100%;
 }
 
+.main-header .navbar .user-menu .btn {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: transparent;
+    color: #fff;
+}
+.main-header .navbar .user-menu .btn:active {
+    top: 0;
+}
+.main-header .navbar .user-menu .btn.dropdown-toggle {
+    padding: 6px 8px;
+}
+.main-header .navbar .user-menu .btn-group:hover .btn {
+    background: rgba(255, 255, 255, 0.2);
+}
+.main-header .navbar .user-menu .btn-group {
+    height: 35px;
+}
+.main-header .navbar .user-menu .btn-group .btn {
+    border-radius: 0;
+}
+.main-header .navbar .user-menu .dropdown-menu {
+    background: #fff;
+    box-shadow: 1px 1px 3px #ccc;
+    border-radius: 2px;
+    position: absolute;
+    left: auto;
+    right: 0;
+}
+.main-header .navbar .user-menu .dropdown-menu i {
+    margin: 0;
+}
+.main-header .navbar .user-menu .dropdown-menu a {
+    color: #777;
+}
+
 {# Main body
    ------------------------------------------------------------------------- #}
 #content #main {

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -96,11 +96,12 @@
                                             </button>
                                             <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
                                                 <span class="caret"></span>
-                                                <span class="sr-only">Toggle User Options</span>
                                             </button>
                                             <ul class="dropdown-menu" role="menu">
                                                 {% block user_menu_dropdown %}
-                                                <li><a href="{{ logout_path() }}"><i class="fa fa-sign-out"></i> Sign Out</a></li>
+                                                <li>
+                                                    <a href="{{ logout_path() }}"><i class="fa fa-sign-out"></i> {{ 'user.signout'|trans(domain = 'EasyAdminBundle') }}</a>
+                                                </li>
                                                 {% endblock user_menu_dropdown %}
                                             </ul>
                                         </div>

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -75,15 +75,35 @@
 
                     <div class="navbar-custom-menu">
                     {% block header_custom_menu %}
+                        {# logout_path() without arguments only works in Symfony >= 2.7 #}
+                        {% set _is_logout_supported = constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION_ID') >= 20700 %}
                         <ul class="nav navbar-nav">
-                            <li class="user user-menu">
+                            <li class="dropdown user user-menu">
                                 {% block user_menu %}
                                     <span class="sr-only">{{ 'user.logged_in_as'|trans(domain = 'EasyAdminBundle') }}</span>
-                                    <i class="hidden-xs fa fa-user"></i>
-                                    {% if app.user|default %}
+
+                                    {% if app.user|default(false) == false %}
+                                        <i class="hidden-xs fa fa-user-times"></i>
+                                        {{ 'user.anonymous'|trans(domain = 'EasyAdminBundle') }}
+                                    {% elseif not _is_logout_supported %}
+                                        <i class="hidden-xs fa fa-user"></i>
                                         {{ app.user.username|default('user.unnamed'|trans(domain = 'EasyAdminBundle')) }}
                                     {% else %}
-                                        {{ 'user.anonymous'|trans(domain = 'EasyAdminBundle') }}
+                                        <div class="btn-group">
+                                            <button type="button" class="btn" data-toggle="dropdown">
+                                                <i class="hidden-xs fa fa-user"></i>
+                                                {{ app.user.username|default('user.unnamed'|trans(domain = 'EasyAdminBundle')) }}
+                                            </button>
+                                            <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                                                <span class="caret"></span>
+                                                <span class="sr-only">Toggle User Options</span>
+                                            </button>
+                                            <ul class="dropdown-menu" role="menu">
+                                                {% block user_menu_dropdown %}
+                                                <li><a href="{{ logout_path() }}"><i class="fa fa-sign-out"></i> Sign Out</a></li>
+                                                {% endblock user_menu_dropdown %}
+                                            </ul>
+                                        </div>
                                     {% endif %}
                                 {% endblock user_menu %}
                             </li>

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -28,7 +28,7 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->client->followRedirects();
         $crawler = $this->client->request('GET', '/admin', array(), array(), array(
             'PHP_AUTH_USER' => 'admin',
-            'PHP_AUTH_PW'   => 'pa$$word',
+            'PHP_AUTH_PW' => 'pa$$word',
         ));
 
         $this->assertContains('admin', $crawler->filter('header .user-menu')->text());

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -34,7 +34,7 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->assertContains('admin', $crawler->filter('header .user-menu')->text());
 
         if (Kernel::VERSION_ID >= 20700) {
-            $this->assertContains('Sign Out', $crawler->filter('header .user-menu .dropdown-menu')->text());
+            $this->assertContains('Sign out', $crawler->filter('header .user-menu .dropdown-menu')->text());
         } else {
             $this->assertCount(0, $crawler->filter('header .user-menu .dropdown-menu'));
         }

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -12,6 +12,7 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Controller;
 
 use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+use Symfony\Component\HttpKernel\Kernel;
 
 class CustomizedBackendTest extends AbstractTestCase
 {
@@ -20,6 +21,23 @@ class CustomizedBackendTest extends AbstractTestCase
         parent::setUp();
 
         $this->initClient(array('environment' => 'customized_backend'));
+    }
+
+    public function testUserMenuForLoggedUsers()
+    {
+        $this->client->followRedirects();
+        $crawler = $this->client->request('GET', '/admin', array(), array(), array(
+            'PHP_AUTH_USER' => 'admin',
+            'PHP_AUTH_PW'   => 'pa$$word',
+        ));
+
+        $this->assertContains('admin', $crawler->filter('header .user-menu')->text());
+
+        if (Kernel::VERSION_ID >= 20700) {
+            $this->assertContains('Sign Out', $crawler->filter('header .user-menu .dropdown-menu')->text());
+        } else {
+            $this->assertCount(0, $crawler->filter('header .user-menu .dropdown-menu'));
+        }
     }
 
     public function testListViewPageTitle()

--- a/Tests/Controller/DefaultBackendTest.php
+++ b/Tests/Controller/DefaultBackendTest.php
@@ -102,6 +102,14 @@ class DefaultBackendTest extends AbstractTestCase
         }
     }
 
+    public function testUserMenuForAnonymousUsers()
+    {
+        $crawler = $this->getBackendHomepage();
+
+        $this->assertContains('Anonymous', $crawler->filter('header .user-menu')->text());
+        $this->assertCount(0, $crawler->filter('header .user-menu .dropdown-menu'));
+    }
+
     public function testCustomCssFile()
     {
         $this->getBackendHomepage();

--- a/Tests/Fixtures/App/config/config_customized_backend.yml
+++ b/Tests/Fixtures/App/config/config_customized_backend.yml
@@ -1,9 +1,66 @@
-imports:
-    - { resource: config.yml }
+# This file cannot import the main ' config.yml' file because it defines its own
+# security configuration and 'config.yml' also contains some basic security configuration
+# This avoids the following error:
+# Symfony\Component\Config\Definition\Exception\InvalidConfigurationException:
+# You are not allowed to define new elements for path "security.firewalls".
+# Please define all elements for this path in one config file.
+
+parameters:
+    locale: en
+    database_path: '%kernel.root_dir%/../../../build/test.db'
 
 framework:
-    # This file overrides the EasyAdmin controller
-    router: { resource: "%kernel.root_dir%/config/routing_override.yml" }
+    secret:          secret
+    translator:      ~
+    default_locale:  '%locale%'
+    test:            ~
+    router:          { resource: "%kernel.root_dir%/config/routing_override.yml" }
+    form:            true
+    validation:      { enable_annotations: true }
+    templating:      { engines: ['twig'] }
+    profiler:
+        collect: true
+    session:
+        storage_id: session.storage.mock_file
+
+doctrine:
+    dbal:
+        driver: pdo_sqlite
+        path:   '%database_path%'
+    orm:
+        auto_generate_proxy_classes: true
+        auto_mapping: true
+        mappings:
+            FunctionalTestEntities:
+                mapping: true
+                type: annotation
+                dir: '%kernel.root_dir%/../AppTestBundle/Entity/FunctionalTests/'
+                alias: 'FunctionalTests'
+                prefix: 'AppTestBundle\Entity\FunctionalTests'
+                is_bundle: false
+
+services:
+    logger:
+        class: Psr\Log\NullLogger
+
+security:
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
+    providers:
+        in_memory:
+            memory:
+                users:
+                    admin:
+                        password: 'pa$$word'
+    firewalls:
+        main:
+            pattern:   ^/
+            logout:    true
+            anonymous: true
+            http_basic:
+                provider: in_memory
+    access_control:
+        - { path: ^/, roles: IS_AUTHENTICATED_ANONYMOUSLY }
 
 easy_admin:
     site_name: 'ACME Backend'


### PR DESCRIPTION
It uses http://symfony.com/doc/current/reference/twig_reference.html#logout-path  and it looks like this:

![user-menu-logout](https://cloud.githubusercontent.com/assets/73419/24360527/dd2b9aa4-1307-11e7-9261-49a0542462fb.gif)

And in a smartphone:

![user-menu-logout-responsive](https://cloud.githubusercontent.com/assets/73419/24360537/e31f4550-1307-11e7-888e-99b107520aac.gif)
