### PR TITLE
[Doc] Always load the specific EasyAdmin controller

### DIFF
--- a/Resources/doc/book/basic-configuration.rst
+++ b/Resources/doc/book/basic-configuration.rst
@@ -16,7 +16,7 @@ routes of the bundle. Change its value to meet your own requirements:
 
     # app/config/routing.yml
     easy_admin_bundle:
-        resource: "@EasyAdminBundle/Controller/"
+        resource: "@EasyAdminBundle/Controller/AdminController.php"
         type:     annotation
         prefix:   /_secret_backend  # <-- change this value
 

--- a/Resources/doc/book/installation.rst
+++ b/Resources/doc/book/installation.rst
@@ -66,7 +66,7 @@ of the ``app/config/routing.yml`` file:
 
     # app/config/routing.yml
     easy_admin_bundle:
-        resource: "@EasyAdminBundle/Controller/"
+        resource: "@EasyAdminBundle/Controller/AdminController.php"
         type:     annotation
         prefix:   /admin
 


### PR DESCRIPTION
In https://github.com/symfony/recipes/pull/30 @Pierstoval proposes to use the explicit controller instead of the `Controller/` directory. I think it makes a lot of sense, so let's update the docs.