### PR TITLE
JSON encoding nested arrays avoids Twig Exception

### DIFF
--- a/src/Resources/views/default/field_array.html.twig
+++ b/src/Resources/views/default/field_array.html.twig
@@ -2,7 +2,7 @@
     {% if value|length > 0 %}
         <ul>
             {% for element in value %}
-                <li>{{ element }}</li>
+                <li>{{ element is iterable ? element | json_encode : element }}</li>
             {% endfor %}
         </ul>
     {% else %}


### PR DESCRIPTION
Rendering an Entity with an array element which contains a nested array or object was causing a fatal Twig Exception:

> An exception has been thrown during the rendering of a template ("Notice: Array to string conversion")
> Uncaught PHP Exception Twig_Error_Runtime: "An exception has been thrown during the rendering of a template ("Notice: Array to string conversion")." at home/ubuntu/Public/webapp/vendor/easycorp/easyadmin-bundle/src/Resources/views/default/field_array.html.twig line 5

I added a bit to check if the value of an array is also an array or object, and json encode it if so.

This seems like a reasonable balance between infinite nesting hell and just dumping serialized and practically unreadable data, but it's just a 1 line fix to prevent a nasty error for now.

I understand storing nested arrays isn't a particularly common (or good) idea, but it is technically correct and properly handled by Doctrine. This was the least disruptive and opinionated way I could think of to fix this, but I think it might also be a good idea to colorize the json encoded strings or otherwise set them apart so it is clear they are actually objects. Probably nested `<ul>`s or reliance on Twig's new `__toString()` magic method would be better (certainly prettier) long term solutions.

Resolves-resolves issue #1924 and similar.

<!--

BUGS must go to '1.x' branch.
NEW FEATURES must go to 'master' branch.

If the NEW FEATURE is complex, open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license

-->
