### PR TITLE
Strip HTML tags from flash messages

### DIFF
--- a/src/Resources/views/default/flash_messages.html.twig
+++ b/src/Resources/views/default/flash_messages.html.twig
@@ -3,7 +3,7 @@
         {% for label, messages in app.session.flashbag.all %}
             {% for message in messages %}
                 <div class="alert alert-{{ label }}">
-                    {{ message|trans }}
+                    {{ message|trans|striptags }}
                 </div>
             {% endfor %}
         {% endfor %}


### PR DESCRIPTION
This is an alternative to #2439. I've been thinking about this and I think @xabbuh is right in his #2439 comments.

We use `|raw` a lot in our templates ... but it's always for content 100% generated by you (form field helps, translations, etc.) But "flash messages" could contain contents generated by user (not probably, but not impossible).

So, as anything related to security, let's play safe and let's not display flash messages as `|raw`. Instead, this PR applies the `|striptags` filter so flash messages look great if they contain HTML tags (users don't want to see the escaped HTML tags).

If some app must absolutely display HTML tags, the solution is to override the default template (as explained in https://symfony.com/doc/master/bundles/EasyAdminBundle/book/list-search-show-configuration.html#advanced-design-configuration).