### PR TITLE
Add check when to add easyadmin field variable to form views.

### DIFF
--- a/src/Form/Extension/EasyAdminExtension.php
+++ b/src/Form/Extension/EasyAdminExtension.php
@@ -62,10 +62,18 @@ class EasyAdminExtension extends AbstractTypeExtension
                 'entity' => $entity,
                 'view' => $action,
                 'item' => $easyadmin['item'],
-                'field' => isset($fields[$view->vars['name']]) ? $fields[$view->vars['name']] : null,
+                'field' => null,
                 'form_group' => $form->getConfig()->getAttribute('easyadmin_form_group'),
                 'form_tab' => $form->getConfig()->getAttribute('easyadmin_form_tab'),
             );
+
+            /*
+             * Checks if current form view is direct child on the topmost form
+             * (ie. this form view`s field exists in easyadmin configuration)
+             */
+            if (null !== $view->parent && null === $view->parent->parent) {
+                $view->vars['easyadmin']['field'] = isset($fields[$view->vars['name']]) ? $fields[$view->vars['name']] : null;
+            }
         }
     }
 


### PR DESCRIPTION
 Fixes duplicated help block reported in #2359.

The problem was that the easyadmin field form variable was added to all form views.
But we know that only form views that are direct children of the main new or edit form can have a field in easyadmin configuration.

This PR adds a check if current form view is direct child on the topmost form and then proceeds to add the field configuration to the form view.