### PR TITLE
[Bugfix] Depend on router instead of router.default

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -40,7 +40,7 @@
 
         <service id="easyadmin.router" class="EasyCorp\Bundle\EasyAdminBundle\Router\EasyAdminRouter" public="true">
             <argument id="easyadmin.config.manager" type="service" />
-            <argument id="router.default" type="service" />
+            <argument id="router" type="service" />
             <argument id="property_accessor" type="service" />
             <argument id="request_stack" type="service" on-invalid="null" />
         </service>


### PR DESCRIPTION
If i want decorate `symfony/router` it not effect on `easyadmin.router` as it hard dependent from `router.default` 