### PR TITLE
Improved the EntityRemoveException message

### DIFF
--- a/Controller/AdminController.php
+++ b/Controller/AdminController.php
@@ -330,7 +330,7 @@ class AdminController extends Controller
                 $this->em->remove($entity);
                 $this->em->flush();
             } catch (ForeignKeyConstraintViolationException $e) {
-                throw new EntityRemoveException(array('entity_name' => $this->entity['name']));
+                throw new EntityRemoveException(array('entity_name' => $this->entity['name'], 'message' => $e->getMessage()));
             }
 
             $this->dispatch(EasyAdminEvents::POST_REMOVE, array('entity' => $entity));

--- a/Exception/EntityRemoveException.php
+++ b/Exception/EntityRemoveException.php
@@ -20,7 +20,7 @@ class EntityRemoveException extends BaseException
     {
         $exceptionContext = new ExceptionContext(
             'exception.entity_remove',
-            sprintf('There is a ForeignKeyConstraintViolationException for the Doctrine entity associated with "%s". Solution: disable the "delete" action for this entity or configure the "cascade={"remove"}" attribute for the related property in the Doctrine entity.', $parameters['entity_name']),
+            sprintf('There is a ForeignKeyConstraintViolationException for the Doctrine entity associated with "%s". Solution: disable the "delete" action for this entity or configure the "cascade={"remove"}" attribute for the related property in the Doctrine entity. Full exception: %s', $parameters['entity_name'], $parameters['message']),
             $parameters,
             404
         );


### PR DESCRIPTION
This fixes #1775.

### Before

```
There is a ForeignKeyConstraintViolationException for the Doctrine entity associated with 
"Category". Solution: disable the "delete" action for this entity or configure the "cascade=
{"remove"}" attribute for the related property in the Doctrine entity.
```

### After

```
There is a ForeignKeyConstraintViolationException for the Doctrine entity associated with 
"Category". Solution: disable the "delete" action for this entity or configure the "cascade=
{"remove"}" attribute for the related property in the Doctrine entity. Full exception: An
exception  occurred while executing 'DELETE FROM category WHERE id = ?' with params [2]:

SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a 
foreign key constraint fails (`easyadmindemo`.`category`, CONSTRAINT 
`FK_64C19C1727ACA70` FOREIGN KEY (`parent_id`) REFERENCES `category` (`id`))
```