### PR TITLE
Allow 4.x of framework-extra-bundle branch to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/doctrine-bundle"      : "~1.2",
         "doctrine/orm"                  : "~2.3",
         "pagerfanta/pagerfanta"         : "~1.0,>=1.0.1",
-        "sensio/framework-extra-bundle" : "~2.3|~3.0,>=3.0.2|4.0.x-dev",
+        "sensio/framework-extra-bundle" : "~2.3|~3.0,>=3.0.2|4.0.x",
         "symfony/asset"                 : "~2.3|~3.0|~4.0",
         "symfony/config"                : "~2.3|~3.0|~4.0",
         "symfony/dependency-injection"  : "~2.3|~3.0|~4.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/doctrine-bundle"      : "~1.2",
         "doctrine/orm"                  : "~2.3",
         "pagerfanta/pagerfanta"         : "~1.0,>=1.0.1",
-        "sensio/framework-extra-bundle" : "~2.3|~3.0,>=3.0.2",
+        "sensio/framework-extra-bundle" : "~2.3|~3.0,>=3.0.2|4.0.x-dev",
         "symfony/asset"                 : "~2.3|~3.0|~4.0",
         "symfony/config"                : "~2.3|~3.0|~4.0",
         "symfony/dependency-injection"  : "~2.3|~3.0|~4.0",


### PR DESCRIPTION
Currently, this bundle prevents my application to use 4.x branch of `sensio/framework-extra-bundle` (with `@Entity()` param converters)

The documentation of https://symfony.com/doc/master/bundles/SensioFrameworkExtraBundle/annotations/converters.html defaults to 4.x

