### PR TITLE
Refactored some parts of the cache system

### DIFF
--- a/src/CacheWarmer/ConfigCacheWarmer.php
+++ b/src/CacheWarmer/ConfigCacheWarmer.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\CacheWarmer;
+
+use EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManagerInterface;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * Ensures that the backend configuration is fully processed before executing
+ * the application for the first time.
+ *
+ * @internal
+ */
+class ConfigCacheWarmer implements CacheWarmerInterface
+{
+    /** @var ConfigManagerInterface */
+    private $configManager;
+
+    public function __construct(ConfigManagerInterface $configManager)
+    {
+        $this->configManager = $configManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        try {
+            // this forces the full processing of the backend configuration
+            $this->configManager->getBackendConfig();
+        } catch (\PDOException $e) {
+            // this occurs for example when the database doesn't exist yet and the
+            // project is being installed ('composer install' clears the cache at the end)
+            // ignore this error at this point and display an error message later
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isOptional()
+    {
+        return false;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -4,6 +4,16 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="easyadmin.cache.manager" class="EasyCorp\Bundle\EasyAdminBundle\Cache\CacheManager" public="true">
+            <argument>%easyadmin.cache.dir%</argument>
+            <deprecated>The "%service_id%" service is deprecated since EasyAdmin 2.0 and will be removed in 2.1.</deprecated>
+        </service>
+
+        <service id="easyadmin.cache.config_warmer" class="EasyCorp\Bundle\EasyAdminBundle\CacheWarmer\ConfigCacheWarmer" public="false">
+            <argument type="service" id="easyadmin.config.manager" />
+            <tag name="kernel.cache_warmer" priority="-2048" />
+        </service>
+
         <service id="easyadmin.config.manager" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager" public="true">
             <argument type="service" id="property_accessor" />
             <argument>%easyadmin.config%</argument>
@@ -13,7 +23,6 @@
             <argument type="service" id="easyadmin.cache.cache_config_manager.inner" />
             <argument type="service" id="Psr\Cache\CacheItemPoolInterface" />
             <argument>%kernel.debug%</argument>
-            <tag name="kernel.cache_warmer" priority="-2048" />
         </service>
 
         <service id="easyadmin.query_builder" class="EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder" public="true">


### PR DESCRIPTION
This is a continuation of #2128 made by @grachevko. Proposed changes:

* Restore the cache warmer because I don't like mixing responsibilities in the CacheConfigManager class. The cache warmer is a "weird" thing that I prefer to keep it separated.
* Keep `easyadmin.cache.manager` service but add the `deprecated` tag. I guess nobody is using it, but it's easy to be nice for end users.
* The main change is this one, which I think it was a bug of the original PR:
  ```diff
  -        $item = $this->cache->getItem(self::CACHE_KEY);
  +        $item = $this->cache->getItem(self::CACHE_KEY.'.'.$propertyPath);
  ```
  I tested the app and it didn't work as expected without this change. The reason is that if the first call to the config is not the entire config, then we're storing in the cache something that's not the entire config.
  This implies that we now store a single cache item for each config path we use ... but I guess that's right because it won't take much space (roughly double the previous amount).

-----

In any case, while working on this I was wondering if we should simplify this further. @grachevko your solution is not wrong and I appreciate your contribution, but I feel like it's "too much" and we may not need it. Previously it was easier to understand what was going on (because we had just 1 class to manage the cache and we could easily cache the entire config) but now we have 3 classes (the cache manager, the interface and the decorator).