### PR TITLE
Now works with DEFERRED_EXPLICIT tracking policy

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -491,6 +491,7 @@ class AdminController extends Controller
      */
     protected function updateEntity($entity)
     {
+        $this->em->persist($entity);
         $this->em->flush();
     }
 


### PR DESCRIPTION
When using doctrine, it's possible to change the tracking policy of a given entity.

I'm used to choose the `DEFERRED_EXPLICIT` tracking policy. This is the same than the `DEFERRED_IMPLICIT` (default) except that an entity must be marked to be updated.
More information about this feature [here](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/change-tracking-policies.html).

For people using the default tracking policy, persisting (or not) an entity which already exists doesn't change anything.
For people using the `DEFERRED_EXPLICIT` tracking policy, this is very easy to extend the default controller to deal with it but it's even easier to do nothing. ;)