### PR TITLE
Add default sort configuration

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -103,11 +103,11 @@ trait AdminControllerTrait
 
         $action = $request->query->get('action', 'list');
         if (!$request->query->has('sortField')) {
-            $sortField = $this->entity[$action]['sort']['field'] ?? $this->entity['primary_key_field_name'];
+            $sortField = $this->entity[$action]['sort']['field'] ?? $this->config['default_sort_field'] ?? $this->entity['primary_key_field_name'];
             $request->query->set('sortField', $sortField);
         }
         if (!$request->query->has('sortDirection')) {
-            $sortDirection = $this->entity[$action]['sort']['direction'] ?? 'DESC';
+            $sortDirection = $this->entity[$action]['sort']['direction'] ?? $this->config['default_sort_direction'] ?? 'DESC';
             $request->query->set('sortDirection', $sortDirection);
         }
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -87,6 +87,16 @@ class Configuration implements ConfigurationInterface
                     ->defaultValue('messages')
                     ->info('The translation domain used to translate the labels, titles and help messages of all entities.')
                 ->end()
+
+                ->scalarNode('default_sort_field')
+                    ->info('List/Search views will be sorted by default by this field.')
+                ->end()
+
+                ->enumNode('default_sort_direction')
+                    ->defaultValue('DESC')
+                    ->values(['ASC','DESC'])
+                    ->info('List/Search views will be sorted by default by this direction.')
+                ->end()
             ->end()
         ;
     }


### PR DESCRIPTION
A small feature to allow default configuration like this without being tight up to a specific entity:

easy_admin:
    default_sort_field: 'abc'
    default_sort_direction: 'DESC'