### PR TITLE
Fix the overriding of the action configuration

### DIFF
--- a/src/Configuration/ActionConfigPass.php
+++ b/src/Configuration/ActionConfigPass.php
@@ -187,8 +187,7 @@ class ActionConfigPass implements ConfigPassInterface
                     if ('-' === $backendAction['name'][0]) {
                         $actionName = substr($backendAction['name'], 1);
 
-                        unset($backendActions[$actionName]);
-                        unset($backendActions['-'.$actionName]);
+                        unset($backendActions[$actionName], $backendActions['-'.$actionName]);
 
                         // unless the entity explicitly adds this globally removed action, remove it from the
                         // default actions config to avoid adding it to the entity later when merging everything
@@ -203,9 +202,7 @@ class ActionConfigPass implements ConfigPassInterface
                     if ('-' === $entityAction['name'][0]) {
                         $actionName = substr($entityAction['name'], 1);
 
-                        unset($entityActions[$actionName]);
-                        unset($entityActions['-'.$actionName]);
-                        unset($defaultActions[$actionName]);
+                        unset($entityActions[$actionName], $entityActions['-'.$actionName], $defaultActions[$actionName]);
                     }
                 }
 

--- a/tests/Controller/ActionOverrideTest.php
+++ b/tests/Controller/ActionOverrideTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+
+class ActionOverrideTest extends AbstractTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initClient(array('environment' => 'action_override'));
+    }
+
+    public function testListViewActions()
+    {
+        $crawler = $this->requestListView();
+
+        $this->assertCount(15, $crawler->filter('table a:contains("Edit")'));
+    }
+
+    public function testEditViewActions()
+    {
+        $crawler = $this->requestEditView();
+
+        $this->assertCount(1, $crawler->filter('.form-actions a:contains("Back to listing")'));
+    }
+
+    public function testShowViewActions()
+    {
+        $crawler = $this->requestShowView();
+
+        $this->assertCount(1, $crawler->filter('.form-actions a:contains("Delete")'));
+    }
+
+    public function testNewViewActions()
+    {
+        $crawler = $this->requestNewView();
+
+        $this->assertCount(1, $crawler->filter('.form-actions a:contains("Back to listing")'));
+    }
+}

--- a/tests/Fixtures/App/config/config_action_override.yml
+++ b/tests/Fixtures/App/config/config_action_override.yml
@@ -1,0 +1,23 @@
+imports:
+    - { resource: config.yml }
+
+easy_admin:
+    list:
+        actions: ['-edit']
+    edit:
+        actions: ['-list']
+    show:
+        actions: ['-delete']
+    new:
+        actions: ['-list']
+    entities:
+        Category:
+            class: AppTestBundle\Entity\FunctionalTests\Category
+            list:
+                actions: ['edit']
+            edit:
+                actions: ['list']
+            show:
+                actions: ['delete']
+            new:
+                actions: ['list']


### PR DESCRIPTION
This fixes #1701.

-----

The overriding of actions didn't work as explained in the docs: https://symfony.com/doc/master/bundles/EasyAdminBundle/book/actions-configuration.html#removing-actions-per-entity

I did my best to make the code understandable ... but the feature is a bit hard to understand because of the multiple level overriding.