### PR TITLE
Fix #1968 [Bug] Add workaround for cache permissions dev environment

### DIFF
--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -22,7 +22,12 @@ class CacheManager extends FilesystemCache
 {
     public function __construct($cacheDir)
     {
+      if ($_SERVER['APP_ENV'] === 'dev') {
+        parent::__construct($cacheDir, self::EXTENSION, 0000);
+      }
+      else {
         parent::__construct($cacheDir);
+      }
     }
 
     /**

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -22,7 +22,7 @@ class CacheManager extends FilesystemCache
 {
     public function __construct($cacheDir)
     {
-      if ($_SERVER['APP_ENV'] === 'dev') {
+      if (isset($_SERVER['APP_ENV']) && $_SERVER['APP_ENV'] === 'dev') {
         parent::__construct($cacheDir, self::EXTENSION, 0000);
       }
       else {


### PR DESCRIPTION
Applied the workaround in #1968 comment 2. It seems to be important to get this in because the steps are communicated in the [quick demo blog article from Fabian](http://fabien.potencier.org/symfony4-demo.html)

Many people can reproduce the issue with the following steps:

1. Install latest stable Symfony 4 version
2. Install this bundle with the admin package (composer req admin)
3. Creating a product and update doctrine
4. Go to the website and you should see the error: 
5. The directory "/var/www/project/var/cache/dev/easy_admin" is not writable.
6. Temporary solve it by chmod 777 var/cache/dev/easy_admin
7. Cache clear the error appears again (permission of the folder is set to 775

With the patch the issue does not occur and the permissions of the directory is set to 777. It seems the patch is only needed for the development environment because in the production environment the cache is build before pages are visited (warmup).