### PR TITLE
Fix doc example

### DIFF
--- a/doc/integration/fosuserbundle.rst
+++ b/doc/integration/fosuserbundle.rst
@@ -37,7 +37,7 @@ override the way users are created and persisted:
         public function persistUserEntity($user)
         {
             $this->get('fos_user.user_manager')->updateUser($user, false);
-            parent::persistUserEntity($user);
+            parent::persistEntity($user);
         }
     }
 
@@ -87,7 +87,7 @@ Therefore, open your AdminController and add the following method:
         public function updateUserEntity($user)
         {
             $this->get('fos_user.user_manager')->updateUser($user, false);
-            parent::updateUserEntity($user);
+            parent::updateEntity($user);
         }
     }
 


### PR DESCRIPTION
Methods `persistUserEntity` and `updateUserEntity` not exist in `EasyCorp\Bundle\EasyAdminBundle\Controller\AdminController`
