### PR TITLE
Fix context menu selection loss

### DIFF
--- a/src/Resources/views/default/show.html.twig
+++ b/src/Resources/views/default/show.html.twig
@@ -43,7 +43,7 @@
             <div class="col-sm-10 col-sm-offset-2">
             {% block item_actions %}
                 {% set _show_actions = easyadmin_get_actions_for_show_item(_entity_config.name) %}
-                {% set _request_parameters = { entity: _entity_config.name, referer: app.request.query.get('referer') } %}
+                {% set _request_parameters = app.request.query.all %}
 
                 {{ include('@EasyAdmin/default/includes/_actions.html.twig', {
                     actions: _show_actions,


### PR DESCRIPTION
On a show template, after clicking on an action (edit, etc.) the context menu won't unfold to the current entity because the `menuIndex` and the `subMenuIndex` are not included in the request parameters.
I think including all the parameters in the query string should be the default behavior, just like it is in the default listing template.