### PR TITLE
Remove numeric label for collection items by default

### DIFF
--- a/assets/css/easyadmin-theme/forms.scss
+++ b/assets/css/easyadmin-theme/forms.scss
@@ -185,10 +185,6 @@ fieldset .form-group .nullable-control label {
 }
 
 // Form collections
-.form-widget-compound label {
-    display: none;
-}
-
 .form-widget-compound .collection-empty {
     padding-top: 5px;
 }

--- a/src/Form/Type/Configurator/CollectionTypeConfigurator.php
+++ b/src/Form/Type/Configurator/CollectionTypeConfigurator.php
@@ -36,6 +36,11 @@ class CollectionTypeConfigurator implements TypeConfiguratorInterface
             $options['entry_type'] = FormTypeHelper::getTypeClass($options['entry_type']);
         }
 
+        // Default : do not display numeric labels for entries
+        if (!isset($options['entry_options']['label'])) {
+            $options['entry_options']['label'] = false;
+        }
+
         return $options;
     }
 

--- a/src/Form/Type/Configurator/CollectionTypeConfigurator.php
+++ b/src/Form/Type/Configurator/CollectionTypeConfigurator.php
@@ -40,6 +40,10 @@ class CollectionTypeConfigurator implements TypeConfiguratorInterface
         if (!isset($options['entry_options']['label'])) {
             $options['entry_options']['label'] = false;
         }
+        // configure entry_options.label to TRUE to keep default symfony numeric labels
+        elseif (true === $options['entry_options']['label']) {
+            unset($options['entry_options']['label']);
+        }
 
         return $options;
     }


### PR DESCRIPTION
By default, numeric labels for collection items are hidden.

To keep default symfony behavior, explicitely set entry_options.label config to TRUE.

Fix #2510 