### PR TITLE
Strip HTML tags from text properties in "list" view by default

### DIFF
--- a/src/Resources/views/default/field_string.html.twig
+++ b/src/Resources/views/default/field_string.html.twig
@@ -1,5 +1,5 @@
 {% if view == 'show' %}
     {{ value|nl2br }}
 {% else %}
-    {{ value|easyadmin_truncate }}
+    {{ value|striptags|easyadmin_truncate }}
 {% endif %}

--- a/src/Resources/views/default/field_text.html.twig
+++ b/src/Resources/views/default/field_text.html.twig
@@ -1,5 +1,5 @@
 {% if view == 'show' %}
     {{ value|nl2br }}
 {% else %}
-    {{ value|easyadmin_truncate }}
+    {{ value|striptags|easyadmin_truncate }}
 {% endif %}

--- a/tests/Controller/DefaultBackendTest.php
+++ b/tests/Controller/DefaultBackendTest.php
@@ -281,6 +281,13 @@ class DefaultBackendTest extends AbstractTestCase
         $this->assertCount(0, $crawler->filter('td[data-label="Enabled"].boolean'));
     }
 
+    public function testListViewStripsHtmlTags()
+    {
+        $crawler = $this->requestListView('Product');
+
+        $this->assertNotContains('&lt;ul&gt;', trim($crawler->filter('#main table td[data-label="Html features"]')->first()->text()), 'HTML tags are removed by default in the "list" view.');
+    }
+
     public function testShowViewPageTitle()
     {
         $crawler = $this->requestShowView();
@@ -351,6 +358,13 @@ class DefaultBackendTest extends AbstractTestCase
         parse_str($queryString, $refererParameters);
 
         $this->assertSame($parameters, $refererParameters);
+    }
+
+    public function testShowViewMaintainsHtmlTags()
+    {
+        $crawler = $this->requestShowView('Product', 1);
+
+        $this->assertContains('<ul>', trim($crawler->filter('.form-group:contains("Html features")')->first()->text()), 'HTML tags are maintained by default in the "show" view.');
     }
 
     public function testEditViewTitle()


### PR DESCRIPTION
This was on my TODO list for a long time. In the `list` view there's usually not much space left for contents, so it's sad to waste it with useless HTML tags. Let's strip them by default. In `show` view you'll see everything and if you want to render the HTML tags, you can define the property as `raw` instead of `string` or `text`.