### PR TITLE
Update configuration-reference.rst

### DIFF
--- a/doc/book/configuration-reference.rst
+++ b/doc/book/configuration-reference.rst
@@ -291,8 +291,6 @@ This is the full list of templates that can be redefined:
                 new: '...'
                 # Used to render the contents stored by a given entity
                 show: '...'
-                # Used to render the form displayed in the new and edit pages
-                form: '...'
                 # Used to render the notification area were flash messages are displayed
                 flash_messages: '...'
                 # Used to render the paginator in the list page


### PR DESCRIPTION
Fixes #2408 

Because this template doesn't exist nor processed anywhere. The Symfony doc https://symfony.com/doc/current/form/form_themes.html#creating-a-form-theme-in-a-separate-template should cover this use case.
