### PR TITLE
add a branch alias for the master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,5 +64,10 @@
     },
     "autoload-dev": {
         "psr-4": { "AppTestBundle\\": "Tests/Fixtures/AppTestBundle/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.16.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This makes it possible to depend on `^1.16@dev` instead of `dev-master`
to get the latest development version.