### PR TITLE
Fix autocomplete form type

### DIFF
--- a/src/Form/EventListener/EasyAdminAutocompleteSubscriber.php
+++ b/src/Form/EventListener/EasyAdminAutocompleteSubscriber.php
@@ -54,21 +54,26 @@ class EasyAdminAutocompleteSubscriber implements EventSubscriberInterface
             $options['choices'] = array();
         } else {
             $options['choices'] = $options['em']->getRepository($options['class'])->findBy(array(
-                $options['id_reader']->getIdField() => $data['autocomplete'],
+                $this->getIdField($options) => $data['autocomplete'],
             ));
         }
 
-        if (isset($options['choice_list'])) {
-            // clear choice list for SF < 3.0
-            $options['choice_list'] = null;
-        }
-
-        if (!empty($options['choices_as_values'])) {
-            // avoid deprecation notice since SF 3.1 until 4.0
-            $options['choices_as_values'] = null;
-        }
+        // reset some critical lazy options
+        unset($options['em'], $options['loader'], $options['empty_data'], $options['choice_list'], $options['choices_as_values']);
 
         $form->add('autocomplete', LegacyFormHelper::getType('entity'), $options);
+    }
+
+    private function getIdField(array $options)
+    {
+        if (isset($options['id_reader'])) {
+            $idField = $options['id_reader']->getIdField();
+        } else {
+            // BC for 2.3
+            $idField = current($options['em']->getClassMetadata($options['class'])->getIdentifierFieldNames());
+        }
+
+        return $idField;
     }
 }
 

--- a/src/Form/EventListener/EasyAdminAutocompleteSubscriber.php
+++ b/src/Form/EventListener/EasyAdminAutocompleteSubscriber.php
@@ -46,21 +46,26 @@ class EasyAdminAutocompleteSubscriber implements EventSubscriberInterface
 
     public function preSubmit(FormEvent $event)
     {
+        $data = $event->getData();
         $form = $event->getForm();
-
-        if (null === $data = $event->getData()) {
-            $data = array('autocomplete' => array());
-            $event->setData($data);
-        }
-
         $options = $form->get('autocomplete')->getConfig()->getOptions();
-        $options['choices'] = $options['em']->getRepository($options['class'])->findBy(array(
-            $options['id_reader']->getIdField() => $data['autocomplete'],
-        ));
+
+        if (!isset($data['autocomplete']) || '' === $data['autocomplete']) {
+            $options['choices'] = array();
+        } else {
+            $options['choices'] = $options['em']->getRepository($options['class'])->findBy(array(
+                $options['id_reader']->getIdField() => $data['autocomplete'],
+            ));
+        }
 
         if (isset($options['choice_list'])) {
             // clear choice list for SF < 3.0
             $options['choice_list'] = null;
+        }
+
+        if (!empty($options['choices_as_values'])) {
+            // avoid deprecation notice since SF 3.1 until 4.0
+            $options['choices_as_values'] = null;
         }
 
         $form->add('autocomplete', LegacyFormHelper::getType('entity'), $options);

--- a/src/Form/Type/EasyAdminAutocompleteType.php
+++ b/src/Form/Type/EasyAdminAutocompleteType.php
@@ -18,7 +18,6 @@ use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -72,15 +71,10 @@ class EasyAdminAutocompleteType extends AbstractType implements DataMapperInterf
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $emptyData = function (Options $options) {
-            return $options['multiple'] ? array() : '';
-        };
-
         $resolver->setDefaults(array(
             'multiple' => false,
             // force display errors on this form field
             'error_bubbling' => false,
-            'empty_data' => $emptyData,
         ));
 
         $resolver->setRequired(array('class'));
@@ -113,9 +107,8 @@ class EasyAdminAutocompleteType extends AbstractType implements DataMapperInterf
      */
     public function mapDataToForms($data, $forms)
     {
-        $forms = iterator_to_array($forms);
-
-        $forms['autocomplete']->setData($data);
+        $form = current(iterator_to_array($forms));
+        $form->setData($data);
     }
 
     /**
@@ -123,9 +116,8 @@ class EasyAdminAutocompleteType extends AbstractType implements DataMapperInterf
      */
     public function mapFormsToData($forms, &$data)
     {
-        $forms = iterator_to_array($forms);
-
-        $data = $forms['autocomplete']->getData();
+        $form = current(iterator_to_array($forms));
+        $data = $form->getData();
     }
 }
 

--- a/src/Form/Type/EasyAdminAutocompleteType.php
+++ b/src/Form/Type/EasyAdminAutocompleteType.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\DataMapperInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -28,7 +29,6 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
  */
 class EasyAdminAutocompleteType extends AbstractType implements DataMapperInterface
 {
-    /** @var ConfigManager */
     private $configManager;
 
     public function __construct(ConfigManager $configManager)
@@ -72,10 +72,15 @@ class EasyAdminAutocompleteType extends AbstractType implements DataMapperInterf
      */
     public function configureOptions(OptionsResolver $resolver)
     {
+        $emptyData = function (Options $options) {
+            return $options['multiple'] ? array() : '';
+        };
+
         $resolver->setDefaults(array(
             'multiple' => false,
             // force display errors on this form field
             'error_bubbling' => false,
+            'empty_data' => $emptyData,
         ));
 
         $resolver->setRequired(array('class'));

--- a/tests/Fixtures/AppTestBundle/Entity/UnitTests/Category.php
+++ b/tests/Fixtures/AppTestBundle/Entity/UnitTests/Category.php
@@ -15,4 +15,9 @@ class Category
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     public $id;
+
+    public function __toString()
+    {
+        return (string) $this->id;
+    }
 }

--- a/tests/Form/Type/EasyAdminAutocompleteTypeTest.php
+++ b/tests/Form/Type/EasyAdminAutocompleteTypeTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Type;
+
+use AppTestBundle\Entity\UnitTests\Category;
+use Doctrine\Common\Collections\ArrayCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminAutocompleteType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class EasyAdminAutocompleteTypeTest extends TypeTestCase
+{
+    const ENTITY_CLASS = 'AppTestBundle\Entity\UnitTests\Category';
+
+    private $doctrine;
+    private $entityManager;
+    private $classMetadata;
+    private $repository;
+    private $configManager;
+
+    protected function setUp()
+    {
+        $this->repository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->classMetadata = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->classMetadata
+            ->expects($this->any())
+            ->method('getIdentifierFieldNames')
+            ->willReturn(array('id'));
+        $this->classMetadata
+            ->expects($this->any())
+            ->method('getTypeOfField')
+            ->willReturn('integer');
+
+        $this->entityManager = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->entityManager
+            ->expects($this->any())
+            ->method('getRepository')
+            ->with(self::ENTITY_CLASS)
+            ->willReturn($this->repository);
+        $this->entityManager
+            ->expects($this->any())
+            ->method('getClassMetadata')
+            ->with(self::ENTITY_CLASS)
+            ->willReturn($this->classMetadata);
+
+        $this->doctrine = $this->getMockBuilder('Doctrine\Bundle\DoctrineBundle\Registry')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->doctrine
+            ->expects($this->any())
+            ->method('getManagerForClass')
+            ->with(self::ENTITY_CLASS)
+            ->willReturn($this->entityManager);
+
+        $this->configManager = $this->getMockBuilder('EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->configManager
+            ->expects($this->any())
+            ->method('getEntityConfigByClass')
+            ->with(self::ENTITY_CLASS)
+            ->willReturn(array('name' => 'Category'));
+
+        parent::setUp();
+    }
+
+    protected function getExtensions()
+    {
+        $types = array(
+            'entity' => new EntityType($this->doctrine),
+            'easyadmin_autocomplete' => new EasyAdminAutocompleteType($this->configManager),
+        );
+
+        return array(
+            new PreloadedExtension($types, array()),
+        );
+    }
+
+    public function testSubmitValidSingleData()
+    {
+        $category = new Category();
+        $category->id = 1;
+
+        $this->entityManager
+            ->expects($this->any())
+            ->method('contains')
+            ->with($category)
+            ->willReturn(true);
+
+        $this->repository
+            ->expects($this->any())
+            ->method('findBy')
+            ->willReturn(array($category));
+
+        $this->classMetadata
+            ->expects($this->any())
+            ->method('getIdentifierValues')
+            ->with($category)
+            ->willReturn(array('id' => $category->id));
+
+        $form = $this->factory->create(LegacyFormHelper::getType('easyadmin_autocomplete'), null, array(
+            'class' => self::ENTITY_CLASS,
+        ));
+        $formData = array('autocomplete' => '1');
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertSame($category, $form->getData());
+
+        $view = $form->createView();
+        $children = $view->children;
+        foreach (array_keys($formData) as $key) {
+            $this->assertArrayHasKey($key, $children);
+        }
+
+        if (class_exists('Symfony\Component\Form\ChoiceList\View\ChoiceView', false)) {
+            $choiceView = new \Symfony\Component\Form\ChoiceList\View\ChoiceView($category, 1, '1');
+        } else {
+            $choiceView = new \Symfony\Component\Form\Extension\Core\View\ChoiceView($category, 1, '1');
+        }
+
+        $this->assertEquals(array('1' => $choiceView), $children['autocomplete']->vars['choices']);
+    }
+
+    public function testSubmitValidMultipleData()
+    {
+        $category1 = new Category();
+        $category1->id = 1;
+
+        $this->entityManager
+            ->expects($this->any())
+            ->method('contains')
+            ->with($category1)
+            ->willReturn(true);
+
+        $this->repository
+            ->expects($this->any())
+            ->method('findBy')
+            ->withAnyParameters()
+            ->willReturn(array($category1));
+
+        $this->classMetadata
+            ->expects($this->any())
+            ->method('getIdentifierValues')
+            ->with($category1)
+            ->willReturn(array('id' => $category1->id));
+
+        $form = $this->factory->create(LegacyFormHelper::getType('easyadmin_autocomplete'), null, array(
+            'class' => self::ENTITY_CLASS,
+            'multiple' => true,
+        ));
+        $form->submit(array('autocomplete' => array('1')));
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals(new ArrayCollection(array($category1)), $form->getData());
+    }
+
+    public function testSubmitEmptySingleData()
+    {
+        $form = $this->factory->create(LegacyFormHelper::getType('easyadmin_autocomplete'), null, array(
+            'class' => self::ENTITY_CLASS,
+        ));
+        $form->submit(array('autocomplete' => ''));
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertNull($form->getData());
+    }
+
+    public function testSubmitEmptyMultipleData()
+    {
+        $form = $this->factory->create(LegacyFormHelper::getType('easyadmin_autocomplete'), null, array(
+            'class' => self::ENTITY_CLASS,
+            'multiple' => true,
+        ));
+        $form->submit(null);
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertEquals(new ArrayCollection(), $form->getData());
+    }
+}


### PR DESCRIPTION
Fixes #1845

* Avoid useless DB query if the submitted data is empty.
* Added BC for Symfony 2.3
    - Avoid indirect deprecation notice over `choices_as_value` option (#1751 he was right).
* Added unit tests.

