### PR TITLE
Check user before displaying it

### DIFF
--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -114,8 +114,8 @@
 
                 <div class="content-top navbar-custom-menu">
                     <div class="user {{ _user_is_impersonated ? 'user-is-impersonated' }}" data-toggle="popover" data-placement="bottom" data-content="{{ _user_menu_content|e('html_attr') }}" data-html="true">
-                        <i class="fa {{ app.user|default(false) == false ? 'fa-user-times' : 'fa-user-circle' }} user-icon"></i>
-                        {{ app.user ?? app.user.username ?? '' }}
+                        <i class="fa {{ app.user is not null ? 'fa-user-times' : 'fa-user-circle' }} user-icon"></i>
+                        {{ app.user is not null ? app.user.username : '' }}
                     </div>
                 </div>
 


### PR DESCRIPTION
Don't try to cast user as string to avoid an exception when user don't implement a `__toString` method.

For example when using HwiOauthBundle:
```
An exception has been thrown during the rendering of a template ("Catchable Fatal Error: Object of class HWI\Bundle\OAuthBundle\Security\Core\User\OAuthUser could not be converted to string").
```

With this fix, is the user exists it displays its username, otherwise it displays an empty string.