### PR TITLE
Defined a default typography for the h1, h2, h3, ... headings

### DIFF
--- a/src/Resources/views/css/easyadmin.css.twig
+++ b/src/Resources/views/css/easyadmin.css.twig
@@ -61,6 +61,10 @@ body {
     font-family: Helvetica, "Helvetica Neue", Arial, sans-serif;
 }
 
+h1, h2, h3, h4, h5, h6 {
+    font-family: Helvetica, "Helvetica Neue", Arial, sans-serif;
+}
+
 {# Links
    ------------------------------------------------------------------------- #}
 a        { color: {{ colors.link }}; }


### PR DESCRIPTION
Yesterday we closed #2165 (reported by @TomasNyvlt) because it wasn't a bug from this bundle but something defined in the external template we use. However, the original styles from that template for elements like h1, h2, etc. are a bit weird, so let's add this minor style to make headings always look the same.