### PR TITLE
Add warning button color

### DIFF
--- a/src/Resources/views/css/easyadmin.css.twig
+++ b/src/Resources/views/css/easyadmin.css.twig
@@ -4,6 +4,8 @@
 
 {% set color_schemes = {
     'dark': {
+        info: '#39A0ED',
+        warning: '#F0AD4E',
         danger: '#D42124',
         success: '#006B2E',
         text: '#222222',
@@ -22,6 +24,8 @@
         table_row_border: '#DDD',
     },
     'light': {
+        info: '#39A0ED',
+        warning: '#F0AD4E',
         danger: '#D42124',
         success: '#006B2E',
         text: '#444444',
@@ -270,6 +274,13 @@ button.btn:active {
     padding: 1px 5px;
 }
 
+.btn-default,
+.btn-default:hover,
+.btn-default:active,
+.btn-default:focus,
+.btn-default:active:hover {
+    border-color: transparent;
+}
 .btn-primary,
 .btn-primary:hover,
 .btn-primary:active,
@@ -284,18 +295,19 @@ button.btn:active {
 .btn-info:active,
 .btn-info:focus,
 .btn-info:active:hover {
-    background-color: #39a0ed;
+    background-color: {{ colors.info }};
     border-color: transparent;
     color: {{ colors.white }};
 }
-.btn-default,
-.btn-default:hover,
-.btn-default:active,
-.btn-default:focus,
-.btn-default:active:hover {
+.btn-warning,
+.btn-warning:hover,
+.btn-warning:active,
+.btn-warning:focus,
+.btn-warning:active:hover {
+    background-color: {{ colors.warning }};
     border-color: transparent;
+    color: {{ colors.white }};
 }
-
 .btn-danger,
 .btn-danger:hover,
 .btn-danger:active,
@@ -305,7 +317,6 @@ button.btn:active {
     border-color: transparent;
     color: {{ colors.white }};
 }
-
 .btn-success,
 .btn-success:hover,
 .btn-success:active,
@@ -331,6 +342,7 @@ button.btn:active {
 }
 
 .btn-primary,
+.btn-warning,
 .btn-danger,
 .btn-success,
 .btn-info {


### PR DESCRIPTION
- Adds `warning` Bootstrap color state for buttons.
- Dynamic btn-info color in color_schemes variables
- Put btn-default definition first as it is default

Completes #1898 

BEFORE
![BEFORE](https://user-images.githubusercontent.com/738765/43593472-2015d98e-9678-11e8-9e15-c305e2addcf6.png)

AFTER
![AFTER](https://user-images.githubusercontent.com/738765/43593473-203bce0a-9678-11e8-9d02-e146f6fd6010.png)
