### PR TITLE
Don't extend from the deprecated Controller class

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -16,7 +16,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Search\Autocomplete;
 use EasyCorp\Bundle\EasyAdminBundle\Search\Paginator;
 use EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder as EasyAdminQueryBuilder;
 use Pagerfanta\Pagerfanta;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Form;
@@ -36,8 +38,10 @@ use Symfony\Component\Routing\Annotation\Route;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class AdminController extends AbstractController
+class AdminController implements ContainerAwareInterface
 {
+    /** @var ContainerInterface */
+    protected $container;
     /** @var array The full configuration of the entire backend */
     protected $config;
     /** @var array The full configuration of the current entity */
@@ -47,16 +51,42 @@ class AdminController extends AbstractController
     /** @var EntityManager The Doctrine entity manager for the current entity */
     protected $em;
 
+    use ControllerTrait;
+
+    protected function getParameter(string $name)
+    {
+        return $this->container->get('parameter_bag')->get($name);
+    }
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
     public static function getSubscribedServices()
     {
-        return array_merge(parent::getSubscribedServices(), [
+        return [
+            'doctrine' => '?'.ManagerRegistry::class,
             'easyadmin.autocomplete' => Autocomplete::class,
             'easyadmin.config.manager' => ConfigManager::class,
-            'event_dispatcher' => EventDispatcherInterface::class,
             'easyadmin.paginator' => Paginator::class,
             'easyadmin.query_builder' => EasyAdminQueryBuilder::class,
+            'event_dispatcher' => EventDispatcherInterface::class,
+            'form.factory' => '?'.FormFactoryInterface::class,
+            'http_kernel' => '?'.HttpKernelInterface::class,
+            'message_bus' => '?'.MessageBusInterface::class,
+            'parameter_bag' => '?'.ContainerBagInterface::class,
             'property_accessor' => PropertyAccessorInterface::class,
-        ]);
+            'request_stack' => '?'.RequestStack::class,
+            'router' => '?'.RouterInterface::class,
+            'security.authorization_checker' => '?'.AuthorizationCheckerInterface::class,
+            'security.csrf.token_manager' => '?'.CsrfTokenManagerInterface::class,
+            'security.token_storage' => '?'.TokenStorageInterface::class,
+            'serializer' => '?'.SerializerInterface::class,
+            'session' => '?'.SessionInterface::class,
+            'templating' => '?'.EngineInterface::class,
+            'twig' => '?'.Environment::class,
+        ];
     }
 
     /**

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -5,14 +5,19 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Controller;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager;
 use EasyCorp\Bundle\EasyAdminBundle\Event\EasyAdminEvents;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\EntityRemoveException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\NoEntitiesConfiguredException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
+use EasyCorp\Bundle\EasyAdminBundle\Search\Autocomplete;
+use EasyCorp\Bundle\EasyAdminBundle\Search\Paginator;
+use EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder as EasyAdminQueryBuilder;
 use Pagerfanta\Pagerfanta;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
@@ -23,6 +28,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -30,7 +36,7 @@ use Symfony\Component\Routing\Annotation\Route;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class AdminController extends Controller
+class AdminController extends AbstractController
 {
     /** @var array The full configuration of the entire backend */
     protected $config;
@@ -40,6 +46,18 @@ class AdminController extends Controller
     protected $request;
     /** @var EntityManager The Doctrine entity manager for the current entity */
     protected $em;
+
+    public static function getSubscribedServices()
+    {
+        return array_merge(parent::getSubscribedServices(), [
+            'easyadmin.autocomplete' => Autocomplete::class,
+            'easyadmin.config.manager' => ConfigManager::class,
+            'event_dispatcher' => EventDispatcherInterface::class,
+            'easyadmin.paginator' => Paginator::class,
+            'easyadmin.query_builder' => EasyAdminQueryBuilder::class,
+            'property_accessor' => PropertyAccessorInterface::class,
+        ]);
+    }
 
     /**
      * @Route("/", name="easyadmin")
@@ -397,11 +415,11 @@ class AdminController extends Controller
     {
         $entityConfig = $this->entity;
 
-        if (!$this->get('easy_admin.property_accessor')->isWritable($entity, $property)) {
+        if (!$this->get('property_accessor')->isWritable($entity, $property)) {
             throw new \RuntimeException(\sprintf('The "%s" property of the "%s" entity is not writable.', $property, $entityConfig['name']));
         }
 
-        $this->get('easy_admin.property_accessor')->setValue($entity, $property, $value);
+        $this->get('property_accessor')->setValue($entity, $property, $value);
 
         $this->dispatch(EasyAdminEvents::PRE_UPDATE, ['entity' => $entity, 'newValue' => $value]);
         $this->executeDynamicMethod('update<EntityName>Entity', [$entity]);

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -112,6 +112,10 @@
             <tag name="easyadmin.config_pass" priority="10" />
         </service>
 
-        <service id="easy_admin.property_accessor" alias="property_accessor" public="true" />
+        <!-- aliases needed for the service locator of the AdminController -->
+        <service id="EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager" alias="easyadmin.config.manager"></service>
+        <service id="EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder" alias="easyadmin.query_builder"></service>
+        <service id="EasyCorp\Bundle\EasyAdminBundle\Search\Paginator" alias="easyadmin.paginator"></service>
+        <service id="EasyCorp\Bundle\EasyAdminBundle\Search\Autocomplete" alias="easyadmin.autocomplete"></service>
     </services>
 </container>

--- a/tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
+++ b/tests/Fixtures/AppTestBundle/Controller/OverridingEasyAdminController.php
@@ -2,11 +2,11 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
-class OverridingEasyAdminController extends Controller
+class OverridingEasyAdminController extends AbstractController
 {
     /**
      * @Route("/override_layout", name="override_layout")


### PR DESCRIPTION
This fixes the following deprecation:

```
The "Symfony\Bundle\FrameworkBundle\Controller\Controller" class is deprecated
since Symfony 4.2, use AbstractController instead.
```

But it creates an even more annoying deprecation:

```
Auto-injection of the container for "EasyCorp\Bundle\EasyAdminBundle\Controller\AdminController"
is deprecated since Symfony 4.2. Configure it as a service instead.
```

I don't know how can I solve that. I need your help. Thanks!