### PR TITLE
Allow to disable labels for fields

### DIFF
--- a/doc/book/list-search-show-configuration.rst
+++ b/doc/book/list-search-show-configuration.rst
@@ -254,9 +254,13 @@ These are the options that you can define for each field:
   the ``list`` and ``search`` views and as the ``<label>`` element in the
   ``show`` view).
 
-  The default title is the "humanized" version of the property name (e.g.
-  ``published`` is displayed as ``Published`` and ``dateOfBirth`` as
-  ``Date of birth``).
+  If you don't define this option or set it to ``null``, the title is generated
+  automatically as the "humanized" version of the property name (e.g. ``published``
+  is displayed as ``Published`` and ``dateOfBirth`` as ``Date of birth``).
+
+  If you don't want to display any title for a field (e.g. when displaying an
+  image in the "avatar" property) set this option to ``false``. This also sets
+  the ``sortable`` option to ``false`` for the field.
 * ``css_class`` (optional): the CSS class applied to the parent HTML element that
   encloses the field contents. In the ``list`` and ``search`` views, this class
   is also applied to the ``<th>`` header of the column associated with this field.

--- a/src/Configuration/PropertyConfigPass.php
+++ b/src/Configuration/PropertyConfigPass.php
@@ -22,7 +22,7 @@ class PropertyConfigPass implements ConfigPassInterface
         'format' => null,
         // form field help message
         'help' => null,
-        // form field label (if 'null', autogenerate it)
+        // form field label (if 'null', autogenerate it; if 'false', hide it)
         'label' => null,
         // its value matches the value of 'dataType' for list/show and the value of 'fieldType' for new/edit
         'type' => null,

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -88,7 +88,7 @@
                 {% for field, metadata in fields %}
                     {% set isSortingField = (metadata.property == app.request.get('sortField')) or ('association' == metadata.type and app.request.get('sortField') starts with metadata.property ~ '.') %}
                     {% set nextSortDirection = isSortingField ? (app.request.get('sortDirection') == 'DESC' ? 'ASC' : 'DESC') : 'DESC' %}
-                    {% set _column_label = (metadata.label ?: field|humanize)|trans(_trans_parameters) %}
+                    {% set _column_label = metadata.label|trans(_trans_parameters) %}
                     {% set _column_icon = isSortingField ? (nextSortDirection == 'DESC' ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
 
                     <th class="{{ isSortingField ? 'sorted' }} {{ metadata.virtual ? 'virtual' }} {{ metadata.dataType|lower }} {{ metadata.css_class }}" {{ easyadmin_config('design.rtl') ? 'dir="rtl"' }}>

--- a/src/Resources/views/default/show.html.twig
+++ b/src/Resources/views/default/show.html.twig
@@ -23,7 +23,7 @@
                 {% block show_field %}
                     <div class="form-group field-{{ metadata.type|default('default')|lower }} {{ metadata.css_class|default('') }}">
                         <label class="control-label">
-                            {{ (metadata.label ?: field|humanize)|trans(_trans_parameters)|raw }}
+                            {{ metadata.label|trans(_trans_parameters)|raw }}
                         </label>
                         <div class="form-widget">
                             <div class="form-control">

--- a/tests/Configuration/fixtures/configurations/input/admin_151.yml
+++ b/tests/Configuration/fixtures/configurations/input/admin_151.yml
@@ -1,0 +1,40 @@
+# TEST
+# field labels are properly managed and/or generated automatically
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                fields:
+                    - 'id'
+                    - { property: 'field1' }
+                    - { property: 'field2', label: 'some LABEL' }
+                    - { property: 'field3', label: '' }
+                    - { property: 'field4', label: false }
+                    - { property: 'field5', label: null }
+            show:
+                fields:
+                    - { property: 'id', label: 'some ID label' }
+                    - { property: 'field1' }
+                    - { property: 'field2', label: 'some LABEL' }
+                    - { property: 'field3', label: '' }
+                    - { property: 'field4', label: false }
+                    - { property: 'field5', label: null }
+            edit:
+                fields:
+                    - { property: 'id', label: '' }
+                    - { property: 'field1' }
+                    - { property: 'field2', label: 'some LABEL' }
+                    - { property: 'field3', label: '' }
+                    - { property: 'field4', label: false }
+                    - { property: 'field5', label: null }
+            new:
+                fields:
+                    - { property: 'id', label: false }
+                    - { property: 'field1' }
+                    - { property: 'field2', label: 'some LABEL' }
+                    - { property: 'field3', label: '' }
+                    - { property: 'field4', label: false }
+                    - { property: 'field5', label: null }

--- a/tests/Configuration/fixtures/configurations/output/config_032.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_032.yml
@@ -8,7 +8,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field1
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -30,7 +30,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field2
                         type: text
                         fieldType: textarea
                         dataType: null

--- a/tests/Configuration/fixtures/configurations/output/config_033.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_033.yml
@@ -8,7 +8,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field1
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -30,7 +30,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field2
                         type: text
                         fieldType: textarea
                         dataType: null

--- a/tests/Configuration/fixtures/configurations/output/config_034.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_034.yml
@@ -8,7 +8,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field1
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -30,7 +30,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field2
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -62,7 +62,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field3
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -84,7 +84,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field4
                         type: text
                         fieldType: textarea
                         dataType: null

--- a/tests/Configuration/fixtures/configurations/output/config_040.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_040.yml
@@ -8,7 +8,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field1
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -30,7 +30,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field2
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -62,7 +62,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field3
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -84,7 +84,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field4
                         type: text
                         fieldType: textarea
                         dataType: null
@@ -122,7 +122,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field5
                         type: text
                         fieldType: null
                         dataType: text
@@ -144,7 +144,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field6
                         type: text
                         fieldType: null
                         dataType: text
@@ -193,7 +193,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field7
                         type: text
                         fieldType: null
                         dataType: text
@@ -215,7 +215,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field8
                         type: text
                         fieldType: null
                         dataType: text

--- a/tests/Configuration/fixtures/configurations/output/config_041.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_041.yml
@@ -8,7 +8,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field1
                         type: image
                         fieldType: null
                         dataType: image

--- a/tests/Configuration/fixtures/configurations/output/config_042.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_042.yml
@@ -9,7 +9,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field1
                         type: image
                         fieldType: null
                         dataType: image

--- a/tests/Configuration/fixtures/configurations/output/config_043.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_043.yml
@@ -9,7 +9,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field1
                         type: image
                         fieldType: null
                         dataType: image

--- a/tests/Configuration/fixtures/configurations/output/config_107.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_107.yml
@@ -8,7 +8,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field1
                         type: text
                         fieldType: null
                         dataType: text
@@ -30,7 +30,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field2
                         type: text
                         fieldType: null
                         dataType: text
@@ -52,7 +52,7 @@ easy_admin:
                         css_class: ''
                         format: null
                         help: null
-                        label: null
+                        label: Field3
                         type: text
                         fieldType: null
                         dataType: text

--- a/tests/Configuration/fixtures/configurations/output/config_151.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_151.yml
@@ -1,0 +1,59 @@
+easy_admin:
+    entities:
+        Category:
+            list:
+                fields:
+                    id:
+                        label: ID
+                    field1:
+                        label: Field1
+                    field2:
+                        label: 'some LABEL'
+                    field3:
+                        label: ''
+                    field4:
+                        label: ''
+                    field5:
+                        label: 'Field5'
+            show:
+                fields:
+                    id:
+                        label: 'some ID label'
+                    field1:
+                        label: Field1
+                    field2:
+                        label: 'some LABEL'
+                    field3:
+                        label: ''
+                    field4:
+                        label: ''
+                    field5:
+                        label: 'Field5'
+            edit:
+                fields:
+                    id:
+                        label: ''
+                    field1:
+                        label: Field1
+                    field2:
+                        label: 'some LABEL'
+                    field3:
+                        label: ''
+                    field4:
+                        label: ''
+                    field5:
+                        label: 'Field5'
+            new:
+                fields:
+                    id:
+                        label: ''
+                    field1:
+                        label: Field1
+                    field2:
+                        label: 'some LABEL'
+                    field3:
+                        label: ''
+                    field4:
+                        label: ''
+                    field5:
+                        label: 'Field5'


### PR DESCRIPTION
By default labels are "humanized" version of field names:

![null](https://user-images.githubusercontent.com/73419/50045315-f9ef2200-0090-11e9-87dd-4b15905ed85e.png)

If you set the label to an empty string ... you can hide it, but the sortable widget is still displayed:

![empty](https://user-images.githubusercontent.com/73419/50045321-083d3e00-0091-11e9-9177-3511ea9a1572.png)

However, in these edge-cases (for example for the users avatars) you probably don't want to display anything at all for the column label, not even the sortable arrow. Now you can do that setting the `label` option to the boolean `false`:

![false](https://user-images.githubusercontent.com/73419/50045331-286cfd00-0091-11e9-92b6-716d3a13c5bc.png)

-----

In addition to this change, this PR improves performance a bit because we do the "humanize" transformation of the labels once ... instead of doing it on every page refresh in the Twig template.
