### PR TITLE
Improving the use of Data-Transfer-Object on new/edit actions

### DIFF
--- a/src/Form/Type/EasyAdminFormType.php
+++ b/src/Form/Type/EasyAdminFormType.php
@@ -129,14 +129,15 @@ class EasyAdminFormType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $configManager = $this->configManager;
-
         $resolver
             ->setDefaults([
                 'allow_extra_fields' => true,
-                'data_class' => function (Options $options) use ($configManager) {
-                    $entity = $options['entity'];
-                    $entityConfig = $configManager->getEntityConfig($entity);
+                'data_class' => function (Options $options, $dataClass) {
+                    if (null !== $dataClass) {
+                        return $dataClass;
+                    }
+
+                    $entityConfig = $this->configManager->getEntityConfig($options['entity']);
 
                     return $entityConfig['class'];
                 },

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -6,7 +6,7 @@
             'class': [attr.class|default(''), easyadmin.view ~ '-form']|join(' '),
             'data-view': easyadmin.view,
             'data-entity': easyadmin.entity.name,
-            'data-entity-id': attribute(value, easyadmin.entity.primary_key_field_name),
+            'data-entity-id': attribute(value, easyadmin.entity.primary_key_field_name) ?? '',
         }) %}
     {% endif %}
 

--- a/tests/Controller/DataTransferObjectTest.php
+++ b/tests/Controller/DataTransferObjectTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+
+class DataTransferObjectTest extends AbstractTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initClient(['environment' => 'data_transfer_object']);
+    }
+
+    public function testNewProductDTO(): void
+    {
+        $crawler = $this->requestNewView('Product');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('#main form')->eq(0);
+        $this->assertSame('new', \trim($form->attr('data-view')));
+        $this->assertSame('Product', \trim($form->attr('data-entity')));
+        $this->assertEmpty($form->attr('data-entity-id'));
+
+        $form = $crawler->selectButton('Save changes')->form();
+        $this->client->submit($form, [
+            'product[name]' => 'Product X',
+            'product[description]' => 'Description X',
+            'product[price]' => '1000.00',
+            'product[ean]' => '4006381333932',
+        ]);
+        $this->assertSame(302, $this->client->getResponse()->getStatusCode());
+
+        $crawler = $this->requestListView('Product');
+        $this->assertContains('101 results', $crawler->filter('.list-pagination')->text());
+        $crawler = $this->requestSearchView('Product X', 'Product');
+        $this->assertCount(1, $crawler->filter('.table tbody tr'));
+    }
+
+    public function testEditProductPriceDTO(): void
+    {
+        $crawler = $this->requestEditView('Product', '1');
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+
+        $form = $crawler->filter('#main form')->eq(0);
+        $this->assertSame('edit', \trim($form->attr('data-view')));
+        $this->assertSame('Product', \trim($form->attr('data-entity')));
+        $this->assertEmpty($form->attr('data-entity-id'));
+
+        $form = $crawler->selectButton('Save changes')->form();
+        $this->client->submit($form, [
+            'product[name]' => 'Product X',
+        ]);
+        $this->assertSame(302, $this->client->getResponse()->getStatusCode());
+
+        $crawler = $this->requestSearchView('Product X', 'Product');
+        $this->assertCount(1, $crawler->filter('.table tbody tr'));
+    }
+}

--- a/tests/Fixtures/App/config/config_data_transfer_object.yml
+++ b/tests/Fixtures/App/config/config_data_transfer_object.yml
@@ -1,0 +1,12 @@
+imports:
+    - { resource: config.yml }
+
+easy_admin:
+    entities:
+        Product:
+            class: AppTestBundle\Entity\FunctionalTests\Product
+            controller: EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin\ProductController
+            new:
+                fields: ['name', 'description', { property: 'price', type: 'number' }, 'ean']
+            edit:
+                fields: ['name']

--- a/tests/Fixtures/AppTestBundle/Admin/ProductController.php
+++ b/tests/Fixtures/AppTestBundle/Admin/ProductController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AppTestBundle\Admin;
+
+use AppTestBundle\Entity\FunctionalTests\Product;
+use AppTestBundle\Form\Data\AddProductData;
+use AppTestBundle\Form\Data\UpdateProductNameData;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController;
+use Symfony\Component\Form\FormInterface;
+
+class ProductController extends EasyAdminController
+{
+    protected function createNewEntity(): AddProductData
+    {
+        return new AddProductData();
+    }
+
+    /**
+     * @param AddProductData $object
+     */
+    protected function persistEntity($object): void
+    {
+        $product = new Product();
+        $product->setName($object->name);
+        $product->setDescription($object->description);
+        $product->setPrice($object->price);
+        $product->setEan($object->ean);
+        $product->setTags(['x-product']);
+
+        parent::persistEntity($product);
+    }
+
+    /**
+     * @param Product $product
+     */
+    protected function createEditForm($product, array $entityProperties)
+    {
+        $object = new UpdateProductNameData();
+        $object->name = $product->getName();
+
+        return $this->createEntityForm($object, $entityProperties, 'edit');
+    }
+
+    /**
+     * @param Product $product
+     */
+    protected function updateEntity($product, FormInterface $editForm = null): void
+    {
+        /** @var UpdateProductNameData $object */
+        $object = $editForm->getData();
+
+        $product->setName($object->name);
+
+        parent::updateEntity($product);
+    }
+}

--- a/tests/Fixtures/AppTestBundle/Form/Data/AddProductData.php
+++ b/tests/Fixtures/AppTestBundle/Form/Data/AddProductData.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AppTestBundle\Form\Data;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+class AddProductData
+{
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length(min="3")
+     */
+    public $name;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length(min="10")
+     */
+    public $description;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\GreaterThan(0)
+     * @Assert\Type("float")
+     */
+    public $price = 0.0;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length(min="13", max="13")
+     */
+    public $ean;
+}

--- a/tests/Fixtures/AppTestBundle/Form/Data/UpdateProductNameData.php
+++ b/tests/Fixtures/AppTestBundle/Form/Data/UpdateProductNameData.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppTestBundle\Form\Data;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * One case where it is useful to use something like a DTO
+ * is when you have a significant mismatch between the model
+ * in your presentation layer and the underlying domain model.
+ *
+ * In this case it makes sense to make presentation specific
+ * that maps from the domain model and presents an interface
+ * that's convenient for the presentation.
+ */
+class UpdateProductNameData
+{
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length(min="3")
+     */
+    public $name;
+}


### PR DESCRIPTION
DTO in EasyAdmin is currently compatible after https://github.com/EasyCorp/EasyAdminBundle/pull/1679 (the tests added here prove it). In addition, I have made some small changes that will make things even easier. See https://github.com/EasyCorp/EasyAdminBundle/issues/1819#issuecomment-333661648

See example before these changes https://github.com/yceruto/easyadmin-demo/tree/dto_example