### PR TITLE
Fixed errors on Travis CI servers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
     include:
           # Minimum supported dependencies with the latest and oldest PHP version
         - php: 7.2
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="1"
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="2"
         - php: 7.1
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="1"
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="2"
 
           # Test the latest stable release
         - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
     include:
           # Minimum supported dependencies with the latest and oldest PHP version
         - php: 7.2
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="1"
         - php: 7.1
-          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="1"
 
           # Test the latest stable release
         - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
         - COVERAGE="false"
         - PHPUNIT_FLAGS="-v"
         - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
+        # needed to avoid some Doctrine related deprecations
+        - SYMFONY_DEPRECATIONS_HELPER="2"
 
 matrix:
     fast_finish: true

--- a/src/Configuration/TemplateConfigPass.php
+++ b/src/Configuration/TemplateConfigPass.php
@@ -69,7 +69,7 @@ class TemplateConfigPass implements ConfigPassInterface
         $backendConfig = $this->processDefaultTemplates($backendConfig);
         $backendConfig = $this->processFieldTemplates($backendConfig);
 
-        $this->existingTemplates = array();
+        $this->existingTemplates = [];
 
         return $backendConfig;
     }

--- a/src/Form/Type/Configurator/FOSCKEditorTypeConfigurator.php
+++ b/src/Form/Type/Configurator/FOSCKEditorTypeConfigurator.php
@@ -28,12 +28,12 @@ class FOSCKEditorTypeConfigurator implements TypeConfiguratorInterface
     public function configure($name, array $options, array $metadata, FormConfigInterface $parentConfig)
     {
         // when the IvoryCKEditor doesn't define the toolbar to use, EasyAdmin uses a simple toolbar
-        $options['config']['toolbar'] = array(
-            array('name' => 'styles', 'items' => array('Bold', 'Italic', 'Strike', 'Link')),
-            array('name' => 'lists', 'items' => array('BulletedList', 'NumberedList', '-', 'Outdent', 'Indent')),
-            array('name' => 'clipboard', 'items' => array('Copy', 'Paste', 'PasteFromWord', '-', 'Undo', 'Redo')),
-            array('name' => 'advanced', 'items' => array('Source')),
-        );
+        $options['config']['toolbar'] = [
+            ['name' => 'styles', 'items' => ['Bold', 'Italic', 'Strike', 'Link']),
+            ['name' => 'lists', 'items' => ['BulletedList', 'NumberedList', '-', 'Outdent', 'Indent']),
+            ['name' => 'clipboard', 'items' => ['Copy', 'Paste', 'PasteFromWord', '-', 'Undo', 'Redo']),
+            ['name' => 'advanced', 'items' => ['Source']),
+        ];
 
         return $options;
     }
@@ -43,7 +43,7 @@ class FOSCKEditorTypeConfigurator implements TypeConfiguratorInterface
      */
     public function supports($type, array $options, array $metadata)
     {
-        $isFosCkeditorField = in_array($type, array('fos_ckeditor', 'FOS\\CKEditorBundle\\Form\\Type\\CKEditorType'), true);
+        $isFosCkeditorField = in_array($type, ['fos_ckeditor', 'FOS\\CKEditorBundle\\Form\\Type\\CKEditorType'], true);
 
         return $isFosCkeditorField && !isset($options['config']['toolbar']) && !isset($options['config_name']);
     }

--- a/src/Form/Type/Configurator/FOSCKEditorTypeConfigurator.php
+++ b/src/Form/Type/Configurator/FOSCKEditorTypeConfigurator.php
@@ -29,10 +29,10 @@ class FOSCKEditorTypeConfigurator implements TypeConfiguratorInterface
     {
         // when the IvoryCKEditor doesn't define the toolbar to use, EasyAdmin uses a simple toolbar
         $options['config']['toolbar'] = [
-            ['name' => 'styles', 'items' => ['Bold', 'Italic', 'Strike', 'Link']),
-            ['name' => 'lists', 'items' => ['BulletedList', 'NumberedList', '-', 'Outdent', 'Indent']),
-            ['name' => 'clipboard', 'items' => ['Copy', 'Paste', 'PasteFromWord', '-', 'Undo', 'Redo']),
-            ['name' => 'advanced', 'items' => ['Source']),
+            ['name' => 'styles', 'items' => ['Bold', 'Italic', 'Strike', 'Link']],
+            ['name' => 'lists', 'items' => ['BulletedList', 'NumberedList', '-', 'Outdent', 'Indent']],
+            ['name' => 'clipboard', 'items' => ['Copy', 'Paste', 'PasteFromWord', '-', 'Undo', 'Redo']],
+            ['name' => 'advanced', 'items' => ['Source']],
         ];
 
         return $options;

--- a/src/Router/EasyAdminRouter.php
+++ b/src/Router/EasyAdminRouter.php
@@ -99,7 +99,7 @@ final class EasyAdminRouter
      */
     private function getRealClass($class)
     {
-        if (false === $pos = strrpos($class, '\\' . Proxy::MARKER . '\\')) {
+        if (false === $pos = strrpos($class, '\\'.Proxy::MARKER.'\\')) {
             return $class;
         }
 

--- a/tests/Fixtures/App/config/config.yml
+++ b/tests/Fixtures/App/config/config.yml
@@ -17,11 +17,6 @@ framework:
     session:
         storage_id: session.storage.mock_file
 
-sensio_framework_extra:
-    # SensioFramework annotations are deprecated, use Symfony Routing component instead.
-    router:
-        annotations: false
-
 doctrine:
     dbal:
         driver: pdo_sqlite


### PR DESCRIPTION
This tries to fix this error:

```
There is no extension able to load the configuration for "sensio_framework_  
  extra" (in /home/travis/build/EasyCorp/EasyAdminBundle/tests/Fixtures/App/c  
  onfig/config.yml). Looked for namespace "sensio_framework_extra", found "fr  
  amework", "security", "twig", "doctrine", "doctrine_fixtures", "easy_admin"  
   in /home/travis/build/EasyCorp/EasyAdminBundle/tests/Fixtures/App/config/c  
  onfig.yml (which is being imported from "/home/travis/build/EasyCorp/EasyAd  
  minBundle/tests/Fixtures/App/config/config_default_backend.yml").     
```