### PR TITLE
Allow substitute entity before persisting

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -208,7 +208,7 @@ class AdminController extends Controller
             $this->dispatch(EasyAdminEvents::PRE_UPDATE, array('entity' => $entity));
 
             $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity));
-            $this->em->flush();
+            $this->executeDynamicMethod('update<EntityName>Entity', array($entity));
 
             $this->dispatch(EasyAdminEvents::POST_UPDATE, array('entity' => $entity));
 
@@ -278,9 +278,7 @@ class AdminController extends Controller
             $this->dispatch(EasyAdminEvents::PRE_PERSIST, array('entity' => $entity));
 
             $this->executeDynamicMethod('prePersist<EntityName>Entity', array($entity));
-
             $this->executeDynamicMethod('persist<EntityName>Entity', array($entity));
-            $this->em->flush();
 
             $this->dispatch(EasyAdminEvents::POST_PERSIST, array('entity' => $entity));
 
@@ -327,8 +325,7 @@ class AdminController extends Controller
             $this->executeDynamicMethod('preRemove<EntityName>Entity', array($entity));
 
             try {
-                $this->em->remove($entity);
-                $this->em->flush();
+                $this->executeDynamicMethod('remove<EntityName>Entity', array($entity));
             } catch (ForeignKeyConstraintViolationException $e) {
                 throw new EntityRemoveException(array('entity_name' => $this->entity['name'], 'message' => $e->getMessage()));
             }
@@ -436,6 +433,7 @@ class AdminController extends Controller
     protected function persistEntity($entity)
     {
         $this->em->persist($entity);
+        $this->em->flush($entity);
     }
 
     /**
@@ -450,12 +448,35 @@ class AdminController extends Controller
 
     /**
      * Allows applications to modify the entity associated with the item being
+     * edited before updating it.
+     *
+     * @param object $entity
+     */
+    protected function updateEntity($entity)
+    {
+        $this->em->flush($entity);
+    }
+
+    /**
+     * Allows applications to modify the entity associated with the item being
      * deleted before removing it.
      *
      * @param object $entity
      */
     protected function preRemoveEntity($entity)
     {
+    }
+
+    /**
+     * Allows applications to modify the entity associated with the item being
+     * deleted before removing it.
+     *
+     * @param object $entity
+     */
+    protected function removeEntity($entity)
+    {
+        $this->em->remove($entity);
+        $this->em->flush($entity);
     }
 
     /**

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -279,7 +279,7 @@ class AdminController extends Controller
 
             $this->executeDynamicMethod('prePersist<EntityName>Entity', array($entity));
 
-            $this->em->persist($entity);
+            $this->executeDynamicMethod('persist<EntityName>Entity', array($entity));
             $this->em->flush();
 
             $this->dispatch(EasyAdminEvents::POST_PERSIST, array('entity' => $entity));
@@ -425,6 +425,17 @@ class AdminController extends Controller
      */
     protected function prePersistEntity($entity)
     {
+    }
+
+    /**
+     * Allows applications to modify the entity associated with the item being
+     * created while persisting it.
+     *
+     * @param object $entity
+     */
+    protected function persistEntity($entity)
+    {
+        $this->em->persist($entity);
     }
 
     /**


### PR DESCRIPTION
Suppose i want to put data in entity through constructor without setters. 
I can modify `createNewEntity` method to create DTO for form instead of real entity, and use custom form type.
But i can't substitute real entity instead of DTO before persisting.

I see alter option to solve that: add return statement to `prePersistEntity` method, and if it return object, persist it. Whitch one is better?

P.S. Will be great to have option to change `data_class` for `EasyAdminFormType` through config, but it task for another thread.