### PR TITLE
Hide the content footer in edit/new pages

### DIFF
--- a/src/Resources/views/default/edit.html.twig
+++ b/src/Resources/views/default/edit.html.twig
@@ -17,6 +17,8 @@
 {% endspaceless %}
 {% endblock %}
 
+{% block content_footer_wrapper '' %}
+
 {% block main %}
     {% block entity_form %}
         {{ form(form) }}

--- a/src/Resources/views/default/new.html.twig
+++ b/src/Resources/views/default/new.html.twig
@@ -16,6 +16,8 @@
 {% endspaceless %}
 {% endblock %}
 
+{% block content_footer_wrapper '' %}
+
 {% block main %}
     {% block entity_form %}
         {{ form(form) }}


### PR DESCRIPTION
Needed after merging #2585 because otherwise you see an empty section below the form buttons:

![content-footer](https://user-images.githubusercontent.com/73419/51631686-a56f7a00-1f4d-11e9-9f19-8a715a880bb3.png)
