### PR TITLE
Updating DataCollector links

### DIFF
--- a/src/Resources/views/data_collector/easyadmin.html.twig
+++ b/src/Resources/views/data_collector/easyadmin.html.twig
@@ -133,9 +133,9 @@
     <h3>Additional Resources</h3>
 
     <ul>
-        <li><a href="https://github.com/javiereguiluz/EasyAdminBundle/issues">Report an issue</a></li>
-        <li><a href="https://github.com/javiereguiluz/EasyAdminBundle#documentation">Read documentation</a></li>
-        <li><a href="https://github.com/javiereguiluz/EasyAdminBundle">Project homepage</a></li>
+        <li><a href="https://github.com/EasyCorp/EasyAdminBundle/issues">Report an issue</a></li>
+        <li><a href="https://github.com/EasyCorp/EasyAdminBundle#documentation">Read documentation</a></li>
+        <li><a href="https://github.com/EasyCorp/EasyAdminBundle">Project homepage</a></li>
     </ul>
 
 {% endblock %}

--- a/src/Resources/views/data_collector/easyadmin.html.twig
+++ b/src/Resources/views/data_collector/easyadmin.html.twig
@@ -134,7 +134,7 @@
 
     <ul>
         <li><a href="https://github.com/EasyCorp/EasyAdminBundle/issues">Report an issue</a></li>
-        <li><a href="https://github.com/EasyCorp/EasyAdminBundle#documentation">Read documentation</a></li>
+        <li><a href="https://symfony.com/doc/current/bundles/EasyAdminBundle/index.html">Read documentation</a></li>
         <li><a href="https://github.com/EasyCorp/EasyAdminBundle">Project homepage</a></li>
     </ul>
 


### PR DESCRIPTION
Update links in data collector template file:
- Using new namespace `EasyCorp` instead of `javiereguiluz` of the bundle for links.
- Fixing documentation link to point to documentation accessible in symfony.com website