### PR TITLE
Get rid of transchoice filters

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -42,7 +42,6 @@
             <argument type="service" id="easyadmin.router" />
             <argument>%kernel.debug%</argument>
             <argument type="service" id="security.logout_url_generator" on-invalid="null" />
-            <argument type="service" id="translator" on-invalid="null" />
             <tag name="twig.extension" />
         </service>
 

--- a/src/Resources/views/default/exception.html.twig
+++ b/src/Resources/views/default/exception.html.twig
@@ -1,7 +1,7 @@
 {% extends layout_template_path %}
 
 {% block body_class 'error' %}
-{% block page_title %}{{ 'errors'|transchoice(1, {}, 'EasyAdminBundle') }}{% endblock %}
+{% block page_title %}{{ 'errors'|trans({ '%count%': 1 }, 'EasyAdminBundle') }}{% endblock %}
 
 {% block content_header '' %}
 {% block main %}

--- a/src/Resources/views/default/field_association.html.twig
+++ b/src/Resources/views/default/field_association.html.twig
@@ -17,7 +17,7 @@
 
                 {% set _remaining_items = value|length - entity_config.show.max_results %}
                 {% if _remaining_items > 0 %}
-                    <li class="remaining-items">({{ 'show.remaining_items'|transchoice(_remaining_items, {}, 'EasyAdminBundle') }})</li>
+                    <li class="remaining-items">({{ 'show.remaining_items'|trans({ '%count%': _remaining_items }, 'EasyAdminBundle') }})</li>
                 {% endif %}
             </ul>
         {% else %}

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -31,8 +31,8 @@
 {% block content_title %}
 {% spaceless %}
     {% if 'search' == app.request.get('action') %}
-        {% set _default_title = 'search.page_title'|transchoice(paginator.nbResults, {}, 'EasyAdminBundle') %}
-        {{ (_entity_config.search.title is defined ? _entity_config.search.title|transchoice(paginator.nbResults) : _default_title)|raw }}
+        {% set _default_title = 'search.page_title'|trans({ '%count%': paginator.nbResults }, 'EasyAdminBundle') %}
+        {{ (_entity_config.search.title is defined ? _entity_config.search.title|trans({ '%count%': paginator.nbResults }) : _default_title)|raw }}
     {% else %}
         {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
         {{ (_entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title)|raw }}

--- a/src/Resources/views/default/paginator.html.twig
+++ b/src/Resources/views/default/paginator.html.twig
@@ -5,7 +5,7 @@
 {% if paginator.haveToPaginate %}
     <div class="list-pagination">
         <div class="list-pagination-counter">
-            {{ 'paginator.results'|transchoice(paginator.nbResults)|raw }}
+            {{ 'paginator.results'|trans({ '%count%': paginator.nbResults })|raw }}
         </div>
 
         <div class="pager pagination list-pagination-paginator {{ not paginator.hasPreviousPage ? 'first-page' }} {{ not paginator.hasNextPage ? 'last-page' }}">

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -379,7 +379,7 @@
                                     {% endif %}
                                     {{ tab_config['label']|trans(domain = _translation_domain) }}
                                     {% if tab_config.errors > 0 %}
-                                        <span class="badge badge-danger" title="{{ 'form.tab.error_badge_title'|transchoice(tab_config.errors, {}, 'EasyAdminBundle') }}">
+                                        <span class="badge badge-danger" title="{{ 'form.tab.error_badge_title'|trans({ '%count%': tab_config.errors }, 'EasyAdminBundle') }}">
                                             {{ tab_config.errors }}
                                         </span>
                                     {% endif %}

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -5,7 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Twig;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager;
 use EasyCorp\Bundle\EasyAdminBundle\Router\EasyAdminRouter;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -25,17 +24,14 @@ class EasyAdminTwigExtension extends AbstractExtension
     private $easyAdminRouter;
     private $debug;
     private $logoutUrlGenerator;
-    /** @var TranslatorInterface|null */
-    private $translator;
 
-    public function __construct(ConfigManager $configManager, PropertyAccessorInterface $propertyAccessor, EasyAdminRouter $easyAdminRouter, bool $debug = false, LogoutUrlGenerator $logoutUrlGenerator = null, $translator = null)
+    public function __construct(ConfigManager $configManager, PropertyAccessorInterface $propertyAccessor, EasyAdminRouter $easyAdminRouter, bool $debug = false, LogoutUrlGenerator $logoutUrlGenerator = null)
     {
         $this->configManager = $configManager;
         $this->propertyAccessor = $propertyAccessor;
         $this->easyAdminRouter = $easyAdminRouter;
         $this->debug = $debug;
         $this->logoutUrlGenerator = $logoutUrlGenerator;
-        $this->translator = $translator;
     }
 
     /**
@@ -66,10 +62,6 @@ class EasyAdminTwigExtension extends AbstractExtension
             new TwigFilter('easyadmin_truncate', [$this, 'truncateText'], ['needs_environment' => true]),
             new TwigFilter('easyadmin_urldecode', 'urldecode'),
         ];
-
-        if (Kernel::VERSION_ID >= 40200) {
-            $filters[] = new TwigFilter('transchoice', [$this, 'transchoice']);
-        }
 
         return $filters;
     }
@@ -381,19 +373,6 @@ class EasyAdminTwigExtension extends AbstractExtension
         }
 
         return $value;
-    }
-
-    /**
-     * Remove this filter when the Symfony's requirement is equal or greater than 4.2
-     * and use the built-in trans filter instead with a %count% parameter.
-     */
-    public function transchoice($message, $count, array $arguments = [], $domain = null, $locale = null)
-    {
-        if (null === $this->translator) {
-            return strtr($message, $arguments);
-        }
-
-        return $this->translator->trans($message, array_merge(['%count%' => $count], $arguments), $domain, $locale);
     }
 
     /**

--- a/tests/Fixtures/App/config/config_customized_backend.yml
+++ b/tests/Fixtures/App/config/config_customized_backend.yml
@@ -71,7 +71,7 @@ easy_admin:
     list:
         title: 'Global Title for List'
     search:
-        title: 'Global Title for Search in Singular|Global Title for Search in Plural'
+        title: '[0,1] Global Title for Search in Singular|]1,Inf[ Global Title for Search in Plural'
     show:
         title: 'Global Title for Show'
     new:


### PR DESCRIPTION
As the new minimal required version of sf is 4.1, we can safely remove `transchoice` filters.