### PR TITLE
Always show the footer pagination

### DIFF
--- a/src/Resources/views/default/paginator.html.twig
+++ b/src/Resources/views/default/paginator.html.twig
@@ -2,32 +2,30 @@
 
 {% set _paginator_request_parameters = _request_parameters|merge({'referer': null}) %}
 
-{% if paginator.haveToPaginate %}
-    <div class="list-pagination">
-        <div class="list-pagination-counter">
-            {{ 'paginator.results'|transchoice(paginator.nbResults)|raw }}
-        </div>
-
-        <div class="pager pagination list-pagination-paginator {{ not paginator.hasPreviousPage ? 'first-page' }} {{ not paginator.hasNextPage ? 'last-page' }}">
-            {% if paginator.hasPreviousPage %}
-                <a class="btn" href="{{ path('easyadmin', _paginator_request_parameters|merge({ page: paginator.previousPage }) ) }}">
-                    <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
-                </a>
-            {% else %}
-                <span class="btn btn-disabled">
-                    <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
-                </span>
-            {% endif %}
-
-            {% if paginator.hasNextPage %}
-                <a class="btn" href="{{ path('easyadmin', _paginator_request_parameters|merge({ page: paginator.nextPage }) ) }}">
-                    {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
-                </a>
-            {% else %}
-                <span class="btn btn-disabled">
-                    {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
-                </span>
-            {% endif %}
-        </div>
+<div class="list-pagination">
+    <div class="list-pagination-counter">
+        {{ 'paginator.results'|transchoice(paginator.nbResults)|raw }}
     </div>
-{% endif %}
+
+    <div class="pager pagination list-pagination-paginator {{ not paginator.hasPreviousPage ? 'first-page' }} {{ not paginator.hasNextPage ? 'last-page' }}">
+        {% if paginator.hasPreviousPage %}
+            <a class="btn" href="{{ path('easyadmin', _paginator_request_parameters|merge({ page: paginator.previousPage }) ) }}">
+                <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
+            </a>
+        {% else %}
+            <span class="btn btn-disabled">
+                <i class="fa fa-angle-left"></i> {{ 'paginator.previous'|trans }}
+            </span>
+        {% endif %}
+
+        {% if paginator.hasNextPage %}
+            <a class="btn" href="{{ path('easyadmin', _paginator_request_parameters|merge({ page: paginator.nextPage }) ) }}">
+                {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
+            </a>
+        {% else %}
+            <span class="btn btn-disabled">
+                {{ 'paginator.next'|trans }} <i class="fa fa-angle-right"></i>
+            </span>
+        {% endif %}
+    </div>
+</div>


### PR DESCRIPTION
Listings always display a paginator ... except when the number of items is less than your page size (except in search view, which always displays the paginator). This doesn't look entirely correct to me. The design feels like it's ending too abruptly:

![before](https://user-images.githubusercontent.com/73419/50102013-4fa80380-0224-11e9-8a60-f28c74098d34.png)

I propose to remove the `{% if paginator.haveToPaginate %}` condition in the paginator to always display the footer pagination, even in these edge cases where we didn't display it:

![after](https://user-images.githubusercontent.com/73419/50102055-69494b00-0224-11e9-8f8a-4e8f7bdc46e8.png)
