### PR TITLE
Fixed "undedined index: associationType" error in autocomplete type

### DIFF
--- a/src/Form/Type/Configurator/AutocompleteTypeConfigurator.php
+++ b/src/Form/Type/Configurator/AutocompleteTypeConfigurator.php
@@ -34,7 +34,7 @@ class AutocompleteTypeConfigurator implements TypeConfiguratorInterface
         }
 
         // by default, allow to autocomplete multiple values for OneToMany and ManyToMany associations
-        if (!isset($options['multiple']) && $metadata['associationType'] & ClassMetadata::TO_MANY) {
+        if (!isset($options['multiple']) && isset($metadata['associationType']) && $metadata['associationType'] & ClassMetadata::TO_MANY) {
             $options['multiple'] = true;
         }
 


### PR DESCRIPTION
Although I cannot reproduce #1709, this change makes code more robust and hopefully it will fix the mentioned issue.