### PR TITLE
Fix missing default template for dateinterval type.

### DIFF
--- a/src/Configuration/PropertyConfigPass.php
+++ b/src/Configuration/PropertyConfigPass.php
@@ -305,7 +305,7 @@ class PropertyConfigPass implements ConfigPassInterface
      */
     private function getFieldFormat($fieldType, array $backendConfig)
     {
-        if (in_array($fieldType, array('date', 'date_immutable', 'time', 'time_immutable', 'datetime', 'datetime_immutable', 'datetimetz'))) {
+        if (in_array($fieldType, array('date', 'date_immutable', 'dateinterval', 'time', 'time_immutable', 'datetime', 'datetime_immutable', 'datetimetz'))) {
             // make 'datetimetz' use the same format as 'datetime'
             $fieldType = ('datetimetz' === $fieldType) ? 'datetime' : $fieldType;
             $fieldType = ('_immutable' === substr($fieldType, -10)) ? substr($fieldType, 0, -10) : $fieldType;

--- a/src/Configuration/TemplateConfigPass.php
+++ b/src/Configuration/TemplateConfigPass.php
@@ -38,6 +38,7 @@ class TemplateConfigPass implements ConfigPassInterface
         'field_bigint' => '@EasyAdmin/default/field_bigint.html.twig',
         'field_boolean' => '@EasyAdmin/default/field_boolean.html.twig',
         'field_date' => '@EasyAdmin/default/field_date.html.twig',
+        'field_dateinterval' => '@EasyAdmin/default/field_dateinterval.html.twig',
         'field_datetime' => '@EasyAdmin/default/field_datetime.html.twig',
         'field_datetimetz' => '@EasyAdmin/default/field_datetimetz.html.twig',
         'field_decimal' => '@EasyAdmin/default/field_decimal.html.twig',

--- a/src/Configuration/ViewConfigPass.php
+++ b/src/Configuration/ViewConfigPass.php
@@ -223,7 +223,7 @@ class ViewConfigPass implements ConfigPassInterface
      */
     private function getFieldFormat($fieldType, array $backendConfig)
     {
-        if (in_array($fieldType, array('date', 'date_immutable', 'time', 'time_immutable', 'datetime', 'datetime_immutable', 'datetimetz'))) {
+        if (in_array($fieldType, array('date', 'date_immutable', 'dateinterval', 'time', 'time_immutable', 'datetime', 'datetime_immutable', 'datetimetz'))) {
             // make 'datetimetz' use the same format as 'datetime'
             $fieldType = ('datetimetz' === $fieldType) ? 'datetime' : $fieldType;
             $fieldType = ('_immutable' === substr($fieldType, -10)) ? substr($fieldType, 0, -10) : $fieldType;

--- a/src/Configuration/ViewConfigPass.php
+++ b/src/Configuration/ViewConfigPass.php
@@ -270,7 +270,7 @@ class ViewConfigPass implements ConfigPassInterface
             'edit' => array('binary', 'blob', 'json_array', 'json', 'object'),
             'list' => array('array', 'binary', 'blob', 'guid', 'json_array', 'json', 'object', 'simple_array', 'text'),
             'new' => array('binary', 'blob', 'json_array', 'json', 'object'),
-            'search' => array('association', 'binary', 'boolean', 'blob', 'date', 'date_immutable', 'datetime', 'datetime_immutable', 'datetimetz', 'time', 'time_immutable', 'object'),
+            'search' => array('association', 'binary', 'boolean', 'blob', 'date', 'date_immutable', 'datetime', 'datetime_immutable', 'dateinterval', 'datetimetz', 'time', 'time_immutable', 'object'),
             'show' => array(),
         );
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -195,6 +195,11 @@ class Configuration implements ConfigurationInterface
                             ->info('The sprintf-compatible format applied to numeric values.')
                             ->example('%.2d (see http://php.net/sprintf)')
                         ->end()
+                        ->scalarNode('dateinterval')
+                            ->defaultValue('%y Year(s) %m Month(s) %d Day(s)')
+                            ->info('The PHP dateinterval-compatible format applied to "dateinterval" field types.')
+                            ->example('%y Year(s) %m Month(s) %d Day(s) (see http://php.net/manual/en/dateinterval.format.php)')
+                        ->end()
                     ->end()
                 ->end()
 

--- a/src/Form/Util/LegacyFormHelper.php
+++ b/src/Form/Util/LegacyFormHelper.php
@@ -33,6 +33,7 @@ final class LegacyFormHelper
         'datetime_immutable' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateTimeType',
         'date' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateType',
         'date_immutable' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateType',
+        'dateinterval' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\DateIntervalType',
         'email' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\EmailType',
         'entity' => 'Symfony\\Bridge\\Doctrine\\Form\\Type\\EntityType',
         'file' => 'Symfony\\Component\\Form\\Extension\\Core\\Type\\FileType',

--- a/src/Resources/views/default/field_dateinterval.html.twig
+++ b/src/Resources/views/default/field_dateinterval.html.twig
@@ -1,1 +1,1 @@
-{{ value.format('%y Year(s) %m Month(s) %d Day(s)') }}
+{{ value.format(field_options.format) }}

--- a/src/Resources/views/default/field_dateinterval.html.twig
+++ b/src/Resources/views/default/field_dateinterval.html.twig
@@ -1,0 +1,1 @@
+{{ value.format('%y Year(s) %m Month(s) %d Day(s)') }}

--- a/src/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/src/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -30,7 +30,7 @@
         <div class="{{ block('form_group_class') }}">
             {{ form_widget(form) }}
 
-            {% if _field_type in ['datetime', 'datetime_immutable', 'date', 'date_immutable', 'time', 'time_immutable', 'birthday'] and easyadmin.field.nullable|default(false) %}
+            {% if _field_type in ['datetime', 'datetime_immutable', 'date', 'date_immutable', 'dateinterval', 'time', 'time_immutable', 'birthday'] and easyadmin.field.nullable|default(false) %}
                 <div class="nullable-control">
                     <label>
                         <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>

--- a/src/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/src/Resources/views/form/bootstrap_3_layout.html.twig
@@ -265,7 +265,7 @@
         {{- form_label(form) -}}
         {{- form_widget(form) -}}
 
-        {% if _field_type in ['datetime', 'datetime_immutable', 'date', 'date_immutable', 'time', 'time_immutable', 'birthday'] and easyadmin.field.nullable|default(false) %}
+        {% if _field_type in ['datetime', 'datetime_immutable', 'date', 'date_immutable', 'dateinterval', 'time', 'time_immutable', 'birthday'] and easyadmin.field.nullable|default(false) %}
             <div class="nullable-control">
                 <label>
                     <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>


### PR DESCRIPTION
This PR fixes the problem described in #2332 ie. adds default template for dateinterval types.

I have some questions in order to finish the PR:
- What should be the default format for dateinterval types? (Currently I'm using the format described in the issue: `%y Year(s) %m Month(s) %d Day(s)`)

WDYT?

ping @javiereguiluz @BackEndTea