### PR TITLE
Fix typo in documentation

### DIFF
--- a/Resources/doc/tutorials/i18n.rst
+++ b/Resources/doc/tutorials/i18n.rst
@@ -168,7 +168,7 @@ Translate Custom Templates
 --------------------------
 
 All the built-in templates include the following tag to set ``EasyAdminBundle``
-as the defualt domain used to translate the contents of that template:
+as the default domain used to translate the contents of that template:
 
 .. code-block:: twig
 


### PR DESCRIPTION
s/defualt/default

<!-- Note: all your contributions adhere implicitly to the MIT license -->
