### PR TITLE
Deprecated the "light" color scheme

### DIFF
--- a/doc/book/configuration-reference.rst
+++ b/doc/book/configuration-reference.rst
@@ -175,6 +175,11 @@ It defines the colors used in the backend design. If you find the default
             color_scheme: 'light'
         # ...
 
+.. caution::
+
+    The ``light`` color scheme is deprecated since 1.x version and it will be
+    removed in EasyAdmin 2.0. Always use ``dark`` as the value of this option.
+
 brand_color
 ~~~~~~~~~~~
 

--- a/doc/book/design-configuration.rst
+++ b/doc/book/design-configuration.rst
@@ -67,6 +67,12 @@ choice for admin applications. If you prefer a lighter alternative, add the
 .. image:: ../images/easyadmin-design-color-scheme-light.png
    :alt: The default backend homepage using the light color scheme
 
+.. caution::
+
+    The ``light`` color scheme is deprecated since 1.x version and it will be
+    removed in EasyAdmin 2.0. Always use ``dark`` as the value of the
+    ``color_scheme`` option.
+
 Adding Custom Web Assets
 ------------------------
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -246,12 +246,15 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue('dark')
                             ->treatNullLike('dark')
                             ->validate()
-                            ->ifTrue(function ($v) {
-                                return 'light' === $v;
-                            })
-                            ->then(function ($v) {
-                                @trigger_error('The "light" color scheme is deprecated since EasyAdmin 1.x version and it will be removed in 2.0. Use "dark" as the value of the "color_scheme" option.');
-                            })
+                                ->ifTrue(function ($v) {
+                                    return 'light' === $v;
+                                })
+                                ->then(function ($v) {
+                                    @trigger_error('The "light" color scheme is deprecated since EasyAdmin 1.x version and it will be removed in 2.0. Use "dark" as the value of the "color_scheme" option.');
+
+                                    return $v;
+                                })
+                            ->end()
                         ->end()
 
                         ->booleanNode('rtl')

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -245,6 +245,13 @@ class Configuration implements ConfigurationInterface
                             ->info('The color scheme applied to the backend design (values: "dark" or "light").')
                             ->defaultValue('dark')
                             ->treatNullLike('dark')
+                            ->validate()
+                            ->ifTrue(function ($v) {
+                                return 'light' === $v;
+                            })
+                            ->then(function ($v) {
+                                @trigger_error('The "light" color scheme is deprecated since EasyAdmin 1.x version and it will be removed in 2.0. Use "dark" as the value of the "color_scheme" option.');
+                            })
                         ->end()
 
                         ->booleanNode('rtl')


### PR DESCRIPTION
I use this in some backends, so I know how painful is when some software removes a feature you use 😢  ... but removing this color scheme will simplify the maintenance of our custom design and it will allow for an eventual future replacement of the third-party template we currently use.