### PR TITLE
Make specified template more important than resolved ones for properties

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -152,6 +152,10 @@ class EasyAdminTwigExtension extends \Twig_Extension
         }
 
         try {
+            if (isset($fieldMetadata['template'])) {
+                return $twig->render($fieldMetadata['template'], $templateParameters);
+            }
+
             if (null === $templateParameters['value']) {
                 return $twig->render($entityConfiguration['templates']['label_null'], $templateParameters);
             }
@@ -176,7 +180,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
                 return $this->renderVirtualField($templateParameters);
             }
 
-            return $twig->render($fieldMetadata['template'], $templateParameters);
+            throw new \RuntimeException(sprintf('No template found for property %s', $fieldName));
         } catch (\Exception $e) {
             if ($this->debug) {
                 throw $e;


### PR DESCRIPTION
I think this is quite problematic for now to have the `template` property be used as a fallback.

As the compiler pas doesn't set it automatically, I think we can safely consider here that users specifying the `template` option manually for a property do it on purpose.

And if nothing is found, we fall back to an exception, because it's better and should be debugged directly in dev.

WDYT?