### PR TITLE
Fix autocomplete pagination

### DIFF
--- a/Resources/public/javascript/easyadmin.js
+++ b/Resources/public/javascript/easyadmin.js
@@ -56,8 +56,7 @@ function createAutoCompleteFields() {
 
     autocompleteFields.each(function () {
         var $this = $(this),
-            url = $this.data('easyadmin-autocomplete-url'),
-            max_results = $this.data('easyadmin-autocomplete-max-results');
+            url = $this.data('easyadmin-autocomplete-url');
 
         $this.select2({
             theme: 'bootstrap',
@@ -73,7 +72,7 @@ function createAutoCompleteFields() {
                     return {
                         results: data.results,
                         pagination: {
-                            more: data.results.length === max_results
+                            more: data.has_next_page
                         }
                     };
                 },

--- a/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/Resources/views/form/bootstrap_3_layout.html.twig
@@ -523,7 +523,6 @@
 {% block easyadmin_autocomplete_widget %}
     {{ form_widget(form.autocomplete, {
         attr: attr|merge({
-            'data-easyadmin-autocomplete-max-results': easyadmin_config('show.max_results'),
             'data-easyadmin-autocomplete-url' : path('easyadmin', {
                 action: 'autocomplete',
                 entity: autocomplete_entity_name,

--- a/Search/Autocomplete.php
+++ b/Search/Autocomplete.php
@@ -59,7 +59,10 @@ class Autocomplete
 
         $paginator = $this->finder->findByAllProperties($backendConfig['entities'][$entity], $query, $page, $backendConfig['show']['max_results']);
 
-        return array('results' => $this->processResults($paginator->getCurrentPageResults(), $backendConfig['entities'][$entity]));
+        return array(
+            'results' => $this->processResults($paginator->getCurrentPageResults(), $backendConfig['entities'][$entity]),
+            'has_next_page' => $paginator->hasNextPage(),
+        );
     }
 
     /**


### PR DESCRIPTION
This fix a bug when we're paginating a quantity multiple of `max_results` and because the `more` attribute of select2 pagination has a wrong condition: `data.results.length === max_results` which does not guarantee that stop to paginate when the last page is loaded.

![autocomplete-pagination-bug](https://user-images.githubusercontent.com/2028198/28846899-2d41499e-76db-11e7-8d7f-3b0e7585aac0.png)

To reproduce the bug, use the easy-admin-demo and create a new product, then go to categories field and type the letter "a", paginates to the end and see it after the last page is loaded.