### PR TITLE
Fixed the order of update events in AJAX edits

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -415,9 +415,9 @@ class AdminController extends Controller
             throw new \RuntimeException(sprintf('The "%s" property of the "%s" entity is not writable.', $property, $entityConfig['name']));
         }
 
-        $this->dispatch(EasyAdminEvents::PRE_UPDATE, array('entity' => $entity, 'newValue' => $value));
-
         $this->get('easy_admin.property_accessor')->setValue($entity, $property, $value);
+
+        $this->dispatch(EasyAdminEvents::PRE_UPDATE, array('entity' => $entity, 'newValue' => $value));
         $this->executeDynamicMethod('preUpdate<EntityName>Entity', array($entity, true));
 
         $this->em->persist($entity);
@@ -587,7 +587,7 @@ class AdminController extends Controller
         if (empty($sortDirection) || !in_array(strtoupper($sortDirection), array('ASC', 'DESC'))) {
             $sortDirection = 'DESC';
         }
-        
+
         $queryBuilder = $this->executeDynamicMethod('create<EntityName>SearchQueryBuilder', array($entityClass, $searchQuery, $searchableFields, $sortField, $sortDirection, $dqlFilter));
 
         $this->dispatch(EasyAdminEvents::POST_SEARCH_QUERY_BUILDER, array(


### PR DESCRIPTION
As explained in #2296, the order of events is not exactly the same when editing an entity using a normal form or via an Ajax event. So let's tweak slightly the wrong Ajax order. 