### PR TITLE
Fix EntityType configurator

### DIFF
--- a/src/Form/Type/Configurator/EntityTypeConfigurator.php
+++ b/src/Form/Type/Configurator/EntityTypeConfigurator.php
@@ -28,8 +28,8 @@ class EntityTypeConfigurator implements TypeConfiguratorInterface
      */
     public function configure($name, array $options, array $metadata, FormConfigInterface $parentConfig)
     {
-        if ($metadata['associationType'] & ClassMetadata::TO_MANY) {
-            $options['attr']['multiple'] = true;
+        if (!isset($options['multiple']) && $metadata['associationType'] & ClassMetadata::TO_MANY) {
+            $options['multiple'] = true;
         }
 
         // Supported associations are displayed using advanced JavaScript widgets
@@ -53,7 +53,7 @@ class EntityTypeConfigurator implements TypeConfiguratorInterface
     {
         $isEntityType = in_array($type, array('entity', 'Symfony\Bridge\Doctrine\Form\Type\EntityType'), true);
 
-        return $isEntityType && 'association' === $metadata['type'];
+        return $isEntityType && 'association' === $metadata['dataType'];
     }
 
     /**


### PR DESCRIPTION
https://github.com/javiereguiluz/EasyAdminBundle/blob/0a343943b25e973e383c30aab0ce75ed55b3d0ff/src/Configuration/PropertyConfigPass.php#L36-L37
https://github.com/javiereguiluz/EasyAdminBundle/blob/0a343943b25e973e383c30aab0ce75ed55b3d0ff/src/Configuration/PropertyConfigPass.php#L40-L41
So `$metadata['type']` will never contain this value: `association`.

Also `multiple` option should be used instead of `'attr' => ['multiple' => true]`. This enable select2 plugins when `entity` type is configured manually too.


