### PR TITLE
Removed CSS stylesheets related to legacy browsers

### DIFF
--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -47,11 +47,6 @@
             <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/bootstrap-rtl.min.css') }}">
             <link rel="stylesheet" href="{{ asset('bundles/easyadmin/stylesheet/adminlte-rtl.min.css') }}">
         {% endif %}
-
-        <!--[if lt IE 9]>
-            <script src="{{ asset('bundles/easyadmin/stylesheet/html5shiv.min.css') }}"></script>
-            <script src="{{ asset('bundles/easyadmin/stylesheet/respond.min.css') }}"></script>
-        <![endif]-->
     </head>
 
     {% block body %}


### PR DESCRIPTION
I was going to fix #1622 ... but then I thought, does it make sense to try to support these legacy browsers? Let's remove this and if someone needs this, they can easily add these CSS using the `design.assets.css` option as explained in https://symfony.com/doc/master/bundles/EasyAdminBundle/book/design-configuration.html#adding-custom-web-assets