### PR TITLE
Improve the DataCollector code to not use the entire container

### DIFF
--- a/DataCollector/EasyAdminDataCollector.php
+++ b/DataCollector/EasyAdminDataCollector.php
@@ -11,7 +11,7 @@
 
 namespace JavierEguiluz\Bundle\EasyAdminBundle\DataCollector;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use JavierEguiluz\Bundle\EasyAdminBundle\Configuration\ConfigManager;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
@@ -27,15 +27,12 @@ use Symfony\Component\Yaml\Yaml;
  */
 class EasyAdminDataCollector extends DataCollector
 {
-    /** @var ContainerInterface */
-    private $container;
+    /** @var ConfigManager */
+    private $configManager;
 
-    /**
-     * @param ContainerInterface $container to prevent ServiceCircularReferenceException
-     */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ConfigManager $configManager)
     {
-        $this->container = $container;
+        $this->configManager = $configManager;
     }
 
     /**
@@ -43,7 +40,7 @@ class EasyAdminDataCollector extends DataCollector
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
-        $backendConfig = $this->container->get('easyadmin.config.manager')->getBackendConfig();
+        $backendConfig = $this->configManager->getBackendConfig();
         $entityName = $request->query->get('entity', null);
         $currentEntityConfig = array_key_exists($entityName, $backendConfig['entities']) ? $backendConfig['entities'][$entityName] : array();
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -80,7 +80,7 @@
         </service>
 
         <service id="easyadmin.data_collector" class="JavierEguiluz\Bundle\EasyAdminBundle\DataCollector\EasyAdminDataCollector" public="false">
-            <argument type="service" id="service_container" />
+            <argument type="service" id="easyadmin.config.manager" />
             <tag name="data_collector" template="@EasyAdmin/data_collector/easyadmin.html.twig" id="easyadmin" />
         </service>
 


### PR DESCRIPTION
This was needed to solve some circular dependency issue ... but the issue was fixed by @grachevko in a different way, so [we can revert this](https://github.com/javiereguiluz/EasyAdminBundle/pull/1677#issuecomment-314688124)