### PR TITLE
Use translation_domain for form from itself.

### DIFF
--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -161,14 +161,25 @@
 {%- endblock %}
 
 {% block choice_widget_expanded -%}
-    <div {% if '-inline' in label_attr.class|default('') -%}class="control-group"{%- else -%}{{ block('widget_container_attributes') }}{%- endif %}>
-        {%- for child in form %}
-            {{- form_widget(child, {
-                parent_label_class: label_attr.class|default(''),
-                translation_domain: choice_translation_domain
-            }) -}}
-        {% endfor -%}
-    </div>
+    {% if '-inline' in label_attr.class|default('') -%}
+        <div class="control-group">
+            {%- for child in form %}
+                {{- form_widget(child, {
+                    parent_label_class: label_attr.class|default(''),
+                    translation_domain: choice_translation_domain,
+                }) -}}
+            {% endfor -%}
+        </div>
+    {%- else -%}
+        <div {{ block('widget_container_attributes') }}>
+            {%- for child in form %}
+                {{- form_widget(child, {
+                    parent_label_class: label_attr.class|default(''),
+                    translation_domain: choice_translation_domain,
+                }) -}}
+            {% endfor -%}
+        </div>
+    {%- endif %}
 {%- endblock choice_widget_expanded %}
 
 {% block checkbox_widget -%}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -165,7 +165,7 @@
         {%- for child in form %}
             {{- form_widget(child, {
                 parent_label_class: label_attr.class|default(''),
-                translation_domain: choice_translation_domain ?: translation_domain
+                translation_domain: choice_translation_domain
             }) -}}
         {% endfor -%}
     </div>

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -239,7 +239,7 @@
     {% set _field_type = easyadmin.field.fieldType|default('default') %}
     <div class="form-group {% if (not compound or force_error|default(false)) and not valid %}has-error{% endif %} field-{{ block_prefixes|slice(-2)|first }}">
         {% set _field_label = easyadmin.field['label']|default(null) %}
-        {{- form_label(form, _field_label, { translation_domain: easyadmin.entity.translation_domain }) -}}
+        {{- form_label(form, _field_label, { translation_domain: translation_domain ?: easyadmin.entity.translation_domain }) -}}
         {{- form_widget(form) -}}
 
         {% if _field_type in ['datetime', 'date', 'time', 'birthday'] and easyadmin.field.nullable|default(false) %}

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -161,23 +161,14 @@
 {%- endblock %}
 
 {% block choice_widget_expanded -%}
-    {% if '-inline' in label_attr.class|default('') -%}
-        <div class="control-group">
-            {%- for child in form %}
-                {{- form_widget(child, {
-                    parent_label_class: label_attr.class|default(''),
-                }) -}}
-            {% endfor -%}
-        </div>
-    {%- else -%}
-        <div {{ block('widget_container_attributes') }}>
-            {%- for child in form %}
-                {{- form_widget(child, {
-                    parent_label_class: label_attr.class|default(''),
-                }) -}}
-            {% endfor -%}
-        </div>
-    {%- endif %}
+    <div {% if '-inline' in label_attr.class|default('') -%}class="control-group"{%- else -%}{{ block('widget_container_attributes') }}{%- endif %}>
+        {%- for child in form %}
+            {{- form_widget(child, {
+                parent_label_class: label_attr.class|default(''),
+                translation_domain: choice_translation_domain ?: translation_domain
+            }) -}}
+        {% endfor -%}
+    </div>
 {%- endblock choice_widget_expanded %}
 
 {% block checkbox_widget -%}
@@ -237,7 +228,7 @@
         {% endif %}
         <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
             {{- widget|raw -}}
-            {{- label is not same as(false) ? label|trans({}, easyadmin.entity.translation_domain) -}}
+            {{- label is not same as(false) ? label|trans({}, translation_domain ?: easyadmin.entity.translation_domain) -}}
         </label>
     {% endif %}
 {% endblock checkbox_radio_label %}


### PR DESCRIPTION
`translation_domain` for forms must be preffered from itself instead of easy_admin config.
And for choices must be preffered `choice_translation_domain` if defined.
