### PR TITLE
Fix forced toggle colors

### DIFF
--- a/src/Resources/views/css/easyadmin.css.twig
+++ b/src/Resources/views/css/easyadmin.css.twig
@@ -187,9 +187,6 @@ div.flash-error strong {
 .toggle-group .toggle-on:hover,
 .toggle-group .toggle-on:active,
 .toggle-group .toggle-on:active:hover {
-    background: {{ colors.success }};
-    border-color: {{ colors.success }};
-    color: {{ colors.white }};
     padding: 4px 5px 4px 0;
     border: 0;
 }
@@ -198,9 +195,6 @@ div.flash-error strong {
 .toggle-group .toggle-off:hover,
 .toggle-group .toggle-off:active,
 .toggle-group .toggle-off:active:hover {
-    background: {{ colors.danger }};
-    border-color: {{ colors.danger }};
-    color: {{ colors.white }};
     padding: 4px 0 4px 5px;
     border: 0;
 }


### PR DESCRIPTION
Fix #2030 

Leave Bootstrap styles define colors for toggles, and native color config of bootstraptoggle work.