### PR TITLE
EasyAdminRouter improvements

### DIFF
--- a/src/Router/EasyAdminRouter.php
+++ b/src/Router/EasyAdminRouter.php
@@ -74,9 +74,8 @@ final class EasyAdminRouter
         if (false === $referer) {
             unset($parameters['referer']);
         } elseif (
-            !is_string($referer)
-            && false !== $referer
-            && $request
+            $request
+            && !is_string($referer)
             && (true === $referer || in_array($action, array('new', 'edit', 'delete'), true))
         ) {
             $parameters['referer'] = urlencode($request->getUri());

--- a/src/Router/EasyAdminRouter.php
+++ b/src/Router/EasyAdminRouter.php
@@ -68,7 +68,17 @@ final class EasyAdminRouter
         $parameters['entity'] = $config['name'];
         $parameters['action'] = $action;
 
-        if (!array_key_exists('referer', $parameters) && $request = $this->getRequest()) {
+        $referer = array_key_exists('referer', $parameters) ? $parameters['referer'] : null;
+        $request = $this->getRequest();
+
+        if (false === $referer) {
+            unset($parameters['referer']);
+        } elseif (
+            !is_string($referer)
+            && false !== $referer
+            && $request
+            && (true === $referer || in_array($action, array('new', 'edit', 'delete'), true))
+        ) {
             $parameters['referer'] = urlencode($request->getUri());
         }
 


### PR DESCRIPTION
This PR add two improvements about adding `referer` to url.
1. By default `referer` add only for `new`, `edit` and `delete` actions.
2. Ability to force enable/disable adding `referer` by set  `{referer: true/false}`
