### PR TITLE
Simplified the DesignConfigPass class

### DIFF
--- a/src/Configuration/DesignConfigPass.php
+++ b/src/Configuration/DesignConfigPass.php
@@ -2,8 +2,6 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Configuration;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 /**
  * Processes the custom CSS styles applied to the backend design based on the
  * value of the design configuration options.
@@ -12,22 +10,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class DesignConfigPass implements ConfigPassInterface
 {
-    /** @var ContainerInterface */
-    private $container;
-    /** @var bool */
-    private $kernelDebug;
     /** @var string */
     private $locale;
 
-    /**
-     * @var ContainerInterface to prevent ServiceCircularReferenceException
-     * @var bool               $kernelDebug
-     * @var string             $locale
-     */
-    public function __construct(ContainerInterface $container, $kernelDebug, $locale)
+    public function __construct($locale)
     {
-        $this->container = $container;
-        $this->kernelDebug = $kernelDebug;
         $this->locale = $locale;
     }
 

--- a/src/DependencyInjection/EasyAdminExtension.php
+++ b/src/DependencyInjection/EasyAdminExtension.php
@@ -41,7 +41,7 @@ class EasyAdminExtension extends Extension
 
         if ($container->hasParameter('locale')) {
             $container->getDefinition('easyadmin.configuration.design_config_pass')
-                ->replaceArgument(2, $container->getParameter('locale'));
+                ->replaceArgument(0, $container->getParameter('locale'));
         }
     }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -77,8 +77,6 @@
         </service>
 
         <service id="easyadmin.configuration.design_config_pass" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\DesignConfigPass" public="false">
-            <argument id="service_container" type="service" />
-            <argument>%kernel.debug%</argument>
             <argument>%kernel.default_locale%</argument>
             <tag name="easyadmin.config_pass" priority="80" />
         </service>


### PR DESCRIPTION
All this was needed in 1.x version, where we customized the design generating some CSS code with Twig. Now we use proper CSS variables, so we don't need it.