### PR TITLE
Improve text for czech (cs) language in delete modal

### DIFF
--- a/src/Resources/translations/EasyAdminBundle.cs.xlf
+++ b/src/Resources/translations/EasyAdminBundle.cs.xlf
@@ -121,7 +121,7 @@
             </trans-unit>
             <trans-unit id="delete_modal.content">
                 <source>delete_modal.content</source>
-                <target>Není možné se vrátit zpět.</target>
+                <target>Tuto akci není možné vrátit zpět.</target>
             </trans-unit>
             <trans-unit id="delete_modal.action">
                 <source>delete_modal.action</source>


### PR DESCRIPTION
With the old context the message sounds like the user can't go back in his browser, with the new message it means that he can't undo the action.