### PR TITLE
[Deprecated] use filter spaceless instead tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/twig-bundle": "^4.1",
         "symfony/validator": "^4.1",
         "twig/extensions": "^1.5",
-        "twig/twig": "^2.4"
+        "twig/twig": "^2.9"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.3",

--- a/src/Resources/views/default/edit.html.twig
+++ b/src/Resources/views/default/edit.html.twig
@@ -11,10 +11,10 @@
 {% block body_class 'edit edit-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-{% spaceless %}
+{% filter spaceless %}
     {% set _default_title = 'edit.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
     {{ _entity_config.edit.title is defined ? _entity_config.edit.title|trans(_trans_parameters) : _default_title }}
-{% endspaceless %}
+{% endfilter %}
 {% endblock %}
 
 {% block content_footer_wrapper '' %}

--- a/src/Resources/views/default/edit.html.twig
+++ b/src/Resources/views/default/edit.html.twig
@@ -11,10 +11,10 @@
 {% block body_class 'edit edit-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-{% filter spaceless %}
-    {% set _default_title = 'edit.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.edit.title is defined ? _entity_config.edit.title|trans(_trans_parameters) : _default_title }}
-{% endfilter %}
+    {% apply spaceless %}
+        {% set _default_title = 'edit.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+        {{ _entity_config.edit.title is defined ? _entity_config.edit.title|trans(_trans_parameters) : _default_title }}
+    {% endapply %}
 {% endblock %}
 
 {% block content_footer_wrapper '' %}

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -30,15 +30,15 @@
 {% block body_class 'list list-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-{% filter spaceless %}
-    {% if 'search' == app.request.get('action') %}
-        {% set _default_title = 'search.page_title'|transchoice(paginator.nbResults, {}, 'EasyAdminBundle') %}
-        {{ (_entity_config.search.title is defined ? _entity_config.search.title|transchoice(paginator.nbResults) : _default_title)|raw }}
-    {% else %}
-        {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-        {{ (_entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title)|raw }}
-    {% endif %}
-{% endfilter %}
+    {% apply spaceless %}
+        {% if 'search' == app.request.get('action') %}
+            {% set _default_title = 'search.page_title'|transchoice(paginator.nbResults, {}, 'EasyAdminBundle') %}
+            {{ (_entity_config.search.title is defined ? _entity_config.search.title|transchoice(paginator.nbResults) : _default_title)|raw }}
+        {% else %}
+            {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+            {{ (_entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title)|raw }}
+        {% endif %}
+    {% endapply %}
 {% endblock %}
 
 {% block global_actions %}

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -30,7 +30,7 @@
 {% block body_class 'list list-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-{% spaceless %}
+{% filter spaceless %}
     {% if 'search' == app.request.get('action') %}
         {% set _default_title = 'search.page_title'|transchoice(paginator.nbResults, {}, 'EasyAdminBundle') %}
         {{ (_entity_config.search.title is defined ? _entity_config.search.title|transchoice(paginator.nbResults) : _default_title)|raw }}
@@ -38,7 +38,7 @@
         {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
         {{ (_entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title)|raw }}
     {% endif %}
-{% endspaceless %}
+{% endfilter %}
 {% endblock %}
 
 {% block global_actions %}

--- a/src/Resources/views/default/new.html.twig
+++ b/src/Resources/views/default/new.html.twig
@@ -10,10 +10,10 @@
 {% block body_class 'new new-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-{% filter spaceless %}
-    {% set _default_title = 'new.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.new.title is defined ? _entity_config.new.title|trans(_trans_parameters) : _default_title }}
-{% endfilter %}
+    {% apply spaceless %}
+        {% set _default_title = 'new.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+        {{ _entity_config.new.title is defined ? _entity_config.new.title|trans(_trans_parameters) : _default_title }}
+    {% endapply %}
 {% endblock %}
 
 {% block content_footer_wrapper '' %}

--- a/src/Resources/views/default/new.html.twig
+++ b/src/Resources/views/default/new.html.twig
@@ -10,10 +10,10 @@
 {% block body_class 'new new-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-{% spaceless %}
+{% filter spaceless %}
     {% set _default_title = 'new.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
     {{ _entity_config.new.title is defined ? _entity_config.new.title|trans(_trans_parameters) : _default_title }}
-{% endspaceless %}
+{% endfilter %}
 {% endblock %}
 
 {% block content_footer_wrapper '' %}

--- a/src/Resources/views/default/show.html.twig
+++ b/src/Resources/views/default/show.html.twig
@@ -10,10 +10,10 @@
 {% block body_class 'show show-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-{% spaceless %}
+{% filter spaceless %}
     {% set _default_title = 'show.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
     {{ _entity_config.show.title is defined ? _entity_config.show.title|trans(_trans_parameters) : _default_title }}
-{% endspaceless %}
+{% endfilter %}
 {% endblock %}
 
 {% block content_footer_wrapper '' %}

--- a/src/Resources/views/default/show.html.twig
+++ b/src/Resources/views/default/show.html.twig
@@ -10,10 +10,10 @@
 {% block body_class 'show show-' ~ _entity_config.name|lower %}
 
 {% block content_title %}
-{% filter spaceless %}
-    {% set _default_title = 'show.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
-    {{ _entity_config.show.title is defined ? _entity_config.show.title|trans(_trans_parameters) : _default_title }}
-{% endfilter %}
+    {% apply spaceless %}
+        {% set _default_title = 'show.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
+        {{ _entity_config.show.title is defined ? _entity_config.show.title|trans(_trans_parameters) : _default_title }}
+    {% endapply %}
 {% endblock %}
 
 {% block content_footer_wrapper '' %}


### PR DESCRIPTION
<!--

BUGS must go to '1.x' branch.
NEW FEATURES must go to 'master' branch.

If the NEW FEATURE is complex, open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license

-->
Since Twig 2.7 _tag spaceless_ is **Deprecated** use _filter_ instead
