### PR TITLE
Allow installation of pagerfanta 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/common": "^2.4.0",
         "doctrine/doctrine-bundle": "~1.2",
         "doctrine/orm": "~2.3",
-        "pagerfanta/pagerfanta": "~1.0,>=1.0.1",
+        "pagerfanta/pagerfanta": "~1.0,>=1.0.1|~2.0",
         "symfony/asset": "~2.3|~3.0|^4.0",
         "symfony/config": "~2.3|~3.0|^4.0",
         "symfony/dependency-injection": "~2.3|~3.0|^4.0",


### PR DESCRIPTION
Currently pagerfanta 2.0 is not allowed to be installed.

The only BC break that came with 2.0 was that it requires php 7+. So if users have php 7, they might as well install the newest version