### PR TITLE
Continue 2134

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -448,7 +448,9 @@ class AdminController extends Controller
      */
     protected function prePersistEntity($entity)
     {
-        @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use persistEntity instead', __METHOD__), E_USER_DEPRECATED);
+        if (__CLASS__ !== get_class()) {
+            @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use persistEntity() instead', __METHOD__), E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -471,7 +473,9 @@ class AdminController extends Controller
      */
     protected function preUpdateEntity($entity)
     {
-        @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use updateEntity instead', __METHOD__), E_USER_DEPRECATED);
+        if (__CLASS__ !== get_class()) {
+            @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use updateEntity() instead', __METHOD__), E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -493,7 +497,9 @@ class AdminController extends Controller
      */
     protected function preRemoveEntity($entity)
     {
-        @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use removeEntity instead', __METHOD__), E_USER_DEPRECATED);
+        if (__CLASS__ !== get_class()) {
+            @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use removeEntity() instead', __METHOD__), E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -767,9 +773,10 @@ class AdminController extends Controller
         if (!is_callable(array($this, $methodName))) {
             $methodName = str_replace('<EntityName>', '', $methodNamePattern);
 
-            if (false !== strpos($methodName, 'pre')) {
-                $newMethod = strtolower(substr($methodName, 3));
-                @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use %s instead', $methodName, $newMethod), E_USER_DEPRECATED);
+            $isDeprecatedMethod = 0 === strpos($methodName, 'prePersist') || 0 === strpos($methodName, 'preUpdate') || 0 === strpos($methodName, 'preRemove');
+            if (__CLASS__ !== get_class() && $isDeprecatedMethod) {
+                $newMethodName = strtolower(substr($methodName, 3));
+                @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s() instead', $methodName, $newMethodName), E_USER_DEPRECATED);
             }
         }
 
@@ -799,6 +806,7 @@ class AdminController extends Controller
      */
     public function renderCssAction()
     {
+        @trigger_error('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Processed styles are available in the "easyadmin.config._internal.custom_css" container parameter.', E_USER_DEPRECATED);
     }
 
     /**

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -448,7 +448,7 @@ class AdminController extends Controller
      */
     protected function prePersistEntity($entity)
     {
-        if (__CLASS__ !== get_class()) {
+        if (__CLASS__ !== get_class($this)) {
             @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use persistEntity() instead', __METHOD__), E_USER_DEPRECATED);
         }
     }
@@ -473,7 +473,7 @@ class AdminController extends Controller
      */
     protected function preUpdateEntity($entity)
     {
-        if (__CLASS__ !== get_class()) {
+        if (__CLASS__ !== get_class($this)) {
             @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use updateEntity() instead', __METHOD__), E_USER_DEPRECATED);
         }
     }
@@ -497,7 +497,7 @@ class AdminController extends Controller
      */
     protected function preRemoveEntity($entity)
     {
-        if (__CLASS__ !== get_class()) {
+        if (__CLASS__ !== get_class($this)) {
             @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use removeEntity() instead', __METHOD__), E_USER_DEPRECATED);
         }
     }
@@ -774,7 +774,7 @@ class AdminController extends Controller
             $methodName = str_replace('<EntityName>', '', $methodNamePattern);
 
             $isDeprecatedMethod = 0 === strpos($methodName, 'prePersist') || 0 === strpos($methodName, 'preUpdate') || 0 === strpos($methodName, 'preRemove');
-            if (__CLASS__ !== get_class() && $isDeprecatedMethod) {
+            if (__CLASS__ !== get_class($this) && $isDeprecatedMethod) {
                 $newMethodName = strtolower(substr($methodName, 3));
                 @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s() instead', $methodName, $newMethodName), E_USER_DEPRECATED);
             }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -214,7 +214,7 @@ class AdminController extends Controller
         if ($editForm->isSubmitted() && $editForm->isValid()) {
             $this->dispatch(EasyAdminEvents::PRE_UPDATE, array('entity' => $entity));
 
-            $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity));
+            $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity, true));
             $this->executeDynamicMethod('update<EntityName>Entity', array($entity));
 
             $this->dispatch(EasyAdminEvents::POST_UPDATE, array('entity' => $entity));
@@ -288,7 +288,7 @@ class AdminController extends Controller
         if ($newForm->isSubmitted() && $newForm->isValid()) {
             $this->dispatch(EasyAdminEvents::PRE_PERSIST, array('entity' => $entity));
 
-            $this->executeDynamicMethod('prePersist<EntityName>Entity', array($entity));
+            $this->executeDynamicMethod('prePersist<EntityName>Entity', array($entity, true));
             $this->executeDynamicMethod('persist<EntityName>Entity', array($entity));
 
             $this->dispatch(EasyAdminEvents::POST_PERSIST, array('entity' => $entity));
@@ -335,7 +335,7 @@ class AdminController extends Controller
 
             $this->dispatch(EasyAdminEvents::PRE_REMOVE, array('entity' => $entity));
 
-            $this->executeDynamicMethod('preRemove<EntityName>Entity', array($entity));
+            $this->executeDynamicMethod('preRemove<EntityName>Entity', array($entity, true));
 
             try {
                 $this->executeDynamicMethod('remove<EntityName>Entity', array($entity));
@@ -417,7 +417,7 @@ class AdminController extends Controller
         $this->dispatch(EasyAdminEvents::PRE_UPDATE, array('entity' => $entity, 'newValue' => $value));
 
         $this->get('easy_admin.property_accessor')->setValue($entity, $property, $value);
-        $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity));
+        $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity, true));
 
         $this->em->persist($entity);
         $this->em->flush();
@@ -446,11 +446,13 @@ class AdminController extends Controller
      *
      * @param object $entity
      */
-    protected function prePersistEntity($entity)
+    protected function prePersistEntity($entity /*, bool $ignoreDeprecations = false */)
     {
-        if (__CLASS__ !== get_class($this)) {
-            @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use persistEntity() instead', __METHOD__), E_USER_DEPRECATED);
+        if (func_num_args() > 1 && true === func_get_arg(1)) {
+            return;
         }
+
+        @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use persistEntity() instead', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**
@@ -471,11 +473,13 @@ class AdminController extends Controller
      *
      * @param object $entity
      */
-    protected function preUpdateEntity($entity)
+    protected function preUpdateEntity($entity /*, bool $ignoreDeprecations = false */)
     {
-        if (__CLASS__ !== get_class($this)) {
-            @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use updateEntity() instead', __METHOD__), E_USER_DEPRECATED);
+        if (func_num_args() > 1 && true === func_get_arg(1)) {
+            return;
         }
+
+        @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use updateEntity() instead', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**
@@ -495,11 +499,13 @@ class AdminController extends Controller
      *
      * @param object $entity
      */
-    protected function preRemoveEntity($entity)
+    protected function preRemoveEntity($entity /*, bool $ignoreDeprecations = false */)
     {
-        if (__CLASS__ !== get_class($this)) {
-            @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use removeEntity() instead', __METHOD__), E_USER_DEPRECATED);
+        if (func_num_args() > 1 && true === func_get_arg(1)) {
+            return;
         }
+
+        @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use removeEntity() instead', __METHOD__), E_USER_DEPRECATED);
     }
 
     /**
@@ -772,12 +778,12 @@ class AdminController extends Controller
 
         if (!is_callable(array($this, $methodName))) {
             $methodName = str_replace('<EntityName>', '', $methodNamePattern);
+        }
 
-            $isDeprecatedMethod = 0 === strpos($methodName, 'prePersist') || 0 === strpos($methodName, 'preUpdate') || 0 === strpos($methodName, 'preRemove');
-            if (__CLASS__ !== get_class($this) && $isDeprecatedMethod) {
-                $newMethodName = strtolower(substr($methodName, 3));
-                @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s() instead', $methodName, $newMethodName), E_USER_DEPRECATED);
-            }
+        $isDeprecatedMethod = 0 === strpos($methodName, 'prePersist') || 0 === strpos($methodName, 'preUpdate') || 0 === strpos($methodName, 'preRemove');
+        if ($isDeprecatedMethod && isset($arguments[1]) && true !== $arguments[1]) {
+            $newMethodName = strtolower(substr($methodName, 3));
+            @trigger_error(sprintf('The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s() instead', $methodName, $newMethodName), E_USER_DEPRECATED);
         }
 
         return call_user_func_array(array($this, $methodName), $arguments);

--- a/tests/Controller/CustomEntityControllerTest.php
+++ b/tests/Controller/CustomEntityControllerTest.php
@@ -33,4 +33,47 @@ class CustomEntityControllerTest extends AbstractTestCase
         $this->requestShowView();
         $this->assertContains('Overridden show action.', $this->client->getResponse()->getContent());
     }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
+     */
+    public function testDeprecatedPrePersistMethod()
+    {
+        $crawler = $this->requestNewView();
+        $this->client->followRedirects();
+
+        $categoryName = sprintf('The New Category %s', md5(mt_rand()));
+        $form = $crawler->selectButton('Save changes')->form(array(
+            'category[name]' => $categoryName,
+        ));
+        $this->client->submit($form);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
+     */
+    public function testDeprecatedPreUpdateMethod()
+    {
+        $crawler = $this->requestEditView();
+        $this->client->followRedirects();
+
+        $categoryName = sprintf('Modified Category %s', md5(mt_rand()));
+        $form = $crawler->selectButton('Save changes')->form(array(
+            'category[name]' => $categoryName,
+        ));
+        $this->client->submit($form);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
+     */
+    public function testDeprecatedPreRemoveMethod()
+    {
+        $crawler = $this->requestEditView();
+        $form = $crawler->filter('#delete_form_submit')->form();
+        $this->client->submit($form);
+    }
 }

--- a/tests/Controller/CustomEntityControllerTest.php
+++ b/tests/Controller/CustomEntityControllerTest.php
@@ -38,7 +38,7 @@ class CustomEntityControllerTest extends AbstractTestCase
      * @group legacy
      * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
      */
-    public function testDeprecatedPrePersistMethod()
+    public function testDeprecatedPrePersistEntityMethod()
     {
         $crawler = $this->requestNewView();
         $this->client->followRedirects();
@@ -54,7 +54,7 @@ class CustomEntityControllerTest extends AbstractTestCase
      * @group legacy
      * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
      */
-    public function testDeprecatedPreUpdateMethod()
+    public function testDeprecatedPreUpdateEntityMethod()
     {
         $crawler = $this->requestEditView();
         $this->client->followRedirects();
@@ -70,9 +70,52 @@ class CustomEntityControllerTest extends AbstractTestCase
      * @group legacy
      * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
      */
-    public function testDeprecatedPreRemoveMethod()
+    public function testDeprecatedPreRemoveEntityMethod()
     {
         $crawler = $this->requestEditView();
+        $form = $crawler->filter('#delete_form_submit')->form();
+        $this->client->submit($form);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
+     */
+    public function testDeprecatedPrePersistCategory2EntityMethod()
+    {
+        $crawler = $this->requestNewView('Category2');
+        $this->client->followRedirects();
+
+        $categoryName = sprintf('The New Category %s', md5(mt_rand()));
+        $form = $crawler->selectButton('Save changes')->form(array(
+            'category2[name]' => $categoryName,
+        ));
+        $this->client->submit($form);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
+     */
+    public function testDeprecatedPreUpdateCategory2EntityMethod()
+    {
+        $crawler = $this->requestEditView('Category2');
+        $this->client->followRedirects();
+
+        $categoryName = sprintf('Modified Category %s', md5(mt_rand()));
+        $form = $crawler->selectButton('Save changes')->form(array(
+            'category2[name]' => $categoryName,
+        ));
+        $this->client->submit($form);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0. Use %s instead
+     */
+    public function testDeprecatedPreRemoveCategory2EntityMethod()
+    {
+        $crawler = $this->requestEditView('Category2');
         $form = $crawler->filter('#delete_form_submit')->form();
         $this->client->submit($form);
     }

--- a/tests/Controller/DefaultBackendTest.php
+++ b/tests/Controller/DefaultBackendTest.php
@@ -433,10 +433,6 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertSame($parameters, $refererParameters);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use %s instead
-     */
     public function testEditViewEntityModification()
     {
         $crawler = $this->requestEditView();
@@ -455,10 +451,6 @@ class DefaultBackendTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use %s instead
-     */
     public function testEntityModificationViaAjax()
     {
         /* @var EntityManager */
@@ -558,10 +550,6 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertSame($parameters, $refererParameters);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use %s instead
-     */
     public function testNewViewEntityCreation()
     {
         $crawler = $this->requestNewView();
@@ -716,10 +704,6 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertSame($parameters, $refererParameters);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use %s instead
-     */
     public function testEntityDeletion()
     {
         if (PHP_VERSION_ID < 50400) {

--- a/tests/Controller/DisabledActionsTest.php
+++ b/tests/Controller/DisabledActionsTest.php
@@ -68,10 +68,6 @@ class DisabledActionsTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The %s method is deprecated since EasyAdmin 1.x and will be removed in 2.0 version. Use %s instead
-     */
     public function testRedirectingToDisabledActions()
     {
         $crawler = $this->requestEditView();

--- a/tests/Fixtures/App/config/config_custom_entity_controller.yml
+++ b/tests/Fixtures/App/config/config_custom_entity_controller.yml
@@ -6,3 +6,7 @@ easy_admin:
         Category:
             class: AppTestBundle\Entity\FunctionalTests\Category
             controller:  EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin\CustomCategoryController
+
+        Category2:
+            class: AppTestBundle\Entity\FunctionalTests\Category
+            controller:  EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin\CustomController

--- a/tests/Fixtures/AppTestBundle/Admin/CustomCategoryController.php
+++ b/tests/Fixtures/AppTestBundle/Admin/CustomCategoryController.php
@@ -30,4 +30,21 @@ class CustomCategoryController extends EasyAdminController
     {
         return new Response('Overridden show action.');
     }
+
+    /** Empty method defined to trigger a deprecation message */
+    public function prePersistEntity($entity)
+    {
+        parent::prePersistEntity($entity);
+    }
+
+    /** Empty method defined to trigger a deprecation message */
+    public function preUpdateEntity($entity)
+    {
+        parent::preUpdateEntity($entity);
+    }
+
+    /** Empty method defined to trigger a deprecation message */
+    public function preRemoveEntity($entity)
+    {
+    }
 }

--- a/tests/Fixtures/AppTestBundle/Admin/CustomController.php
+++ b/tests/Fixtures/AppTestBundle/Admin/CustomController.php
@@ -12,39 +12,23 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin;
 
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AdminController as EasyAdminController;
-use Symfony\Component\HttpFoundation\Response;
 
-class CustomCategoryController extends EasyAdminController
+class CustomController extends EasyAdminController
 {
-    public function listAction()
-    {
-        return new Response('Overridden list action.');
-    }
-
-    /**
-     * It's absurd to use the entity name in the action method because we are
-     * already using a custom controller for the entity. But this should be
-     * possible for consistency and this test makes sure it's working.
-     */
-    public function showCategoryAction()
-    {
-        return new Response('Overridden show action.');
-    }
-
     /** Empty method defined to trigger a deprecation message */
-    public function prePersistEntity($entity)
+    public function prePersistCategory2Entity($entity)
     {
         parent::prePersistEntity($entity);
     }
 
     /** Empty method defined to trigger a deprecation message */
-    public function preUpdateEntity($entity)
+    public function preUpdateCategory2Entity($entity)
     {
         parent::preUpdateEntity($entity);
     }
 
     /** Empty method defined to trigger a deprecation message */
-    public function preRemoveEntity($entity)
+    public function preRemoveCategory2Entity($entity)
     {
         parent::preUpdateEntity($entity);
     }


### PR DESCRIPTION
This finishes the work done in #2134 by @lex111.

I think this now works as expected: we don't show deprecations if the preXXX() methods are called by ourselves, only when it's overridden by the user. But I'd need more people testing this. Thanks!