### PR TITLE
Adding missing instruction to update the Kernel

### DIFF
--- a/doc/tutorials/complex-backend-config.rst
+++ b/doc/tutorials/complex-backend-config.rst
@@ -67,5 +67,18 @@ create the four files with these contents:
             User:
                 # ...
 
+
+Update your Kernel to make symfony load the file:
+
+.. code-block:: php
+
+    # src/Kernel.php
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
+    {
+        # ...
+        $loader->load($confDir.'/{packages}/easy_admin/*'.self::CONFIG_EXTS, 'glob');
+    }
+
+
 Beware that each configuration file must define its contents under the ``easy_admin``
 key. Otherwise, Symfony won't be able to merge the different configurations.


### PR DESCRIPTION
Symfony won't know about the new config unless explicitly told, by default it loads the files under the packages folder and doesn't go deeper.

<!--

BUGS must go to '1.x' branch.
NEW FEATURES must go to 'master' branch.

If the NEW FEATURE is complex, open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license

-->
