### PR TITLE
2563 Add missing pl translation for paginator.results

### DIFF
--- a/src/Resources/translations/EasyAdminBundle.pl.xlf
+++ b/src/Resources/translations/EasyAdminBundle.pl.xlf
@@ -57,6 +57,10 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> z <strong>%results%</strong>]]></target>
             </trans-unit>
+            <trans-unit id="paginator.results">
+                <source>paginator.results</source>
+                <target><![CDATA[{0} Brak wyników|{1} <strong>1</strong> wynik|{2,3,4} <strong>%count%</strong> wyniki|[5,21] <strong>%count%</strong> wyników|[22,Inf]Liczba wyników <strong>%count%</strong>]]></target>
+            </trans-unit>
 
             <!-- labels -->
             <trans-unit id="label.true">


### PR DESCRIPTION
Fix for missing translation https://github.com/EasyCorp/EasyAdminBundle/issues/2563 for v2.0

It's tricky as in PL we have
0 wynik **ów**
1 wynik
2 wynik **i**
3 wynik **i**
4 wynik **i**
5 wynik **ów**
6 wynik **ów**
..
20 wynik **ów** 
21 wynik **ów**
22 wynik **i**
23 wynik **i**
24 wynik **i**
25 wynik **ów**
26 wynik **ów**
...
30 wynik **ów** 
31 wynik **ów**
32 wynik **i**
33 wynik **i**
34 wynik **i**
35 wynik **ów**
36 wynik **ów**
.. etc.