### PR TITLE
ship a forward compatible annotation route loader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,20 +35,17 @@ matrix:
         - SYMFONY_VERSION="3.4.*"
         - STABILITY=beta
     # Symfony 2 LTS
-    - php: 5.6
+    - php: 5.3
+      dist: precise
       env:
         - SYMFONY_VERSION="2.8.*"
     # legacy (oldest supported versions)
-    - php: 5.3
-      dist: precise
     - php: 5.6
       env:
-        - SYMFONY_VERSION="2.3.*"
-        - COMPOSER_FLAGS="--prefer-lowest"
+        - COMPOSER_FLAGS="--prefer-lowest --prefer-stable"
   allow_failures:
     - php: nightly
     - php: 5.3
-    - php: 5.6
 
 before_install:
   - stty cols 120

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "symfony/console": "~2.3|~3.0|^4.0",
         "symfony/css-selector": "~2.3|~3.0|^4.0",
         "symfony/dom-crawler": "~2.3|~3.0|^4.0",
-        "symfony/phpunit-bridge": "^3.2|^4.0",
+        "symfony/phpunit-bridge": "^3.4.19|^4.1.8",
         "symfony/var-dumper": "~2.3|~3.0|^4.0",
         "symfony/yaml": "~2.3|~3.0|^4.0"
     },

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -837,19 +837,19 @@ class AdminController extends Controller
                 return $this->redirect(urldecode($refererUrl));
             }
 
-            return $this->redirectToRoute('easyadmin', array(
+            return $this->redirect($this->generateUrl('easyadmin', array(
                 'action' => 'list',
                 'entity' => $this->entity['name'],
                 'menuIndex' => $this->request->query->get('menuIndex'),
                 'submenuIndex' => $this->request->query->get('submenuIndex'),
-            ));
+            )));
         }
 
         // 2. from new|edit action, redirect to edit if possible
         if (in_array($refererAction, array('new', 'edit')) && $this->isActionAllowed('edit')) {
             $easyAdminAttributes = $this->request->attributes->get('easyadmin');
 
-            return $this->redirectToRoute('easyadmin', array(
+            return $this->redirect($this->generateUrl('easyadmin', array(
                 'action' => 'edit',
                 'entity' => $this->entity['name'],
                 'menuIndex' => $this->request->query->get('menuIndex'),
@@ -857,17 +857,17 @@ class AdminController extends Controller
                 'id' => ('new' === $refererAction)
                     ? PropertyAccess::createPropertyAccessor()->getValue($easyAdminAttributes['item'], $this->entity['primary_key_field_name'])
                     : $this->request->query->get('id'),
-            ));
+            )));
         }
 
         // 3. from new action, redirect to new if possible
         if ('new' === $refererAction && $this->isActionAllowed('new')) {
-            return $this->redirectToRoute('easyadmin', array(
+            return $this->redirect($this->generateUrl('easyadmin', array(
                 'action' => 'new',
                 'entity' => $this->entity['name'],
                 'menuIndex' => $this->request->query->get('menuIndex'),
                 'submenuIndex' => $this->request->query->get('submenuIndex'),
-            ));
+            )));
         }
 
         return $this->redirectToBackendHomepage();

--- a/src/DependencyInjection/Compiler/AnnotatedRouteControllerLoaderPass.php
+++ b/src/DependencyInjection/Compiler/AnnotatedRouteControllerLoaderPass.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Christian Flothmann <christian.flothmann@sensiolabs.de>
+ */
+class AnnotatedRouteControllerLoaderPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (class_exists('Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader')) {
+            // FrameworkBundle 3.4+ ships it own AnnotationClassLoader implementation
+            return;
+        }
+
+        if (!$container->has('routing.resolver') || $container->has('sensio_framework_extra.routing.loader.annot_class')) {
+            return;
+        }
+
+        $container->register('easyadmin.routing.loader.annotation', 'EasyCorp\Bundle\EasyAdminBundle\Router\AnnotatedRouteControllerLoader')
+            ->setPublic(false)
+            ->addArgument(new Reference('annotation_reader'))
+            ->addTag('routing.loader');
+
+        $container->register('easyadmin.routing.loader.directory', 'Symfony\Component\Routing\Loader\AnnotationDirectoryLoader')
+            ->setPublic(false)
+            ->setArguments(array(
+                new Reference('file_locator'),
+                new Reference('easyadmin.routing.loader.annotation'),
+            ))
+            ->addTag('routing.loader');
+
+        $container->register('easyadmin.routing.loader.file', 'Symfony\Component\Routing\Loader\AnnotationFileLoader')
+            ->setPublic(false)
+            ->addTag('routing.loader', array('priority' => -10))
+            ->setArguments(array(
+                new Reference('file_locator'),
+                new Reference('easyadmin.routing.loader.annotation'),
+            ));
+    }
+}

--- a/src/EasyAdminBundle.php
+++ b/src/EasyAdminBundle.php
@@ -11,6 +11,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle;
 
+use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\Compiler\AnnotatedRouteControllerLoaderPass;
 use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\Compiler\EasyAdminConfigPass;
 use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\Compiler\EasyAdminFormTypePass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -28,6 +29,15 @@ class EasyAdminBundle extends Bundle
     {
         $container->addCompilerPass(new EasyAdminFormTypePass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new EasyAdminConfigPass());
+
+        if (trait_exists('Symfony\Component\DependencyInjection\PriorityTaggedServiceTrait')) { // DI >= 3.2, we can use priority rules
+            $container->addCompilerPass(new AnnotatedRouteControllerLoaderPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
+        } else {
+            $passConfig = $container->getCompilerPassConfig();
+            $passes = $passConfig->getBeforeOptimizationPasses();
+            array_unshift($passes, new AnnotatedRouteControllerLoaderPass()); // Make sure our pass is executed before the RoutingResolverPass
+            $passConfig->setBeforeOptimizationPasses($passes);
+        }
     }
 }
 

--- a/src/Router/AnnotatedRouteControllerLoader.php
+++ b/src/Router/AnnotatedRouteControllerLoader.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the EasyAdminBundle.
+ *
+ * (c) Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Router;
+
+use Symfony\Component\Routing\Loader\AnnotationClassLoader;
+use Symfony\Component\Routing\Route;
+
+/**
+ * AnnotatedRouteControllerLoader is an implementation of AnnotationClassLoader that sets the '_controller' default
+ * based on the class and method names.
+ *
+ * This implementation is borrowed from the Symfony FrameworkBundle to allow support for releases of said bundle that
+ * did not contain this class (i.e. FrameworkBundle < 3.4).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class AnnotatedRouteControllerLoader extends AnnotationClassLoader
+{
+    protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annotation)
+    {
+        if ('__invoke' === $method->getName()) {
+            $route->setDefault('_controller', $class->getName());
+        } else {
+            $route->setDefault('_controller', $class->getName().'::'.$method->getName());
+        }
+    }
+
+    protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
+    {
+        return preg_replace(array(
+            '/(bundle|controller)_/',
+            '/action(_\d+)?$/',
+            '/__/',
+        ), array(
+            '_',
+            '\\1',
+            '_',
+        ), parent::getDefaultRouteName($class, $method));
+    }
+}

--- a/tests/Controller/CustomizedBackendTest.php
+++ b/tests/Controller/CustomizedBackendTest.php
@@ -671,7 +671,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
     public function testListViewImmutableDates()
     {
-        if (!class_exists('\DateTimeImmutable')) {
+        if (!class_exists('Doctrine\DBAL\Types\DateTimeImmutableType') || !class_exists('\DateTimeImmutable')) {
             $this->markTestSkipped('DateTimeImmutable class does not exist in this PHP version.');
         }
 

--- a/tests/Fixtures/AbstractTestCase.php
+++ b/tests/Fixtures/AbstractTestCase.php
@@ -31,6 +31,11 @@ abstract class AbstractTestCase extends WebTestCase
         $this->initDatabase();
     }
 
+    protected static function getKernelClass()
+    {
+        return 'AppKernel';
+    }
+
     protected function initClient(array $options = array())
     {
         $this->client = static::createClient($options);

--- a/tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadUsers.php
+++ b/tests/Fixtures/AppTestBundle/DataFixtures/ORM/LoadUsers.php
@@ -24,7 +24,7 @@ class LoadUsers extends AbstractFixture implements OrderedFixtureInterface
             $user->setEmail('user'.$i.'@example.com');
 
             // TODO: remove this check when PHP 5.3 is no longer supported
-            if (class_exists('\DateTimeImmutable')) {
+            if (class_exists('Doctrine\DBAL\Types\DateTimeImmutableType') && class_exists('\DateTimeImmutable')) {
                 $user->setCreatedAtDateTimeImmutable(new \DateTimeImmutable('October 18th 2005 16:27:36'));
                 $user->setCreatedAtDateImmutable(new \DateTimeImmutable('October 18th 2005'));
                 $user->setCreatedAtTimeImmutable(new \DateTimeImmutable('16:27:36'));

--- a/tests/Fixtures/AppTestBundle/Entity/FunctionalTests/BaseUser.php
+++ b/tests/Fixtures/AppTestBundle/Entity/FunctionalTests/BaseUser.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace AppTestBundle\Entity\FunctionalTests;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+abstract class BaseUser
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=64)
+     */
+    protected $username;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(type="string", length=255)
+     */
+    protected $email;
+
+    /**
+     * @var Purchase[]
+     *
+     * @ORM\OneToMany(targetEntity="Purchase", mappedBy="buyer", cascade={"remove"})
+     */
+    private $purchases;
+
+    public function __toString()
+    {
+        return $this->username;
+    }
+
+    public function __construct()
+    {
+        $this->purchases = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * @param string $email
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param Purchase[] $purchases
+     */
+    public function setPurchases($purchases)
+    {
+        $this->purchases = $purchases;
+    }
+
+    /**
+     * @return Purchase[]
+     */
+    public function getPurchases()
+    {
+        return $this->purchases;
+    }
+}

--- a/tests/Fixtures/AppTestBundle/Entity/FunctionalTests/BaseUserDbal25.php
+++ b/tests/Fixtures/AppTestBundle/Entity/FunctionalTests/BaseUserDbal25.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace AppTestBundle\Entity\FunctionalTests;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass
+ */
+abstract class BaseUserDbal25 extends BaseUser
+{
+    /**
+     * @var \DateTimeInterface
+     *
+     * @ORM\Column(name="createdAtDateTimeImmutable", type="datetime")
+     */
+    private $createdAtDateTimeImmutable;
+
+    /**
+     * @var \DateTimeInterface
+     *
+     * @ORM\Column(name="createdAtDateImmutable", type="date")
+     */
+    private $createdAtDateImmutable;
+
+    /**
+     * @var \DateTimeInterface
+     *
+     * @ORM\Column(name="createdAtTimeImmutable", type="time")
+     */
+    private $createdAtTimeImmutable;
+
+    /**
+     * @param \DateTimeInterface $createdAt
+     */
+    public function setCreatedAtDateTimeImmutable($createdAt)
+    {
+        $this->createdAtDateTimeImmutable = $createdAt;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCreatedAtDateTimeImmutable()
+    {
+        return $this->createdAtDateTimeImmutable;
+    }
+
+    /**
+     * @param \DateTimeInterface $createdAt
+     */
+    public function setCreatedAtDateImmutable($createdAt)
+    {
+        $this->createdAtDateImmutable = $createdAt;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCreatedAtDateImmutable()
+    {
+        return $this->createdAtDateImmutable;
+    }
+
+    /**
+     * @param \DateTimeInterface $createdAt
+     */
+    public function setCreatedAtTimeImmutable($createdAt)
+    {
+        $this->createdAtTimeImmutable = $createdAt;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCreatedAtTimeImmutable()
+    {
+        return $this->createdAtTimeImmutable;
+    }
+}

--- a/tests/Fixtures/AppTestBundle/Entity/FunctionalTests/BaseUserDbal26.php
+++ b/tests/Fixtures/AppTestBundle/Entity/FunctionalTests/BaseUserDbal26.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace AppTestBundle\Entity\FunctionalTests;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass
+ */
+abstract class BaseUserDbal26 extends BaseUser
+{
+    /**
+     * @var \DateTimeInterface
+     *
+     * @ORM\Column(name="createdAtDateTimeImmutable", type="datetime_immutable")
+     */
+    private $createdAtDateTimeImmutable;
+
+    /**
+     * @var \DateTimeInterface
+     *
+     * @ORM\Column(name="createdAtDateImmutable", type="date_immutable")
+     */
+    private $createdAtDateImmutable;
+
+    /**
+     * @var \DateTimeInterface
+     *
+     * @ORM\Column(name="createdAtTimeImmutable", type="time_immutable")
+     */
+    private $createdAtTimeImmutable;
+
+    /**
+     * @param \DateTimeInterface $createdAt
+     */
+    public function setCreatedAtDateTimeImmutable($createdAt)
+    {
+        $this->createdAtDateTimeImmutable = $createdAt;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCreatedAtDateTimeImmutable()
+    {
+        return $this->createdAtDateTimeImmutable;
+    }
+
+    /**
+     * @param \DateTimeInterface $createdAt
+     */
+    public function setCreatedAtDateImmutable($createdAt)
+    {
+        $this->createdAtDateImmutable = $createdAt;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCreatedAtDateImmutable()
+    {
+        return $this->createdAtDateImmutable;
+    }
+
+    /**
+     * @param \DateTimeInterface $createdAt
+     */
+    public function setCreatedAtTimeImmutable($createdAt)
+    {
+        $this->createdAtTimeImmutable = $createdAt;
+    }
+
+    /**
+     * @return \DateTimeInterface
+     */
+    public function getCreatedAtTimeImmutable()
+    {
+        return $this->createdAtTimeImmutable;
+    }
+}

--- a/tests/Fixtures/AppTestBundle/Entity/FunctionalTests/User.php
+++ b/tests/Fixtures/AppTestBundle/Entity/FunctionalTests/User.php
@@ -2,171 +2,20 @@
 
 namespace AppTestBundle\Entity\FunctionalTests;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
-class User
-{
+if (class_exists('Doctrine\DBAL\Types\DateTimeImmutableType') && class_exists('\DateTimeImmutable')) {
     /**
-     * @ORM\Id
-     * @ORM\Column(name="id", type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\Entity
      */
-    protected $id;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(type="string", length=64)
-     */
-    protected $username;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(type="string", length=255)
-     */
-    protected $email;
-
-    /**
-     * @var Purchase[]
-     *
-     * @ORM\OneToMany(targetEntity="Purchase", mappedBy="buyer", cascade={"remove"})
-     */
-    private $purchases;
-
-    /**
-     * @var \DateTimeInterface
-     *
-     * @ORM\Column(name="createdAtDateTimeImmutable", type="datetime_immutable")
-     */
-    private $createdAtDateTimeImmutable;
-
-    /**
-     * @var \DateTimeInterface
-     *
-     * @ORM\Column(name="createdAtDateImmutable", type="date_immutable")
-     */
-    private $createdAtDateImmutable;
-
-    /**
-     * @var \DateTimeInterface
-     *
-     * @ORM\Column(name="createdAtTimeImmutable", type="time_immutable")
-     */
-    private $createdAtTimeImmutable;
-
-    public function __toString()
+    class User extends BaseUserDbal26
     {
-        return $this->username;
     }
-
-    public function __construct()
-    {
-        $this->purchases = new ArrayCollection();
-    }
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
+} else {
     /**
-     * @param string $username
+     * @ORM\Entity
      */
-    public function setUsername($username)
+    class User extends BaseUserDbal25
     {
-        $this->username = $username;
-    }
-
-    /**
-     * @return string
-     */
-    public function getUsername()
-    {
-        return $this->username;
-    }
-
-    /**
-     * @param string $email
-     */
-    public function setEmail($email)
-    {
-        $this->email = $email;
-    }
-
-    /**
-     * @return string
-     */
-    public function getEmail()
-    {
-        return $this->email;
-    }
-
-    /**
-     * @param Purchase[] $purchases
-     */
-    public function setPurchases($purchases)
-    {
-        $this->purchases = $purchases;
-    }
-
-    /**
-     * @return Purchase[]
-     */
-    public function getPurchases()
-    {
-        return $this->purchases;
-    }
-
-    /**
-     * @param \DateTimeInterface $createdAt
-     */
-    public function setCreatedAtDateTimeImmutable($createdAt)
-    {
-        $this->createdAtDateTimeImmutable = $createdAt;
-    }
-
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getCreatedAtDateTimeImmutable()
-    {
-        return $this->createdAtDateTimeImmutable;
-    }
-
-    /**
-     * @param \DateTimeInterface $createdAt
-     */
-    public function setCreatedAtDateImmutable($createdAt)
-    {
-        $this->createdAtDateImmutable = $createdAt;
-    }
-
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getCreatedAtDateImmutable()
-    {
-        return $this->createdAtDateImmutable;
-    }
-
-    /**
-     * @param \DateTimeInterface $createdAt
-     */
-    public function setCreatedAtTimeImmutable($createdAt)
-    {
-        $this->createdAtTimeImmutable = $createdAt;
-    }
-
-    /**
-     * @return \DateTimeInterface
-     */
-    public function getCreatedAtTimeImmutable()
-    {
-        return $this->createdAtTimeImmutable;
     }
 }


### PR DESCRIPTION
In previous versions of EasyAdminBundle, the loading of annotated routes
was handled by the SensioFrameworkExtraBundle. With version 5.2 of the
SensioFrameworkExtraBundle their route annotation loader was deprecated
in favour of the implementation shipped with the Symfony FrameworkBundle
3.4+.

This commit provides a BC layer by wiring up the implementation of the
annotated route controller for older versions of the FrameworkBundle in
the same manner the Symfony core uses nowadays.