### PR TITLE
Add default field for percent type. Fixes #2208.

### DIFF
--- a/src/Configuration/TemplateConfigPass.php
+++ b/src/Configuration/TemplateConfigPass.php
@@ -52,6 +52,7 @@ class TemplateConfigPass implements ConfigPassInterface
         'field_json_array' => '@EasyAdmin/default/field_json_array.html.twig',
         'field_integer' => '@EasyAdmin/default/field_integer.html.twig',
         'field_object' => '@EasyAdmin/default/field_object.html.twig',
+        'field_percent' => '@EasyAdmin/default/field_percent.html.twig',
         'field_raw' => '@EasyAdmin/default/field_raw.html.twig',
         'field_simple_array' => '@EasyAdmin/default/field_simple_array.html.twig',
         'field_smallint' => '@EasyAdmin/default/field_smallint.html.twig',

--- a/src/Resources/views/default/field_percent.html.twig
+++ b/src/Resources/views/default/field_percent.html.twig
@@ -1,0 +1,6 @@
+{%- set type = field_options.type_options.type|default('fractional') -%}
+{%- set scale = field_options.type_options.scale|default(0) -%}
+{%- if type == 'fractional' -%}
+    {%- set value = value * 100  -%}
+{%- endif -%}
+{{ value|number_format(scale) }}%


### PR DESCRIPTION
This PR adds missing percent field template.

This field doesn't depend on format configuration it will use type options if provided to render the value properly. If they aren't provided it will use the defaults of the percent type which are `type = fractional` and `scale = 0`.