### PR TITLE
Trigger a proper deprecaton notice when using the deprecated route name

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -61,6 +61,10 @@ class AdminController extends Controller
      */
     public function indexAction(Request $request)
     {
+        if ('admin' === $request->attributes->get('_route')) {
+            trigger_error(sprintf('The "admin" route is deprecated since version 1.8.0 and it will be removed in 2.0. Use the "easyadmin" route instead.'), E_USER_DEPRECATED);
+        }
+
         $this->initialize($request);
 
         if (null === $request->query->get('entity')) {


### PR DESCRIPTION
We removed this in master (#2137) but it may be nice to trigger a real deprecation notice in 1.x. @grachevko what do you think? Thanks!