### PR TITLE
Sort entity on autocomplete action

### DIFF
--- a/doc/book/edit-new-configuration.rst
+++ b/doc/book/edit-new-configuration.rst
@@ -551,6 +551,7 @@ change this value (globally or per entity):
 You can use the ``list.sort`` option to sort your autocomplete entity.
 
 .. code-block:: yaml
+
     # app/config/config.yml
     easy_admin:
         entities:

--- a/doc/book/edit-new-configuration.rst
+++ b/doc/book/edit-new-configuration.rst
@@ -548,6 +548,17 @@ change this value (globally or per entity):
                     max_results: 5
         # ...
 
+You can use the ``list.sort`` option to sort your autocomplete entity.
+
+.. code-block:: yaml
+    # app/config/config.yml
+    easy_admin:
+        entities:
+            Category:
+                list:
+                    sort: ['label', 'ASC']
+        # ...
+
 .. _edit-new-advanced-form-design:
 
 Advanced Form Design

--- a/doc/book/edit-new-configuration.rst
+++ b/doc/book/edit-new-configuration.rst
@@ -549,6 +549,7 @@ change this value (globally or per entity):
         # ...
 
 You can use the ``list.sort`` option to sort your autocomplete entity.
+The ``dql_filter`` option is available to allow you to filter your autocomplete results.
 
 .. code-block:: yaml
 
@@ -557,6 +558,7 @@ You can use the ``list.sort`` option to sort your autocomplete entity.
         entities:
             Category:
                 list:
+                    dql_filter: 'entity.publishedAt IS NOT NULL'
                     sort: ['label', 'ASC']
         # ...
 

--- a/src/Search/Autocomplete.php
+++ b/src/Search/Autocomplete.php
@@ -51,8 +51,9 @@ class Autocomplete
 
         $sortField = $entityConfig['list']['sort']['field'] ?? null;
         $sortDirection = $entityConfig['list']['sort']['direction'] ?? null;
+        $dqlFilter = $entityConfig['list']['dql_filter'] ?? null;
 
-        $paginator = $this->finder->findByAllProperties($entityConfig, $query, $page, $backendConfig['show']['max_results'], $sortField, $sortDirection);
+        $paginator = $this->finder->findByAllProperties($entityConfig, $query, $page, $backendConfig['show']['max_results'], $sortField, $sortDirection, $dqlFilter);
 
         return [
             'results' => $this->processResults($paginator->getCurrentPageResults(), $entityConfig),

--- a/src/Search/Autocomplete.php
+++ b/src/Search/Autocomplete.php
@@ -47,10 +47,15 @@ class Autocomplete
             throw new \InvalidArgumentException(\sprintf('The "entity" argument must contain the name of an entity managed by EasyAdmin ("%s" given).', $entity));
         }
 
-        $paginator = $this->finder->findByAllProperties($backendConfig['entities'][$entity], $query, $page, $backendConfig['show']['max_results']);
+        $entityConfig = $backendConfig['entities'][$entity];
+
+        $sortField = $entityConfig['list']['sort']['field'] ?? null;
+        $sortDirection = $entityConfig['list']['sort']['direction'] ?? null;
+
+        $paginator = $this->finder->findByAllProperties($entityConfig, $query, $page, $backendConfig['show']['max_results'], $sortField, $sortDirection);
 
         return [
-            'results' => $this->processResults($paginator->getCurrentPageResults(), $backendConfig['entities'][$entity]),
+            'results' => $this->processResults($paginator->getCurrentPageResults(), $entityConfig),
             'has_next_page' => $paginator->hasNextPage(),
         ];
     }

--- a/src/Search/Finder.php
+++ b/src/Search/Finder.php
@@ -30,12 +30,13 @@ class Finder
      * @param int    $maxResults
      * @param string $sortField
      * @param string $sortDirection
+     * @param string $dqlFilter
      *
      * @return Pagerfanta
      */
-    public function findByAllProperties(array $entityConfig, $searchQuery, $page = 1, $maxResults = self::MAX_RESULTS, $sortField = null, $sortDirection = null)
+    public function findByAllProperties(array $entityConfig, $searchQuery, $page = 1, $maxResults = self::MAX_RESULTS, $sortField = null, $sortDirection = null, $dqlFilter = null)
     {
-        $queryBuilder = $this->queryBuilder->createSearchQueryBuilder($entityConfig, $searchQuery, $sortField, $sortDirection);
+        $queryBuilder = $this->queryBuilder->createSearchQueryBuilder($entityConfig, $searchQuery, $sortField, $sortDirection, $dqlFilter);
 
         return $this->paginator->createOrmPaginator($queryBuilder, $page, $maxResults);
     }


### PR DESCRIPTION
Use option `list.sort` to sort an entity on autocomplete action. #2587 