### PR TITLE
Show all FontAwesome icons with fixed width

### DIFF
--- a/src/Resources/views/default/exception.html.twig
+++ b/src/Resources/views/default/exception.html.twig
@@ -6,7 +6,7 @@
 {% block content_header '' %}
 {% block main %}
     <div class="error-message">
-        <h1><i class="fa fa-exclamation-circle"></i> {{ block('page_title') }}</h1>
+        <h1><i class="fa fa-fw fa-exclamation-circle"></i> {{ block('page_title') }}</h1>
         {{ exception.publicMessage|trans(exception.translationParameters, 'EasyAdminBundle') }}
     </div>
 {% endblock %}

--- a/src/Resources/views/default/includes/_actions_dropdown.html.twig
+++ b/src/Resources/views/default/includes/_actions_dropdown.html.twig
@@ -1,6 +1,6 @@
 <div class="actions-dropdown">
     <button type="button" class="btn btn-secondary btn-sm dropdown-toggle">
-        <i class="fa fa-ellipsis-h"></i>
+        <i class="fa fa-fw fa-ellipsis-h"></i>
     </button>
 
     <div class="dropdown-menu dropdown-menu-right">

--- a/src/Resources/views/default/includes/_delete_form.html.twig
+++ b/src/Resources/views/default/includes/_delete_form.html.twig
@@ -21,7 +21,7 @@
                 {% if easyadmin_action_is_enabled(view, 'delete', _entity_config.name) %}
                     {% set _delete_action = easyadmin_get_action(view, 'delete', _entity_config.name) %}
                     <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button" formtarget="{{ _delete_action.target }}">
-                        {% if _delete_action.icon %}<i class="fa fa-{{ _delete_action.icon }}"></i>{% endif %}
+                        {% if _delete_action.icon %}<i class="fa fa-fw fa-{{ _delete_action.icon }}"></i>{% endif %}
                         <span class="btn-label">{{ 'delete_modal.action'|trans(_trans_parameters, 'EasyAdminBundle') }}</span>
                     </button>
                 {% endif %}

--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -51,7 +51,7 @@
                 {% block header %}
                     <nav class="navbar" role="navigation">
                         <button id="navigation-toggler" type="button" aria-label="Toggle navigation">
-                            <i class="fa fa-bars"></i>
+                            <i class="fa fa-fw fa-bars"></i>
                         </button>
 
                         <div id="header-logo">
@@ -98,7 +98,7 @@
                             {% if easyadmin_config('user.display_avatar') %}
                                 {% set _avatar_image_path = easyadmin_read_property(app.user, easyadmin_config('user.avatar_property_path')) %}
                                 {% if null == _avatar_image_path %}
-                                    <i class="fa {{ app.user is not null ? 'fa-user-circle' : 'fa-user-times' }} user-avatar"></i>
+                                    <i class="fa fa-fw {{ app.user is not null ? 'fa-user-circle' : 'fa-user-times' }} user-avatar"></i>
                                 {% else %}
                                     <img class="user-avatar" src="{{ _avatar_image_path }}" />
                                 {% endif %}

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -71,7 +71,7 @@
         {% block new_action %}
             <div class="button-action">
                 <a class="{{ _action.css_class|default('') }}" href="{{ path('easyadmin', _request_parameters|merge({ action: _action.name })) }}" target="{{ _action.target }}">
-                    {% if _action.icon %}<i class="fa fa-{{ _action.icon }}"></i>{% endif %}
+                    {% if _action.icon %}<i class="fa fa-fw fa-{{ _action.icon }}"></i>{% endif %}
                     {{ _action.label is defined and not _action.label is empty ? _action.label|trans(_trans_parameters) }}
                 </a>
             </div>
@@ -113,7 +113,7 @@
                     <th class="{{ isSortingField ? 'sorted' }} {{ metadata.virtual ? 'virtual' }} {{ metadata.dataType|lower }} {{ metadata.css_class }}" {{ easyadmin_config('design.rtl') ? 'dir="rtl"' }}>
                         {% if metadata.sortable %}
                             <a href="{{ path('easyadmin', _request_parameters|merge({ page: 1, sortField: metadata.property, sortDirection: nextSortDirection })) }}">
-                                {{ _column_label|raw }} <i class="fa {{ _column_icon }}"></i>
+                                {{ _column_label|raw }} <i class="fa fa-fw {{ _column_icon }}"></i>
                             </a>
                         {% else %}
                             <span>{{ _column_label|raw }}</span>

--- a/src/Resources/views/default/menu.html.twig
+++ b/src/Resources/views/default/menu.html.twig
@@ -22,9 +22,9 @@
            class="{{ item.css_class|default('') }}"
            {% if item.target|default(false) %}target="{{ item.target }}"{% endif %}
            {% if item.rel|default(false) %}rel="{{ item.rel }}"{% endif %}>
-            {% if item.icon is not empty %}<i class="fa {{ item.icon }}"></i>{% endif %}
+            {% if item.icon is not empty %}<i class="fa fa-fw {{ item.icon }}"></i>{% endif %}
             <span>{{ item.label|trans(domain = translation_domain) }}</span>
-            {% if item.children|default([]) is not empty %}<i class="fa fa-angle-right treeview-icon"></i>{% endif %}
+            {% if item.children|default([]) is not empty %}<i class="fa fa-fw fa-angle-right treeview-icon"></i>{% endif %}
         </a>
     {% endif %}
 {% endmacro %}

--- a/src/Resources/views/default/paginator.html.twig
+++ b/src/Resources/views/default/paginator.html.twig
@@ -10,12 +10,12 @@
     <div class="pager pagination list-pagination-paginator {{ not paginator.hasPreviousPage ? 'first-page' }} {{ not paginator.hasNextPage ? 'last-page' }}">
         <a class="btn btn-secondary {{ not paginator.hasPreviousPage ? 'disabled' }}"
            href="{{ not paginator.hasPreviousPage ? '#' : path('easyadmin', _paginator_request_parameters|merge({ page: paginator.previousPage }) ) }}">
-            <i class="fa fa-angle-left"></i> <span class="btn-label">{{ 'paginator.previous'|trans }}</span>
+            <i class="fa fa-fw fa-angle-left"></i> <span class="btn-label">{{ 'paginator.previous'|trans }}</span>
         </a>
 
         <a class="btn btn-secondary {{ not paginator.hasNextPage ? 'disabled' }}"
            href="{{ not paginator.hasNextPage ? '#' : path('easyadmin', _paginator_request_parameters|merge({ page: paginator.nextPage }) ) }}">
-            <span class="btn-label">{{ 'paginator.next'|trans }}</span> <i class="fa fa-angle-right"></i>
+            <span class="btn-label">{{ 'paginator.next'|trans }}</span> <i class="fa fa-fw fa-angle-right"></i>
         </a>
     </div>
 </div>

--- a/src/Resources/views/default/show.html.twig
+++ b/src/Resources/views/default/show.html.twig
@@ -33,7 +33,7 @@
                             </div>
 
                             {% if metadata.help|default('') != '' %}
-                                <span class="help-block"><i class="fa fa-info-circle"></i> {{ metadata.help|trans|raw }}</span>
+                                <span class="help-block"><i class="fa fa-fw fa-info-circle"></i> {{ metadata.help|trans|raw }}</span>
                             {% endif %}
                         </div>
                     </div>

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -48,7 +48,7 @@
         <div class="field-collection-item-row">
             <div class="field-collection-item-action">
                 <a href="#" onclick="{{ remove_item_javascript|raw }}; return false;" class="text-danger" title="{{ 'action.remove_item'|trans({}, 'EasyAdminBundle') }}">
-                    <i class="fa fa-window-close"></i>
+                    <i class="fa fa-fw fa-window-close"></i>
                 </a>
             </div>
             <div class="field-collection-item-widget">
@@ -105,7 +105,7 @@
 
         <div class="text-right field-collection-item-action">
             <a href="#" onclick="{{ remove_item_javascript|raw }}" class="text-danger">
-                <i class="fa fa-remove"></i>
+                <i class="fa fa-fw fa-remove"></i>
                 {{ 'action.remove_item'|trans({}, 'EasyAdminBundle') }}
             </a>
         </div>
@@ -169,7 +169,7 @@
         <div class="form-group field-collection-action">
             <div class="form-widget">
                 <a href="#" onclick="{{ js_add_item|raw }}; return false;" class="btn btn-secondary btn-sm">
-                    <i class="fa fa-plus"></i>
+                    <i class="fa fa-fw fa-plus"></i>
                     <span class="btn-label">{{ (form|length == 0 ? 'action.add_new_item' : 'action.add_another_item')|trans({}, 'EasyAdminBundle') }}</span>
                 </a>
             </div>
@@ -251,7 +251,7 @@
                 'zip': 'fa-file-archive-o'
             } %}
             <a class="easyadmin-vich-file-name" href="{{ asset(download_uri) }}">
-                <i class="fa {{ extension_icons[file_extension] ?? 'fa-file-o' }}"></i>
+                <i class="fa fa-fw {{ extension_icons[file_extension] ?? 'fa-file-o' }}"></i>
                 {{ download_title }}
             </a>
         {% endif %}
@@ -266,7 +266,7 @@
         <div class="easyadmin-vich-file-actions">
             {# the container element is needed to allow customizing the <input type="file" /> #}
             <div class="btn btn-secondary input-file-container">
-                <i class="fa fa-upload"></i> {{ 'action.choose_file'|trans({}, 'EasyAdminBundle') }}
+                <i class="fa fa-fw fa-upload"></i> {{ 'action.choose_file'|trans({}, 'EasyAdminBundle') }}
                 <span class="btn-label">{{ form_widget(form.file, { 'attr': { 'onchange': file_upload_js }}) }}</span>
             </div>
 
@@ -313,7 +313,7 @@
         <div class="easyadmin-vich-image-actions">
             {# the container element is needed to allow customizing the <input type="file" /> #}
             <div class="btn btn-secondary input-file-container">
-                <i class="fa fa-upload"></i> {{ 'action.choose_file'|trans({}, 'EasyAdminBundle') }}
+                <i class="fa fa-fw fa-upload"></i> {{ 'action.choose_file'|trans({}, 'EasyAdminBundle') }}
                 <span class="btn-label">{{ form_widget(form.file, { 'attr': { 'onchange': file_upload_js }}) }}</span>
             </div>
 
@@ -376,7 +376,7 @@
                             <li class="nav-item">
                                 <a class="nav-link {% if tab_config.active %}active{% endif %}" href="#{{ tab_config['id'] }}" id="{{ tab_config['id'] }}-tab" data-toggle="tab">
                                     {% if tab_config.icon|default(false) %}
-                                        <i class="fa fa-{{ tab_config.icon }}"></i>
+                                        <i class="fa fa-fw fa-{{ tab_config.icon }}"></i>
                                     {% endif %}
                                     {{ tab_config['label']|trans(domain = _translation_domain) }}
                                     {% if tab_config.errors > 0 %}
@@ -418,7 +418,7 @@
                 {% if group_config.label|default(false) or group_config.icon|default(false) or group_config.collapsible|default(false) %}
                     <legend class="{{ group_config.icon|default(false) ? 'with-icon' }}">
                         {% if group_config.icon|default(false) %}
-                            <i class="fa fa-{{ group_config.icon }}"></i>
+                            <i class="fa fa-fw fa-{{ group_config.icon }}"></i>
                         {% endif %}
                         {{ group_config.label|trans(domain = _translation_domain)|raw }}
                     </legend>
@@ -470,7 +470,7 @@
     {% set _translation_domain = easyadmin.entity.translation_domain %}
     <div class="form-section {{ easyadmin.field.icon|default(false) == false and easyadmin.field.label|default(false) == false ? 'form-section-empty' }} {{ easyadmin.field.css_class|default('') }}">
         <h2>
-            {% if easyadmin.field.icon|default(false) %}<i class="fa fa-{{ easyadmin.field.icon }}"></i>{% endif %}
+            {% if easyadmin.field.icon|default(false) %}<i class="fa fa-fw fa-{{ easyadmin.field.icon }}"></i>{% endif %}
             <span>{% if easyadmin.field.label|default(false) %}{{ easyadmin.field.label|default('')|trans(domain = _translation_domain)|raw }}{% endif %}</span>
         </h2>
 
@@ -489,7 +489,7 @@
     <button type="button" class="btn btn-link deselect-batch-button">{{ 'action.deselect'|trans(_trans_parameters, _translation_domain) }}</button>
     {% for action in batch_actions %}
         <button type="submit" class="btn {{ action.css_class|default('btn-secondary') }}" title="{{ action.title|default('') is empty ? '' : action.title|trans(_trans_parameters) }}" name="{{ form.name.vars.full_name }}" value="{{ action.name }}">
-            {%- if action.icon %}<i class="fa fa-{{ action.icon }}"></i> {% endif -%}
+            {%- if action.icon %}<i class="fa fa-fw fa-{{ action.icon }}"></i> {% endif -%}
             {%- if action.label is defined and not action.label is empty -%}
                 {{ action.label|trans }}
             {%- endif -%}

--- a/tests/Controller/AdvancedFormLayoutTest.php
+++ b/tests/Controller/AdvancedFormLayoutTest.php
@@ -36,7 +36,7 @@ class AdvancedFormLayoutTest extends AbstractTestCase
                 'The first tab of the form is displayed correctly.'
             );
             $this->assertContains(
-                'fa fa-pencil',
+                'fa fa-fw fa-pencil',
                 $crawler->filter('ul.nav-tabs li')->eq(0)->filter('i')->attr('class'),
                 'The first tab displays the configured icon.'
             );
@@ -76,7 +76,7 @@ class AdvancedFormLayoutTest extends AbstractTestCase
                 \trim($crawler->filter('form .field-group')->eq(1)->filter('fieldset legend')->text())
             );
             $this->assertSame(
-                'fa fa-pencil',
+                'fa fa-fw fa-pencil',
                 $crawler->filter('form .field-group')->eq(1)->filter('fieldset legend i')->attr('class')
             );
             $this->assertSame(
@@ -129,7 +129,7 @@ class AdvancedFormLayoutTest extends AbstractTestCase
                 \trim($crawler->filter('form .field-group')->eq(2)->filter('fieldset .form-section h2')->text())
             );
             $this->assertSame(
-                'fa fa-warning',
+                'fa fa-fw fa-warning',
                 $crawler->filter('form .field-group')->eq(2)->filter('fieldset .form-section i')->attr('class')
             );
             $this->assertSame(
@@ -180,7 +180,7 @@ class AdvancedFormLayoutTest extends AbstractTestCase
                 \trim($crawler->filter('form .field-group')->eq(5)->filter('fieldset legend')->text())
             );
             $this->assertSame(
-                'fa fa-paperclip',
+                'fa fa-fw fa-paperclip',
                 $crawler->filter('form .field-group')->eq(5)->filter('fieldset legend i')->attr('class')
             );
             $this->assertSame(

--- a/tests/Controller/BatchActionTest.php
+++ b/tests/Controller/BatchActionTest.php
@@ -20,7 +20,7 @@ class BatchActionTest extends AbstractTestCase
         $this->assertSame('Delete', $crawler->filter('form[name="batch_form"] button[value="delete"]')->text());
 
         $this->assertSame('Custom batch action', trim($crawler->filter('form[name="batch_form"] button[value="custom_batch_action"]')->text()));
-        $this->assertSame('fa fa-custom-icon', trim($crawler->filter('form[name="batch_form"] button[value="custom_batch_action"] i')->attr('class')));
+        $this->assertSame('fa fa-fw fa-custom-icon', trim($crawler->filter('form[name="batch_form"] button[value="custom_batch_action"] i')->attr('class')));
     }
 
     public function testBatchActionsCheckboxes()

--- a/tests/Controller/CustomMenuTest.php
+++ b/tests/Controller/CustomMenuTest.php
@@ -78,13 +78,13 @@ class CustomMenuTest extends AbstractTestCase
         $crawler = $this->getBackendHomepage();
 
         $this->assertSame(
-            'fa fa-shopping-basket',
+            'fa fa-fw fa-shopping-basket',
             $crawler->filter('.sidebar-menu li:contains("Products") i')->attr('class'),
             'First level menu item with custom icon'
         );
 
         $this->assertSame(
-            'fa fa-folder-open',
+            'fa fa-fw fa-folder-open',
             $crawler->filter('.sidebar-menu li:contains("Images") i')->attr('class'),
             'First level menu item with default icon'
         );
@@ -96,7 +96,7 @@ class CustomMenuTest extends AbstractTestCase
         );
 
         $this->assertSame(
-            'fa fa-th-list',
+            'fa fa-fw fa-th-list',
             $crawler->filter('.sidebar-menu .treeview-menu li:contains("List Products") i')->attr('class'),
             'Second level menu item with custom icon'
         );

--- a/tests/Controller/CustomizedBackendTest.php
+++ b/tests/Controller/CustomizedBackendTest.php
@@ -77,7 +77,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         $this->assertSame('New Category', \trim($crawler->filter('.global-actions a.action-new')->text()));
         $this->assertSame('custom_class_new action-new', $crawler->filter('.global-actions a.action-new')->attr('class'));
-        $this->assertSame('fa fa-plus-circle', $crawler->filter('.global-actions a.action-new i')->attr('class'));
+        $this->assertSame('fa fa-fw fa-plus-circle', $crawler->filter('.global-actions a.action-new i')->attr('class'));
         $this->assertStringStartsWith('/admin/?action=new&entity=Category&view=list&sortField=id&sortDirection=DESC&page=1', $crawler->filter('.global-actions a.action-new')->attr('href'));
     }
 
@@ -124,7 +124,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         $this->assertCount(1, $crawler->filter('.table thead th[class*="sorted"]'), 'Table is sorted only by one column.');
         $this->assertSame('ID', \trim($crawler->filter('.table thead th[class*="sorted"]')->text()), 'By default, table is soreted by ID column.');
-        $this->assertSame('fa fa-arrow-down', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
+        $this->assertSame('fa fa-fw fa-arrow-down', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
     }
 
     public function testListViewTableContents()
@@ -522,7 +522,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         $this->assertCount(1, $crawler->filter('.table thead th[class*="sorted"]'), 'Table is sorted only by one column.');
         $this->assertSame('Label', \trim($crawler->filter('.table thead th[class*="sorted"]')->text()), 'By default, table is soreted by "Label" column (which is the "name" property).');
-        $this->assertSame('fa fa-arrow-up', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
+        $this->assertSame('fa fa-fw fa-arrow-up', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
     }
 
     public function testSearchViewTableContents()

--- a/tests/Controller/DefaultBackendTest.php
+++ b/tests/Controller/DefaultBackendTest.php
@@ -185,7 +185,7 @@ class DefaultBackendTest extends AbstractTestCase
 
         $this->assertCount(1, $crawler->filter('.table thead th[class*="sorted"]'), 'Table is sorted only by one column.');
         $this->assertSame('ID', \trim($crawler->filter('.table thead th[class*="sorted"]')->text()), 'By default, table is soreted by ID column.');
-        $this->assertSame('fa fa-arrow-down', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
+        $this->assertSame('fa fa-fw fa-arrow-down', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
     }
 
     public function testListViewColumnSortingResetsPaginator()
@@ -570,7 +570,7 @@ class DefaultBackendTest extends AbstractTestCase
 
         $this->assertCount(1, $crawler->filter('.table thead th[class*="sorted"]'), 'Table is sorted only by one column.');
         $this->assertSame('ID', \trim($crawler->filter('.table thead th[class*="sorted"]')->text()), 'By default, table is soreted by ID column.');
-        $this->assertSame('fa fa-arrow-down', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
+        $this->assertSame('fa fa-fw fa-arrow-down', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
     }
 
     public function testSearchViewColumnSortingResetsPaginator()


### PR DESCRIPTION
After merging #2700 ... I wondered if we should display all icons with fixed width. For some elements, such as the menu, looks mandatory ... for others, I'm not sure.