### PR TITLE
Fix form attribute collision in theme

### DIFF
--- a/src/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/src/Resources/views/form/bootstrap_3_layout.html.twig
@@ -509,7 +509,7 @@
                         {% endif %}
 
                         <div class="row">
-                            {% for field in form.children if 'hidden' not in field.vars.block_prefixes and field.vars.easyadmin.form_group == group_name %}
+                            {% for field in form if 'hidden' not in field.vars.block_prefixes and field.vars.easyadmin.form_group == group_name %}
                                 <div class="col-xs-12 {{ field.vars.easyadmin.field.css_class|default('') }}">
                                     {{ form_row(field) }}
                                 </div>
@@ -519,7 +519,7 @@
                 </div>
             </div>
         {% else %}
-            {% for field in form.children if 'hidden' not in field.vars.block_prefixes %}
+            {% for field in form if 'hidden' not in field.vars.block_prefixes %}
                 <div class="col-xs-12 {{ field.vars.easyadmin.field.css_class|default('') }}">
                     {{ form_row(field) }}
                 </div>


### PR DESCRIPTION
This PR fixes name collision between the "children" attribute and a form field with the same name:
```php
$builder->add('children', ...);
```

See https://github.com/twigphp/Twig/blob/2.x/lib/Twig/Extension/Core.php#L1437-L1445