### PR TITLE
Redirect changes

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -816,7 +816,7 @@ class AdminController extends Controller
         // else from new|edit action, redirect on edit if possible
         elseif (in_array($refererAction, array('new', 'edit')) && $this->isActionAllowed('edit')) {
 
-            $this->addFlash('success', ($refererAction == 'new')
+            $this->addFlash('success', ('new' === $refererAction)
                 ? $this->get('translator')->trans('flash.new.success', array(), 'EasyAdminBundle')
                 : $this->get('translator')->trans('flash.edit.success', array(), 'EasyAdminBundle')
             );
@@ -826,14 +826,14 @@ class AdminController extends Controller
                 'entity' => $this->entity['name'],
                 'menuIndex' => $this->request->query->get('menuIndex'),
                 'submenuIndex' => $this->request->query->get('submenuIndex'),
-                'id' => ($refererAction == 'new')
+                'id' => ('new' === $refererAction)
                     ? PropertyAccess::createPropertyAccessor()->getValue($this->request->attributes->get('easyadmin')['item'], $this->entity['primary_key_field_name'])
                     : $this->request->query->get('id')
             )));
         }
 
         // elseif from new action, redirect on new if possible
-        elseif ($refererAction == 'new' && $this->isActionAllowed('new')) {
+        elseif ('new' === $refererAction && $this->isActionAllowed('new')) {
 
             $this->addFlash('success', $this->get('translator')->trans('flash.new.success', array(), 'EasyAdminBundle'));
 

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -803,19 +803,16 @@ class AdminController extends Controller
 
         // redirect on list if possible
         if ($this->isActionAllowed('list')) {
-
             return $this->redirect($this->generateUrl('easyadmin', array(
                 'action' => 'list',
                 'entity' => $this->entity['name'],
                 'menuIndex' => $this->request->query->get('menuIndex'),
                 'submenuIndex' => $this->request->query->get('submenuIndex'),
             )));
-
         }
 
         // else from new|edit action, redirect on edit if possible
         elseif (in_array($refererAction, array('new', 'edit')) && $this->isActionAllowed('edit')) {
-
             $this->addFlash('success', ('new' === $refererAction)
                 ? $this->get('translator')->trans('flash.new.success', array(), 'EasyAdminBundle')
                 : $this->get('translator')->trans('flash.edit.success', array(), 'EasyAdminBundle')
@@ -834,7 +831,6 @@ class AdminController extends Controller
 
         // elseif from new action, redirect on new if possible
         elseif ('new' === $refererAction && $this->isActionAllowed('new')) {
-
             $this->addFlash('success', $this->get('translator')->trans('flash.new.success', array(), 'EasyAdminBundle'));
 
             return $this->redirect($this->generateUrl('easyadmin', array(
@@ -843,7 +839,6 @@ class AdminController extends Controller
                 'menuIndex' => $this->request->query->get('menuIndex'),
                 'submenuIndex' => $this->request->query->get('submenuIndex'),
             )));
-
         }
 
         if (!empty($refererUrl)) {

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -828,7 +828,7 @@ class AdminController extends Controller
                 'submenuIndex' => $this->request->query->get('submenuIndex'),
                 'id' => ('new' === $refererAction)
                     ? PropertyAccess::createPropertyAccessor()->getValue($this->request->attributes->get('easyadmin')['item'], $this->entity['primary_key_field_name'])
-                    : $this->request->query->get('id')
+                    : $this->request->query->get('id'),
             )));
         }
 

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -804,45 +804,45 @@ class AdminController extends Controller
         // redirect on list if possible
         if ($this->isActionAllowed('list')) {
 
-            return $this->redirect($this->generateUrl('easyadmin', [
-                'action'        => 'list',
-                'entity'        => $this->entity['name'],
-                'menuIndex'     => $this->request->query->get('menuIndex'),
-                'submenuIndex'  => $this->request->query->get('submenuIndex'),
-            ]));
+            return $this->redirect($this->generateUrl('easyadmin', array(
+                'action' => 'list',
+                'entity' => $this->entity['name'],
+                'menuIndex' => $this->request->query->get('menuIndex'),
+                'submenuIndex' => $this->request->query->get('submenuIndex'),
+            )));
 
         }
 
         // else from new|edit action, redirect on edit if possible
-        elseif (in_array($refererAction, ['new', 'edit']) && $this->isActionAllowed('edit')) {
+        elseif (in_array($refererAction, array('new', 'edit')) && $this->isActionAllowed('edit')) {
 
             $this->addFlash('success', ($refererAction == 'new')
-                ? $this->get('translator')->trans('flash.new.success', [], 'EasyAdminBundle')
-                : $this->get('translator')->trans('flash.edit.success', [], 'EasyAdminBundle')
+                ? $this->get('translator')->trans('flash.new.success', array(), 'EasyAdminBundle')
+                : $this->get('translator')->trans('flash.edit.success', array(), 'EasyAdminBundle')
             );
 
-            return $this->redirect($this->generateUrl('easyadmin', [
-                'action'        => 'edit',
-                'entity'        => $this->entity['name'],
-                'menuIndex'     => $this->request->query->get('menuIndex'),
-                'submenuIndex'  => $this->request->query->get('submenuIndex'),
-                'id'            => ($refererAction == 'new')
+            return $this->redirect($this->generateUrl('easyadmin', array(
+                'action' => 'edit',
+                'entity' => $this->entity['name'],
+                'menuIndex' => $this->request->query->get('menuIndex'),
+                'submenuIndex' => $this->request->query->get('submenuIndex'),
+                'id' => ($refererAction == 'new')
                     ? PropertyAccess::createPropertyAccessor()->getValue($this->request->attributes->get('easyadmin')['item'], $this->entity['primary_key_field_name'])
                     : $this->request->query->get('id')
-            ]));
+            )));
         }
 
         // elseif from new action, redirect on new if possible
         elseif ($refererAction == 'new' && $this->isActionAllowed('new')) {
 
-            $this->addFlash('success', $this->get('translator')->trans('flash.new.success', [], 'EasyAdminBundle'));
+            $this->addFlash('success', $this->get('translator')->trans('flash.new.success', array(), 'EasyAdminBundle'));
 
-            return $this->redirect($this->generateUrl('easyadmin', [
-                'action'        => 'new',
-                'entity'        => $this->entity['name'],
-                'menuIndex'     => $this->request->query->get('menuIndex'),
-                'submenuIndex'  => $this->request->query->get('submenuIndex'),
-            ]));
+            return $this->redirect($this->generateUrl('easyadmin', array(
+                'action' => 'new',
+                'entity' => $this->entity['name'],
+                'menuIndex' => $this->request->query->get('menuIndex'),
+                'submenuIndex' => $this->request->query->get('submenuIndex'),
+            )));
 
         }
 

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -798,16 +798,56 @@ class AdminController extends Controller
      */
     protected function redirectToReferrer()
     {
-        $referrerUrl = $this->request->query->get('referer', '');
+        $refererUrl = $this->request->query->get('referer', '');
+        $refererAction = $this->request->query->get('action');
 
-        if (!empty($referrerUrl)) {
-            return $this->redirect(urldecode($referrerUrl));
+        // redirect on list if possible
+        if ($this->isActionAllowed('list')) {
+
+            return $this->redirect($this->generateUrl('easyadmin', [
+                'action'        => 'list',
+                'entity'        => $this->entity['name'],
+                'menuIndex'     => $this->request->query->get('menuIndex'),
+                'submenuIndex'  => $this->request->query->get('submenuIndex'),
+            ]));
+
         }
 
-        if ($this->isActionAllowed('list')) {
-            return $this->redirect($this->generateUrl('easyadmin', array(
-                'action' => 'list', 'entity' => $this->entity['name'],
-            )));
+        // else from new|edit action, redirect on edit if possible
+        elseif (in_array($refererAction, ['new', 'edit']) && $this->isActionAllowed('edit')) {
+
+            $this->addFlash('success', ($refererAction == 'new')
+                ? $this->get('translator')->trans('flash.new.success', [], 'EasyAdminBundle')
+                : $this->get('translator')->trans('flash.edit.success', [], 'EasyAdminBundle')
+            );
+
+            return $this->redirect($this->generateUrl('easyadmin', [
+                'action'        => 'edit',
+                'entity'        => $this->entity['name'],
+                'menuIndex'     => $this->request->query->get('menuIndex'),
+                'submenuIndex'  => $this->request->query->get('submenuIndex'),
+                'id'            => ($refererAction == 'new')
+                    ? PropertyAccess::createPropertyAccessor()->getValue($this->request->attributes->get('easyadmin')['item'], $this->entity['primary_key_field_name'])
+                    : $this->request->query->get('id')
+            ]));
+        }
+
+        // elseif from new action, redirect on new if possible
+        elseif ($refererAction == 'new' && $this->isActionAllowed('new')) {
+
+            $this->addFlash('success', $this->get('translator')->trans('flash.new.success', [], 'EasyAdminBundle'));
+
+            return $this->redirect($this->generateUrl('easyadmin', [
+                'action'        => 'new',
+                'entity'        => $this->entity['name'],
+                'menuIndex'     => $this->request->query->get('menuIndex'),
+                'submenuIndex'  => $this->request->query->get('submenuIndex'),
+            ]));
+
+        }
+
+        if (!empty($refererUrl)) {
+            return $this->redirect(urldecode($refererUrl));
         }
 
         return $this->redirectToBackendHomepage();

--- a/src/Resources/translations/EasyAdminBundle.en.xlf
+++ b/src/Resources/translations/EasyAdminBundle.en.xlf
@@ -181,6 +181,16 @@
                 <source>exception.undefined_entity</source>
                 <target>The application is not properly configured for this kind of items.</target>
             </trans-unit>
+
+            <!-- Flash messages -->
+            <trans-unit id="flash.new.success">
+                <source>flash.new.success</source>
+                <target>Your element has been created.</target>
+            </trans-unit>
+            <trans-unit id="flash.edit.success">
+                <source>flash.edit.success</source>
+                <target>Your element has been updated.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/src/Resources/translations/EasyAdminBundle.fr.xlf
@@ -177,6 +177,16 @@
                 <source>exception.undefined_entity</source>
                 <target>L'application n'est pas correctement configurée pour ce type d'élément.</target>
             </trans-unit>
+
+            <!-- Flash messages -->
+            <trans-unit id="flash.new.success">
+                <source>flash.new.success</source>
+                <target>Votre élément a été crée.</target>
+            </trans-unit>
+            <trans-unit id="flash.edit.success">
+                <source>flash.edit.success</source>
+                <target>Votre élément a été modifié.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/tests/Controller/DisabledActionsTest.php
+++ b/tests/Controller/DisabledActionsTest.php
@@ -74,9 +74,9 @@ class DisabledActionsTest extends AbstractTestCase
         $form = $crawler->selectButton('Save changes')->form();
         $this->client->submit($form);
 
-        $this->assertTrue(
-            $this->client->getResponse()->isRedirect('https://example.com'),
-            'After editing a Category, the user is redirected to the homepage because the "list" action is disabled for Category.'
+        $this->assertContains(
+            '/admin/?action=edit&entity=Category&id=200',
+            $this->client->getResponse()->headers->get('location')
         );
     }
 


### PR DESCRIPTION
Cf #2099, I've change the redirect's workflow after submitting the new, edit or delete form:
* if we can redirect to List > go on List
* else if from new or edit and we can redirect to edit > go on Edit
* else if from new and we can redirect to add > go on Add
* else > go on default backend homepage

so:
* when possible, redirect to List
* if trying to edit but list disabled, put flash msg + redirect to Edit (on the current recordset)
* if trying to add but list disabled, put flash msg + redirect to Edit (on the recordset created)
* if trying to add but list + edit disabled, put flash msg + redirect to Add (empty form)
* if trying to delete but list disabled, redirect to default backend

ps: I've only added translations for flash messages in french (native) and english.