### PR TITLE
Fixed the use of HTML in help messages

### DIFF
--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -121,7 +121,7 @@
                                     {% block content_help %}
                                         {% if _entity_config is defined and _entity_config[app.request.query.get('action')]['help']|default(false) %}
                                             <div class="content-header-help">
-                                                {{ _entity_config[app.request.query.get('action')]['help']|trans(domain = _entity_config.translation_domain)|nl2br|raw }}
+                                                {{ _entity_config[app.request.query.get('action')]['help']|trans(domain = _entity_config.translation_domain)|raw }}
                                             </div>
                                         {% endif %}
                                     {% endblock content_help %}

--- a/tests/Controller/CustomizedBackendTest.php
+++ b/tests/Controller/CustomizedBackendTest.php
@@ -45,7 +45,7 @@ class CustomizedBackendTest extends AbstractTestCase
     {
         $crawler = $this->requestListView();
 
-        $this->assertSame('Global help message for categories', \trim($crawler->filter('.content-header-help')->text()));
+        $this->assertSame('Global help message for <b>categories</b>', \trim($crawler->filter('.content-header-help')->html()));
     }
 
     public function testListViewSearchAction()

--- a/tests/Fixtures/App/config/config_customized_backend.yml
+++ b/tests/Fixtures/App/config/config_customized_backend.yml
@@ -80,7 +80,7 @@ easy_admin:
         title: 'Global Title for Edit'
     entities:
         Category:
-            help:  'Global help message for categories'
+            help:  'Global help message for <b>categories</b>'
             class: AppTestBundle\Entity\FunctionalTests\Category
             label: 'Categories'
             list:


### PR DESCRIPTION
If the help contents contained HTML tags, they were escaped instead of being rendered.