### PR TITLE
Add missing translation domain for the help message of a managed entity.

### DIFF
--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -1,3 +1,5 @@
+{% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
+{% trans_default_domain _entity_config.translation_domain %}
 <!DOCTYPE html>
 <html lang="{{ app.request.locale|split('_')|first|default('en') }}">
     <head>

--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -1,5 +1,3 @@
-{% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
-{% trans_default_domain _entity_config.translation_domain %}
 <!DOCTYPE html>
 <html lang="{{ app.request.locale|split('_')|first|default('en') }}">
     <head>
@@ -144,7 +142,7 @@
                     {% if _entity_config is defined and _entity_config[app.request.query.get('action')]['help']|default(false) %}
                         <div class="box box-widget help-entity">
                             <div class="box-body">
-                                {{ _entity_config[app.request.query.get('action')]['help']|trans|raw }}
+                                {{ _entity_config[app.request.query.get('action')]['help']|trans(domain = _entity_config.translation_domain)|raw }}
                             </div>
                         </div>
                     {% endif %}


### PR DESCRIPTION
<!--

BUGS must go to '1.x' branch.
NEW FEATURES must go to 'master' branch.

If the NEW FEATURE is complex, open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license

-->
Add missing translation domain for the help message of a managed entity. Fixes #2340 