### PR TITLE
Use ArgumentResolver for actions.

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -88,10 +88,9 @@ class AdminController extends Controller
      */
     public function __call($name, $arguments)
     {
-        if ($method = $this->getDefaultActionName($name)) {
-            if (method_exists($this, $method)) {
-                return call_user_func_array(array($this, $method), $arguments);
-            }
+        $method = $this->getDefaultActionName($name);
+        if ($method && method_exists($this, $method)) {
+            return call_user_func_array(array($this, $method), $arguments);
         }
 
         throw new \BadMethodCallException(sprintf('Undefined method "%s"', $name));

--- a/src/Controller/ArgumentResolver.php
+++ b/src/Controller/ArgumentResolver.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
+
+/**
+ * Wrapper to access private service argument_resolver as public
+ *
+ * @author Konstantin Grachev <me@grachevko.ru>
+ */
+final class ArgumentResolver implements ArgumentResolverInterface
+{
+    /**
+     * @var ArgumentResolverInterface
+     */
+    private $argumentResolver;
+
+    public function __construct(ArgumentResolverInterface $argumentResolver)
+    {
+        $this->argumentResolver = $argumentResolver;
+    }
+
+    public function getArguments(Request $request, $controller)
+    {
+        return $this->argumentResolver->getArguments($request, $controller);
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -20,6 +20,10 @@
             <argument>%kernel.debug%</argument>
         </service>
 
+        <service id="easyadmin.controller.argument_resolver" class="EasyCorp\Bundle\EasyAdminBundle\Controller\ArgumentResolver">
+            <argument type="service" id="argument_resolver" />
+        </service>
+
         <service id="easyadmin.query_builder" class="EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder">
             <argument type="service" id="doctrine" />
         </service>


### PR DESCRIPTION
Renaming default actions is need to allow change signature in user code.

No BC breaks, but calls like `parent::listAction()` in user code will mark in IDE as `method not found`

WDYTH?

todo: add compatibility to old symfony versions