### PR TITLE
Don't override the primary color definition with custom CSS

### DIFF
--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -11,15 +11,15 @@
 
         {% block head_stylesheets %}
             <link rel="stylesheet" href="{{ asset('bundles/easyadmin/app.css') }}">
-
-            <style>
-                :root { --color-primary: {{ easyadmin_config('design.brand_color') }}; }
-            </style>
         {% endblock %}
 
         {% for css_asset in easyadmin_config('design.assets.css') %}
             <link rel="stylesheet" href="{{ asset(css_asset) }}">
         {% endfor %}
+
+        <style>
+            :root { --color-primary: {{ easyadmin_config('design.brand_color') }}; }
+        </style>
 
         {% block head_favicon %}
             {% set favicon = easyadmin_config('design.assets.favicon') %}


### PR DESCRIPTION
This fixes #2652 giving `--color-primary` the top priority. This would "break" an edge-case: you don't set a value for the `design.brand_color` config option and define it instead using custom CSS files. But the solution is easy: use `design.brand_color` or tweak your custom CSS files.