### PR TITLE
Fix search action for `simple_array` type

### DIFF
--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -124,7 +124,7 @@ class QueryBuilder
             $isSmallIntegerField = 'smallint' === $metadata['dataType'];
             $isIntegerField = 'integer' === $metadata['dataType'];
             $isNumericField = in_array($metadata['dataType'], array('number', 'bigint', 'decimal', 'float'));
-            $isTextField = in_array($metadata['dataType'], array('string', 'text', 'simple_array'));
+            $isTextField = in_array($metadata['dataType'], array('string', 'text', 'array', 'simple_array'));
             $isGuidField = 'guid' === $metadata['dataType'];
 
             // this complex condition is needed to avoid issues on PostgreSQL databases

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -124,7 +124,7 @@ class QueryBuilder
             $isSmallIntegerField = 'smallint' === $metadata['dataType'];
             $isIntegerField = 'integer' === $metadata['dataType'];
             $isNumericField = in_array($metadata['dataType'], array('number', 'bigint', 'decimal', 'float'));
-            $isTextField = in_array($metadata['dataType'], array('string', 'text'));
+            $isTextField = in_array($metadata['dataType'], array('string', 'text', 'simple_array'));
             $isGuidField = 'guid' === $metadata['dataType'];
 
             // this complex condition is needed to avoid issues on PostgreSQL databases


### PR DESCRIPTION
**simple_array** is type of array for property in entity, but it is type of string in database _(exploded array by `,`)_
This fix help for search data by field with simple_array type. 


https://www.doctrine-project.org/projects/doctrine-dbal/en/2.9/reference/types.html#simple-array