### PR TITLE
New global configuration option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -172,6 +172,11 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('EasyAdmin')
                     ->info('The name displayed as the title of the administration zone (e.g. company name, project name).')
                 ->end()
+                
+                ->scalarNode('site_name_route')
+                    ->defaultValue('easyAdmin')
+                    ->info('The route that site_name points to.')
+                ->end()
 
                 ->arrayNode('formats')
                     ->addDefaultsIfNotSet()

--- a/Resources/views/default/layout.html.twig
+++ b/Resources/views/default/layout.html.twig
@@ -67,7 +67,7 @@
 
                     <div id="header-logo">
                         {% block header_logo %}
-                            <a class="logo {{ easyadmin_config('site_name')|length > 14 ? 'logo-long' }}" title="{{ easyadmin_config('site_name')|striptags }}" href="{{ path('easyadmin') }}">
+                            <a class="logo {{ easyadmin_config('site_name')|length > 14 ? 'logo-long' }}" title="{{ easyadmin_config('site_name')|striptags }}" href="{{ path(easyadmin_config('site_name_route')) }}">
                                 {{ easyadmin_config('site_name')|raw }}
                             </a>
                         {% endblock header_logo %}


### PR DESCRIPTION
The goal of this new configuration option is to give the user of this bundle the ability to change the default route that site_name points to (which is by default easyadmin).
Now instead of overriding the layout template just to change the href of the header logo, it can be simply configured like this in config.yml: 
```yaml
easy_admin:
    site_name_route: 'homepage'
```
<!-- Note: all your contributions adhere implicitly to the MIT license -->
