### PR TITLE
Remove deprecations, fix #2279

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "doctrine/doctrine-bundle": "~1.2",
         "doctrine/orm": "~2.3",
         "pagerfanta/pagerfanta": "~1.0,>=1.0.1",
-        "sensio/framework-extra-bundle": "~2.3|~3.0,>=3.0.2|4.0.x|~5.0",
         "symfony/asset": "~2.3|~3.0|^4.0",
         "symfony/config": "~2.3|~3.0|^4.0",
         "symfony/dependency-injection": "~2.3|~3.0|^4.0",

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -21,7 +21,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Exception\NoEntitiesConfiguredException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Util\LegacyFormHelper;
 use Pagerfanta\Pagerfanta;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Form;
@@ -33,6 +32,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * The controller used to render all the default EasyAdmin actions.

--- a/src/EventListener/ControllerListener.php
+++ b/src/EventListener/ControllerListener.php
@@ -67,17 +67,7 @@ class ControllerListener
             return;
         }
 
-        $customController = $entity['controller'];
-        $controllerMethod = $currentController[1];
-
-        // build the full controller name depending on its type
-        if (class_exists($customController)) {
-            // 'class::method' syntax for normal controllers
-            $customController .= '::'.$controllerMethod;
-        } else {
-            // 'service:method' syntax for controllers as services
-            $customController .= ':'.$controllerMethod;
-        }
+        $customController = $entity['controller'].'::'.$currentController[1];
 
         $request->attributes->set('_controller', $customController);
         $newController = $this->resolver->getController($request);

--- a/tests/Fixtures/App/AppKernel.php
+++ b/tests/Fixtures/App/AppKernel.php
@@ -25,7 +25,6 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-            // new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
             new EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle(),
             new EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\AppTestBundle(),

--- a/tests/Fixtures/App/AppKernel.php
+++ b/tests/Fixtures/App/AppKernel.php
@@ -25,7 +25,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
+            // new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle(),
             new EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle(),
             new EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\AppTestBundle(),
@@ -49,18 +49,6 @@ class AppKernel extends Kernel
                 $container->loadFromExtension('framework', array(
                     'templating' => array(
                         'engines' => array('twig'),
-                    ),
-                ));
-            });
-        }
-
-        if ($this->requiresLogoutOnUserChange()) {
-            $loader->load(function (ContainerBuilder $container) {
-                $container->loadFromExtension('security', array(
-                    'firewalls' => array(
-                        'main' => array(
-                            'logout_on_user_change' => true,
-                        ),
                     ),
                 ));
             });
@@ -91,10 +79,5 @@ class AppKernel extends Kernel
     protected function requiresTemplatingConfig()
     {
         return 2 === (int) Kernel::MAJOR_VERSION && 3 === (int) Kernel::MINOR_VERSION;
-    }
-
-    protected function requiresLogoutOnUserChange()
-    {
-        return (int) Kernel::VERSION_ID >= 30400;
     }
 }

--- a/tests/Fixtures/App/config/config.yml
+++ b/tests/Fixtures/App/config/config.yml
@@ -17,6 +17,9 @@ framework:
     session:
         storage_id: session.storage.mock_file
 
+twig:
+    strict_variables: '%kernel.debug%'
+
 doctrine:
     dbal:
         driver: pdo_sqlite

--- a/tests/Fixtures/App/config/config_customized_backend.yml
+++ b/tests/Fixtures/App/config/config_customized_backend.yml
@@ -22,6 +22,9 @@ framework:
     session:
         storage_id: session.storage.mock_file
 
+twig:
+    strict_variables: '%kernel.debug%'
+
 doctrine:
     dbal:
         driver: pdo_sqlite

--- a/tests/Fixtures/App/config/routing_custom_menu.yml
+++ b/tests/Fixtures/App/config/routing_custom_menu.yml
@@ -6,5 +6,5 @@ easy_admin_bundle:
 custom_route:
     path:   /custom-route
     defaults:
-        _controller: FrameworkBundle:Template:template
+        _controller: Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction
         template:    'custom_menu/template.html.twig'

--- a/tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
+++ b/tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
@@ -2,9 +2,9 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
 
 class OverridingEasyAdminController extends Controller
 {


### PR DESCRIPTION
Remove Sf 4.1 deprecations, Fix #2279 and replaces #2284 :

- Remove dependency to Sensio FrameworkExtraBundle (Routing now uses symfony/routing annotations)
- Declare twig.strict_variables with value of kernel.debug
- Use double semi-colon for routing.
- No more logout_on_user_change security config

I'm not sure this is compatible with Sf 2.8 and Sf 3.3. Maybe it requires some cases OR tests should simply not take care of those deprecations ?
