### PR TITLE
Do not override whole popover interface for user menu

### DIFF
--- a/assets/css/easyadmin-theme/base.scss
+++ b/assets/css/easyadmin-theme/base.scss
@@ -88,30 +88,33 @@ body {
     color: var(--color-danger);
 }
 
-.user-details .user-name {
-    font-size: var(--font-size-base);
-    font-weight: 500;
-    margin-bottom: 0;
-}
+#user-menu-wrapper {
 
-.user-menu .user-action {
-    display: block;
-    font-size: var(--font-size-sm);
-}
-.user-menu .user-action + .user-action {
-    margin-top: var(--font-size-sm);
-}
+    // Popovers (used for the user menu)
+    .popover-body {
+        padding: 0;
+    }
+    .popover-content-section {
+        padding: 12px;
+    }
+    .popover-content-section + .popover-content-section {
+        border-top: var(--border-width) var(--border-style) var(--border-color);
+        padding-top: 12px;
+    }
 
-// Popovers (used for the user menu)
-.popover-body {
-    padding: 0;
-}
-.popover-content-section {
-    padding: 12px;
-}
-.popover-content-section + .popover-content-section {
-    border-top: var(--border-width) var(--border-style) var(--border-color);
-    padding-top: 12px;
+    .user-details .user-name {
+        font-size: var(--font-size-base);
+        font-weight: 500;
+        margin-bottom: 0;
+    }
+
+    .user-menu .user-action {
+        display: block;
+        font-size: var(--font-size-sm);
+    }
+    .user-menu .user-action + .user-action {
+        margin-top: var(--font-size-sm);
+    }
 }
 
 /* Sidebar menu */

--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -99,7 +99,7 @@
                 {% endset %}
 
                 <div class="content-top navbar-custom-menu">
-                    <div class="user {{ _user_is_impersonated ? 'user-is-impersonated' }}" data-toggle="popover" data-placement="bottom" data-content="{{ _user_menu_content|e('html_attr') }}" data-html="true">
+                    <div id="user-menu-wrapper" class="user {{ _user_is_impersonated ? 'user-is-impersonated' }}" data-toggle="popover" data-container="#user-menu-wrapper" data-placement="bottom" data-content="{{ _user_menu_content|e('html_attr') }}" data-html="true">
                         <i class="fa {{ app.user is not null ? 'fa-user-circle' : 'fa-user-times' }} user-icon"></i>
                         {{ app.user is not null ? app.user.username }}
                     </div>


### PR DESCRIPTION
Keeps user menu style in place, and keeps bootstrap `popover` style safe.

Requires to re-compile styles at merge.

Fix #2528 