### PR TITLE
Controlling entities accessibility and menu items depending on user's roles

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -89,6 +89,7 @@
         </service>
 
         <service id="easyadmin.configuration.menu_config_pass" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\MenuConfigPass" public="false">
+            <argument type="service" id="security.token_storage" />
             <tag name="easyadmin.config_pass" priority="70" />
         </service>
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -93,6 +93,7 @@
         </service>
 
         <service id="easyadmin.configuration.action_config_pass" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\ActionConfigPass" public="false">
+            <argument type="service" id="security.token_storage" />
             <tag name="easyadmin.config_pass" priority="60" />
         </service>
 


### PR DESCRIPTION
Example of configuration:

```
easy_admin:
    design:
            menu:
                - entity: TEST
                  icon: 'question'
                  #only users with ROLE_ADMIN can see this entity in the menu section 
                  roles:
                    - ROLE_ADMIN
    entities:
              TEST:
                  #only users with ROLE_ADMIN can have access to the entity         
                  roles:
                    - ROLE_ADMIN
                  class: App\Entity\Test



```