### PR TITLE
Move to 1.17.x branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.16.x-dev"
+            "dev-master": "1.17.x-dev"
         }
     }
 }


### PR DESCRIPTION
Because you already pushed a 1.17.x release.