### PR TITLE
Display boolean properties as toggles unless defined explicitly

### DIFF
--- a/src/Configuration/PropertyConfigPass.php
+++ b/src/Configuration/PropertyConfigPass.php
@@ -199,6 +199,17 @@ class PropertyConfigPass implements ConfigPassInterface
                         );
                     }
 
+                    // special case for the 'list' view: 'boolean' properties are displayed
+                    // as toggleable flip switches when certain conditions are met
+                    if ('list' === $view && 'boolean' === $normalizedConfig['dataType']) {
+                        // conditions:
+                        //   1) the end-user hasn't configured the field type explicitly
+                        //   2) the 'edit' action is enabled for the 'list' view of this entity
+                        if (!isset($originalFieldConfig['type']) && !in_array('edit', $entityConfig['disabled_actions'])) {
+                            $normalizedConfig['dataType'] = 'toggle';
+                        }
+                    }
+
                     if (null === $normalizedConfig['format']) {
                         $normalizedConfig['format'] = $this->getFieldFormat($normalizedConfig['type'], $backendConfig);
                     }

--- a/tests/Controller/DefaultBackendTest.php
+++ b/tests/Controller/DefaultBackendTest.php
@@ -258,6 +258,14 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertRegExp('/\d{2}:\d{2}/', trim($crawler->filter('#main table tr')->eq(1)->filter('td.time')->text()));
     }
 
+    public function testListViewBooleanToggles()
+    {
+        $crawler = $this->requestListView('Product');
+
+        $this->assertCount(15, $crawler->filter('td[data-label="Enabled"].toggle'), 'Boolean properties are displayed with a toggle widget unless configured explicitly.');
+        $this->assertCount(0, $crawler->filter('td[data-label="Enabled"].boolean'));
+    }
+
     public function testShowViewPageTitle()
     {
         $crawler = $this->requestShowView();


### PR DESCRIPTION
This fixes #1893.