### PR TITLE
Custom translation for "Add item" collection buttons

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -170,7 +170,21 @@
             <div class="form-widget">
                 <a href="#" onclick="{{ js_add_item|raw }}; return false;" class="btn btn-secondary btn-sm">
                     <i class="fa fa-fw fa-plus"></i>
-                    <span class="btn-label">{{ (form|length == 0 ? 'action.add_new_item' : 'action.add_another_item')|trans({}, 'EasyAdminBundle') }}</span>
+                    <span class="btn-label">
+                        {%- if form|length == 0 -%}
+                            {{
+                                easyadmin.field.label_add_new_item
+                                | default('action.add_new_item')
+                                | trans({}, 'EasyAdminBundle')
+                            }}
+                        {%- else -%}
+                            {{
+                                easyadmin.field.label_add_another_item
+                                | default('action.add_another_item')
+                                | trans({}, 'EasyAdminBundle')
+                            }}
+                        {%- endif -%}
+                    </span>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
In regards to #2682 issue, I've added possibility to set custom translations to buttons in collections form ("Add a new item" and "Add another item"). The default translation keys are:

- `action.add_new_item`
- `action.add_another_item`

If there is a need to set custom translation in that button, just translate string with generated field `id`.

For example, for given config

```yaml
easy_admin:
  entities:
    User:
      class: App\Entity\User
      form:
        fields:
          - property: roles
            type: collection
```

we can translate these strings:

- `action.add_new_item.user_roles`
- `action.add_another_item.user_roles`