### PR TITLE
Fix EventDispatcher::dispatch() argument order deprecation on Symfony 4.3

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -24,6 +24,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -129,7 +130,11 @@ trait AdminControllerTrait
         $subject = $arguments['paginator'] ?? $arguments['entity'];
         $event = new GenericEvent($subject, $arguments);
 
-        $this->get('event_dispatcher')->dispatch($eventName, $event);
+        if (Kernel::VERSION_ID >= 40300) {
+            $this->get('event_dispatcher')->dispatch($event, $eventName);
+        } else {
+            $this->get('event_dispatcher')->dispatch($eventName, $event);
+        }
     }
 
     /**


### PR DESCRIPTION
https://travis-ci.org/EasyCorp/EasyAdminBundle/jobs/531004595#L626
```bash
  1061x: Calling the "Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()" method with the event name as first argument is deprecated since Symfony 4.3, pass it second and provide the event object first instead.
    45x in DisabledActionsTest::testRedirectToDisabledActions from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    20x in AutocompleteTest::testAutocompleteWithMissingParameters from EasyCorp\Bundle\EasyAdminBundle\Tests\Search
    19x in DataTransferObjectTest::testNewProductDTO from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    15x in DefaultBackendTest::testListViewColumnSortingResetsPaginator from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    15x in DefaultBackendTest::testSearchViewColumnSortingResetsPaginator from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    15x in DefaultBackendTest::testEntityDeletion from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    14x in CustomMenuTest::testCustomQueryParametersAreMaintained from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    14x in DefaultBackendTest::testEditViewEntityModification from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    14x in DataTransferObjectTest::testEditProductPriceDTO from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    14x in DefaultBackendTest::testNewViewEntityCreation from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    13x in CustomizedBackendTest::testChainedReferer from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    10x in EntitySortingTest::testMainMenuSorting from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    10x in EntitySortingTest::testListViewSorting from EasyCorp\Bundle\EasyAdminBundle\Tests\Controller
    10x in EntitySortingTest::testSearchViewSorting from 
    ...
```
(Travis failures unrelated)