### PR TITLE
Deprecated the feature to override templates by convention

### DIFF
--- a/doc/book/edit-new-configuration.rst
+++ b/doc/book/edit-new-configuration.rst
@@ -256,7 +256,7 @@ are displayed in the same order as defined in the related Doctrine entity.
     Fields that represent an association with another entity are displayed as
     ``<select>`` lists. For that reason, you must define the ``__toString()``
     magic method in any entity which is used in a Doctrine relation. Otherwise
-    you'll see the following error message:  
+    you'll see the following error message:
     ``Catchable Fatal Error: Object of class XY could not be converted to string``
 
 Virtual Properties
@@ -896,6 +896,13 @@ option under the global ``design`` option:
 
 Overriding the Default Templates By Convention
 ..............................................
+
+.. caution::
+
+    Overriding the default EasyAdmin templates by convention is deprecated since
+    1.x version and it will be removed in EasyAdmin 2.0. Instead, use Symfony's
+    template overriding mechanism or override the templates by configuration as
+    explained the previous section.
 
 If you don't mind the location of your custom templates, consider creating them
 in the ``app/Resources/views/easy_admin/`` directory. When the ``templates``

--- a/doc/book/list-search-show-configuration.rst
+++ b/doc/book/list-search-show-configuration.rst
@@ -927,6 +927,13 @@ option under the global ``design`` option:
 Overriding the Default Templates By Convention
 ..............................................
 
+.. caution::
+
+    Overriding the default EasyAdmin templates by convention is deprecated since
+    1.x version and it will be removed in EasyAdmin 2.0. Instead, use Symfony's
+    template overriding mechanism or override the templates by configuration as
+    explained the previous section.
+
 If you don't mind the location of your custom templates, consider creating them
 in the ``app/Resources/views/easy_admin/`` directory. When the ``templates``
 option is not defined, EasyAdmin looks into this directory before falling back

--- a/src/Configuration/TemplateConfigPass.php
+++ b/src/Configuration/TemplateConfigPass.php
@@ -277,6 +277,10 @@ class TemplateConfigPass implements ConfigPassInterface
             }
 
             if (null !== $templatePath && isset($this->existingTemplates[$namespace][$templatePath])) {
+                if ('easy_admin/' === substr($templatePath, 0, 11)) {
+                    @trigger_error(sprintf('Using the "convention mode" to override templates is deprecated since EasyAdmin 1.x and it will be removed in 2.0. Instead, use Symfony\'s template overriding mechanism and move the "%s" template to "app/Resources/EasyAdminBundle/views/default/%s" (or "templates/bundles/EasyAdminBundle/default/%s" if you use the modern Symfony dir structure). Alternatively, you can define the custom template using the "design.templates" global option or the "templates" option of your entities as explained in the docs.', $templatePath, substr($templatePath, 11), substr($templatePath, 11)), E_USER_DEPRECATED);
+                }
+
                 return $templatePath;
             }
         }

--- a/tests/Controller/CustomFieldTemplateTest.php
+++ b/tests/Controller/CustomFieldTemplateTest.php
@@ -22,6 +22,9 @@ class CustomFieldTemplateTest extends AbstractTestCase
         $this->initClient(array('environment' => 'custom_field_template'));
     }
 
+    /**
+     * @group legacy
+     */
     public function testListViewCustomFieldTemplate()
     {
         $crawler = $this->requestListView();
@@ -31,6 +34,9 @@ class CustomFieldTemplateTest extends AbstractTestCase
         $this->assertContains('The custom template knows that the "this_property_does_no_exist" field is not accessible.', $crawler->filter('#main table td[data-label="This property does no exist"]')->eq(0)->text());
     }
 
+    /**
+     * @group legacy
+     */
     public function testShowViewCustomFieldTemplate()
     {
         $crawler = $this->requestShowView();


### PR DESCRIPTION
This fixes #2293. This "convention mode" was created because Symfony's overriding mechanism was not good enough. But our friend @yceruto fixed that in Symfony 3.4 thanks to [improved template overriding](https://symfony.com/blog/new-in-symfony-3-4-improved-the-overriding-of-templates). So there's no need to use "our mechanism".

This is the last big deprecation planned for 1.x.

Note: I know the deprecation message is a bit long, but I wanted to explain as clearly as possible the alternative solutions. This is how it looks:

![deprecation-template](https://user-images.githubusercontent.com/73419/48967963-9bcaa400-efe8-11e8-8a85-053b6e5d3113.png)
