### PR TITLE
Do not restrict select2 to #main

### DIFF
--- a/src/Resources/views/default/includes/_select2_widget.html.twig
+++ b/src/Resources/views/default/includes/_select2_widget.html.twig
@@ -12,7 +12,7 @@
     // explicitly ask for it
 
     function init() {
-      $('#main').find('form select[data-widget="select2"]').select2({
+      $('form select[data-widget="select2"]').select2({
         theme: 'bootstrap',
         language: '{{ _select2_locale }}'
       });


### PR DESCRIPTION
I use select2 in custom forms.
I have several sections on some pages, none of them with the `main` id which prevent me to have select2 working.