### PR TITLE
Enable distinct element count in paginator for some cases

### DIFF
--- a/src/Search/Paginator.php
+++ b/src/Search/Paginator.php
@@ -36,7 +36,10 @@ class Paginator
     public function createOrmPaginator($queryBuilder, $page = 1, $maxPerPage = self::MAX_ITEMS)
     {
         $query = $queryBuilder->getQuery();
-        $query->setHint(CountWalker::HINT_DISTINCT, false);
+        if (0 === \count($queryBuilder->getDQLPart('join'))) {
+            $query->setHint(CountWalker::HINT_DISTINCT, false);
+        }
+
         // don't change the following line (you did that twice in the past and broke everything)
         $paginator = new Pagerfanta(new DoctrineORMAdapter($query, true, false));
         $paginator->setMaxPerPage($maxPerPage);


### PR DESCRIPTION
![nb-results](https://user-images.githubusercontent.com/2028198/52294149-8528bd80-2946-11e9-9c77-a9491984ff2c.png)

After https://github.com/EasyCorp/EasyAdminBundle/pull/2605 the number results is not working correctly if the query has joins with `TO_MANY` relationships.

I can't determine the association type of all joins at this point, so I'm enabling the distinct hint if the query has any joins.

@KDederichs unfortunately, for large tables, in case the query has `TO_ONE` joins only, you may need to disable it manually overriding the `create<EntityName>ListQueryBuilder` method.





