### PR TITLE
Fix sorting field detection for related attributes on table header in list view

### DIFF
--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -105,7 +105,7 @@
         {% block table_head %}
             <tr>
                 {% for field, metadata in fields %}
-                    {% set isSortingField = metadata.property == app.request.get('sortField')|split('.')|first %}
+                    {% set isSortingField = metadata.property == app.request.get('sortField') %}
                     {% set nextSortDirection = isSortingField ? (app.request.get('sortDirection') == 'DESC' ? 'ASC' : 'DESC') : 'DESC' %}
                     {% set _column_label = (metadata.label ?: field|humanize)|trans(_trans_parameters) %}
                     {% set _column_icon = isSortingField ? (nextSortDirection == 'DESC' ? 'fa-caret-up' : 'fa-caret-down') : 'fa-sort' %}


### PR DESCRIPTION
On the default list view of an entity where we want to make a related attribute sortable, the sort direction can only be ASC because the attribute is not detected as a sorting field in the table header.
I currently have to override the block to make the sorting work.

I don't know what the string splitting is for, but it doesn't seem to belong here.