### PR TITLE
Make action column in list view as small as possible

### DIFF
--- a/src/Resources/views/css/easyadmin.css.twig
+++ b/src/Resources/views/css/easyadmin.css.twig
@@ -1330,6 +1330,10 @@ body.error .error-message {
         border-top: 1px solid {{ colors.table_row_border }};
         display: table-cell;
     }
+    body.list table tbody td:last-child {
+        white-space: nowrap;
+        width: 1%;
+    }
     table td:before {
         content: none;
         float: none;


### PR DESCRIPTION
Before:

<img width="719" alt="before" src="https://user-images.githubusercontent.com/1752683/32406908-bf31cc1c-c180-11e7-97d2-993a4208dce1.png">

After:

<img width="719" alt="after" src="https://user-images.githubusercontent.com/1752683/32406915-c5885d4c-c180-11e7-81ce-a4dcd7a19d13.png">

This way the action column always has the same width. I think it looks better this way. Let me know what you think.