### PR TITLE
Initialize Select2 in collections on item-add

### DIFF
--- a/src/Resources/views/default/includes/_select2_widget.html.twig
+++ b/src/Resources/views/default/includes/_select2_widget.html.twig
@@ -7,12 +7,18 @@
 
 <script src="{{ asset('bundles/easyadmin/javascript/select2/i18n/' ~ _select2_locale ~ '.js') }}"></script>
 <script type="text/javascript">
-$(function() {
+  $(function() {
     // Select2 widget is only enabled for the <select> elements which
     // explicitly ask for it
-    $('#main').find('form select[data-widget="select2"]').select2({
+
+    function init() {
+      $('#main').find('form select[data-widget="select2"]').select2({
         theme: 'bootstrap',
         language: '{{ _select2_locale }}'
-    });
-});
+      });
+    }
+
+    $(document).on('easyadmin.collection.item-added', init);
+    init();
+  });
 </script>


### PR DESCRIPTION
Currently select2 initialize only on page load. 
This changes initialize select2 after added items in collection.

This need if collection have field with select2 behaviour.