### PR TITLE
Fixed the CollectionType overwrite bug

### DIFF
--- a/src/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/src/Resources/views/form/bootstrap_3_layout.html.twig
@@ -292,7 +292,7 @@
 
                 var collection = $('#{{ id }}');
                 // Use a counter to avoid having the same index more than once
-                var numItems = collection.data('count') || collection.children('div.form-group').length;
+                var numItems = collection.data('count') || {{ form.children|length ? form.children|keys|last + 1 : 0 }};
 
                 collection.prev('.collection-empty').remove();
 


### PR DESCRIPTION
While editing an entity with a CollectionType field with _allow add_ and _allow delete_ options enabled, the bug causes to overwrite existing values while adding new ones.

__Steps to Reproduce__
- Create an entity `Product` with a property `$tags` containing array of strings
- Define _easy_admin_ configurations for this entity
- Go to _Add Product_ page. Under _Tags_ field click on _Add new item_ a couple of times. This will add two text input fields with labels _0_ and _1_
- Remove the field labelled as _0_ and put a value `Tag1` to the field labelled as _1_. Save the Product
- Edit the same Product. Under _Tags_ field click on _Add another item_. Observe that the label for the newly added field is _1_, the same as the existing (saved) field
- Put a value `Tag2` to the newly added field and save the edited Product

__Actual Result__
The new tag will overwrite existing tag instead of being added as a new one

__Expected Result__
When adding new tags the system should not overwrite existing tags