### PR TITLE
Make add new item javascript in collections use the correct prototype name.

### DIFF
--- a/src/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/src/Resources/views/form/bootstrap_3_layout.html.twig
@@ -297,9 +297,9 @@
                 collection.prev('.collection-empty').remove();
 
                 var newItem = collection.attr('data-prototype')
-                    .replace(/\>__name__label__\</g, '>' + numItems + '<')
-                    .replace(/_{{ name }}___name__/g, '_{{ name }}_' + numItems)
-                    .replace(/{{ name }}\]\[__name__\]/g, '{{ name }}][' + numItems + ']')
+                    .replace(/\>{{ prototype.vars.name }}label__\</g, '>' + numItems + '<')
+                    .replace(/_{{ name }}_{{ prototype.vars.name }}/g, '_{{ name }}_' + numItems)
+                    .replace(/{{ name }}\]\[{{ prototype.vars.name }}\]/g, '{{ name }}][' + numItems + ']')
                 ;
 
                 // Increment the counter and store it in the collection


### PR DESCRIPTION
This PR fixes #2210. It makes the javascript use the correct variable for the prototype name property in order to replace it in the newly created fields.
