### PR TITLE
fix(image-preview): support svg

### DIFF
--- a/src/Resources/views/css/easyadmin.css.twig
+++ b/src/Resources/views/css/easyadmin.css.twig
@@ -631,6 +631,7 @@ button.btn:active {
     display: block;
 }
 .easyadmin-lightbox img {
+    width: 100%;
     max-width: 100%;
 }
 


### PR DESCRIPTION
SVG files are currently not displayed when you want to preview them from the list or from the forms.

Before:
<img width="1110" alt="image" src="https://user-images.githubusercontent.com/3658119/56224096-4cf0da00-606f-11e9-9b3e-9aa7d3500431.png">

After:
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/3658119/56224132-5da15000-606f-11e9-9ef0-4a099f7bf993.png">
