### PR TITLE
Fixed a CSS issue in Firefox for boolean flip switches

### DIFF
--- a/src/Resources/views/css/easyadmin.css.twig
+++ b/src/Resources/views/css/easyadmin.css.twig
@@ -158,6 +158,11 @@ div.flash-error strong {
 
 {# Switches / toggles
    ------------------------------------------------------------------------- #}
+{# needed to neutralize the default .toggle styles applied by Bootstrap Toggle
+   which collide with the .toggle class applied to <th> too #}
+.toggle { position: initial; }
+.toggle:not(th) { position: relative; }
+
 .toggle.btn-xs {
  width: 44px;
 }


### PR DESCRIPTION
This fixes #1909. The border is now displayed as any other browser:

![firefox-css-issue](https://user-images.githubusercontent.com/73419/32460376-e504fd8e-c332-11e7-95cf-431d8e377282.png)
