### PR TITLE
Simplified the Controller listener

### DIFF
--- a/src/EventListener/ControllerListener.php
+++ b/src/EventListener/ControllerListener.php
@@ -65,17 +65,9 @@ class ControllerListener
             return;
         }
 
-        $customController = $entity['controller'];
+        // build the full controller name using the 'class::method' syntax
         $controllerMethod = $currentController[1];
-
-        // build the full controller name depending on its type
-        if (Kernel::VERSION_ID >= 40100 || \class_exists($customController)) {
-            // 'class::method' syntax for normal controllers
-            $customController .= '::'.$controllerMethod;
-        } else {
-            // 'service:method' syntax for controllers as services
-            $customController .= ':'.$controllerMethod;
-        }
+        $customController = $entity['controller'].'::'.$controllerMethod;
 
         $request->attributes->set('_controller', $customController);
         $newController = $this->resolver->getController($request);

--- a/tests/Fixtures/App/config/config_custom_entity_controller_service.yml
+++ b/tests/Fixtures/App/config/config_custom_entity_controller_service.yml
@@ -5,10 +5,9 @@ easy_admin:
     entities:
         Category:
             class: AppTestBundle\Entity\FunctionalTests\Category
-            controller: app.controller
+            controller: EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin\CustomCategoryControllerAsService
 
 services:
-    app.controller:
-        class: EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin\CustomCategoryControllerAsService
+    EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin\CustomCategoryControllerAsService:
         arguments: ['@request_stack']
         public: true


### PR DESCRIPTION
EasyAdmin 2.x requires Symfony 4.1, so we don't need to support older Symfony versions.