### PR TITLE
Fix VichUploaderBundle example

### DIFF
--- a/doc/integration/vichuploaderbundle.rst
+++ b/doc/integration/vichuploaderbundle.rst
@@ -219,7 +219,7 @@ VichUploaderBundle configuration.
     .. code-block:: twig
 
         {# app/Resources/views/easy_admin/vich_uploader_image.html.twig #}
-        <img src="{{ vich_uploader_asset(value, 'image') }}" />
+        <img src="{{ vich_uploader_asset(item, 'image') }}" />
 
 Uploading the Images in the ``edit`` and ``new`` Views
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I'm not 100% sure this is the right fix because I'm not using the exact same example but still it looks like the method `vich_uploader_asset` is expecting the whole object instead of a file name.