### PR TITLE
Enabled the form type configurator for FOS CKEditor

### DIFF
--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -69,6 +69,11 @@
             <tag name="easyadmin.form.type.configurator" priority="-130" />
         </service>
 
+        <service id="easyadmin.form.type.configurator.fos_ivory_ckeditor" public="false"
+                 class="EasyCorp\Bundle\EasyAdminBundle\Form\Type\Configurator\FOSCKEditorTypeConfigurator">
+            <tag name="easyadmin.form.type.configurator" priority="-130" />
+        </service>
+
         <!-- Type Configurators -->
 
         <service id="easyadmin.form.guesser.missing_doctrine_orm_type_guesser" public="true"

--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -69,7 +69,7 @@
             <tag name="easyadmin.form.type.configurator" priority="-130" />
         </service>
 
-        <service id="easyadmin.form.type.configurator.fos_ivory_ckeditor" public="false"
+        <service id="easyadmin.form.type.configurator.fos_ckeditor" public="false"
                  class="EasyCorp\Bundle\EasyAdminBundle\Form\Type\Configurator\FOSCKEditorTypeConfigurator">
             <tag name="easyadmin.form.type.configurator" priority="-130" />
         </service>


### PR DESCRIPTION
This bug was discovered when I tested the upcoming EasyAdmin 2.0 in the EasyAdmin Demo app and replaced IvoryCKEditor by FOSCkEditor.