### PR TITLE
Pass the $form to updateEntity and persistEntity

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -339,7 +339,7 @@ class AdminController extends Controller
             $this->executeDynamicMethod('preRemove<EntityName>Entity', array($entity, true));
 
             try {
-                $this->executeDynamicMethod('remove<EntityName>Entity', array($entity));
+                $this->executeDynamicMethod('remove<EntityName>Entity', array($entity, $form));
             } catch (ForeignKeyConstraintViolationException $e) {
                 throw new EntityRemoveException(array('entity_name' => $this->entity['name'], 'message' => $e->getMessage()));
             }

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -216,7 +216,7 @@ class AdminController extends Controller
             $this->dispatch(EasyAdminEvents::PRE_UPDATE, array('entity' => $entity));
 
             $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity, true));
-            $this->executeDynamicMethod('update<EntityName>Entity', array($entity));
+            $this->executeDynamicMethod('update<EntityName>Entity', array($entity, $editForm));
 
             $this->dispatch(EasyAdminEvents::POST_UPDATE, array('entity' => $entity));
 
@@ -290,7 +290,7 @@ class AdminController extends Controller
             $this->dispatch(EasyAdminEvents::PRE_PERSIST, array('entity' => $entity));
 
             $this->executeDynamicMethod('prePersist<EntityName>Entity', array($entity, true));
-            $this->executeDynamicMethod('persist<EntityName>Entity', array($entity));
+            $this->executeDynamicMethod('persist<EntityName>Entity', array($entity, $newForm));
 
             $this->dispatch(EasyAdminEvents::POST_PERSIST, array('entity' => $entity));
 


### PR DESCRIPTION
Use case: One form field is not mapped to the entity, and I need
the value in the `updateEntity` method.

This field is a checkbox. If the checkbox is checked, I use the
workflow component to `apply` a transition.