### PR TITLE
Custom label in `url` type fields inside show/list

### DIFF
--- a/doc/book/list-search-show-configuration.rst
+++ b/doc/book/list-search-show-configuration.rst
@@ -631,6 +631,22 @@ new browser tab:
                         # ...
         # ...
 
+There is possibility to define `label` type option which will result in
+displaying links with proper label.
+
+.. code-block:: yaml
+
+    # config/packages/easy_admin.yaml
+    easy_admin:
+        entities:
+            Product:
+                class: App\Entity\User
+                list:
+                    fields:
+                        - { property: 'blogUrl', type: 'url', type_options: { label: 'URL' } }
+                        # ...
+        # ...
+
 Telephone Data Type
 ~~~~~~~~~~~~~~~~~~~
 

--- a/src/Resources/views/default/field_url.html.twig
+++ b/src/Resources/views/default/field_url.html.twig
@@ -1,5 +1,17 @@
 {% if view == 'show' %}
-    <a target="_blank" href="{{ value }}">{{ value }}</a>
+    <a
+        target="_blank"
+        href="{{ value }}"
+    >
+        {{- field_options.type_options.label|default(value) -}}
+    </a>
 {% else %}
-    <a target="_blank" href="{{ value }}">{{ value|replace({ 'https://': '', 'http://': '' })|easyadmin_truncate }}</a>
+    <a
+        target="_blank"
+        href="{{ value }}"
+    >
+        {{- field_options.type_options.label|default(
+            value|replace({ 'https://': '', 'http://': '' })|easyadmin_truncate
+        ) -}}
+    </a>
 {% endif %}


### PR DESCRIPTION
Added possibility to define custom label in `url` type fields used inside "show" and "list" views.