### PR TITLE
Trim whitespaces in tab header.

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -375,15 +375,15 @@
                         {% for tab_name, tab_config in easyadmin_form_tabs %}
                             <li class="nav-item">
                                 <a class="nav-link {% if tab_config.active %}active{% endif %}" href="#{{ tab_config['id'] }}" id="{{ tab_config['id'] }}-tab" data-toggle="tab">
-                                    {% if tab_config.icon|default(false) %}
+                                    {%- if tab_config.icon|default(false) -%}
                                         <i class="fa fa-fw fa-{{ tab_config.icon }}"></i>
-                                    {% endif %}
+                                    {%- endif -%}
                                     {{ tab_config['label']|trans(domain = _translation_domain) }}
-                                    {% if tab_config.errors > 0 %}
+                                    {%- if tab_config.errors > 0 -%}
                                         <span class="badge badge-danger" title="{{ 'form.tab.error_badge_title'|transchoice(tab_config.errors, {}, 'EasyAdminBundle') }}">
-                                            {{ tab_config.errors }}
+                                            {{- tab_config.errors -}}
                                         </span>
-                                    {% endif %}
+                                    {%- endif -%}
                                 </a>
                             </li>
                         {% endfor %}


### PR DESCRIPTION
This is my proposition for trimming white spaces in tabs headers.

**BEFORE:**
![Selection_002](https://user-images.githubusercontent.com/14212721/57086080-c807f080-6cfd-11e9-938c-a15db9338b78.png)
**AFTER:**
![Selection_001](https://user-images.githubusercontent.com/14212721/57086093-cfc79500-6cfd-11e9-9ca3-cd60ad75b8d2.png)
