### PR TITLE
Replace VichUploader trans delete keys

### DIFF
--- a/src/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/src/Resources/views/form/bootstrap_3_layout.html.twig
@@ -412,7 +412,7 @@
         <div class="row">
             {% if form.delete is defined %}
             <div class="col-sm-3 col-md-2">
-                {{ form_row(form.delete, { label: 'action.delete' }) }}
+                {{ form_row(form.delete, { label: 'form.label.delete' }) }}
             </div>
             {% endif %}
             <div class="{{ form.delete is defined ? 'col-sm-9 col-md-10' : 'col-sm-12' }}">
@@ -433,7 +433,7 @@
     <div class="easyadmin-vich-image">
         {{ form_widget(form.file) }}
         {% if form.delete is defined %}
-            {{ form_row(form.delete, { label: 'action.delete' }) }}
+            {{ form_row(form.delete, { label: 'form.label.delete' }) }}
         {% endif %}
 
         {% if download_uri|default('') is not empty %}


### PR DESCRIPTION
It appear a translation key have change in VichUploader.

Actually, the vich form use action.delete key, but the correct key is: form.label.delete.