### PR TITLE
Fix Symfony DataCollector deprecation for reset() method

### DIFF
--- a/src/DataCollector/EasyAdminDataCollector.php
+++ b/src/DataCollector/EasyAdminDataCollector.php
@@ -33,6 +33,14 @@ class EasyAdminDataCollector extends DataCollector
     public function __construct(ConfigManager $configManager)
     {
         $this->configManager = $configManager;
+        $this->reset();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
         $this->data = array(
             'num_entities' => 0,
             'request_parameters' => null,

--- a/tests/DataCollector/EasyAdminDataCollectorTest.php
+++ b/tests/DataCollector/EasyAdminDataCollectorTest.php
@@ -77,4 +77,15 @@ class EasyAdminDataCollectorTest extends AbstractTestCase
         $backendConfig = $collector->getBackendConfig();
         $this->assertCount(5, $backendConfig['entities']);
     }
+
+    public function testCollectorReset()
+    {
+        $this->client->enableProfiler();
+        $this->requestListView();
+        $collector = $this->client->getProfile()->getCollector('easyadmin');
+
+        $this->assertSame(5, $collector->getNumEntities());
+        $collector->reset();
+        $this->assertSame(0, $collector->getNumEntities());
+    }
 }


### PR DESCRIPTION
This PR will remove the `Implementing "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface" without the "reset()" method is deprecated since version 3.4 and will be unsupported in 4.0 for class` warning when using EasyAdminBundle with Symfony 3.4.