### PR TITLE
Removed the config of the Coveralls service

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,4 +1,0 @@
-service_name: travis-ci
-src_dir: .
-coverage_clover: build/logs/clover.xml
-


### PR DESCRIPTION
This is another service that we don't really use, so let's remove it. Next we'll remove the code coverage from Travis CI, because it's something that we never look at or use for anything.