### PR TITLE
Don't allow null values for fields which are nullable but required

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -121,7 +121,8 @@
         <div class="form-widget">
             {{- form_widget(form) -}}
 
-            {% if _field_type in ['datetime', 'datetime_immutable', 'date', 'date_immutable', 'dateinterval', 'time', 'time_immutable', 'birthday'] and easyadmin.field.nullable|default(false) %}
+            {% if _field_type in ['datetime', 'datetime_immutable', 'date', 'date_immutable', 'dateinterval', 'time', 'time_immutable', 'birthday'] and easyadmin.field.nullable|default(false) and not easyadmin.field.required|default(true) %}
+                {{ dump(easyadmin.field) }}
                 <div class="nullable-control">
                     <label>
                         <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>


### PR DESCRIPTION
I have the following edge-case in a real app:

* The property is nullable in the database (`@ORM\Column(type="date", nullable=true)`) for historical reasons
* But I want to make the property required in the backend (`- { property: 'expirationDate', type_options: { required: true, html5: true, widget: 'single_text' } }`)

This is how it looks:

![leave-empty](https://user-images.githubusercontent.com/73419/50042840-e4b2cd00-0069-11e9-982a-b5c44dc0d0db.png)

It looks "required" but the "leave empty" is shown too, so EasyAdmin is doing exactly what I asked: nullable + required.

This PR changes this to not display "leave empty" when the field is "required".

Does it make sense to do this change? It's better to not change anything because this is an absurd edge-case on my side? Thanks!
