### PR TITLE
[Translations] Fix `errors` key for Russian locale

### DIFF
--- a/Resources/translations/EasyAdminBundle.ru.xlf
+++ b/Resources/translations/EasyAdminBundle.ru.xlf
@@ -141,7 +141,7 @@
             </trans-unit>
             <trans-unit id="errors">
                 <source>errors</source>
-                <target>Ошибка|Ошибки</target>
+                <target>Ошибка|Ошибки|Ошибок</target>
             </trans-unit>
             <trans-unit id="form.are_you_sure">
                 <source>form.are_you_sure</source>


### PR DESCRIPTION
We have 3 forms in Russian. So, 6 errors is different from 3 errors.

[Symfony documentation tells about the Russian rules](http://symfony.com/doc/current/components/translation/usage.html#pluralization).