### PR TITLE
Change cast from string to int on editAction for new boolean value

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -195,7 +195,7 @@ class AdminController extends Controller
 
             $this->updateEntityProperty($entity, $property, $newValue);
 
-            return new Response((string) $newValue);
+            return new Response((int) $newValue);
         }
 
         $fields = $this->entity['edit']['fields'];

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -194,7 +194,8 @@ class AdminController extends Controller
             }
 
             $this->updateEntityProperty($entity, $property, $newValue);
-
+    
+            // cast to integer instead of string to avoid sending empty responses for 'false'
             return new Response((int) $newValue);
         }
 


### PR DESCRIPTION
Hi,

This PR resolves a little bug on editAction for a boolean field from list page.
When trying to disable the switch (toggle off) two requests are sents:

<img width="1173" alt="screen shot 2017-10-06 at 16 51 04" src="https://user-images.githubusercontent.com/4582866/31283763-ce7f96bc-aab6-11e7-96ef-314e8bebf1b9.png">


The controller `AdminController` sends a empty response for `false` boolean
```
(string) true => 1
(string) false =>       (empty string)
```
and with empty response it's handled by `fail` and not by `done`.

list.html.twig::210
```
var toggleRequest = $.ajax({ type: "GET", url: toggleUrl, data: {} });

toggleRequest.done(function(result) {});

toggleRequest.fail(function() {
  toggle.bootstrapToggle(oldValue == true ? 'on' : 'off');
  toggle.bootstrapToggle('disable');
});
```

