### PR TITLE
Doc: inveted quotes in some examples

### DIFF
--- a/Resources/doc/book/list-search-show-configuration.rst
+++ b/Resources/doc/book/list-search-show-configuration.rst
@@ -522,7 +522,7 @@ put anything that is considered valid as a ``WHERE`` clause in a Doctrine query)
             UrgentIssues:
                 class: AppBundle\Entity\Issue
                 list:
-                    dql_filter: 'entity.label = "CRITICAL" OR entity.priority > 4'
+                    dql_filter: "entity.label = 'CRITICAL' OR entity.priority > 4"
             ImportantIssues:
                 class: AppBundle\Entity\Issue
                 list:
@@ -546,7 +546,7 @@ put anything that is considered valid as a ``WHERE`` clause in a Doctrine query)
                         dql_filter: "LOWER(entity.title) LIKE '%%issue%%'"
                     search:
                         # defining a different condition than 'list'
-                        dql_filter: 'entity.status != "DELETED"'
+                        dql_filter: "entity.status != 'DELETED'"
                         # using an empty value to not apply any condition when searching
                         # elements (this prevents inheriting the 'dql_filter' value defined in 'list')
                         dql_filter: ''


### PR DESCRIPTION
The examples as they were did not work for me, but inverting the quotes does

<!-- Note: all your contributions adhere implicitly to the MIT license -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/javiereguiluz/easyadminbundle/1793)
<!-- Reviewable:end -->
