### PR TITLE
Force "list" and "show" value to fallback to specified field template

### DIFF
--- a/src/Configuration/TemplateConfigPass.php
+++ b/src/Configuration/TemplateConfigPass.php
@@ -143,6 +143,7 @@ class TemplateConfigPass implements ConfigPassInterface
                             'easy_admin/'.$entityName.'/'.$templatePath,
                             'easy_admin/'.$templatePath,
                             $templatePath,
+                            $fieldMetadata['template'],
                         ));
                     } else {
                         // At this point, we don't know the exact data type associated with each field.

--- a/tests/Configuration/fixtures/templates/overridden_by_application/input/admin_006.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_application/input/admin_006.yml
@@ -1,0 +1,18 @@
+# TEST
+# default behavior when template exists in the "easy_admin/" directory
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    - property: name
+                      template: 'custom_templates/my_template.html.twig'
+            show:
+                fields:
+                    - property: name
+                      template: 'custom_templates/my_other_template.html.twig'
+
+

--- a/tests/Configuration/fixtures/templates/overridden_by_application/input/admin_007.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_application/input/admin_007.yml
@@ -1,0 +1,18 @@
+# TEST
+# overriding of list/show templates with custom ones
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    - property: name
+                      template: 'easy_admin/custom_templates/my_template.html.twig'
+            show:
+                fields:
+                    - property: name
+                      template: 'easy_admin/custom_templates/my_other_template.html.twig'
+
+

--- a/tests/Configuration/fixtures/templates/overridden_by_application/output/config_006.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_application/output/config_006.yml
@@ -1,0 +1,14 @@
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    name:
+                        property: name
+                        template: 'custom_templates/my_template.html.twig'
+            show:
+                fields:
+                    name:
+                        property: name
+                        template: 'custom_templates/my_other_template.html.twig'

--- a/tests/Configuration/fixtures/templates/overridden_by_application/output/config_007.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_application/output/config_007.yml
@@ -1,0 +1,14 @@
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    name:
+                        property: name
+                        template: 'easy_admin/custom_templates/my_template.html.twig'
+            show:
+                fields:
+                    name:
+                        property: name
+                        template: 'easy_admin/custom_templates/my_other_template.html.twig'

--- a/tests/Configuration/fixtures/templates/overridden_by_entity/input/admin_006.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_entity/input/admin_006.yml
@@ -1,0 +1,18 @@
+# TEST
+# default behavior when template exists in the "easy_admin/" directory
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    - property: name
+                      template: 'custom_templates/my_template.html.twig'
+            show:
+                fields:
+                    - property: name
+                      template: 'custom_templates/my_other_template.html.twig'
+
+

--- a/tests/Configuration/fixtures/templates/overridden_by_entity/input/admin_007.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_entity/input/admin_007.yml
@@ -1,0 +1,18 @@
+# TEST
+# overriding of list/show templates with custom ones
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    - property: name
+                      template: 'easy_admin/custom_templates/my_template.html.twig'
+            show:
+                fields:
+                    - property: name
+                      template: 'easy_admin/custom_templates/my_other_template.html.twig'
+
+

--- a/tests/Configuration/fixtures/templates/overridden_by_entity/output/config_006.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_entity/output/config_006.yml
@@ -1,0 +1,14 @@
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    name:
+                        property: name
+                        template: 'custom_templates/my_template.html.twig'
+            show:
+                fields:
+                    name:
+                        property: name
+                        template: 'custom_templates/my_other_template.html.twig'

--- a/tests/Configuration/fixtures/templates/overridden_by_entity/output/config_007.yml
+++ b/tests/Configuration/fixtures/templates/overridden_by_entity/output/config_007.yml
@@ -1,0 +1,14 @@
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    name:
+                        property: name
+                        template: 'easy_admin/custom_templates/my_template.html.twig'
+            show:
+                fields:
+                    name:
+                        property: name
+                        template: 'easy_admin/custom_templates/my_other_template.html.twig'


### PR DESCRIPTION
By default, any custom template that doesn't fit the "automatic name resolution" (the one based on the `{templates_dir}/easy_admin/` dir) is dismissed and replaced by `null`, then the configurator will use the default templates of the entity & global ones.

If a template is explicitly specified by the user AND is not found in the automatic resolver, I'd expect to use it anyway, such as when I specify a template path like `easy_admin/MyEntity/my_template.html.twig`.

This PR fixes this behavior so that if the template is set and not found in the automatic resolver, it falls back on what the user wrote, so it's always valid.