### PR TITLE
Fixed width for action icons in list view

### DIFF
--- a/src/Resources/views/default/includes/_actions.html.twig
+++ b/src/Resources/views/default/includes/_actions.html.twig
@@ -8,7 +8,7 @@
     {% endif %}
 
     <a class="{{ is_dropdown|default(false) ? 'dropdown-item' }} {{ action.css_class|default('') }}" title="{{ action.title|default('') is empty ? '' : action.title|trans(trans_parameters, translation_domain) }}" href="{{ action_href }}" target="{{ action.target }}">
-        {%- if action.icon %}<i class="fa fa-{{ action.icon }}"></i> {% endif -%}
+        {%- if action.icon %}<i class="fa fa-fw fa-{{ action.icon }}"></i> {% endif -%}
         {%- if action.label is defined and not action.label is empty -%}
             {{ action.label|trans(arguments = trans_parameters|merge({ '%entity_id%': item_id }), domain = translation_domain) }}
         {%- endif -%}

--- a/tests/Controller/EmptyActionLabelsTest.php
+++ b/tests/Controller/EmptyActionLabelsTest.php
@@ -19,11 +19,11 @@ class EmptyActionLabelsTest extends AbstractTestCase
 
         // edit action
         $this->assertSame('', \trim($crawler->filter('#main table tr:first-child td.actions a')->eq(0)->text()));
-        $this->assertSame('fa fa-pencil', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(0)->attr('class')));
+        $this->assertSame('fa fa-fw fa-pencil', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(0)->attr('class')));
 
         // delete action
         $this->assertSame('', \trim($crawler->filter('#main table tr:first-child td.actions a')->eq(1)->text()));
-        $this->assertSame('fa fa-minus-circle', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(1)->attr('class')));
+        $this->assertSame('fa fa-fw fa-minus-circle', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(1)->attr('class')));
     }
 
     public function testCustomActionLabels()
@@ -32,11 +32,11 @@ class EmptyActionLabelsTest extends AbstractTestCase
 
         // custom action 1
         $this->assertSame('', \trim($crawler->filter('#main table tr:first-child td.actions a')->eq(2)->text()));
-        $this->assertSame('fa fa-icon1', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(2)->attr('class')));
+        $this->assertSame('fa fa-fw fa-icon1', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(2)->attr('class')));
 
         // custom action 2
         $this->assertSame('', \trim($crawler->filter('#main table tr:first-child td.actions a')->eq(3)->text()));
-        $this->assertSame('fa fa-icon2', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(3)->attr('class')));
+        $this->assertSame('fa fa-fw fa-icon2', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(3)->attr('class')));
     }
 
     public function testFalseActionLabels()
@@ -45,6 +45,6 @@ class EmptyActionLabelsTest extends AbstractTestCase
 
         // custom action with 'false' label used as a string instead of a boolean
         $this->assertSame('false', \trim($crawler->filter('#main table tr:first-child td.actions a')->eq(4)->text()));
-        $this->assertSame('fa fa-icon3', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(4)->attr('class')));
+        $this->assertSame('fa fa-fw fa-icon3', \trim($crawler->filter('#main table tr:first-child td.actions a i')->eq(4)->attr('class')));
     }
 }


### PR DESCRIPTION
Set fixed width for action icons in the list view with `fa-fw` CSS class. This should fix problem mentioned in #2635.