### PR TITLE
Allow for easier ajax usage of newAction

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -294,7 +294,18 @@ class AdminController extends Controller
 
             $this->dispatch(EasyAdminEvents::POST_PERSIST, array('entity' => $entity));
 
-            return $this->redirectToReferrer();
+            if ( !$this->request->isXmlHttpRequest() ) {
+
+                return $this->redirectToReferrer();
+            } else {
+
+                return new JsonResponse(
+                    [
+                        'id' => $entity->getId(),
+                        'string' => $entity->__toString(),
+                    ]
+                );
+            }
         }
 
         $this->dispatch(EasyAdminEvents::POST_NEW, array(


### PR DESCRIPTION
Upon successfull creation of a new entity, in case the request was made via ajax, instead of sending a redirect, send a Json Response that can be used for instance for adding the new record to a select widget (Use case I happen to be working on right now :)

<!--

BUGS must go to '1.x' branch.
NEW FEATURES must go to 'master' branch.

If the NEW FEATURE is complex, open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license

-->
