### PR TITLE
Allow using short form types in the 'entry_type' of collections

### DIFF
--- a/src/Form/Type/Configurator/CollectionTypeConfigurator.php
+++ b/src/Form/Type/Configurator/CollectionTypeConfigurator.php
@@ -11,6 +11,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\Type\Configurator;
 
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
 use Symfony\Component\Form\FormConfigInterface;
 
 /**
@@ -39,6 +40,11 @@ class CollectionTypeConfigurator implements TypeConfiguratorInterface
             if (!isset($options['delete_empty'])) {
                 $options['delete_empty'] = true;
             }
+        }
+
+        // allow using short form types as the 'entry_type' of the collection
+        if (isset($options['entry_type'])) {
+            $options['entry_type'] = LegacyFormHelper::getType($options['entry_type']);
         }
 
         return $options;


### PR DESCRIPTION
This fixes #1635. Is there any other form option where we could do the same? Thanks!