### PR TITLE
Fixed some search conditions related to integers

### DIFF
--- a/Search/QueryBuilder.php
+++ b/Search/QueryBuilder.php
@@ -95,8 +95,8 @@ class QueryBuilder
         }
 
         $isSearchQueryNumeric = is_numeric($searchQuery);
-        $isSearchQuerySmallInteger = is_int($searchQuery) && abs($searchQuery) <= 32767;
-        $isSearchQueryInteger = is_int($searchQuery) && abs($searchQuery) <= PHP_INT_MAX;
+        $isSearchQuerySmallInteger = (is_int($searchQuery) || ctype_digit($searchQuery)) && abs($searchQuery) <= 32767;
+        $isSearchQueryInteger = (is_int($searchQuery) || ctype_digit($searchQuery)) && abs($searchQuery) <= PHP_INT_MAX;
         $isSearchQueryUuid = 1 === preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i', $searchQuery);
         $lowerSearchQuery = mb_strtolower($searchQuery);
 


### PR DESCRIPTION
This is needed because the search input comes from the query string and it's always a string, so `is_int()` will be `false`.

---

@xabbuh reported this issue and provided the solution. So all credit goes to him. Thanks!