### PR TITLE
fix compatibility with PHP 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
     - php: 7.1
       env:
         - SYMFONY_VERSION="4.0.*"
-        - STABILITY=beta
     # stable (most recent stable versions)
     - php: 7.1
       env:
@@ -43,7 +42,6 @@ matrix:
     - php: 7.1
       env:
         - SYMFONY_VERSION="3.4.*"
-        - STABILITY=beta
         - SYMFONY_DEPRECATIONS_HELPER="strict"
     # legacy (oldest supported versions)
     - php: 5.3
@@ -54,10 +52,6 @@ matrix:
   allow_failures:
     - php: nightly
     - php: 5.3
-    # code coverage is very slow; allow a failure to get the Travis result early
-    - env:
-        - SYMFONY_VERSION="2.8.*"
-        - ENABLE_CODE_COVERAGE="true"
 
 before_install:
   - stty cols 120

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "php": ">=5.3.0",
         "doctrine/cache": "~1.5",
         "doctrine/doctrine-bundle": "~1.2",
-        "doctrine/persistence": "^1.0",
         "doctrine/orm": "~2.3",
         "pagerfanta/pagerfanta": "~1.0,>=1.0.1|~2.0",
         "symfony/asset": "~2.3|~3.0|^4.0",


### PR DESCRIPTION
This commit removes the dependency on the `doctrine/persistence` package which requires PHP 7. The only class from that package the bundle relies on is the `ManagerRegistry`. On PHP 5, this class is provided by the `doctrine/common` package which will be pulled in by `doctrine/orm`. On PHP 7, the now needed `doctrine/persistence` package is installed as `doctrine/common` (still required by `doctrine/orm`) depends on it.

This fixes #2321.