### PR TITLE
Add support for objects as the value of entity associations primary keys

### DIFF
--- a/src/Resources/views/default/field_association.html.twig
+++ b/src/Resources/views/default/field_association.html.twig
@@ -6,7 +6,8 @@
                 {% for item in value|slice(0, easyadmin_config('show.max_results')) %}
                     <li>
                         {% if link_parameters is defined %}
-                            {% set primary_key_value = attribute(item, link_parameters.primary_key_name) %}
+                            {# the empty string concatenation is needed when the primary key is an object (e.g. an Uuid object) #}
+                            {% set primary_key_value = '' ~ attribute(item, link_parameters.primary_key_name) %}
                             <a href="{{ path('easyadmin', link_parameters|merge({ id: primary_key_value, referer: '' })) }}">{{ item }}</a>
                         {% else %}
                             {{ item }}


### PR DESCRIPTION
Needed to correctly display links to the associated *_TO_MANY entities. 
I've done it the same way as here: https://github.com/javiereguiluz/EasyAdminBundle/commit/d28817898a2ad0077e71a6359b85e96f7fe14d3e