### PR TITLE
add a build job for Symfony 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ matrix:
       env:
         - SYMFONY_VERSION="2.8.*"
         - ENABLE_CODE_COVERAGE="true"
+    # Symfony 3 LTS
+    - php: 7.1
+      env:
+        - SYMFONY_VERSION="3.4.*"
+        - STABILITY=beta
+        - SYMFONY_DEPRECATIONS_HELPER="strict"
     # legacy (oldest supported versions)
     - php: 5.3
       env:
@@ -59,6 +65,7 @@ before_install:
   - composer self-update
   - if [[ "$SYMFONY_VERSION" != "" ]]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
   - if [[ "$TWIG_VERSION" != "" ]]; then composer require "twig/twig:${TWIG_VERSION}" --no-update; fi;
+  - if [[ "$STABILITY" != "" ]]; then composer config minimum-stability $STABILITY; fi
 
 install:
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then composer require --dev --no-update friendsofphp/php-cs-fixer; fi;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,7 @@
 
     <php>
         <server name="KERNEL_DIR" value="./tests/Fixtures/App" />
+        <server name="KERNEL_CLASS" value="\AppKernel" />
         <ini name="error_reporting" value="E_ALL" />
         <ini name="display_errors" value="1" />
         <ini name="display_startup_errors" value="1" />

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -399,13 +399,13 @@ class AdminController extends Controller
         $entityConfig = $this->entity;
 
         // the method_exists() check is needed because Symfony 2.3 doesn't have isWritable() method
-        if (method_exists($this->get('property_accessor'), 'isWritable') && !$this->get('property_accessor')->isWritable($entity, $property)) {
+        if (method_exists($this->get('easy_admin.property_accessor'), 'isWritable') && !$this->get('easy_admin.property_accessor')->isWritable($entity, $property)) {
             throw new \RuntimeException(sprintf('The "%s" property of the "%s" entity is not writable.', $property, $entityConfig['name']));
         }
 
         $this->dispatch(EasyAdminEvents::PRE_UPDATE, array('entity' => $entity, 'newValue' => $value));
 
-        $this->get('property_accessor')->setValue($entity, $property, $value);
+        $this->get('easy_admin.property_accessor')->setValue($entity, $property, $value);
         $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity));
 
         $this->em->persist($entity);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -122,5 +122,7 @@
         <service id="easyadmin.configuration.default_config_pass" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\DefaultConfigPass" public="false">
             <tag name="easyadmin.config_pass" priority="10" />
         </service>
+
+        <service id="easy_admin.property_accessor" alias="property_accessor" public="true" />
     </services>
 </container>

--- a/tests/Fixtures/App/config/config_custom_entity_controller_service.yml
+++ b/tests/Fixtures/App/config/config_custom_entity_controller_service.yml
@@ -12,3 +12,4 @@ services:
         class: EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin\CustomCategoryControllerAsService
         # TODO: when Symfony 2.3 support is dropped, we can inject @reuqest_stack instead of the entire container
         arguments: ['@service_container']
+        public: true

--- a/tests/Fixtures/App/config/config_customized_backend.yml
+++ b/tests/Fixtures/App/config/config_customized_backend.yml
@@ -51,6 +51,7 @@ security:
                 users:
                     admin:
                         password: 'pa$$word'
+                        roles: [ROLE_USER]
     firewalls:
         main:
             pattern:   ^/


### PR DESCRIPTION
To make tests with Symfony 4 pass, we should first make sure that the code is deprecation free when run against Symfony 3.4.

#SymfonyConHackday2017