### PR TITLE
Apply datagrid hover on th

### DIFF
--- a/assets/css/easyadmin-theme/datagrids.scss
+++ b/assets/css/easyadmin-theme/datagrids.scss
@@ -46,7 +46,7 @@ table.datagrid {
 .datagrid tr:last-child > td {
   border: 0;
 }
-.datagrid tbody tr:hover td {
+.datagrid tbody tr:hover td, .datagrid tbody tr:hover th {
   background: var(--form-bg);
 }
 .datagrid td.actions {


### PR DESCRIPTION
I'm used to use `<th scope="row">` in custom tables.
This change apply the hover css rule on `<th>` located in `<tbody>`
It doesn't change anything on the current design as all `<th>` are in `<thead>`.