### PR TITLE
Only display empty_collection when value is empty and iterable

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -364,10 +364,10 @@
 {% endblock form_errors %}
 
 {%- block form_widget_compound -%}
-    {% if value is empty %}
+    {% if value is iterable and value is empty %}
         {{ block('empty_collection') }}
     {% endif %}
-    {% if value is empty or form.vars.prototype is defined %}
+    {% if value is iterable and value is empty or form.vars.prototype is defined %}
         {% set attr = attr|merge({'data-empty-collection': block('empty_collection') }) %}
     {% endif %}
 

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -364,6 +364,8 @@
 {% endblock form_errors %}
 
 {%- block form_widget_compound -%}
+    {# the "is iterable" check is needed because if an object implements __toString() and
+       returns an empty string, "is empty" returns true even if it's not a collection #}
     {% if value is iterable and value is empty %}
         {{ block('empty_collection') }}
     {% endif %}


### PR DESCRIPTION
In `bootstrap_3_layout.html.twig`, form_widget_compound is displaying the block empty_collection when value is empty.

Problem is, `value is empty` will return true when the object does implements __toString() (and returns an empty string), even if it's not a collection.

I only added the check `is iterable` to be sure the `is empty` is run only on arrays and collections.