### PR TITLE
Replace deprecated SensioFrameWorkBundle @Route annotation

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -12,7 +12,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Exception\NoEntitiesConfiguredException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
 use Pagerfanta\Pagerfanta;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Form;
@@ -24,6 +23,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * The controller used to render all the default EasyAdmin actions.

--- a/tests/Fixtures/App/AppKernel.php
+++ b/tests/Fixtures/App/AppKernel.php
@@ -44,18 +44,6 @@ class AppKernel extends Kernel
                 ]);
             });
         }
-
-        if ($this->requiresLogoutOnUserChange()) {
-            $loader->load(function (ContainerBuilder $container) {
-                $container->loadFromExtension('security', [
-                    'firewalls' => [
-                        'main' => [
-                            'logout_on_user_change' => true,
-                        ],
-                    ],
-                ]);
-            });
-        }
     }
 
     /**
@@ -82,10 +70,5 @@ class AppKernel extends Kernel
     protected function requiresTemplatingConfig()
     {
         return 2 === (int) Kernel::MAJOR_VERSION && 3 === (int) Kernel::MINOR_VERSION;
-    }
-
-    protected function requiresLogoutOnUserChange()
-    {
-        return (int) Kernel::VERSION_ID >= 30400;
     }
 }

--- a/tests/Fixtures/App/config/config.yml
+++ b/tests/Fixtures/App/config/config.yml
@@ -17,6 +17,11 @@ framework:
     session:
         storage_id: session.storage.mock_file
 
+sensio_framework_extra:
+    # SensioFramework annotations are deprecated, use Symfony Routing component instead.
+    router:
+        annotations: false
+
 doctrine:
     dbal:
         driver: pdo_sqlite

--- a/tests/Fixtures/App/config/routing_custom_menu.yml
+++ b/tests/Fixtures/App/config/routing_custom_menu.yml
@@ -6,5 +6,5 @@ easy_admin_bundle:
 custom_route:
     path:   /custom-route
     defaults:
-        _controller: FrameworkBundle:Template:template
+        _controller: FrameworkBundle::Template::template
         template:    'custom_menu/template.html.twig'

--- a/tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
+++ b/tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
@@ -2,8 +2,8 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Response;
 
 class OverridingEasyAdminController extends Controller

--- a/tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
+++ b/tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
@@ -3,8 +3,8 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
 class OverridingEasyAdminController extends Controller
 {


### PR DESCRIPTION
Replace usages of `Sensio\Bundle\FrameworkExtraBundle\Configuration\Route` with `Symfony\Component\Routing\Annotation\Route` since SensioFrameworkExtraBundle [deprecated the Route annotation](https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/CHANGELOG.md).

Closes: #2279 