### PR TITLE
Action templates

### DIFF
--- a/doc/tutorials/custom-actions.rst
+++ b/doc/tutorials/custom-actions.rst
@@ -224,7 +224,7 @@ other actions like ``list``, ``edit`` or ``delete`` will stay untouched):
 
     {% if item.stock < 10 %}
         {# this will trigger action's default behaviour, if "stock" is less than 10 #}
-        {% include '@EasyAdmin/default/action.html.twig' %}
+        {{ include('@EasyAdmin/default/action.html.twig') }}
     {% else %}
         {# don't show this action, if stock is more than 9 #}
     {% endif %}

--- a/doc/tutorials/custom-actions.rst
+++ b/doc/tutorials/custom-actions.rst
@@ -195,6 +195,43 @@ Similarly to method based actions, you can configure any option for these
 actions (icons, labels, etc.) and you can also leverage the action inheritance
 mechanism.
 
+Custom Template on Actions
+--------------------------
+
+Sometimes you want to customize text or visibility of an custom action depending
+on the entity. You can use ``template`` in action method like you can do in fields.
+
+Imagine you want to show ``Restock`` action only on items with a stock less than
+10. Just use a custom template for this case:
+
+.. code-block:: yaml
+
+    # config/packages/easy_admin.yaml
+    easy_admin:
+        entities:
+            Product:
+                show:
+                    actions:
+                        - { name: 'restock', template: 'admin/publish_action.html.twig' }
+            # ...
+
+And then you can customize your ``Restock`` action using your own template (all
+other actions like ``edit`` or ``delete`` will stay untouched):
+
+.. code-block:: twig
+
+    {# templates/admin/publish_action.html.twig #}
+
+    {% if item.stock < 10 %}
+        {# this will trigger action's default behaviour, if "stock" is less than 10 #}
+        {% include '@EasyAdmin/default/action.html.twig' %}
+    {% else %}
+        {# don't show this action, if stock is more than 9 #}
+    {% endif %}
+
+Make sure you have configured other parameters for your custom action too like in
+the sections before.
+
 .. _custom-batch-actions:
 
 Batch Actions

--- a/doc/tutorials/custom-actions.rst
+++ b/doc/tutorials/custom-actions.rst
@@ -216,7 +216,7 @@ Imagine you want to show ``Restock`` action only on items with a stock less than
             # ...
 
 And then you can customize your ``Restock`` action using your own template (all
-other actions like ``edit`` or ``delete`` will stay untouched):
+other actions like ``list``, ``edit`` or ``delete`` will stay untouched):
 
 .. code-block:: twig
 

--- a/doc/tutorials/custom-actions.rst
+++ b/doc/tutorials/custom-actions.rst
@@ -212,7 +212,7 @@ Imagine you want to show ``Restock`` action only on items with a stock less than
             Product:
                 show:
                     actions:
-                        - { name: 'restock', template: 'admin/publish_action.html.twig' }
+                        - { name: 'restock', template: 'admin/restock_action.html.twig' }
             # ...
 
 And then you can customize your ``Restock`` action using your own template (all
@@ -220,7 +220,7 @@ other actions like ``edit`` or ``delete`` will stay untouched):
 
 .. code-block:: twig
 
-    {# templates/admin/publish_action.html.twig #}
+    {# templates/admin/restock_action.html.twig #}
 
     {% if item.stock < 10 %}
         {# this will trigger action's default behaviour, if "stock" is less than 10 #}

--- a/src/Configuration/ActionConfigPass.php
+++ b/src/Configuration/ActionConfigPass.php
@@ -26,6 +26,8 @@ class ActionConfigPass implements ConfigPassInterface
         'icon' => null,
         // the value of the HTML 'target' attribute add to the links of the actions (e.g. '_blank')
         'target' => '_self',
+        // the value of the template. Will be set in the TemplateConfigPass, if value will stay null.
+        'template' => null,
     ];
 
     public function process(array $backendConfig)

--- a/src/Configuration/TemplateConfigPass.php
+++ b/src/Configuration/TemplateConfigPass.php
@@ -21,6 +21,7 @@ class TemplateConfigPass implements ConfigPassInterface
         'list' => '@EasyAdmin/default/list.html.twig',
         'new' => '@EasyAdmin/default/new.html.twig',
         'show' => '@EasyAdmin/default/show.html.twig',
+        'action' => '@EasyAdmin/default/action.html.twig',
         'exception' => '@EasyAdmin/default/exception.html.twig',
         'flash_messages' => '@EasyAdmin/default/flash_messages.html.twig',
         'paginator' => '@EasyAdmin/default/paginator.html.twig',

--- a/src/Configuration/TemplateConfigPass.php
+++ b/src/Configuration/TemplateConfigPass.php
@@ -71,6 +71,7 @@ class TemplateConfigPass implements ConfigPassInterface
         $backendConfig = $this->processEntityTemplates($backendConfig);
         $backendConfig = $this->processDefaultTemplates($backendConfig);
         $backendConfig = $this->processFieldTemplates($backendConfig);
+        $backendConfig = $this->processActionTemplates($backendConfig);
 
         $this->existingTemplates = [];
 
@@ -202,6 +203,29 @@ class TemplateConfigPass implements ConfigPassInterface
             }
 
             $backendConfig['entities'][$entityName] = $entityConfig;
+        }
+
+        return $backendConfig;
+    }
+
+    /**
+     * Sets the default action template for every action, if it is not already set.
+     *
+     * @param array $backendConfig
+     *
+     * @return array
+     */
+    private function processActionTemplates(array $backendConfig)
+    {
+        foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
+            foreach (['list', 'show', 'edit', 'new'] as $viewName) {
+                foreach ($entityConfig[$viewName]['actions'] as $actionName => $actionConfig) {
+                    if (null === $actionConfig['template']) {
+                        $templateName = $backendConfig['design']['templates']['action'];
+                        $backendConfig['entities'][$entityName][$viewName]['actions'][$actionName]['template'] = $templateName;
+                    }
+                }
+            }
         }
 
         return $backendConfig;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -214,6 +214,7 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode('list')->info('Used to render the listing page and the search results page')->end()
                                 ->scalarNode('new')->info('Used to render the page where new entities are created')->end()
                                 ->scalarNode('show')->info('Used to render the contents stored by a given entity')->end()
+                                ->scalarNode('action')->info('Used to render an action for a given entity')->end()
                                 ->scalarNode('exception')->info('Used to render the error page when some exception happens')->end()
                                 ->scalarNode('flash_messages')->info('Used to render the notification area were flash messages are displayed')->end()
                                 ->scalarNode('paginator')->info('Used to render the paginator in the list page')->end()

--- a/src/Resources/views/default/action.html.twig
+++ b/src/Resources/views/default/action.html.twig
@@ -1,0 +1,6 @@
+<a class="{{ is_dropdown|default(false) ? 'dropdown-item' }} {{ action.css_class|default('') }}" title="{{ action.title|default('') is empty ? '' : action.title|trans(trans_parameters, translation_domain) }}" href="{{ action_href }}" target="{{ action.target }}">
+    {%- if action.icon %}<i class="fa fa-{{ action.icon }}"></i> {% endif -%}
+    {%- if action.label is defined and not action.label is empty -%}
+        {{ action.label|trans(arguments = trans_parameters|merge({ '%entity_id%': item_id }), domain = translation_domain) }}
+    {%- endif -%}
+</a>

--- a/src/Resources/views/default/includes/_actions.html.twig
+++ b/src/Resources/views/default/includes/_actions.html.twig
@@ -16,5 +16,5 @@
         request_parameters: request_parameters,
         translation_domain: translation_domain,
         trans_parameters: trans_parameters,
-    }) }}
+    }, with_context = false) }}
 {% endfor %}

--- a/src/Resources/views/default/includes/_actions.html.twig
+++ b/src/Resources/views/default/includes/_actions.html.twig
@@ -7,10 +7,14 @@
         {% set action_href = path(action.name, request_parameters|merge({ action: action.name, id: item_id })) %}
     {% endif %}
 
-    <a class="{{ is_dropdown|default(false) ? 'dropdown-item' }} {{ action.css_class|default('') }}" title="{{ action.title|default('') is empty ? '' : action.title|trans(trans_parameters, translation_domain) }}" href="{{ action_href }}" target="{{ action.target }}">
-        {%- if action.icon %}<i class="fa fa-{{ action.icon }}"></i> {% endif -%}
-        {%- if action.label is defined and not action.label is empty -%}
-            {{ action.label|trans(arguments = trans_parameters|merge({ '%entity_id%': item_id }), domain = translation_domain) }}
-        {%- endif -%}
-    </a>
+    {{ include(action.template|default(entity_config.templates.action), {
+        action: action,
+        action_href: action_href,
+        is_dropdown: is_dropdown|default(false),
+        item: item,
+        item_id: item_id,
+        request_parameters: request_parameters,
+        translation_domain: translation_domain,
+        trans_parameters: trans_parameters,
+    }) }}
 {% endfor %}

--- a/src/Resources/views/default/includes/_actions.html.twig
+++ b/src/Resources/views/default/includes/_actions.html.twig
@@ -7,7 +7,7 @@
         {% set action_href = path(action.name, request_parameters|merge({ action: action.name, id: item_id })) %}
     {% endif %}
 
-    {{ include(action.template|default(entity_config.templates.action), {
+    {{ include(action.template, {
         action: action,
         action_href: action_href,
         is_dropdown: is_dropdown|default(false),

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -159,6 +159,7 @@
                             %}
                             {{ include(_actions_template, {
                                 actions: _list_item_actions,
+                                entity_config: _entity_config,
                                 request_parameters: _request_parameters,
                                 translation_domain: _entity_config.translation_domain,
                                 trans_parameters: _trans_parameters,

--- a/src/Resources/views/default/show.html.twig
+++ b/src/Resources/views/default/show.html.twig
@@ -50,6 +50,7 @@
 
                 {{ include('@EasyAdmin/default/includes/_actions.html.twig', {
                     actions: _show_actions,
+                    entity_config: _entity_config,
                     request_parameters: _request_parameters,
                     translation_domain: _entity_config.translation_domain,
                     trans_parameters: _trans_parameters,

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -356,6 +356,7 @@
 
     {{ include('@EasyAdmin/default/includes/_actions.html.twig', {
         actions: _entity_actions,
+        entity_config: easyadmin.entity,
         request_parameters: _request_parameters,
         translation_domain: _translation_domain,
         trans_parameters: _trans_parameters,

--- a/tests/Configuration/fixtures/configurations/input/admin_176.yml
+++ b/tests/Configuration/fixtures/configurations/input/admin_176.yml
@@ -1,0 +1,13 @@
+# TEST
+# 'template' in actions "edit" and "delete" should have the default template.
+# 'template' in action "custom" should have a custom template.
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            actions: ['edit', 'delete']
+            list:
+                actions:
+                    - { name: 'custom', template: 'admin/custom.html.twig' }

--- a/tests/Configuration/fixtures/configurations/output/config_176.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_176.yml
@@ -1,0 +1,9 @@
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                actions:
+                    edit: { name: 'edit', template: '@EasyAdmin/default/action.html.twig' }
+                    delete: { name: 'delete', template: '@EasyAdmin/default/action.html.twig' }
+                    custom: { name: 'custom', template: 'admin/custom.html.twig' }

--- a/tests/Controller/ActionTemplateTest.php
+++ b/tests/Controller/ActionTemplateTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
+
+class ActionTemplateTest extends AbstractTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->initClient(['environment' => 'action_template']);
+    }
+
+    public function testListViewActions()
+    {
+        // List is sorted DESC by "action_template" configuration, to ensure Child Categories first
+        $crawler = $this->requestListView();
+        file_put_contents('/home/tfreitag/Projects/opensource/EasyAdminBundle/test.html', $crawler->html());
+
+        $this->assertCount(15, $crawler->filter('table .actions a:contains("Parent")'));
+        $this->assertCount(0, $crawler->filter('table .actions:contains("No Parent")'));
+    }
+
+    public function testShowViewActionsWithChildCategory()
+    {
+        $crawler = $this->requestShowView('Category', 101);
+
+        $this->assertCount(1, $crawler->filter('.form-actions a:contains("Show Parent")'));
+        $this->assertCount(0, $crawler->filter('.form-actions span:contains("No Parent")'));
+    }
+
+    public function testShowViewActionsWithParentCategory()
+    {
+        $crawler = $this->requestShowView('Category', 1);
+
+        $this->assertCount(0, $crawler->filter('.form-actions a:contains("Show Parent")'));
+        $this->assertCount(1, $crawler->filter('.form-actions span:contains("No Parent")'));
+    }
+
+    public function testEditViewActionsWithChildCategory()
+    {
+        $crawler = $this->requestEditView('Category', 150);
+
+        $this->assertCount(1, $crawler->filter('.form-actions a:contains("Go to Parent")'));
+        $this->assertCount(0, $crawler->filter('.form-actions span:contains("No Parent")'));
+    }
+
+    public function testEditViewActionsWithParentCategory()
+    {
+        $crawler = $this->requestEditView('Category', 50);
+
+        $this->assertCount(0, $crawler->filter('.form-actions a:contains("Go to Parent")'));
+        $this->assertCount(1, $crawler->filter('.form-actions span:contains("No Parent")'));
+    }
+}

--- a/tests/Controller/ActionTemplateTest.php
+++ b/tests/Controller/ActionTemplateTest.php
@@ -17,7 +17,6 @@ class ActionTemplateTest extends AbstractTestCase
     {
         // List is sorted DESC by "action_template" configuration, to ensure Child Categories first
         $crawler = $this->requestListView();
-        file_put_contents('/home/tfreitag/Projects/opensource/EasyAdminBundle/test.html', $crawler->html());
 
         $this->assertCount(15, $crawler->filter('table .actions a:contains("Parent")'));
         $this->assertCount(0, $crawler->filter('table .actions:contains("No Parent")'));

--- a/tests/Fixtures/App/config/config_action_template.yml
+++ b/tests/Fixtures/App/config/config_action_template.yml
@@ -1,0 +1,17 @@
+imports:
+    - { resource: config.yml }
+
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\FunctionalTests\Category
+            list:
+                sort: ['id', DESC]
+                actions:
+                    - { name: 'show_parent', template: 'custom_templates/custom_action.html.twig', label: 'Parent' }
+            show:
+                actions:
+                    - { name: 'show_parent', template: 'custom_templates/custom_action.html.twig', label: 'Show Parent' }
+            edit:
+                actions:
+                    - { name: 'show_parent', template: 'custom_templates/custom_action.html.twig', label: 'Go to Parent' }

--- a/tests/Fixtures/App/templates/custom_templates/custom_action.html.twig
+++ b/tests/Fixtures/App/templates/custom_templates/custom_action.html.twig
@@ -1,10 +1,10 @@
 {% if item.parent -%}
-    {% include '@EasyAdmin/default/action.html.twig' with {
+    {{ include('@EasyAdmin/default/action.html.twig', {
         action_href: path('easyadmin', request_parameters|merge({
             action: 'show',
             id: item.parent.id
         }))
-    } %}
+    }, with_context = true) }}
 {%- else -%}
     <span class="sr-only">No Parent</span>
 {%- endif %}

--- a/tests/Fixtures/App/templates/custom_templates/custom_action.html.twig
+++ b/tests/Fixtures/App/templates/custom_templates/custom_action.html.twig
@@ -1,0 +1,10 @@
+{% if item.parent -%}
+    {% include '@EasyAdmin/default/action.html.twig' with {
+        action_href: path('easyadmin', request_parameters|merge({
+            action: 'show',
+            id: item.parent.id
+        }))
+    } %}
+{%- else -%}
+    <span class="sr-only">No Parent</span>
+{%- endif %}


### PR DESCRIPTION
Hello!

We need more customizable action buttons, and I wondered why there isn't there a `template` option on a `action`.

There are many useful scenarios:
* Label or icon depending on entity's state
* Show "Publish" action only on unpublished items (useful for blogs)
* Show "Restock" action only on items with a low stock (see documentation in this PR)
* "Show Parent" on child entities (see unit tests in this PR)

It's a new feature. This feature isn't too complex, so I only have this chat messages from Slack (instead in form of an issue):

![image](https://user-images.githubusercontent.com/546813/55977583-6cfb5480-5c8f-11e9-80b7-ad8202bdd828.png)


According to the documentation you are able to use this code:

```yaml
# config/packages/easy_admin.yaml
easy_admin:
    entities:
        Product:
            show:
                actions:
                    - { name: 'restock', template: 'admin/restock_action.html.twig' }
        # ...
```

And your custom action button template:

```twig
{# templates/admin/restock_action.html.twig #}

{% if item.stock < 10 %}
    {# this will trigger action's default behaviour, if "stock" is less than 10 #}
    {% include '@EasyAdmin/default/action.html.twig' %}
{% else %}
    {# don't show this action, if stock is more than 9 #}
{% endif %}
```

I hope, you will like it!