### PR TITLE
removed a deprecation warning

### DIFF
--- a/src/Configuration/PropertyConfigPass.php
+++ b/src/Configuration/PropertyConfigPass.php
@@ -11,7 +11,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Configuration;
 
-use JavierEguiluz\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
 use Symfony\Component\Form\FormRegistryInterface;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;


### PR DESCRIPTION
I did a `composer update` to update all the things in one of my Symfony projects, but there was a deprecation warning that can only be resolved here in the sources.

> User Deprecated: The JavierEguiluz\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper class is deprecated since version 1.16 and will be removed in 2.0. Use the EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper class instead.