### PR TITLE
EasyAdminRouter

### DIFF
--- a/Configuration/DesignConfigPass.php
+++ b/Configuration/DesignConfigPass.php
@@ -29,7 +29,7 @@ class DesignConfigPass implements ConfigPassInterface
     private $locale;
 
     /**
-     * @var ContainerInterface $container to prevent ServiceCircularReferenceException
+     * @var ContainerInterface to prevent ServiceCircularReferenceException
      * @var bool               $kernelDebug
      * @var string             $locale
      */

--- a/Configuration/DesignConfigPass.php
+++ b/Configuration/DesignConfigPass.php
@@ -11,6 +11,8 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 /**
  * Processes the custom CSS styles applied to the backend design based on the
  * value of the design configuration options.
@@ -19,16 +21,21 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Configuration;
  */
 class DesignConfigPass implements ConfigPassInterface
 {
-    /** @var \Twig_Environment */
-    private $twig;
+    /** @var ContainerInterface */
+    private $container;
     /** @var bool */
     private $kernelDebug;
     /** @var string */
     private $locale;
 
-    public function __construct(\Twig_Environment $twig, $kernelDebug, $locale)
+    /**
+     * @var ContainerInterface $container to prevent ServiceCircularReferenceException
+     * @var bool               $kernelDebug
+     * @var string             $locale
+     */
+    public function __construct(ContainerInterface $container, $kernelDebug, $locale)
     {
-        $this->twig = $twig;
+        $this->container = $container;
         $this->kernelDebug = $kernelDebug;
         $this->locale = $locale;
     }
@@ -57,7 +64,7 @@ class DesignConfigPass implements ConfigPassInterface
 
     private function processCustomCss(array $backendConfig)
     {
-        $customCssContent = $this->twig->render('@EasyAdmin/css/easyadmin.css.twig', array(
+        $customCssContent = $this->container->get('twig')->render('@EasyAdmin/css/easyadmin.css.twig', array(
             'brand_color' => $backendConfig['design']['brand_color'],
             'color_scheme' => $backendConfig['design']['color_scheme'],
             'kernel_debug' => $this->kernelDebug,

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -43,10 +43,10 @@
         </service>
 
         <service id="easyadmin.router" class="JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminRouter">
-          <argument id="easyadmin.config.manager" type="service" />
-          <argument id="router.default" type="service" />
-          <argument id="property_accessor" type="service" />
-          <argument id="request_stack" type="service" on-invalid="null" />
+            <argument id="easyadmin.config.manager" type="service" />
+            <argument id="router.default" type="service" />
+            <argument id="property_accessor" type="service" />
+            <argument id="request_stack" type="service" on-invalid="null" />
         </service>
 
         <service id="easyadmin.twig.extension" class="JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension" public="false">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -90,7 +90,7 @@
         </service>
 
         <service id="easyadmin.configuration.design_config_pass" class="JavierEguiluz\Bundle\EasyAdminBundle\Configuration\DesignConfigPass" public="false">
-            <argument id="twig" type="service" />
+            <argument id="service_container" type="service" />
             <argument>%kernel.debug%</argument>
             <argument>%kernel.default_locale%</argument>
             <tag name="easyadmin.config_pass" priority="80" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -45,8 +45,8 @@
         <service id="easyadmin.router" class="JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminEntityRouter">
           <argument id="easyadmin.config.manager" type="service"/>
           <argument id="router.default" type="service"/>
-          <argument id="request_stack" type="service"/>
           <argument id="property_accessor" type="service"/>
+          <argument id="request_stack" type="service" on-invalid="null"/>
         </service>
 
         <service id="easyadmin.twig.extension" class="JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension" public="false">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -43,10 +43,10 @@
         </service>
 
         <service id="easyadmin.router" class="JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminEntityRouter">
-          <argument id="easyadmin.config.manager" type="service"/>
-          <argument id="router.default" type="service"/>
-          <argument id="property_accessor" type="service"/>
-          <argument id="request_stack" type="service" on-invalid="null"/>
+          <argument id="easyadmin.config.manager" type="service" />
+          <argument id="router.default" type="service" />
+          <argument id="property_accessor" type="service" />
+          <argument id="request_stack" type="service" on-invalid="null" />
         </service>
 
         <service id="easyadmin.twig.extension" class="JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension" public="false">

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -42,9 +42,17 @@
         <service id="easyadmin.paginator" class="JavierEguiluz\Bundle\EasyAdminBundle\Search\Paginator">
         </service>
 
+        <service id="easyadmin.router" class="JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminEntityRouter">
+          <argument id="easyadmin.config.manager" type="service"/>
+          <argument id="router.default" type="service"/>
+          <argument id="request_stack" type="service"/>
+          <argument id="property_accessor" type="service"/>
+        </service>
+
         <service id="easyadmin.twig.extension" class="JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension" public="false">
             <argument type="service" id="easyadmin.config.manager" />
             <argument type="service" id="property_accessor" />
+            <argument type="service" id="easyadmin.router" />
             <argument>%kernel.debug%</argument>
             <argument type="service" id="security.logout_url_generator" on-invalid="null" />
             <tag name="twig.extension" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -42,7 +42,7 @@
         <service id="easyadmin.paginator" class="JavierEguiluz\Bundle\EasyAdminBundle\Search\Paginator">
         </service>
 
-        <service id="easyadmin.router" class="JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminEntityRouter">
+        <service id="easyadmin.router" class="JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminRouter">
           <argument id="easyadmin.config.manager" type="service" />
           <argument id="router.default" type="service" />
           <argument id="property_accessor" type="service" />

--- a/Router/EasyAdminEntityRouter.php
+++ b/Router/EasyAdminEntityRouter.php
@@ -7,7 +7,7 @@ use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ConfigManager;
 use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Konstantin Grachev <me@grachevko.ru>
@@ -16,17 +16,17 @@ final class EasyAdminEntityRouter
 {
     /** @var ConfigManager */
     private $configManager;
-    /** @var RouterInterface */
-    private $router;
+    /** @var UrlGeneratorInterface */
+    private $urlGenerator;
     /** @var RequestStack */
     private $requestStack;
     /** @var PropertyAccessorInterface */
     private $propertyAccessor;
 
-    public function __construct(ConfigManager $configManager, RouterInterface $router, RequestStack $requestStack, PropertyAccessorInterface $propertyAccessor)
+    public function __construct(ConfigManager $configManager, UrlGeneratorInterface $urlGenerator, RequestStack $requestStack, PropertyAccessorInterface $propertyAccessor)
     {
         $this->configManager = $configManager;
-        $this->router = $router;
+        $this->urlGenerator = $urlGenerator;
         $this->requestStack = $requestStack;
         $this->propertyAccessor = $propertyAccessor;
     }
@@ -60,7 +60,7 @@ final class EasyAdminEntityRouter
             $parameters['referer'] = urlencode($request->getUri());
         }
 
-        return $this->router->generate('easyadmin', $parameters);
+        return $this->urlGenerator->generate('easyadmin', $parameters);
     }
 
     /**

--- a/Router/EasyAdminEntityRouter.php
+++ b/Router/EasyAdminEntityRouter.php
@@ -33,37 +33,34 @@ final class EasyAdminEntityRouter
 
     /**
      * @param object|string $entity
+     * @param string        $action
      * @param array         $parameters
      *
      * @throws UndefinedEntityException
      *
      * @return string
      */
-    public function generate($entity, array $parameters = array())
+    public function generate($entity, $action, array $parameters = array())
     {
         if (is_object($entity)) {
             $config = $this->getEntityConfigByClass(get_class($entity));
 
-            $params = array(
-                'id' => $this->propertyAccessor->getValue($entity, 'id'),
-                'action' => 'edit',
-            );
+            $parameters['id'] = $this->propertyAccessor->getValue($entity, 'id');
         } else {
             $config = class_exists($entity)
                 ? $this->getEntityConfigByClass($entity)
                 : $this->configManager->getEntityConfig($entity);
-
-            $params = array(
-                'action' => 'new',
-            );
         }
 
-        $request = $this->requestStack->getMasterRequest();
+        $parameters['entity'] = $config['name'];
+        $parameters['action'] = $action;
 
-        $params['entity'] = $config['name'];
-        $params['referer'] = urlencode($request->getUri());
+        if (!array_key_exists('referer', $parameters)) {
+            $request = $this->requestStack->getMasterRequest();
+            $parameters['referer'] = urlencode($request->getUri());
+        }
 
-        return $this->router->generate('easyadmin', array_merge($params, $parameters));
+        return $this->router->generate('easyadmin', $parameters);
     }
 
     /**

--- a/Router/EasyAdminEntityRouter.php
+++ b/Router/EasyAdminEntityRouter.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Router;
+
+use Doctrine\Common\Util\ClassUtils;
+use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ConfigManager;
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @author Konstantin Grachev <me@grachevko.ru>
+ */
+final class EasyAdminEntityRouter
+{
+    /** @var ConfigManager */
+    private $configManager;
+    /** @var RouterInterface */
+    private $router;
+    /** @var RequestStack */
+    private $requestStack;
+    /** @var PropertyAccessorInterface */
+    private $propertyAccessor;
+
+    public function __construct(ConfigManager $configManager, RouterInterface $router, RequestStack $requestStack, PropertyAccessorInterface $propertyAccessor) {
+        $this->configManager = $configManager;
+        $this->router = $router;
+        $this->requestStack = $requestStack;
+        $this->propertyAccessor = $propertyAccessor;
+    }
+
+    /**
+     * @param object|string $entity
+     * @param array         $parameters
+     *
+     * @throws UndefinedEntityException
+     *
+     * @return string
+     */
+    public function generate($entity, array $parameters = array())
+    {
+        if (is_object($entity)) {
+            $config = $this->getEntityConfigByClass(get_class($entity));
+
+            $params = array(
+                'id' => $this->propertyAccessor->getValue($entity, 'id'),
+                'action' => 'edit',
+            );
+        } else {
+            $config = class_exists($entity)
+                ? $this->getEntityConfigByClass($entity)
+                : $this->configManager->getEntityConfig($entity);
+
+            $params = array(
+                'action' => 'new',
+            );
+        }
+
+        $request = $this->requestStack->getMasterRequest();
+
+        $params['entity'] = $config['name'];
+        $params['referer'] = urlencode($request->getUri());
+
+        return $this->router->generate('easyadmin', array_merge($params, $parameters));
+    }
+
+    /**
+     * @param string $class
+     *
+     * @throws UndefinedEntityException
+     *
+     * @return array
+     */
+    private function getEntityConfigByClass($class)
+    {
+        if (!$config = $this->configManager->getEntityConfigByClass(ClassUtils::getRealClass($class))) {
+            throw new UndefinedEntityException(array('entity_name' => $class));
+        }
+
+        return $config;
+    }
+}

--- a/Router/EasyAdminEntityRouter.php
+++ b/Router/EasyAdminEntityRouter.php
@@ -56,7 +56,7 @@ final class EasyAdminEntityRouter
         $parameters['action'] = $action;
 
         if (!array_key_exists('referer', $parameters)) {
-            $request = $this->requestStack->getMasterRequest();
+            $request = $this->requestStack->getCurrentRequest();
             $parameters['referer'] = urlencode($request->getUri());
         }
 

--- a/Router/EasyAdminEntityRouter.php
+++ b/Router/EasyAdminEntityRouter.php
@@ -23,7 +23,8 @@ final class EasyAdminEntityRouter
     /** @var PropertyAccessorInterface */
     private $propertyAccessor;
 
-    public function __construct(ConfigManager $configManager, RouterInterface $router, RequestStack $requestStack, PropertyAccessorInterface $propertyAccessor) {
+    public function __construct(ConfigManager $configManager, RouterInterface $router, RequestStack $requestStack, PropertyAccessorInterface $propertyAccessor)
+    {
         $this->configManager = $configManager;
         $this->router = $router;
         $this->requestStack = $requestStack;

--- a/Router/EasyAdminEntityRouter.php
+++ b/Router/EasyAdminEntityRouter.php
@@ -18,17 +18,17 @@ final class EasyAdminEntityRouter
     private $configManager;
     /** @var UrlGeneratorInterface */
     private $urlGenerator;
-    /** @var RequestStack */
-    private $requestStack;
     /** @var PropertyAccessorInterface */
     private $propertyAccessor;
+    /** @var RequestStack */
+    private $requestStack;
 
-    public function __construct(ConfigManager $configManager, UrlGeneratorInterface $urlGenerator, RequestStack $requestStack, PropertyAccessorInterface $propertyAccessor)
+    public function __construct(ConfigManager $configManager, UrlGeneratorInterface $urlGenerator, PropertyAccessorInterface $propertyAccessor, RequestStack $requestStack = null)
     {
         $this->configManager = $configManager;
         $this->urlGenerator = $urlGenerator;
-        $this->requestStack = $requestStack;
         $this->propertyAccessor = $propertyAccessor;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -55,7 +55,7 @@ final class EasyAdminEntityRouter
         $parameters['entity'] = $config['name'];
         $parameters['action'] = $action;
 
-        if (!array_key_exists('referer', $parameters)) {
+        if ($this->requestStack && !array_key_exists('referer', $parameters)) {
             $request = $this->requestStack->getCurrentRequest();
             $parameters['referer'] = urlencode($request->getUri());
         }

--- a/Router/EasyAdminRouter.php
+++ b/Router/EasyAdminRouter.php
@@ -64,8 +64,7 @@ final class EasyAdminRouter
         $parameters['entity'] = $config['name'];
         $parameters['action'] = $action;
 
-        if ($this->requestStack && !array_key_exists('referer', $parameters)) {
-            $request = $this->requestStack->getCurrentRequest();
+        if ($this->requestStack && !array_key_exists('referer', $parameters) && ($request = $this->requestStack->getCurrentRequest())) {
             $parameters['referer'] = urlencode($request->getUri());
         }
 

--- a/Router/EasyAdminRouter.php
+++ b/Router/EasyAdminRouter.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Router;
 
 use Doctrine\Common\Util\ClassUtils;

--- a/Router/EasyAdminRouter.php
+++ b/Router/EasyAdminRouter.php
@@ -12,7 +12,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * @author Konstantin Grachev <me@grachevko.ru>
  */
-final class EasyAdminEntityRouter
+final class EasyAdminRouter
 {
     /** @var ConfigManager */
     private $configManager;

--- a/Router/EasyAdminRouter.php
+++ b/Router/EasyAdminRouter.php
@@ -14,6 +14,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Router;
 use Doctrine\Common\Util\ClassUtils;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ConfigManager;
 use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -31,6 +32,8 @@ final class EasyAdminRouter
     private $propertyAccessor;
     /** @var RequestStack */
     private $requestStack;
+    /** @var Request */
+    private $request;
 
     public function __construct(ConfigManager $configManager, UrlGeneratorInterface $urlGenerator, PropertyAccessorInterface $propertyAccessor, RequestStack $requestStack = null)
     {
@@ -64,11 +67,34 @@ final class EasyAdminRouter
         $parameters['entity'] = $config['name'];
         $parameters['action'] = $action;
 
-        if ($this->requestStack && !array_key_exists('referer', $parameters) && ($request = $this->requestStack->getCurrentRequest())) {
+        if (!array_key_exists('referer', $parameters) && $request = $this->getRequest()) {
             $parameters['referer'] = urlencode($request->getUri());
         }
 
         return $this->urlGenerator->generate('easyadmin', $parameters);
+    }
+
+    /**
+     * BC for SF < 2.4.
+     * To be replaced by the usage of the request stack when 2.3 support is dropped.
+     *
+     * @param Request|null $request
+     */
+    public function setRequest(Request $request = null)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return Request|null
+     */
+    private function getRequest()
+    {
+        if ($this->requestStack && $request = $this->requestStack->getCurrentRequest()) {
+            return $request;
+        }
+
+        return $this->request;
     }
 
     /**

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -59,7 +59,7 @@ final class EasyAdminRouterTest extends AbstractTestCase
 
         return array(
             array('AppTestBundle\Entity\FunctionalTests\Category', 'new', 'Category', array('modal' => 1)),
-            array('Product', 'new', 'Product', array('entity' => 'Category'), array('entity' => 'product')),
+            array('Product', 'new', 'Product', array('entity' => 'Category'), array('entity' => 'Product')),
             array($product, 'show', 'Product', array(), array('id' => 1)),
         );
     }

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -77,7 +77,7 @@ final class EasyAdminRouterTest extends AbstractTestCase
     public function provideUndefinedEntities()
     {
         return array(
-            array('SomeNotExistedEntity', 'new')
+            array('SomeNotExistedEntity', 'new'),
         );
     }
 }

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -53,7 +53,9 @@ final class EasyAdminRouterTest extends AbstractTestCase
     {
         $product = new Product();
         $ref = new \ReflectionClass($product);
-        $ref->getProperty('id')->setValue($product, 1);
+        $refPropertyId = $ref->getProperty('id');
+        $refPropertyId->setAccessible(true);
+        $refPropertyId->setValue($product, 1);
 
         return array(
             array('AppTestBundle\Entity\FunctionalTests\Category', 'new', 'Category', array('modal' => 1)),

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -41,11 +41,11 @@ final class EasyAdminRouterTest extends AbstractTestCase
     {
         $url = $this->router->generate($entity, $action, $parameters);
 
-        self::assertContains('entity='.$expectEntity, $url);
-        self::assertContains('action='.$action, $url);
+        $this->assertContains('entity='.$expectEntity, $url);
+        $this->assertContains('action='.$action, $url);
 
         foreach (array_merge($parameters, $expectParameters) as $key => $value) {
-            self::assertContains($key.'='.$value, $url);
+            $this->assertContains($key.'='.$value, $url);
         }
     }
 
@@ -77,7 +77,7 @@ final class EasyAdminRouterTest extends AbstractTestCase
     public function provideUndefinedEntities()
     {
         return array(
-            array('SomeNotExistedEntity', 'new'),
+            array('ThisEntityDoesNotExist', 'new'),
         );
     }
 }

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -12,7 +12,6 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Router;
 
 use AppTestBundle\Entity\FunctionalTests\Product;
-use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminRouter;
 use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
@@ -53,7 +52,7 @@ final class EasyAdminRouterTest extends AbstractTestCase
     /**
      * @dataProvider provideUndefinedEntities
      *
-     * @expectedException UndefinedEntityException
+     * @expectedException \JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException
      */
     public function testUndefinedEntityException($entity, $action)
     {

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -49,7 +49,7 @@ final class EasyAdminRouterTest extends AbstractTestCase
         return array(
             array('AppTestBundle\Entity\FunctionalTests\Category', 'new', 'Category', array('modal' => 1)),
             array('Product', 'new', 'Product', array('entity' => 'Category'), array('entity' => 'product')),
-            array($product, 'show', 'Product', array(), array('id' => 1))
+            array($product, 'show', 'Product', array(), array('id' => 1)),
         );
     }
 }

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -12,6 +12,7 @@
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Router;
 
 use AppTestBundle\Entity\FunctionalTests\Product;
+use JavierEguiluz\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminRouter;
 use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
@@ -37,7 +38,7 @@ final class EasyAdminRouterTest extends AbstractTestCase
     /**
      * @dataProvider provideEntities
      */
-    public function testRouter($entity, $action, $expectEntity, array $parameters = array(), array $expectParameters = array())
+    public function testUrlGeneration($entity, $action, $expectEntity, array $parameters = array(), array $expectParameters = array())
     {
         $url = $this->router->generate($entity, $action, $parameters);
 
@@ -47,6 +48,16 @@ final class EasyAdminRouterTest extends AbstractTestCase
         foreach (array_merge($parameters, $expectParameters) as $key => $value) {
             self::assertContains($key.'='.$value, $url);
         }
+    }
+
+    /**
+     * @dataProvider provideUndefinedEntities
+     *
+     * @expectedException UndefinedEntityException
+     */
+    public function testUndefinedEntityException($entity, $action)
+    {
+        $this->router->generate($entity, $action);
     }
 
     public function provideEntities()
@@ -61,6 +72,13 @@ final class EasyAdminRouterTest extends AbstractTestCase
             array('AppTestBundle\Entity\FunctionalTests\Category', 'new', 'Category'),
             array('Product', 'new', 'Product', array('entity' => 'Category'), array('entity' => 'Product')),
             array($product, 'show', 'Product', array('modal' => 1), array('id' => 1)),
+        );
+    }
+
+    public function provideUndefinedEntities()
+    {
+        return array(
+            array('SomeNotExistedEntity', 'new')
         );
     }
 }

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Router;
+
+use AppTestBundle\Entity\FunctionalTests\Product;
+use JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminRouter;
+use JavierEguiluz\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+
+/**
+ * @author Konstantin Grachev <me@grachevko.ru>
+ */
+final class EasyAdminRouterTest extends AbstractTestCase
+{
+    /**
+     * @var EasyAdminRouter
+     */
+    private $router;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initClient(array('environment' => 'default_backend'));
+
+        $this->router = $this->client->getContainer()->get('easyadmin.router');
+    }
+
+    /**
+     * @dataProvider provideEntities
+     */
+    public function testRouter($entity, $action, $expectEntity, array $parameters, array $expectParameters = array())
+    {
+        $url = $this->router->generate($entity, $action, $parameters);
+
+        self::assertContains('entity='.$expectEntity, $url);
+        self::assertContains('action='.$action, $url);
+
+        foreach (array_merge($parameters, $expectParameters) as $key => $value) {
+            self::assertContains($key.'='.$value, $url);
+        }
+    }
+
+    public function provideEntities()
+    {
+        $product = new Product();
+        $ref = new \ReflectionClass($product);
+        $ref->getProperty('id')->setValue($product, 1);
+
+        return array(
+            array('AppTestBundle\Entity\FunctionalTests\Category', 'new', 'Category', array('modal' => 1)),
+            array('Product', 'new', 'Product', array('entity' => 'Category'), array('entity' => 'product')),
+            array($product, 'show', 'Product', array(), array('id' => 1))
+        );
+    }
+}

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace JavierEguiluz\Bundle\EasyAdminBundle\Tests\Router;
 
 use AppTestBundle\Entity\FunctionalTests\Product;

--- a/Tests/Router/EasyAdminRouterTest.php
+++ b/Tests/Router/EasyAdminRouterTest.php
@@ -37,7 +37,7 @@ final class EasyAdminRouterTest extends AbstractTestCase
     /**
      * @dataProvider provideEntities
      */
-    public function testRouter($entity, $action, $expectEntity, array $parameters, array $expectParameters = array())
+    public function testRouter($entity, $action, $expectEntity, array $parameters = array(), array $expectParameters = array())
     {
         $url = $this->router->generate($entity, $action, $parameters);
 
@@ -58,9 +58,9 @@ final class EasyAdminRouterTest extends AbstractTestCase
         $refPropertyId->setValue($product, 1);
 
         return array(
-            array('AppTestBundle\Entity\FunctionalTests\Category', 'new', 'Category', array('modal' => 1)),
+            array('AppTestBundle\Entity\FunctionalTests\Category', 'new', 'Category'),
             array('Product', 'new', 'Product', array('entity' => 'Category'), array('entity' => 'Product')),
-            array($product, 'show', 'Product', array(), array('id' => 1)),
+            array($product, 'show', 'Product', array('modal' => 1), array('id' => 1)),
         );
     }
 }

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -13,7 +13,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Twig;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ConfigManager;
-use JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminEntityRouter;
+use JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminRouter;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 /**
@@ -29,13 +29,13 @@ class EasyAdminTwigExtension extends \Twig_Extension
     private $configManager;
     /** @var PropertyAccessor */
     private $propertyAccessor;
-    /** @var EasyAdminEntityRouter */
+    /** @var EasyAdminRouter */
     private $entityRouter;
     /** @var bool */
     private $debug;
     private $logoutUrlGenerator;
 
-    public function __construct(ConfigManager $configManager, PropertyAccessor $propertyAccessor, EasyAdminEntityRouter $entityRouter, $debug = false, $logoutUrlGenerator)
+    public function __construct(ConfigManager $configManager, PropertyAccessor $propertyAccessor, EasyAdminRouter $entityRouter, $debug = false, $logoutUrlGenerator)
     {
         $this->configManager = $configManager;
         $this->propertyAccessor = $propertyAccessor;

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -105,7 +105,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
     /**
      * @param object|string $entity
      * @param string        $action
-     * @param array|string  $parameters
+     * @param array         $parameters
      *
      * @return string
      */

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -104,21 +104,14 @@ class EasyAdminTwigExtension extends \Twig_Extension
 
     /**
      * @param object|string $entity
+     * @param string        $action
      * @param array|string  $parameters
      *
      * @return string
      */
-    public function getEntityPath($entity, $parameters = null)
+    public function getEntityPath($entity, $action, array $parameters = array())
     {
-        if (is_string($parameters)) {
-            $parameters = array('action' => $parameters);
-        }
-
-        if (null === $parameters) {
-            $parameters = array();
-        }
-
-        return $this->entityRouter->generate($entity, $parameters);
+        return $this->entityRouter->generate($entity, $action, $parameters);
     }
 
     /**

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -13,6 +13,7 @@ namespace JavierEguiluz\Bundle\EasyAdminBundle\Twig;
 
 use Doctrine\ORM\Mapping\ClassMetadata;
 use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ConfigManager;
+use JavierEguiluz\Bundle\EasyAdminBundle\Router\EasyAdminEntityRouter;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 /**
@@ -28,14 +29,17 @@ class EasyAdminTwigExtension extends \Twig_Extension
     private $configManager;
     /** @var PropertyAccessor */
     private $propertyAccessor;
+    /** @var EasyAdminEntityRouter */
+    private $entityRouter;
     /** @var bool */
     private $debug;
     private $logoutUrlGenerator;
 
-    public function __construct(ConfigManager $configManager, PropertyAccessor $propertyAccessor, $debug = false, $logoutUrlGenerator)
+    public function __construct(ConfigManager $configManager, PropertyAccessor $propertyAccessor, EasyAdminEntityRouter $entityRouter, $debug = false, $logoutUrlGenerator)
     {
         $this->configManager = $configManager;
         $this->propertyAccessor = $propertyAccessor;
+        $this->entityRouter = $entityRouter;
         $this->debug = $debug;
         $this->logoutUrlGenerator = $logoutUrlGenerator;
     }
@@ -49,6 +53,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('easyadmin_render_field_for_*_view', array($this, 'renderEntityField'), array('is_safe' => array('html'), 'needs_environment' => true)),
             new \Twig_SimpleFunction('easyadmin_config', array($this, 'getBackendConfiguration')),
             new \Twig_SimpleFunction('easyadmin_entity', array($this, 'getEntityConfiguration')),
+            new \Twig_SimpleFunction('easyadmin_path', array($this, 'getEntityPath')),
             new \Twig_SimpleFunction('easyadmin_action_is_enabled', array($this, 'isActionEnabled')),
             new \Twig_SimpleFunction('easyadmin_action_is_enabled_for_*_view', array($this, 'isActionEnabled')),
             new \Twig_SimpleFunction('easyadmin_get_action', array($this, 'getActionConfiguration')),
@@ -95,6 +100,25 @@ class EasyAdminTwigExtension extends \Twig_Extension
         return null !== $this->getBackendConfiguration('entities.'.$entityName)
             ? $this->configManager->getEntityConfig($entityName)
             : null;
+    }
+
+    /**
+     * @param object|string $entity
+     * @param array|string  $parameters
+     *
+     * @return string
+     */
+    public function getEntityPath($entity, $parameters = null)
+    {
+        if (is_string($parameters)) {
+            $parameters = array('action' => $parameters);
+        }
+
+        if (null === $parameters) {
+            $parameters = array();
+        }
+
+        return $this->entityRouter->generate($entity, $parameters);
     }
 
     /**

--- a/Twig/EasyAdminTwigExtension.php
+++ b/Twig/EasyAdminTwigExtension.php
@@ -30,16 +30,16 @@ class EasyAdminTwigExtension extends \Twig_Extension
     /** @var PropertyAccessor */
     private $propertyAccessor;
     /** @var EasyAdminRouter */
-    private $entityRouter;
+    private $easyAdminRouter;
     /** @var bool */
     private $debug;
     private $logoutUrlGenerator;
 
-    public function __construct(ConfigManager $configManager, PropertyAccessor $propertyAccessor, EasyAdminRouter $entityRouter, $debug = false, $logoutUrlGenerator)
+    public function __construct(ConfigManager $configManager, PropertyAccessor $propertyAccessor, EasyAdminRouter $easyAdminRouter, $debug = false, $logoutUrlGenerator)
     {
         $this->configManager = $configManager;
         $this->propertyAccessor = $propertyAccessor;
-        $this->entityRouter = $entityRouter;
+        $this->easyAdminRouter = $easyAdminRouter;
         $this->debug = $debug;
         $this->logoutUrlGenerator = $logoutUrlGenerator;
     }
@@ -111,7 +111,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
      */
     public function getEntityPath($entity, $action, array $parameters = array())
     {
-        return $this->entityRouter->generate($entity, $action, $parameters);
+        return $this->easyAdminRouter->generate($entity, $action, $parameters);
     }
 
     /**


### PR DESCRIPTION
I want to suggest an option for easy url generation by entity name, namespace or object.

In twig:
```
<a href="{{ easyadmin_path(entity, 'edit') }}">Edit</a>
<a href="{{ easyadmin_path('EntityName', 'new') }}">New</a>
<a href="{{ easyadmin_path(entity, 'show') }}">Show</a>
```
 in php:
```php
$this->entityRouter->generate(App\Entity\Book::class, 'new');
```