### PR TITLE
#1632 renderTemplate now supports custom render method

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -784,11 +784,11 @@ class AdminController extends Controller
      * If the controller implements an action specific method (e.g. renderEditTemplate)
      * it will be used
      *
-     * @param string $actionName The name of the current action (list, show, new, etc.)
+     * @param string $actionName   The name of the current action (list, show, new, etc.)
      * @param string $templatePath The path of the Twig template to render
-     * @param array $parameters The parameters passed to the template
+     * @param array  $parameters   The parameters passed to the template
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     protected function renderTemplate($actionName, $templatePath, array $parameters = [])
     {
@@ -800,5 +800,4 @@ class AdminController extends Controller
 
         return $this->render($templatePath, $parameters);
     }
-
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -781,17 +781,24 @@ class AdminController extends Controller
 
     /**
      * Used to add/modify/remove parameters before passing them to the Twig template.
-     * Instead of defining a render method per action (list, show, search, etc.) use
-     * the $actionName argument to discriminate between actions.
+     * If the controller implements an action specific method (e.g. renderEditTemplate)
+     * it will be used
      *
-     * @param string $actionName   The name of the current action (list, show, new, etc.)
+     * @param string $actionName The name of the current action (list, show, new, etc.)
      * @param string $templatePath The path of the Twig template to render
-     * @param array  $parameters   The parameters passed to the template
+     * @param array $parameters The parameters passed to the template
      *
-     * @return Response
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     protected function renderTemplate($actionName, $templatePath, array $parameters = [])
     {
+        $customRenderMethod = 'render' . ucfirst($actionName) . 'Template';
+
+        if (method_exists($this, $customRenderMethod)) {
+            return $this->$customRenderMethod($actionName, $templatePath, $parameters);
+        }
+
         return $this->render($templatePath, $parameters);
     }
+
 }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -792,7 +792,7 @@ class AdminController extends Controller
      */
     protected function renderTemplate($actionName, $templatePath, array $parameters = [])
     {
-        $customRenderMethod = 'render' . ucfirst($actionName) . 'Template';
+        $customRenderMethod = 'render'.ucfirst($actionName).'Template';
 
         if (method_exists($this, $customRenderMethod)) {
             return $this->$customRenderMethod($actionName, $templatePath, $parameters);


### PR DESCRIPTION
This is about https://github.com/EasyCorp/EasyAdminBundle/issues/1632
which was added to the feature board in "Features that MIGHT be implemented #3"

With these changes, the renderTemplate() method will look for an action-specific render method in the current (extended) controller, for example renderEditTemplate(). This way, custom template variables can be injected very easily.