### PR TITLE
Show/Use entities depending on user's roles

### DIFF
--- a/src/Configuration/ActionConfigPass.php
+++ b/src/Configuration/ActionConfigPass.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Configuration;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
 /**
  * Merges all the actions that can be configured in the backend and normalizes
  * them to get the final action configuration for each entity view.
@@ -87,7 +88,10 @@ class ActionConfigPass implements ConfigPassInterface
         // first, normalize actions defined globally for the entire backend
         foreach ($this->views as $view) {
             $actionsConfig = $backendConfig[$view]['actions'];
-            $actionsConfig = $this->doNormalizeActionsConfig($actionsConfig, sprintf('the global "%s" view defined under "easy_admin" option', $view));
+            $actionsConfig = $this->doNormalizeActionsConfig(
+                $actionsConfig,
+                sprintf('the global "%s" view defined under "easy_admin" option', $view)
+            );
             $actionsConfig = $this->doNormalizeDefaultActionsConfig($actionsConfig, $view);
 
             $backendConfig[$view]['actions'] = $actionsConfig;
@@ -97,7 +101,10 @@ class ActionConfigPass implements ConfigPassInterface
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
             foreach ($this->views as $view) {
                 $actionsConfig = $entityConfig[$view]['actions'];
-                $actionsConfig = $this->doNormalizeActionsConfig($actionsConfig, sprintf('the "%s" view of the "%s" entity', $view, $entityName));
+                $actionsConfig = $this->doNormalizeActionsConfig(
+                    $actionsConfig,
+                    sprintf('the "%s" view of the "%s" entity', $view, $entityName)
+                );
                 $actionsConfig = $this->doNormalizeDefaultActionsConfig($actionsConfig, $view);
 
                 $backendConfig['entities'][$entityName][$view]['actions'] = $actionsConfig;
@@ -113,7 +120,12 @@ class ActionConfigPass implements ConfigPassInterface
 
         foreach ($actionsConfig as $i => $actionConfig) {
             if (!is_string($actionConfig) && !is_array($actionConfig)) {
-                throw new \RuntimeException(sprintf('One of the actions defined by %s contains an invalid value (action config can only be a YAML string or hash).', $errorOrigin));
+                throw new \RuntimeException(
+                    sprintf(
+                        'One of the actions defined by %s contains an invalid value (action config can only be a YAML string or hash).',
+                        $errorOrigin
+                    )
+                );
             }
 
             // config format #1
@@ -126,7 +138,12 @@ class ActionConfigPass implements ConfigPassInterface
             // 'name' is the only mandatory option for actions (it might
             // be missing when using the config format #2)
             if (!isset($actionConfig['name'])) {
-                throw new \RuntimeException(sprintf('One of the actions defined by %s does not define its name, which is the only mandatory option for actions.', $errorOrigin));
+                throw new \RuntimeException(
+                    sprintf(
+                        'One of the actions defined by %s does not define its name, which is the only mandatory option for actions.',
+                        $errorOrigin
+                    )
+                );
             }
 
             $actionName = $actionConfig['name'];
@@ -147,7 +164,7 @@ class ActionConfigPass implements ConfigPassInterface
      * default value for any option that you don't explicitly set (e.g. the icon
      * or the CSS class).
      *
-     * @param array  $actionsConfig
+     * @param array $actionsConfig
      * @param string $view
      *
      * @return array
@@ -159,9 +176,12 @@ class ActionConfigPass implements ConfigPassInterface
         foreach ($actionsConfig as $actionName => $actionConfig) {
             if (array_key_exists($actionName, $defaultActionsConfig)) {
                 // remove null config options but maintain empty options (this allows to set an empty label for the action)
-                $actionConfig = array_filter($actionConfig, function ($element) {
-                    return null !== $element;
-                });
+                $actionConfig = array_filter(
+                    $actionConfig,
+                    function ($element) {
+                        return null !== $element;
+                    }
+                );
                 $actionsConfig[$actionName] = array_merge($defaultActionsConfig[$actionName], $actionConfig);
             }
         }
@@ -233,7 +253,14 @@ class ActionConfigPass implements ConfigPassInterface
                     // 'name' value is used as the class method name or the Symfony route name
                     // check that its value complies with the PHP method name rules
                     if (!$this->isValidMethodName($actionName)) {
-                        throw new \InvalidArgumentException(sprintf('The name of the "%s" action defined in the "%s" view of the "%s" entity contains invalid characters (allowed: letters, numbers, underscores; the first character cannot be a number).', $actionName, $view, $entityName));
+                        throw new \InvalidArgumentException(
+                            sprintf(
+                                'The name of the "%s" action defined in the "%s" view of the "%s" entity contains invalid characters (allowed: letters, numbers, underscores; the first character cannot be a number).',
+                                $actionName,
+                                $view,
+                                $entityName
+                            )
+                        );
                     }
 
                     if (null === $actionConfig['label']) {
@@ -262,14 +289,26 @@ class ActionConfigPass implements ConfigPassInterface
      */
     private function getDefaultActionsConfig($view)
     {
-        $actions = $this->doNormalizeActionsConfig([
-            'delete' => ['name' => 'delete', 'label' => 'action.delete', 'icon' => 'trash-o', 'css_class' => 'btn btn-default'],
-            'edit' => ['name' => 'edit', 'label' => 'action.edit', 'icon' => 'edit', 'css_class' => 'btn btn-primary'],
-            'new' => ['name' => 'new', 'label' => 'action.new', 'css_class' => 'btn btn-primary'],
-            'search' => ['name' => 'search', 'label' => 'action.search'],
-            'show' => ['name' => 'show', 'label' => 'action.show'],
-            'list' => ['name' => 'list', 'label' => 'action.list', 'css_class' => 'btn btn-secondary'],
-        ]);
+        $actions = $this->doNormalizeActionsConfig(
+            [
+                'delete' => [
+                    'name' => 'delete',
+                    'label' => 'action.delete',
+                    'icon' => 'trash-o',
+                    'css_class' => 'btn btn-default',
+                ],
+                'edit' => [
+                    'name' => 'edit',
+                    'label' => 'action.edit',
+                    'icon' => 'edit',
+                    'css_class' => 'btn btn-primary',
+                ],
+                'new' => ['name' => 'new', 'label' => 'action.new', 'css_class' => 'btn btn-primary'],
+                'search' => ['name' => 'search', 'label' => 'action.search'],
+                'show' => ['name' => 'show', 'label' => 'action.show'],
+                'list' => ['name' => 'list', 'label' => 'action.list', 'css_class' => 'btn btn-secondary'],
+            ]
+        );
 
         // minor tweaks for some action + view combinations
         if ('list' === $view) {
@@ -353,24 +392,28 @@ class ActionConfigPass implements ConfigPassInterface
 
         return $newArray;
     }
+
     /**
      * Checks if user has the right to use the entity
      *
      * @author luxferoo <imamharir@gmail.com>
+     *
      * @param array $backendConfig
+     *
      * @return array
      */
-    private
-    function processEntitiesSecurityConfig(array $backendConfig)
+    private function processEntitiesSecurityConfig(array $backendConfig)
     {
         $userRoles = [];
-        if (!is_string($this->tokenStorage->getToken()->getUser()))
+        if (!is_string($this->tokenStorage->getToken()->getUser())) {
             $userRoles = $this->tokenStorage->getToken()->getUser()->getRoles();
+        }
 
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
             $rolesForEntity = isset($entityConfig['roles']) ? $entityConfig['roles'] : [];
-            if (!array_intersect($rolesForEntity, $userRoles) && $rolesForEntity)
+            if (!array_intersect($rolesForEntity, $userRoles) && $rolesForEntity) {
                 unset($backendConfig['entities'][$entityName]);
+            }
         }
 
         return $backendConfig;

--- a/src/Configuration/ActionConfigPass.php
+++ b/src/Configuration/ActionConfigPass.php
@@ -88,10 +88,7 @@ class ActionConfigPass implements ConfigPassInterface
         // first, normalize actions defined globally for the entire backend
         foreach ($this->views as $view) {
             $actionsConfig = $backendConfig[$view]['actions'];
-            $actionsConfig = $this->doNormalizeActionsConfig(
-                $actionsConfig,
-                sprintf('the global "%s" view defined under "easy_admin" option', $view)
-            );
+            $actionsConfig = $this->doNormalizeActionsConfig($actionsConfig, sprintf('the global "%s" view defined under "easy_admin" option', $view));
             $actionsConfig = $this->doNormalizeDefaultActionsConfig($actionsConfig, $view);
 
             $backendConfig[$view]['actions'] = $actionsConfig;
@@ -101,10 +98,7 @@ class ActionConfigPass implements ConfigPassInterface
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
             foreach ($this->views as $view) {
                 $actionsConfig = $entityConfig[$view]['actions'];
-                $actionsConfig = $this->doNormalizeActionsConfig(
-                    $actionsConfig,
-                    sprintf('the "%s" view of the "%s" entity', $view, $entityName)
-                );
+                $actionsConfig = $this->doNormalizeActionsConfig($actionsConfig, sprintf('the "%s" view of the "%s" entity', $view, $entityName));
                 $actionsConfig = $this->doNormalizeDefaultActionsConfig($actionsConfig, $view);
 
                 $backendConfig['entities'][$entityName][$view]['actions'] = $actionsConfig;
@@ -120,12 +114,7 @@ class ActionConfigPass implements ConfigPassInterface
 
         foreach ($actionsConfig as $i => $actionConfig) {
             if (!is_string($actionConfig) && !is_array($actionConfig)) {
-                throw new \RuntimeException(
-                    sprintf(
-                        'One of the actions defined by %s contains an invalid value (action config can only be a YAML string or hash).',
-                        $errorOrigin
-                    )
-                );
+                throw new \RuntimeException(sprintf('One of the actions defined by %s contains an invalid value (action config can only be a YAML string or hash).', $errorOrigin));
             }
 
             // config format #1
@@ -138,12 +127,7 @@ class ActionConfigPass implements ConfigPassInterface
             // 'name' is the only mandatory option for actions (it might
             // be missing when using the config format #2)
             if (!isset($actionConfig['name'])) {
-                throw new \RuntimeException(
-                    sprintf(
-                        'One of the actions defined by %s does not define its name, which is the only mandatory option for actions.',
-                        $errorOrigin
-                    )
-                );
+                throw new \RuntimeException(sprintf('One of the actions defined by %s does not define its name, which is the only mandatory option for actions.', $errorOrigin));
             }
 
             $actionName = $actionConfig['name'];
@@ -164,7 +148,7 @@ class ActionConfigPass implements ConfigPassInterface
      * default value for any option that you don't explicitly set (e.g. the icon
      * or the CSS class).
      *
-     * @param array $actionsConfig
+     * @param array  $actionsConfig
      * @param string $view
      *
      * @return array
@@ -176,12 +160,9 @@ class ActionConfigPass implements ConfigPassInterface
         foreach ($actionsConfig as $actionName => $actionConfig) {
             if (array_key_exists($actionName, $defaultActionsConfig)) {
                 // remove null config options but maintain empty options (this allows to set an empty label for the action)
-                $actionConfig = array_filter(
-                    $actionConfig,
-                    function ($element) {
-                        return null !== $element;
-                    }
-                );
+                $actionConfig = array_filter($actionConfig, function ($element) {
+                    return null !== $element;
+                });
                 $actionsConfig[$actionName] = array_merge($defaultActionsConfig[$actionName], $actionConfig);
             }
         }
@@ -253,14 +234,7 @@ class ActionConfigPass implements ConfigPassInterface
                     // 'name' value is used as the class method name or the Symfony route name
                     // check that its value complies with the PHP method name rules
                     if (!$this->isValidMethodName($actionName)) {
-                        throw new \InvalidArgumentException(
-                            sprintf(
-                                'The name of the "%s" action defined in the "%s" view of the "%s" entity contains invalid characters (allowed: letters, numbers, underscores; the first character cannot be a number).',
-                                $actionName,
-                                $view,
-                                $entityName
-                            )
-                        );
+                        throw new \InvalidArgumentException(sprintf('The name of the "%s" action defined in the "%s" view of the "%s" entity contains invalid characters (allowed: letters, numbers, underscores; the first character cannot be a number).', $actionName, $view, $entityName));
                     }
 
                     if (null === $actionConfig['label']) {
@@ -289,26 +263,14 @@ class ActionConfigPass implements ConfigPassInterface
      */
     private function getDefaultActionsConfig($view)
     {
-        $actions = $this->doNormalizeActionsConfig(
-            [
-                'delete' => [
-                    'name' => 'delete',
-                    'label' => 'action.delete',
-                    'icon' => 'trash-o',
-                    'css_class' => 'btn btn-default',
-                ],
-                'edit' => [
-                    'name' => 'edit',
-                    'label' => 'action.edit',
-                    'icon' => 'edit',
-                    'css_class' => 'btn btn-primary',
-                ],
-                'new' => ['name' => 'new', 'label' => 'action.new', 'css_class' => 'btn btn-primary'],
-                'search' => ['name' => 'search', 'label' => 'action.search'],
-                'show' => ['name' => 'show', 'label' => 'action.show'],
-                'list' => ['name' => 'list', 'label' => 'action.list', 'css_class' => 'btn btn-secondary'],
-            ]
-        );
+        $actions = $this->doNormalizeActionsConfig([
+            'delete' => ['name' => 'delete', 'label' => 'action.delete', 'icon' => 'trash-o', 'css_class' => 'btn btn-default'],
+            'edit' => ['name' => 'edit', 'label' => 'action.edit', 'icon' => 'edit', 'css_class' => 'btn btn-primary'],
+            'new' => ['name' => 'new', 'label' => 'action.new', 'css_class' => 'btn btn-primary'],
+            'search' => ['name' => 'search', 'label' => 'action.search'],
+            'show' => ['name' => 'show', 'label' => 'action.show'],
+            'list' => ['name' => 'list', 'label' => 'action.list', 'css_class' => 'btn btn-secondary'],
+        ]);
 
         // minor tweaks for some action + view combinations
         if ('list' === $view) {

--- a/src/Configuration/ActionConfigPass.php
+++ b/src/Configuration/ActionConfigPass.php
@@ -367,7 +367,7 @@ class ActionConfigPass implements ConfigPassInterface
     private function processEntitiesSecurityConfig(array $backendConfig)
     {
         $userRoles = [];
-        if (!is_string($this->tokenStorage->getToken()->getUser())) {
+        if ($this->tokenStorage->getToken() && !is_string($this->tokenStorage->getToken()->getUser())) {
             $userRoles = $this->tokenStorage->getToken()->getUser()->getRoles();
         }
 

--- a/src/Configuration/MenuConfigPass.php
+++ b/src/Configuration/MenuConfigPass.php
@@ -198,7 +198,7 @@ class MenuConfigPass implements ConfigPassInterface
     private function processMenuSecurityConfig(array $menuConfig)
     {
         $userRoles = [];
-        if (!is_string($this->tokenStorage->getToken()->getUser())) {
+        if ($this->tokenStorage->getToken() && !is_string($this->tokenStorage->getToken()->getUser())) {
             $userRoles = $this->tokenStorage->getToken()->getUser()->getRoles();
         }
 

--- a/src/Configuration/MenuConfigPass.php
+++ b/src/Configuration/MenuConfigPass.php
@@ -51,7 +51,7 @@ class MenuConfigPass implements ConfigPassInterface
      *
      * @param array $menuConfig
      * @param array $backendConfig
-     * @param int $parentItemIndex The index of the parent item for this menu item (allows to treat submenus differently)
+     * @param int   $parentItemIndex The index of the parent item for this menu item (allows to treat submenus differently)
      *
      * @return array
      */
@@ -96,21 +96,21 @@ class MenuConfigPass implements ConfigPassInterface
             if (!array_key_exists('default', $itemConfig)) {
                 $itemConfig['default'] = false;
             } else {
-                $itemConfig['default'] = (bool)$itemConfig['default'];
+                $itemConfig['default'] = (bool) $itemConfig['default'];
             }
 
             // normalize 'target' option, which allows to open menu items in different windows or tabs
             if (!array_key_exists('target', $itemConfig)) {
                 $itemConfig['target'] = false;
             } else {
-                $itemConfig['target'] = (string)$itemConfig['target'];
+                $itemConfig['target'] = (string) $itemConfig['target'];
             }
 
             // normalize 'rel' option, which adds html5 rel attribute (https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)
             if (!array_key_exists('rel', $itemConfig)) {
                 $itemConfig['rel'] = array_key_exists('url', $itemConfig) ? 'noreferrer' : false;
             } else {
-                $itemConfig['rel'] = (string)$itemConfig['rel'];
+                $itemConfig['rel'] = (string) $itemConfig['rel'];
             }
 
             $menuConfig[$i] = $itemConfig;
@@ -132,13 +132,7 @@ class MenuConfigPass implements ConfigPassInterface
                 $entityName = $itemConfig['entity'];
 
                 if (!array_key_exists($entityName, $backendConfig['entities'])) {
-                    throw new \RuntimeException(
-                        sprintf(
-                            'The "%s" entity included in the "menu" option is not managed by EasyAdmin. The menu can only include any of these entities: %s. NOTE: If your menu worked before, this error may be caused by a change introduced by EasyAdmin 1.12.0 version. Check out https://github.com/javiereguiluz/EasyAdminBundle/releases/tag/v1.12.0 for more details.',
-                            $entityName,
-                            implode(', ', array_keys($backendConfig['entities']))
-                        )
-                    );
+                    throw new \RuntimeException(sprintf('The "%s" entity included in the "menu" option is not managed by EasyAdmin. The menu can only include any of these entities: %s. NOTE: If your menu worked before, this error may be caused by a change introduced by EasyAdmin 1.12.0 version. Check out https://github.com/javiereguiluz/EasyAdminBundle/releases/tag/v1.12.0 for more details.', $entityName, implode(', ', array_keys($backendConfig['entities']))));
                 }
 
                 if (!isset($itemConfig['label'])) {
@@ -148,29 +142,23 @@ class MenuConfigPass implements ConfigPassInterface
                 if (!isset($itemConfig['params'])) {
                     $itemConfig['params'] = [];
                 }
-            } // 2nd level priority: if 'url' is defined, link to the given absolute/relative URL
+            }
+
+            // 2nd level priority: if 'url' is defined, link to the given absolute/relative URL
             elseif (isset($itemConfig['url'])) {
                 $itemConfig['type'] = 'link';
 
                 if (!isset($itemConfig['label'])) {
-                    throw new \RuntimeException(
-                        sprintf(
-                            'The configuration of the menu item with "url = %s" must define the "label" option.',
-                            $itemConfig['url']
-                        )
-                    );
+                    throw new \RuntimeException(sprintf('The configuration of the menu item with "url = %s" must define the "label" option.', $itemConfig['url']));
                 }
-            } // 3rd level priority: if 'route' is defined, link to the path generated with the given route
+            }
+
+            // 3rd level priority: if 'route' is defined, link to the path generated with the given route
             elseif (isset($itemConfig['route'])) {
                 $itemConfig['type'] = 'route';
 
                 if (!isset($itemConfig['label'])) {
-                    throw new \RuntimeException(
-                        sprintf(
-                            'The configuration of the menu item with "route = %s" must define the "label" option.',
-                            $itemConfig['route']
-                        )
-                    );
+                    throw new \RuntimeException(sprintf('The configuration of the menu item with "route = %s" must define the "label" option.', $itemConfig['route']));
                 }
 
                 if (!isset($itemConfig['params'])) {
@@ -189,12 +177,7 @@ class MenuConfigPass implements ConfigPassInterface
                     $itemConfig['type'] = 'empty';
                 }
             } else {
-                throw new \RuntimeException(
-                    sprintf(
-                        'The configuration of the menu item in the position %d (being 0 the first item) must define at least one of these options: entity, url, route, label.',
-                        $i
-                    )
-                );
+                throw new \RuntimeException(sprintf('The configuration of the menu item in the position %d (being 0 the first item) must define at least one of these options: entity, url, route, label.', $i));
             }
 
             $menuConfig[$i] = $itemConfig;

--- a/src/Configuration/MenuConfigPass.php
+++ b/src/Configuration/MenuConfigPass.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Configuration;
 
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
 /**
  * Processes the main menu configuration defined in the "design.menu"
  * option or creates the default config for the menu if none is defined.
@@ -50,7 +51,7 @@ class MenuConfigPass implements ConfigPassInterface
      *
      * @param array $menuConfig
      * @param array $backendConfig
-     * @param int   $parentItemIndex The index of the parent item for this menu item (allows to treat submenus differently)
+     * @param int $parentItemIndex The index of the parent item for this menu item (allows to treat submenus differently)
      *
      * @return array
      */
@@ -95,21 +96,21 @@ class MenuConfigPass implements ConfigPassInterface
             if (!array_key_exists('default', $itemConfig)) {
                 $itemConfig['default'] = false;
             } else {
-                $itemConfig['default'] = (bool) $itemConfig['default'];
+                $itemConfig['default'] = (bool)$itemConfig['default'];
             }
 
             // normalize 'target' option, which allows to open menu items in different windows or tabs
             if (!array_key_exists('target', $itemConfig)) {
                 $itemConfig['target'] = false;
             } else {
-                $itemConfig['target'] = (string) $itemConfig['target'];
+                $itemConfig['target'] = (string)$itemConfig['target'];
             }
 
             // normalize 'rel' option, which adds html5 rel attribute (https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types)
             if (!array_key_exists('rel', $itemConfig)) {
                 $itemConfig['rel'] = array_key_exists('url', $itemConfig) ? 'noreferrer' : false;
             } else {
-                $itemConfig['rel'] = (string) $itemConfig['rel'];
+                $itemConfig['rel'] = (string)$itemConfig['rel'];
             }
 
             $menuConfig[$i] = $itemConfig;
@@ -131,7 +132,13 @@ class MenuConfigPass implements ConfigPassInterface
                 $entityName = $itemConfig['entity'];
 
                 if (!array_key_exists($entityName, $backendConfig['entities'])) {
-                    throw new \RuntimeException(sprintf('The "%s" entity included in the "menu" option is not managed by EasyAdmin. The menu can only include any of these entities: %s. NOTE: If your menu worked before, this error may be caused by a change introduced by EasyAdmin 1.12.0 version. Check out https://github.com/javiereguiluz/EasyAdminBundle/releases/tag/v1.12.0 for more details.', $entityName, implode(', ', array_keys($backendConfig['entities']))));
+                    throw new \RuntimeException(
+                        sprintf(
+                            'The "%s" entity included in the "menu" option is not managed by EasyAdmin. The menu can only include any of these entities: %s. NOTE: If your menu worked before, this error may be caused by a change introduced by EasyAdmin 1.12.0 version. Check out https://github.com/javiereguiluz/EasyAdminBundle/releases/tag/v1.12.0 for more details.',
+                            $entityName,
+                            implode(', ', array_keys($backendConfig['entities']))
+                        )
+                    );
                 }
 
                 if (!isset($itemConfig['label'])) {
@@ -141,23 +148,29 @@ class MenuConfigPass implements ConfigPassInterface
                 if (!isset($itemConfig['params'])) {
                     $itemConfig['params'] = [];
                 }
-            }
-
-            // 2nd level priority: if 'url' is defined, link to the given absolute/relative URL
+            } // 2nd level priority: if 'url' is defined, link to the given absolute/relative URL
             elseif (isset($itemConfig['url'])) {
                 $itemConfig['type'] = 'link';
 
                 if (!isset($itemConfig['label'])) {
-                    throw new \RuntimeException(sprintf('The configuration of the menu item with "url = %s" must define the "label" option.', $itemConfig['url']));
+                    throw new \RuntimeException(
+                        sprintf(
+                            'The configuration of the menu item with "url = %s" must define the "label" option.',
+                            $itemConfig['url']
+                        )
+                    );
                 }
-            }
-
-            // 3rd level priority: if 'route' is defined, link to the path generated with the given route
+            } // 3rd level priority: if 'route' is defined, link to the path generated with the given route
             elseif (isset($itemConfig['route'])) {
                 $itemConfig['type'] = 'route';
 
                 if (!isset($itemConfig['label'])) {
-                    throw new \RuntimeException(sprintf('The configuration of the menu item with "route = %s" must define the "label" option.', $itemConfig['route']));
+                    throw new \RuntimeException(
+                        sprintf(
+                            'The configuration of the menu item with "route = %s" must define the "label" option.',
+                            $itemConfig['route']
+                        )
+                    );
                 }
 
                 if (!isset($itemConfig['params'])) {
@@ -176,7 +189,12 @@ class MenuConfigPass implements ConfigPassInterface
                     $itemConfig['type'] = 'empty';
                 }
             } else {
-                throw new \RuntimeException(sprintf('The configuration of the menu item in the position %d (being 0 the first item) must define at least one of these options: entity, url, route, label.', $i));
+                throw new \RuntimeException(
+                    sprintf(
+                        'The configuration of the menu item in the position %d (being 0 the first item) must define at least one of these options: entity, url, route, label.',
+                        $i
+                    )
+                );
             }
 
             $menuConfig[$i] = $itemConfig;
@@ -189,25 +207,31 @@ class MenuConfigPass implements ConfigPassInterface
      * Checks if the entity should be displayed in the menu section
      *
      * @author luxferoo <imamharir@gmail.com>
+     *
      * @param array $menuConfig
+     *
      * @return array
      */
-    private
-    function processMenuSecurityConfig(array $menuConfig){
+    private function processMenuSecurityConfig(array $menuConfig)
+    {
         $userRoles = [];
-        if (!is_string($this->tokenStorage->getToken()->getUser()))
+        if (!is_string($this->tokenStorage->getToken()->getUser())) {
             $userRoles = $this->tokenStorage->getToken()->getUser()->getRoles();
+        }
 
         foreach ($menuConfig as $i => &$itemConfig) {
             $rolesForItem = isset($itemConfig['roles']) ? $itemConfig['roles'] : [];
-            if (!array_intersect($rolesForItem, $userRoles) && $rolesForItem)
+            if (!array_intersect($rolesForItem, $userRoles) && $rolesForItem) {
                 unset($menuConfig[$i]);
-            foreach ($itemConfig['children'] as $index => $subItem){
+            }
+            foreach ($itemConfig['children'] as $index => $subItem) {
                 $rolesForSubItem = isset($subItem['roles']) ? $subItem['roles'] : [];
-                if (!array_intersect($rolesForSubItem, $userRoles) && $rolesForSubItem)
+                if (!array_intersect($rolesForSubItem, $userRoles) && $rolesForSubItem) {
                     unset($itemConfig['children'][$index]);
+                }
             }
         }
+
         return $menuConfig;
     }
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
         <service id="easyadmin.config.manager" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager" public="true">
@@ -89,10 +89,12 @@
         </service>
 
         <service id="easyadmin.configuration.menu_config_pass" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\MenuConfigPass" public="false">
+            <argument type="service" id="security.token_storage"/>
             <tag name="easyadmin.config_pass" priority="70" />
         </service>
 
         <service id="easyadmin.configuration.action_config_pass" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\ActionConfigPass" public="false">
+            <argument type="service" id="security.token_storage"/>
             <tag name="easyadmin.config_pass" priority="60" />
         </service>
 

--- a/tests/Configuration/ActionConfigPassTest.php
+++ b/tests/Configuration/ActionConfigPassTest.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\DependencyInjection\Compiler;
 
 use EasyCorp\Bundle\EasyAdminBundle\Configuration\ActionConfigPass;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 
 class ActionConfigPassTest extends TestCase
 {
@@ -15,7 +16,7 @@ class ActionConfigPassTest extends TestCase
      */
     public function testActionconfigFormat($actionsConfig)
     {
-        $configPass = new ActionConfigPass();
+        $configPass = new ActionConfigPass(new TokenStorage());
         $method = new \ReflectionMethod($configPass, 'doNormalizeActionsConfig');
         $method->setAccessible(true);
 


### PR DESCRIPTION
configuration example: 

```
easy_admin:
    design:
            menu:
                - entity: TEST
                  icon: 'question'
                  #only users with ROLE_ADMIN can see this entity in the menu section
                  roles:
                    - ROLE_ADMIN
    entities:
              TEST:
                  #only users with ROLE_ADMIN can have access to the entity
                  roles:
                    - ROLE_ADMIN
                  class: App\Entity\Test



```