### PR TITLE
noreferrer option for external links from menu

### DIFF
--- a/src/Configuration/MenuConfigPass.php
+++ b/src/Configuration/MenuConfigPass.php
@@ -96,9 +96,9 @@ class MenuConfigPass implements ConfigPassInterface
                 $itemConfig['target'] = (string) $itemConfig['target'];
             }
 
-            // normalize 'rel' option, which adds html5 rel attribute (https://www.w3schools.com/TAGS/att_a_rel.asp)
+            // normalize 'rel' option, which adds html5 rel attribute (https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)
             if (!array_key_exists('rel', $itemConfig)) {
-                $itemConfig['rel'] = false;
+                $itemConfig['rel'] = array_key_exists('url', $itemConfig) ? 'noreferrer' : false;
             } else {
                 $itemConfig['rel'] = (string) $itemConfig['rel'];
             }

--- a/src/Configuration/MenuConfigPass.php
+++ b/src/Configuration/MenuConfigPass.php
@@ -96,6 +96,13 @@ class MenuConfigPass implements ConfigPassInterface
                 $itemConfig['target'] = (string) $itemConfig['target'];
             }
 
+            // normalize 'rel' option, which adds html5 rel attribute (https://www.w3schools.com/TAGS/att_a_rel.asp)
+            if (!array_key_exists('rel', $itemConfig)) {
+                $itemConfig['rel'] = false;
+            } else {
+                $itemConfig['rel'] = (string) $itemConfig['rel'];
+            }
+
             $menuConfig[$i] = $itemConfig;
         }
 

--- a/src/Resources/views/default/menu.html.twig
+++ b/src/Resources/views/default/menu.html.twig
@@ -18,7 +18,9 @@
             {% set path = path(item.route, menu_params|merge(item.params)) %}
         {% endif %}
 
-        <a href="{{ path }}" {% if item.target|default(false) %}target="{{ item.target }}"{% endif %}>
+        <a href="{{ path }}"
+           {% if item.target|default(false) %}target="{{ item.target }}"{% endif %}
+           {% if item.rel|default(false) %}rel="{{ item.rel }}"{% endif %}>
             {% if item.icon is not empty %}<i class="fa {{ item.icon }}"></i>{% endif %}
             <span>{{ item.label|trans(domain = translation_domain) }}</span>
             {% if item.children|default([]) is not empty %}<i class="fa fa-angle-left pull-right"></i>{% endif %}


### PR DESCRIPTION
Adds an HTML "rel" property to the external links in the menu.
By default, it will generate a link with noreferrer value: `<a ... rel="noreferrer" />`
This value can be cutomized in the config:
```
easy_admin:
    design:
        menu:
            - { label: 'My external link', url: 'http://example.com', rel: 'noreferrer nofollow' }
```
See [https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types) for the possible values.

Fixes #2129 