### PR TITLE
AdminController - change visibility into protected

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -395,7 +395,7 @@ class AdminController extends Controller
      *
      * @throws \RuntimeException
      */
-    private function updateEntityProperty($entity, $property, $value)
+    protected function updateEntityProperty($entity, $property, $value)
     {
         $entityConfig = $this->entity;
 
@@ -711,7 +711,7 @@ class AdminController extends Controller
      *
      * @return mixed
      */
-    private function executeDynamicMethod($methodNamePattern, array $arguments = array())
+    protected function executeDynamicMethod($methodNamePattern, array $arguments = array())
     {
         $methodName = str_replace('<EntityName>', $this->entity['name'], $methodNamePattern);
 


### PR DESCRIPTION
In order to override easily editAction, in which we call "updateEntityProperty", is it possible to change the visibility of these methods ?

<!-- Note: all your contributions adhere implicitly to the MIT license -->
