### PR TITLE
install PHPUnit before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ before_install:
 install:
   - if [[ "$CHECK_PHP_SYNTAX" == "yes" ]]; then composer require --dev --no-update friendsofphp/php-cs-fixer; fi;
   - composer update --prefer-dist --no-interaction --no-suggest --no-progress --ansi $COMPOSER_FLAGS
+  - vendor/bin/simple-phpunit install
 
 script:
   - vendor/bin/simple-phpunit


### PR DESCRIPTION
Doing so prevent the actual test runs from being polluted by the
installation output.