### PR TITLE
Route to the new controller

### DIFF
--- a/doc/book/installation.rst
+++ b/doc/book/installation.rst
@@ -15,7 +15,7 @@ enable the routes of the bundle:
 
     # config/routes/easy_admin.yaml
     easy_admin_bundle:
-        resource: '@EasyAdminBundle/Controller/AdminController.php'
+        resource: '@EasyAdminBundle/Controller/EasyAdminController.php'
         prefix: /admin
         type: annotation
 


### PR DESCRIPTION
When installing, route to the controller that doesn't extend a deprecated class.

<!--

BUGS must go to '1.x' branch.
NEW FEATURES must go to 'master' branch.

If the NEW FEATURE is complex, open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license

-->
