### PR TITLE
Call preUpdate() method when editing entities via Ajax too

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -405,6 +405,7 @@ class AdminController extends Controller
         $this->dispatch(EasyAdminEvents::PRE_UPDATE, array('entity' => $entity, 'newValue' => $value));
 
         $this->get('property_accessor')->setValue($entity, $property, $value);
+        $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity));
 
         $this->em->persist($entity);
         $this->em->flush();


### PR DESCRIPTION
This fixes #1600.

We call this method when editing an entity via a Symfony form ... so we should do the same when editing some of its properties via the boolean toggles displayed on listings.