### PR TITLE
fix(help-text): use form translation domain

### DIFF
--- a/src/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
+++ b/src/Resources/views/form/bootstrap_3_horizontal_layout.html.twig
@@ -42,7 +42,7 @@
             {{ form_errors(form) }}
 
             {% if easyadmin.field.help|default('') != '' %}
-                <span class="help-block"><i class="fa fa-info-circle"></i> {{ easyadmin.field.help|trans(domain = easyadmin.entity.translation_domain)|raw }}</span>
+                <span class="help-block"><i class="fa fa-info-circle"></i> {{ easyadmin.field.help|trans(domain = form.vars.translation_domain)|raw }}</span>
             {% endif %}
         </div>
     </div>

--- a/src/Resources/views/form/bootstrap_3_layout.html.twig
+++ b/src/Resources/views/form/bootstrap_3_layout.html.twig
@@ -277,7 +277,7 @@
         {{- form_errors(form) -}}
 
         {% if easyadmin.field.help|default('') != '' %}
-            <span class="help-block"><i class="fa fa-info-circle"></i> {{ easyadmin.field.help|trans(domain = easyadmin.entity.translation_domain)|raw }}</span>
+            <span class="help-block"><i class="fa fa-info-circle"></i> {{ easyadmin.field.help|trans(domain = form.vars.translation_domain)|raw }}</span>
         {% endif %}
     </div>
 {%- endblock form_row %}


### PR DESCRIPTION
I'm trying to set a custom translation domain for my help text with a custom type configurator.

But it is not possible because in the block, the value is hardcoded to the entity translation domain.

However, I think we can use the form value here because its default value is already the entity translation domain (it is set in the `TypeConfigurator` class).