### PR TITLE
Deprecated some options related to forms

### DIFF
--- a/doc/book/edit-new-configuration.rst
+++ b/doc/book/edit-new-configuration.rst
@@ -256,7 +256,7 @@ are displayed in the same order as defined in the related Doctrine entity.
     Fields that represent an association with another entity are displayed as
     ``<select>`` lists. For that reason, you must define the ``__toString()``
     magic method in any entity which is used in a Doctrine relation. Otherwise
-    you'll see the following error message:  
+    you'll see the following error message:
     ``Catchable Fatal Error: Object of class XY could not be converted to string``
 
 Virtual Properties
@@ -649,6 +649,11 @@ more advanced layouts.
 Form Dividers
 .............
 
+.. caution::
+
+    The ``divider`` form type is deprecated since 1.x version and it will
+    be removed in EasyAdmin 2.0. Use the ``section`` type instead.
+
 This is the simplest form design element. It just displays a straight horizontal
 line. It's useful to easily separate fields in long forms:
 
@@ -765,6 +770,11 @@ very advanced layouts.
         - { type: 'group', collapsible: true }
         # allow to show/hide contents and hide them by default
         - { type: 'group', collapsible: true, expanded: false }
+
+    .. caution::
+
+        The ``collapsible`` option is deprecated since 1.x version and it will
+        be removed in EasyAdmin 2.0.
 
 Form Tabs
 .........

--- a/src/Configuration/NormalizerConfigPass.php
+++ b/src/Configuration/NormalizerConfigPass.php
@@ -294,6 +294,14 @@ class NormalizerConfigPass implements ConfigPassInterface
                     // this is a form design element instead of a regular property
                     $isFormDesignElement = !isset($fieldConfig['property']) && isset($fieldConfig['type']);
                     if ($isFormDesignElement && in_array($fieldConfig['type'], array('divider', 'group', 'section', 'tab'))) {
+                        if ('divider' === $fieldConfig['type']) {
+                            @trigger_error(sprintf('The "type: divider" form design element used in the "%s" config of the "%s" entity is deprecated since EasyAdmin 1.x version and it will be removed in 2.0. Use the "type: section" design element instead.', $view, $entityName), E_USER_DEPRECATED);
+                        }
+
+                        if ('group' === $fieldConfig['type'] and isset($fieldConfig['collapsible'])) {
+                            @trigger_error(sprintf('The "collapsible" option used in a "type: group" form design element in the "%s" config of the "%s" entity is deprecated since EasyAdmin 1.x version and it will be removed in 2.0.', $view, $entityName), E_USER_DEPRECATED);
+                        }
+
                         // assign them a property name to add them later as unmapped form fields
                         $fieldConfig['property'] = $fieldName;
 

--- a/tests/Configuration/ConfigManagerTest.php
+++ b/tests/Configuration/ConfigManagerTest.php
@@ -25,6 +25,7 @@ class ConfigManagerTest extends TestCase
     }
 
     /**
+     * @group legacy
      * @dataProvider provideConfigFilePaths
      */
     public function testLoadConfig($backendConfigFilePath, $expectedConfigFilePath)

--- a/tests/Controller/AdvancedFormLayoutTest.php
+++ b/tests/Controller/AdvancedFormLayoutTest.php
@@ -23,6 +23,8 @@ class AdvancedFormLayoutTest extends AbstractTestCase
     }
 
     /**
+     * @group legacy
+     *
      * This test checks that a complex form layout is properly generated for
      * both 'edit' and 'new' forms. Testing very specific CSS selectors and
      * HTML elements is needed to prevent regressions.

--- a/tests/Controller/FormViewTest.php
+++ b/tests/Controller/FormViewTest.php
@@ -22,6 +22,9 @@ class FormViewTest extends AbstractTestCase
         $this->initClient(array('environment' => 'form_view'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testNewView()
     {
         $crawler = $this->requestNewView('Product');
@@ -42,6 +45,9 @@ class FormViewTest extends AbstractTestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
     public function testEditView()
     {
         $crawler = $this->requestEditView('Product', 1);


### PR DESCRIPTION
This deprecates more minor features related to forms which were already removed in the "master" branch because EasyAdmin 2.0 won't support them.