### PR TITLE
Fix action url for delete form

### DIFF
--- a/src/Resources/views/default/includes/_delete_form.html.twig
+++ b/src/Resources/views/default/includes/_delete_form.html.twig
@@ -1,6 +1,6 @@
 {{
     form(delete_form, {
-        action: delete_form.vars.action ~ '&referer=' ~ referer,
+        action: delete_form.vars.action ~ ('?' in delete_form.vars.action ? '&' : '?') ~ 'referer=' ~ referer,
         method: 'DELETE',
         attr: { id: 'delete-form', style: 'display: none' }
     })

--- a/src/Resources/views/default/includes/_delete_form.html.twig
+++ b/src/Resources/views/default/includes/_delete_form.html.twig
@@ -1,6 +1,6 @@
 {{
     form(delete_form, {
-        action: delete_form.vars.action ~ ('?' in delete_form.vars.action ? '&' : '?') ~ 'referer=' ~ referer,
+        action: delete_form.vars.action ~ (delete_form.vars.action starts with '?' ? '&' : '?') ~ 'referer=' ~ referer,
         method: 'DELETE',
         attr: { id: 'delete-form', style: 'display: none' }
     })


### PR DESCRIPTION
I have defined this custom route for easyadmin:

```php
    /**
     * @Route("/{entity}/{action}/{id}", name="easyadmin")
     */
    public function indexAction(Request $request, $entity = null, $action = null, $id = null): Response
    {
        // ...
    }
```
and `delete_form.vars.action` doesn't contain ``?``.
