### PR TITLE
#2203 Update the bootstrap form themes

### DIFF
--- a/doc/book/configuration-reference.rst
+++ b/doc/book/configuration-reference.rst
@@ -206,10 +206,10 @@ form_theme
 **values**: ``'horizontal'``, ``'vertical'``, any valid form theme template path)
 
 The form theme used to render the form fields in the ``edit`` and ``new`` views.
-The default ``'horizontal'`` value is a shortcut of ``@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig``
+The default ``'horizontal'`` value is a shortcut of ``@EasyAdmin/form/horizontal_layout.html.twig``
 which displays the form fields using the default horizontal Bootstrap 3 design.
 
-The ``'vertical'`` value is a shortcut of ``@EasyAdmin/form/bootstrap_3_layout.html.twig``
+The ``'vertical'`` value is a shortcut of ``@EasyAdmin/form/layout.html.twig``
 which displays the form fields using the more common vertical Bootstrap 3 design.
 This style is better than ``'horizontal'`` when you want to increase the space
 available to edit the property values. Example:

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -268,8 +268,8 @@ class Configuration implements ConfigurationInterface
                         ->end()
 
                         ->variableNode('form_theme')
-                            ->defaultValue(['@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'])
-                            ->treatNullLike(['@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'])
+                            ->defaultValue(['@EasyAdmin/form/horizontal_layout.html.twig'])
+                            ->treatNullLike(['@EasyAdmin/form/horizontal_layout.html.twig'])
                             ->info('The form theme applied to backend forms. Allowed values: "horizontal", "vertical", any valid form theme path or an array of theme paths.')
                             ->validate()
                                 ->ifString()->then(function ($v) {
@@ -280,9 +280,9 @@ class Configuration implements ConfigurationInterface
                                 ->ifArray()->then(function ($values) {
                                     foreach ($values as $k => $v) {
                                         if ('horizontal' === $v) {
-                                            $values[$k] = '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig';
+                                            $values[$k] = '@EasyAdmin/form/horizontal_layout.html.twig';
                                         } elseif ('vertical' === $v) {
-                                            $values[$k] = '@EasyAdmin/form/bootstrap_3_layout.html.twig';
+                                            $values[$k] = '@EasyAdmin/form/layout.html.twig';
                                         }
                                     }
 

--- a/src/Resources/views/form/horizontal_layout.html.twig
+++ b/src/Resources/views/form/horizontal_layout.html.twig
@@ -1,4 +1,4 @@
-{% use "@EasyAdmin/form/bootstrap_3_layout.html.twig" %}
+{% extends 'bootstrap_3_horizontal_layout.html.twig' %}
 
 {% block form_start -%}
     {% set _easyadmin_form_type = 'horizontal' %}
@@ -79,16 +79,3 @@
     </div>
 {% endspaceless %}
 {% endblock submit_row %}
-
-{% block reset_row -%}
-{% spaceless %}
-    <div class="form-group">
-        <div class="{{ block('form_label_class') }}"></div>
-        <div class="{{ block('form_group_class') }}">
-            {{ form_widget(form) }}
-        </div>
-    </div>
-{% endspaceless %}
-{% endblock reset_row %}
-
-{% block form_group_class 'col-sm-10' %}

--- a/src/Resources/views/form/layout.html.twig
+++ b/src/Resources/views/form/layout.html.twig
@@ -1,3 +1,5 @@
+{% extends 'bootstrap_3_layout.html.twig' %}
+
 {% use 'form_div_layout.html.twig' %}
 
 {% block form_start -%}
@@ -59,23 +61,6 @@
         </div>
     {% endif %}
 {% endblock form_widget %}
-
-{% block form_widget_simple -%}
-    {% if type is not defined or type not in ['file', 'hidden'] %}
-        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) -%}
-    {% endif %}
-    {{- parent() -}}
-{%- endblock form_widget_simple %}
-
-{% block textarea_widget -%}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-control')|trim}) %}
-    {{- parent() -}}
-{%- endblock textarea_widget %}
-
-{% block button_widget -%}
-    {% set attr = attr|merge({class: (attr.class|default('btn-default') ~ ' btn')|trim}) %}
-    {{- parent() -}}
-{%- endblock %}
 
 {% block money_widget -%}
     <div class="input-group">
@@ -195,40 +180,7 @@
     {%- endif %}
 {%- endblock choice_widget_expanded %}
 
-{% block checkbox_widget -%}
-    {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
-    {% if 'checkbox-inline' in parent_label_class %}
-        {{- form_label(form, null, { widget: parent() }) -}}
-    {% else -%}
-        <div class="checkbox">
-            {{- form_label(form, null, { widget: parent() }) -}}
-        </div>
-    {%- endif %}
-{%- endblock checkbox_widget %}
-
-{% block radio_widget -%}
-    {%- set parent_label_class = parent_label_class|default(label_attr.class|default('')) -%}
-    {% if 'radio-inline' in parent_label_class %}
-        {{- form_label(form, null, { widget: parent() }) -}}
-    {% else -%}
-        <div class="radio">
-            {{- form_label(form, null, { widget: parent() }) -}}
-        </div>
-    {%- endif %}
-{%- endblock radio_widget %}
-
 {# Labels #}
-
-{% block form_label -%}
-    {%- set label_attr = label_attr|merge({class: (label_attr.class|default('') ~ ' control-label')|trim}) -%}
-    {{- parent() -}}
-{%- endblock form_label %}
-
-{% block choice_label -%}
-    {# remove the checkbox-inline and radio-inline class, it's only useful for embed labels #}
-    {%- set label_attr = label_attr|merge({class: label_attr.class|default('')|replace({'checkbox-inline': '', 'radio-inline': ''})|trim}) -%}
-    {{- block('form_label') -}}
-{% endblock %}
 
 {% block checkbox_label -%}
     {{- block('checkbox_radio_label') -}}
@@ -323,26 +275,6 @@
         {{- form_widget(form) -}}
     </div>
 {%- endblock button_row %}
-
-{% block choice_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
-{%- endblock choice_row %}
-
-{% block date_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
-{%- endblock date_row %}
-
-{% block time_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
-{%- endblock time_row %}
-
-{% block datetime_row -%}
-    {% set force_error = true %}
-    {{- block('form_row') }}
-{%- endblock datetime_row %}
 
 {% block checkbox_row -%}
     <div class="form-group {% if not valid %}has-error{% endif %} field-{{ block_prefixes|slice(-2)|first }}">

--- a/tests/Configuration/fixtures/configurations/output/config_001.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_001.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_002.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_002.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_003.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_003.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_004.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_004.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_005.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_005.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: CustomCategory

--- a/tests/Configuration/fixtures/configurations/output/config_009.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_009.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_010.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_010.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: CustomCategory

--- a/tests/Configuration/fixtures/configurations/output/config_012.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_012.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_016.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_016.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_017.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_017.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_018.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_018.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_019.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_019.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_022.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_022.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_023.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_023.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_024.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_024.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_025.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_025.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_027.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_027.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_028.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_028.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_030.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_030.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_031.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_031.yml
@@ -225,7 +225,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_032.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_032.yml
@@ -265,7 +265,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_033.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_033.yml
@@ -265,7 +265,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_034.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_034.yml
@@ -309,7 +309,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_039.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_039.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_040.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_040.yml
@@ -353,7 +353,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_041.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_041.yml
@@ -222,7 +222,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_042.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_042.yml
@@ -223,7 +223,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_043.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_043.yml
@@ -223,7 +223,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_045.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_045.yml
@@ -224,7 +224,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_046.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_046.yml
@@ -223,7 +223,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_047.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_047.yml
@@ -224,7 +224,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_048.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_048.yml
@@ -223,7 +223,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_049.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_049.yml
@@ -236,7 +236,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_050.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_050.yml
@@ -223,7 +223,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_051.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_051.yml
@@ -224,7 +224,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_052.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_052.yml
@@ -223,7 +223,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_053.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_053.yml
@@ -224,7 +224,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_054.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_054.yml
@@ -223,7 +223,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_055.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_055.yml
@@ -224,7 +224,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_056.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_056.yml
@@ -223,7 +223,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_057.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_057.yml
@@ -231,7 +231,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_058.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_058.yml
@@ -243,7 +243,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_059.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_059.yml
@@ -231,7 +231,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_060.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_060.yml
@@ -243,7 +243,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_061.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_061.yml
@@ -255,7 +255,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_062.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_062.yml
@@ -279,7 +279,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_063.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_063.yml
@@ -255,7 +255,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_064.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_064.yml
@@ -279,7 +279,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_065.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_065.yml
@@ -297,7 +297,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_066.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_066.yml
@@ -236,7 +236,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_067.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_067.yml
@@ -15,7 +15,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_068.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_068.yml
@@ -215,7 +215,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_069.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_069.yml
@@ -215,7 +215,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_070.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_070.yml
@@ -215,7 +215,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_071.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_071.yml
@@ -215,7 +215,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_072.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_072.yml
@@ -231,7 +231,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_073.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_073.yml
@@ -255,7 +255,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_074.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_074.yml
@@ -231,7 +231,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_075.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_075.yml
@@ -255,7 +255,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_076.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_076.yml
@@ -267,7 +267,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_077.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_077.yml
@@ -279,7 +279,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_078.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_078.yml
@@ -267,7 +267,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_079.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_079.yml
@@ -279,7 +279,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_080.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_080.yml
@@ -255,7 +255,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_081.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_081.yml
@@ -519,7 +519,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_082.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_082.yml
@@ -365,7 +365,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_083.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_083.yml
@@ -4,7 +4,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_084.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_084.yml
@@ -1,7 +1,7 @@
 easy_admin:
     design:
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         theme: default
         color_scheme: dark
         brand_color: '#205081'

--- a/tests/Configuration/fixtures/configurations/output/config_085.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_085.yml
@@ -1,7 +1,7 @@
 easy_admin:
     design:
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         theme: default
         color_scheme: dark
         brand_color: '#205081'

--- a/tests/Configuration/fixtures/configurations/output/config_086.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_086.yml
@@ -1,7 +1,7 @@
 easy_admin:
     design:
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_layout.html.twig'
+            - '@EasyAdmin/form/layout.html.twig'
         theme: default
         color_scheme: dark
         brand_color: '#205081'

--- a/tests/Configuration/fixtures/configurations/output/config_090.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_090.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         color_scheme: dark
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_091.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_091.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         color_scheme: dark
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_092.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_092.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         color_scheme: dark
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_093.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_093.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         color_scheme: dark
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_094.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_094.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         color_scheme: dark
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_095.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_095.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         color_scheme: dark
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_096.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_096.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         color_scheme: dark
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_097.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_097.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         color_scheme: dark
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_098.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_098.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_099.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_099.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_100.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_100.yml
@@ -4,7 +4,7 @@ easy_admin:
         theme: default
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         assets:
             css: {  }
             js: {  }

--- a/tests/Configuration/fixtures/configurations/output/config_101.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_101.yml
@@ -244,7 +244,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_102.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_102.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_103.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_103.yml
@@ -244,7 +244,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_107.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_107.yml
@@ -265,7 +265,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_108.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_108.yml
@@ -12,7 +12,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_109.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_109.yml
@@ -224,7 +224,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_110.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_110.yml
@@ -222,7 +222,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_111.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_111.yml
@@ -224,7 +224,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_112.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_112.yml
@@ -225,7 +225,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_113.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_113.yml
@@ -232,7 +232,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_114.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_114.yml
@@ -229,7 +229,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_115.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_115.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_116.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_116.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_117.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_117.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_118.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_118.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_119.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_119.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_120.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_120.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_121.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_121.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_122.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_122.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_123.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_123.yml
@@ -10,7 +10,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_124.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_124.yml
@@ -1,8 +1,8 @@
 easy_admin:
     design:
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
-            - '@EasyAdmin/form/bootstrap_3_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
+            - '@EasyAdmin/form/layout.html.twig'
         theme: default
         color_scheme: dark
         brand_color: '#205081'

--- a/tests/Configuration/fixtures/configurations/output/config_125.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_125.yml
@@ -18,7 +18,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_126.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_126.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_127.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_127.yml
@@ -18,7 +18,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_128.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_128.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_129.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_129.yml
@@ -18,7 +18,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_130.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_130.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/configurations/output/config_131.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_131.yml
@@ -24,7 +24,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/configurations/output/config_132.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_132.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/deprecations/output/config_003.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_003.yml
@@ -13,7 +13,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_004.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_004.yml
@@ -31,7 +31,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_005.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_005.yml
@@ -13,7 +13,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_006.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_006.yml
@@ -31,7 +31,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_007.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_007.yml
@@ -31,7 +31,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_008.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_008.yml
@@ -14,7 +14,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_009.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_009.yml
@@ -14,7 +14,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_010.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_010.yml
@@ -18,7 +18,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_011.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_011.yml
@@ -14,7 +14,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/deprecations/output/config_012.yml
+++ b/tests/Configuration/fixtures/deprecations/output/config_012.yml
@@ -14,7 +14,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu: {  }
         templates:
             layout: '@EasyAdmin/default/layout.html.twig'

--- a/tests/Configuration/fixtures/templates/overridden_by_application/output/config_001.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_application/output/config_001.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/templates/overridden_by_application/output/config_004.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_application/output/config_004.yml
@@ -431,7 +431,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category

--- a/tests/Configuration/fixtures/templates/overridden_by_entity/output/config_001.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_entity/output/config_001.yml
@@ -221,7 +221,7 @@ easy_admin:
         color_scheme: dark
         brand_color: '#205081'
         form_theme:
-            - '@EasyAdmin/form/bootstrap_3_horizontal_layout.html.twig'
+            - '@EasyAdmin/form/horizontal_layout.html.twig'
         menu:
             -
                 entity: Category


### PR DESCRIPTION
This addresses https://github.com/EasyCorp/EasyAdminBundle/issues/2203
I posted some questions there, will copy here:
@javiereguiluz When you say Delete all the contents that are in the default form themes and keep only our own widget blocks., do you mean keep just the ones that are not in symfony's bootstrap templates, or also keep the ones that are in both files but are different?

For example {% block button_row -%} is in Resources/views/form/layout.html.twig and in symfony/twig-bridge/Resources/views/Form/bootstrap_3_layout.html.twig, but the block contents is not identical.