### PR TITLE
Refactored the LegacyFormHelper into FormTypeHelper

### DIFF
--- a/src/Configuration/PropertyConfigPass.php
+++ b/src/Configuration/PropertyConfigPass.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Configuration;
 
-use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use Symfony\Component\Form\FormRegistryInterface;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
@@ -93,7 +93,7 @@ class PropertyConfigPass implements ConfigPassInterface
                 $requiredGuess = $this->getFormRequiredGuessOfProperty($entityConfig['class'], $propertyName);
 
                 $guessedType = null !== $typeGuess
-                    ? LegacyFormHelper::getShortType($typeGuess->getType())
+                    ? FormTypeHelper::getTypeName($typeGuess->getType())
                     : $propertyMetadata['type'];
 
                 $guessedTypeOptions = null !== $typeGuess

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -10,7 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Exception\EntityRemoveException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\NoEntitiesConfiguredException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
-use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use Pagerfanta\Pagerfanta;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -628,7 +628,7 @@ class AdminController extends Controller
     {
         $formOptions = $this->executeDynamicMethod('get<EntityName>EntityFormOptions', [$entity, $view]);
 
-        return $this->get('form.factory')->createNamedBuilder(mb_strtolower($this->entity['name']), LegacyFormHelper::getType('easyadmin'), $entity, $formOptions);
+        return $this->get('form.factory')->createNamedBuilder(mb_strtolower($this->entity['name']), FormTypeHelper::getTypeClass('easyadmin'), $entity, $formOptions);
     }
 
     /**
@@ -703,9 +703,9 @@ class AdminController extends Controller
             ->setAction($this->generateUrl('easyadmin', ['action' => 'delete', 'entity' => $entityName, 'id' => $entityId]))
             ->setMethod('DELETE')
         ;
-        $formBuilder->add('submit', LegacyFormHelper::getType('submit'), ['label' => 'delete_modal.action', 'translation_domain' => 'EasyAdminBundle']);
+        $formBuilder->add('submit', FormTypeHelper::getTypeClass('submit'), ['label' => 'delete_modal.action', 'translation_domain' => 'EasyAdminBundle']);
         // needed to avoid submitting empty delete forms (see issue #1409)
-        $formBuilder->add('_easyadmin_delete_flag', LegacyFormHelper::getType('hidden'), ['data' => '1']);
+        $formBuilder->add('_easyadmin_delete_flag', FormTypeHelper::getTypeClass('hidden'), ['data' => '1']);
 
         return $formBuilder->getForm();
     }

--- a/src/Form/EventListener/EasyAdminAutocompleteSubscriber.php
+++ b/src/Form/EventListener/EasyAdminAutocompleteSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\EventListener;
 
-use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
@@ -32,7 +32,7 @@ class EasyAdminAutocompleteSubscriber implements EventSubscriberInterface
         $options['compound'] = false;
         $options['choices'] = \is_array($data) || $data instanceof \Traversable ? $data : [$data];
 
-        $form->add('autocomplete', LegacyFormHelper::getType('entity'), $options);
+        $form->add('autocomplete', FormTypeHelper::getTypeClass('entity'), $options);
     }
 
     public function preSubmit(FormEvent $event)
@@ -52,6 +52,6 @@ class EasyAdminAutocompleteSubscriber implements EventSubscriberInterface
         // reset some critical lazy options
         unset($options['em'], $options['loader'], $options['empty_data'], $options['choice_list'], $options['choices_as_values']);
 
-        $form->add('autocomplete', LegacyFormHelper::getType('entity'), $options);
+        $form->add('autocomplete', FormTypeHelper::getTypeClass('entity'), $options);
     }
 }

--- a/src/Form/Extension/EasyAdminExtension.php
+++ b/src/Form/Extension/EasyAdminExtension.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\Extension;
 
-use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -62,6 +62,6 @@ class EasyAdminExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return LegacyFormHelper::getType('form');
+        return FormTypeHelper::getTypeClass('form');
     }
 }

--- a/src/Form/Type/Configurator/CollectionTypeConfigurator.php
+++ b/src/Form/Type/Configurator/CollectionTypeConfigurator.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\Type\Configurator;
 
-use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\FormConfigInterface;
 
@@ -33,7 +33,7 @@ class CollectionTypeConfigurator implements TypeConfiguratorInterface
 
         // allow using short form types as the 'entry_type' of the collection
         if (isset($options['entry_type'])) {
-            $options['entry_type'] = LegacyFormHelper::getType($options['entry_type']);
+            $options['entry_type'] = FormTypeHelper::getTypeClass($options['entry_type']);
         }
 
         return $options;

--- a/src/Form/Type/EasyAdminFormType.php
+++ b/src/Form/Type/EasyAdminFormType.php
@@ -6,7 +6,7 @@ use ArrayObject;
 use EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager;
 use EasyCorp\Bundle\EasyAdminBundle\Form\EventListener\EasyAdminTabSubscriber;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Configurator\TypeConfiguratorInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
@@ -62,7 +62,7 @@ class EasyAdminFormType extends AbstractType
                 }
             }
 
-            $formFieldType = LegacyFormHelper::getType($metadata['fieldType']);
+            $formFieldType = FormTypeHelper::getTypeClass($metadata['fieldType']);
 
             // if the form field is a special 'group' design element, don't add it
             // to the form. Instead, consider it the current form group (this is

--- a/src/Form/Util/FormTypeHelper.php
+++ b/src/Form/Util/FormTypeHelper.php
@@ -131,7 +131,7 @@ final class FormTypeHelper
     {
         // needed to avoid collisions between immutable and non-immutable date types,
         // which are mapped to the same Symfony Form type classes
-        $filteredNameToClassMap = array_filter(self::$nameToClassMap, function($typeName) {
+        $filteredNameToClassMap = array_filter(self::$nameToClassMap, function ($typeName) {
             return !\in_array($typeName, ['datetime_immutable', 'date_immutable', 'time_immutable']);
         }, ARRAY_FILTER_USE_KEY);
         $classToNameMap = array_flip($filteredNameToClassMap);

--- a/src/Form/Util/FormTypeHelper.php
+++ b/src/Form/Util/FormTypeHelper.php
@@ -42,7 +42,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
-use Symfony\Component\Form\Util\StringUtil;
 
 /*
  * Utility class to map shortcut form types (e.g. `text` or `submit`) to its

--- a/src/Form/Util/FormTypeHelper.php
+++ b/src/Form/Util/FormTypeHelper.php
@@ -2,13 +2,6 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\Util;
 
-/*
- * Utility class to map Symfony 2.x short form types to Symfony 3.x FQCN form types.
- *
- * @author Yonel Ceruto <yonelceruto@gmail.com>
- *
- * @internal
- */
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminAutocompleteType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminDividerType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType;
@@ -20,8 +13,10 @@ use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
+use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -41,6 +36,7 @@ use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\ResetType;
 use Symfony\Component\Form\Extension\Core\Type\SearchType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
@@ -48,21 +44,31 @@ use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\Util\StringUtil;
 
-final class LegacyFormHelper
+/*
+ * Utility class to map shortcut form types (e.g. `text` or `submit`) to its
+ * associated FQCN type.
+ *
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ *
+ * @internal
+ */
+final class FormTypeHelper
 {
-    private static $supportedTypes = [
+    private static $nameToClassMap = [
         // Symfony's built-in types
         'birthday' => BirthdayType::class,
         'button' => ButtonType::class,
         'checkbox' => CheckboxType::class,
         'choice' => ChoiceType::class,
         'collection' => CollectionType::class,
+        'color' => ColorType::class,
         'country' => CountryType::class,
         'currency' => CurrencyType::class,
         'datetime' => DateTimeType::class,
         'datetime_immutable' => DateTimeType::class,
         'date' => DateType::class,
         'date_immutable' => DateType::class,
+        'date_interval' => DateIntervalType::class,
         'email' => EmailType::class,
         'entity' => EntityType::class,
         'file' => FileType::class,
@@ -81,6 +87,7 @@ final class LegacyFormHelper
         'reset' => ResetType::class,
         'search' => SearchType::class,
         'submit' => SubmitType::class,
+        'tel' => TelType::class,
         'textarea' => TextareaType::class,
         'text' => TextType::class,
         'time' => TimeType::class,
@@ -100,47 +107,35 @@ final class LegacyFormHelper
     ];
 
     /**
-     * It returns the FQCN of the given short type name if not use legacy form
-     * and its a supported type, otherwise return the same type name
+     * It returns the FQCN of the given short type name. If the FQCN is not
+     * found, it returs the given value.
      *
-     * @param string $shortType
-     *
-     * @return string
-     */
-    public static function getType($shortType)
-    {
-        if (self::useLegacyFormComponent() || !isset(self::$supportedTypes[$shortType])) {
-            return $shortType;
-        }
-
-        return self::$supportedTypes[$shortType];
-    }
-
-    /**
-     * It returns the short type name of the given FQCN
-     *
-     * @param string $fqcn
+     * @param string $typeName
      *
      * @return string
      */
-    public static function getShortType($fqcn)
+    public static function getTypeClass($typeName)
     {
-        $flippedTypes = array_flip(self::$supportedTypes);
-
-        if (!isset($flippedTypes[$fqcn])) {
-            return $fqcn;
-        }
-
-        return $flippedTypes[$fqcn];
+        return self::$nameToClassMap[$typeName] ?? $typeName;
     }
 
     /**
-     * Returns true if the legacy Form component is being used by the application.
+     * It returns the short type name of the given FQCN. If the type name is not
+     * found, it returns the given value.
      *
-     * @return bool
+     * @param string $typeFqcn
+     *
+     * @return string
      */
-    public static function useLegacyFormComponent()
+    public static function getTypeName($typeFqcn)
     {
-        return false === class_exists(StringUtil::class);
+        // needed to avoid collisions between immutable and non-immutable date types,
+        // which are mapped to the same Symfony Form type classes
+        $filteredNameToClassMap = array_filter(self::$nameToClassMap, function($typeName) {
+            return !\in_array($typeName, ['datetime_immutable', 'date_immutable', 'time_immutable']);
+        }, ARRAY_FILTER_USE_KEY);
+        $classToNameMap = array_flip($filteredNameToClassMap);
+
+        return $classToNameMap[$typeFqcn] ?? $typeFqcn;
     }
 }

--- a/tests/Form/Type/EasyAdminAutocompleteTypeTest.php
+++ b/tests/Form/Type/EasyAdminAutocompleteTypeTest.php
@@ -5,7 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Type;
 use AppTestBundle\Entity\UnitTests\Category;
 use Doctrine\Common\Collections\ArrayCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminAutocompleteType;
-use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -107,7 +107,7 @@ class EasyAdminAutocompleteTypeTest extends TypeTestCase
             ->with($category)
             ->willReturn(['id' => $category->id]);
 
-        $form = $this->factory->create(LegacyFormHelper::getType('easyadmin_autocomplete'), null, [
+        $form = $this->factory->create(FormTypeHelper::getTypeClass('easyadmin_autocomplete'), null, [
             'class' => self::ENTITY_CLASS,
         ]);
         $formData = ['autocomplete' => '1'];
@@ -154,7 +154,7 @@ class EasyAdminAutocompleteTypeTest extends TypeTestCase
             ->with($category1)
             ->willReturn(['id' => $category1->id]);
 
-        $form = $this->factory->create(LegacyFormHelper::getType('easyadmin_autocomplete'), null, [
+        $form = $this->factory->create(FormTypeHelper::getTypeClass('easyadmin_autocomplete'), null, [
             'class' => self::ENTITY_CLASS,
             'multiple' => true,
         ]);
@@ -166,7 +166,7 @@ class EasyAdminAutocompleteTypeTest extends TypeTestCase
 
     public function testSubmitEmptySingleData()
     {
-        $form = $this->factory->create(LegacyFormHelper::getType('easyadmin_autocomplete'), null, [
+        $form = $this->factory->create(FormTypeHelper::getTypeClass('easyadmin_autocomplete'), null, [
             'class' => self::ENTITY_CLASS,
         ]);
         $form->submit(['autocomplete' => '']);
@@ -177,7 +177,7 @@ class EasyAdminAutocompleteTypeTest extends TypeTestCase
 
     public function testSubmitEmptyMultipleData()
     {
-        $form = $this->factory->create(LegacyFormHelper::getType('easyadmin_autocomplete'), null, [
+        $form = $this->factory->create(FormTypeHelper::getTypeClass('easyadmin_autocomplete'), null, [
             'class' => self::ENTITY_CLASS,
             'multiple' => true,
         ]);

--- a/tests/Form/Util/LegacyFormHelperTest.php
+++ b/tests/Form/Util/LegacyFormHelperTest.php
@@ -2,15 +2,12 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Util\Type;
 
-use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @group legacy
- */
-class LegacyFormHelperTest extends TestCase
+class FormTypeHelperTest extends TestCase
 {
-    public function shortTypesToFqcnProvider()
+    public function formTypeNameAndFqcnProvider()
     {
         return [
             'Symfony Type (regular name)' => ['integer', 'Symfony\\Component\\Form\\Extension\\Core\\Type\\IntegerType'],
@@ -22,14 +19,18 @@ class LegacyFormHelperTest extends TestCase
     }
 
     /**
-     * @dataProvider shortTypesToFqcnProvider
+     * @dataProvider formTypeNameAndFqcnProvider
      */
-    public function testGetType($shortType, $expected)
+    public function testGetTypeClass($typeName, $expectedTypeClass)
     {
-        if (LegacyFormHelper::useLegacyFormComponent()) {
-            $expected = $shortType;
-        }
+        $this->assertSame($expectedTypeClass, FormTypeHelper::getTypeClass($typeName));
+    }
 
-        $this->assertSame($expected, LegacyFormHelper::getType($shortType));
+    /**
+     * @dataProvider formTypeNameAndFqcnProvider
+     */
+    public function testGetTypeName($expectedTypeName, $typeClass)
+    {
+        $this->assertSame($expectedTypeName, FormTypeHelper::getTypeName($typeClass));
     }
 }


### PR DESCRIPTION
At the beginning we used this to transition from Symfony 2 and 3 form types. But now we can keep using it because defining type classes in the YAML config file is boring and using the form type name is better in this case.