### PR TITLE
Updated README with new 1.17 namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ class AppKernel extends Kernel
     {
         $bundles = array(
             // ...
-            new JavierEguiluz\Bundle\EasyAdminBundle\EasyAdminBundle(),
+            new EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle(),
         );
     }
 


### PR DESCRIPTION
Updated the Installation section in the README file to reflect the namespace change introduced in the 1.17 version, so a deprecation notice isn't triggered.