### PR TITLE
Add wrapper blocks and avoiding process blocks twice

### DIFF
--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -111,7 +111,7 @@
 
                 {% block content %}
                     <div class="content">
-                        {% if block('content_header')|trim is not empty %}
+                        {% block content_header_wrapper %}
                         {% set _has_content_help = _entity_config is defined and _entity_config[app.request.query.get('action')]['help']|default(false) %}
                         <section class="content-header {{ _has_content_help ? 'has-content-help' }}">
                             {% block content_header %}
@@ -127,24 +127,22 @@
                                     {% endblock content_help %}
                                 </div>
 
-                                {% if block('global_actions')|trim is not empty %}
+                                {% block global_actions_wrapper %}
                                     <div class="global-actions">{% block global_actions %}{% endblock %}</div>
-                                {% endif %}
-
-
+                                {% endblock %}
                             {% endblock content_header %}
                         </section>
-                        {% endif %}
+                        {% endblock content_header_wrapper %}
 
                         <section id="main" class="content-body">
                             {% block main %}{% endblock %}
                         </section>
 
-                        {% if block('content_footer')|trim is not empty %}
+                        {% block content_footer_wrapper %}
                             <section class="content-footer">
                                 {% block content_footer %}{% endblock %}
                             </section>
-                        {% endif %}
+                        {% endblock %}
                     </div>
                 {% endblock content %}
             </div>


### PR DESCRIPTION
As spotted in https://github.com/EasyCorp/EasyAdminBundle/pull/2578 these tests makes impossible to render any form inside these blocks: `content_header`, `global_actions` or `content_footer`.

In addition, it'll process each block content twice (in case of `global_actions` up to 4 times because it belong to `content_header` block).

Here, we are replacing these tests with a new "wrapper block", in order to override them and thus achieve the same goal: "don't show the wrapped elements if empty content".

**Before:**
```yaml
{% block content_header %}{% endblock content_header %}
```

**After:**
```yaml
{% block content_header_wrapper %}{% endblock content_header_wrapper %}
```

In case you're doing something complex inside these blocks, this PR can be tagged as performance optimization too.

Cheers!