### PR TITLE
Bugfix: Call to a member function render() on null

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -23,8 +23,6 @@ use Symfony\Component\PropertyAccess\PropertyAccessor;
  */
 class EasyAdminTwigExtension extends \Twig_Extension
 {
-    /** @var \Twig_Environment */
-    private $twig;
     /** @var ConfigManager */
     private $configManager;
     /** @var PropertyAccessor */
@@ -153,7 +151,7 @@ class EasyAdminTwigExtension extends \Twig_Extension
             }
 
             if (empty($templateParameters['value']) && in_array($fieldMetadata['dataType'], array('image', 'file', 'array', 'simple_array'))) {
-                return $this->twig->render($templateParameters['entity_config']['templates']['label_empty'], $templateParameters);
+                return $twig->render($templateParameters['entity_config']['templates']['label_empty'], $templateParameters);
             }
 
             return $twig->render($fieldMetadata['template'], $templateParameters);


### PR DESCRIPTION
After update to v1.17.8
![image](https://user-images.githubusercontent.com/8628465/34934285-f86f3260-f9ea-11e7-9521-b2722ea483a4.png)
