### PR TITLE
Merge repeated class attributes

### DIFF
--- a/Resources/views/default/paginator.html.twig
+++ b/Resources/views/default/paginator.html.twig
@@ -5,7 +5,7 @@
 {% if paginator.haveToPaginate %}
     <div class="list-pagination">
         <div class="row">
-            <div class="col-sm-3 hidden-xs" class="list-pagination-counter">
+            <div class="col-sm-3 hidden-xs list-pagination-counter">
                 {{ 'paginator.counter'|trans({ '%start%': paginator.currentPageOffsetStart, '%end%': paginator.currentPageOffsetEnd, '%results%': paginator.nbResults})|raw }}
             </div>
 


### PR DESCRIPTION
Merge repeated class attributes for paginator list-pagination-counter. This is useful for test crawler and HTML compliance.

<!-- Note: all your contributions adhere implicitly to the MIT license -->
