### PR TITLE
Removed the Twig::getName() deprecation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/twig-bundle": "~2.3|~3.0|~4.0",
         "symfony/validator": "~2.3|~3.0|~4.0",
         "twig/extensions": "~1.0",
-        "twig/twig": "~1.14,>=1.14.2|~2.0"
+        "twig/twig": "~1.26|~2.0"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle" : "~2.2",

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -426,14 +426,6 @@ class EasyAdminTwigExtension extends \Twig_Extension
 
         return $className;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'easyadmin_extension';
-    }
 }
 
 class_alias('EasyCorp\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension', 'JavierEguiluz\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension', false);


### PR DESCRIPTION
This tries to fix this deprecation:

```
The "Twig_Extension::getName()" method is deprecated since 1.26
(to be removed in 2.0), not used anymore internally.
```

See https://github.com/symfony/symfony/issues/24522 for the related Symfony issue.