### PR TITLE
Fix tests in local machine (OS platform issue)

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,7 @@
     -->
 
     <php>
-        <server name="KERNEL_DIR" value="./Tests/Fixtures/App" />
+        <server name="KERNEL_CLASS" value="AppKernel" />
         <ini name="error_reporting" value="E_ALL" />
         <ini name="display_errors" value="1" />
         <ini name="display_startup_errors" value="1" />


### PR DESCRIPTION
The current tests configuration `<server name="KERNEL_DIR" value="./Tests/Fixtures/App" />` make my tests fail.

**Why?**

There is more than one `*Kernel.php` in this directory, then `KernelTestCase::getKernelClass()` returns the first kernel file found (in my case) in this order:
 1. `DynamicConfigLoadingKernel.php`
 2. `AppKernel.php`

So `DynamicConfigLoadingKernel` class is loaded and all fails.

**Why Travis is OK?**

I guess the below code returns a different order depending of the OS platform and the first file is `AppKernel.php` for Travis, but really I don't know.
```php
$finder = new Finder();
$finder->name('*Kernel.php')->depth(0)->in($dir);
$results = iterator_to_array($finder);
```

Anyway, the proposed changes avoid this setting the `KERNEL_CLASS` parameter directly.