### PR TITLE
Resolve missing controller deprecations

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -7,7 +7,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 /**
  * The controller used to render all the default EasyAdmin actions.
  *
- * @deprecated since 2.x, use {@see EasyAdminController} instead.
+ * @deprecated since 2.0, use {@see EasyAdminController} instead.
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */

--- a/tests/Fixtures/App/config/routing_base.yml
+++ b/tests/Fixtures/App/config/routing_base.yml
@@ -1,4 +1,4 @@
 easy_admin_bundle:
-    resource: "@EasyAdminBundle/Controller/"
+    resource: "@EasyAdminBundle/Controller/EasyAdminController.php"
     type:     annotation
     prefix:   /admin/

--- a/tests/Fixtures/App/config/routing_custom_menu.php
+++ b/tests/Fixtures/App/config/routing_custom_menu.php
@@ -6,7 +6,7 @@ use Symfony\Component\Routing\RouteCollection;
 
 $routes = new RouteCollection();
 
-$easyAdminBundleRoutes = $loader->import('@EasyAdminBundle/Controller/', 'annotation');
+$easyAdminBundleRoutes = $loader->import('@EasyAdminBundle/Controller/EasyAdminController.php', 'annotation');
 $easyAdminBundleRoutes->addPrefix('/admin/');
 $routes->addCollection($easyAdminBundleRoutes);
 

--- a/tests/Fixtures/App/config/routing_override_controller.yml
+++ b/tests/Fixtures/App/config/routing_override_controller.yml
@@ -1,5 +1,5 @@
 easy_admin_bundle:
-    resource: "@EasyAdminBundle/Controller/"
+    resource: "@EasyAdminBundle/Controller/EasyAdminController.php"
     type:     annotation
     prefix:   /admin/
 


### PR DESCRIPTION
Spotted in #2508: https://travis-ci.org/EasyCorp/EasyAdminBundle/jobs/466589245#L663-L668
```bash
  1x: The "Symfony\Bundle\FrameworkBundle\Controller\Controller" class is deprecated since Symfony 4.2, use Symfony\Bundle\FrameworkBundle\Controller\AbstractController instead.
    1x in ActionOverrideTest::testListViewActions from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
  1x: The "EasyCorp\Bundle\EasyAdminBundle\Controller\AdminController" class extends "Symfony\Bundle\FrameworkBundle\Controller\Controller" that is deprecated since Symfony 4.2, use {@see AbstractController} instead.
 *.
    1x in ActionOverrideTest::testListViewActions from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
```
