### PR TITLE
Missing paginator.results translation for Italian

### DIFF
--- a/src/Resources/translations/EasyAdminBundle.it.xlf
+++ b/src/Resources/translations/EasyAdminBundle.it.xlf
@@ -57,6 +57,10 @@
                 <source>paginator.counter</source>
                 <target><![CDATA[<strong>%start%</strong> - <strong>%end%</strong> di <strong>%results%</strong>]]></target>
             </trans-unit>
+            <trans-unit id="paginator.results">
+                <source>paginator.results</source>
+                <target><![CDATA[{0} Nessun risultato|{1} <strong>1</strong> risultato|]1,Inf] <strong>%count%</strong> risultati]]></target>
+            </trans-unit>
 
             <!-- labels -->
             <trans-unit id="label.true">


### PR DESCRIPTION
<!--

BUGS must go to '1.x' branch.
NEW FEATURES must go to 'master' branch.

If the NEW FEATURE is complex, open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license

-->
