### PR TITLE
Added a new easyadmin_logout_path() helper

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -39,6 +39,7 @@
             <argument type="service" id="easyadmin.config.manager" />
             <argument type="service" id="property_accessor" />
             <argument>%kernel.debug%</argument>
+            <argument type="service" id="security.logout_url_generator" on-invalid="null" />
             <tag name="twig.extension" />
         </service>
 

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -75,8 +75,7 @@
 
                     <div class="navbar-custom-menu">
                     {% block header_custom_menu %}
-                        {# logout_path() without arguments only works in Symfony >= 2.7 #}
-                        {% set _is_logout_supported = constant('Symfony\\Component\\HttpKernel\\Kernel::VERSION_ID') >= 20700 %}
+                        {% set _logout_path = easyadmin_logout_path() %}
                         <ul class="nav navbar-nav">
                             <li class="dropdown user user-menu">
                                 {% block user_menu %}
@@ -85,7 +84,7 @@
                                     {% if app.user|default(false) == false %}
                                         <i class="hidden-xs fa fa-user-times"></i>
                                         {{ 'user.anonymous'|trans(domain = 'EasyAdminBundle') }}
-                                    {% elseif not _is_logout_supported %}
+                                    {% elseif not _logout_path %}
                                         <i class="hidden-xs fa fa-user"></i>
                                         {{ app.user.username|default('user.unnamed'|trans(domain = 'EasyAdminBundle')) }}
                                     {% else %}
@@ -100,7 +99,7 @@
                                             <ul class="dropdown-menu" role="menu">
                                                 {% block user_menu_dropdown %}
                                                 <li>
-                                                    <a href="{{ logout_path() }}"><i class="fa fa-sign-out"></i> {{ 'user.signout'|trans(domain = 'EasyAdminBundle') }}</a>
+                                                    <a href="{{ _logout_path }}"><i class="fa fa-sign-out"></i> {{ 'user.signout'|trans(domain = 'EasyAdminBundle') }}</a>
                                                 </li>
                                                 {% endblock user_menu_dropdown %}
                                             </ul>

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -12,7 +12,6 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Controller;
 
 use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
-use Symfony\Component\HttpKernel\Kernel;
 
 class CustomizedBackendTest extends AbstractTestCase
 {

--- a/Tests/Controller/CustomizedBackendTest.php
+++ b/Tests/Controller/CustomizedBackendTest.php
@@ -33,7 +33,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         $this->assertContains('admin', $crawler->filter('header .user-menu')->text());
 
-        if (Kernel::VERSION_ID >= 20700) {
+        if (class_exists('Symfony\\Component\\Security\\Http\\Logout\\LogoutUrlGenerator')) {
             $this->assertContains('Sign out', $crawler->filter('header .user-menu .dropdown-menu')->text());
         } else {
             $this->assertCount(0, $crawler->filter('header .user-menu .dropdown-menu'));

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -30,12 +30,14 @@ class EasyAdminTwigExtension extends \Twig_Extension
     private $propertyAccessor;
     /** @var bool */
     private $debug;
+    private $logoutUrlGenerator;
 
-    public function __construct(ConfigManager $configManager, PropertyAccessor $propertyAccessor, $debug = false)
+    public function __construct(ConfigManager $configManager, PropertyAccessor $propertyAccessor, $debug = false, $logoutUrlGenerator)
     {
         $this->configManager = $configManager;
         $this->propertyAccessor = $propertyAccessor;
         $this->debug = $debug;
+        $this->logoutUrlGenerator = $logoutUrlGenerator;
     }
 
     /**
@@ -52,6 +54,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('easyadmin_get_action', array($this, 'getActionConfiguration')),
             new \Twig_SimpleFunction('easyadmin_get_action_for_*_view', array($this, 'getActionConfiguration')),
             new \Twig_SimpleFunction('easyadmin_get_actions_for_*_item', array($this, 'getActionsForItem')),
+            new \Twig_SimpleFunction('easyadmin_logout_path', array($this, 'getLogoutPath')),
         );
     }
 
@@ -347,6 +350,20 @@ class EasyAdminTwigExtension extends \Twig_Extension
         }
 
         return $value;
+    }
+
+    /**
+     * This reimplementation of Symfony's logout_path() helper is needed because
+     * when no arguments are passed to the getLogoutPath(), it's common to get
+     * exceptions and there is no way to recover from them in a Twig template.
+     */
+    public function getLogoutPath()
+    {
+        try {
+            return $this->logoutUrlGenerator->getLogoutPath();
+        } catch (\Exception $e) {
+            return;
+        }
     }
 
     /**

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -359,6 +359,10 @@ class EasyAdminTwigExtension extends \Twig_Extension
      */
     public function getLogoutPath()
     {
+        if (null === $this->logoutUrlGenerator) {
+            return;
+        }
+
         try {
             return $this->logoutUrlGenerator->getLogoutPath();
         } catch (\Exception $e) {


### PR DESCRIPTION
When we implemented #1560 my fear was that uncaught security exceptions would break it. In #1568 we received the first report. So, let's reimplement Symfony's helper to avoid any issue.