### PR TITLE
Fix tests

### DIFF
--- a/tests/Controller/ActionOverrideTest.php
+++ b/tests/Controller/ActionOverrideTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class ActionOverrideTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'action_override']);
-    }
+    protected static $options = ['environment' => 'action_override'];
 
     public function testListViewActions()
     {

--- a/tests/Controller/ActionTargetTest.php
+++ b/tests/Controller/ActionTargetTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class ActionTargetTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'action_target']);
-    }
+    protected static $options = ['environment' => 'action_target'];
 
     public function testListViewActions()
     {

--- a/tests/Controller/AdvancedFormLayoutTest.php
+++ b/tests/Controller/AdvancedFormLayoutTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class AdvancedFormLayoutTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'advanced_form_layout']);
-    }
+    protected static $options = ['environment' => 'advanced_form_layout'];
 
     /**
      * @group legacy

--- a/tests/Controller/AutocompleteTest.php
+++ b/tests/Controller/AutocompleteTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class AutocompleteTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'autocomplete']);
-    }
+    protected static $options = ['environment' => 'autocomplete'];
 
     /**
      * @dataProvider provideMissingParameters
@@ -31,7 +26,7 @@ class AutocompleteTest extends AbstractTestCase
 
         $this->assertSame(
             ['results' => []],
-            \json_decode($this->client->getResponse()->getContent(), true)
+            \json_decode(static::$client->getResponse()->getContent(), true)
         );
     }
 
@@ -44,7 +39,7 @@ class AutocompleteTest extends AbstractTestCase
         ]);
 
         // the results are the first 10 parent categories
-        $response = \json_decode($this->client->getResponse()->getContent(), true);
+        $response = \json_decode(static::$client->getResponse()->getContent(), true);
         foreach (\range(1, 10) as $i) {
             $this->assertSame($i, $response['results'][$i - 1]['id']);
             $this->assertSame('Parent Category #'.$i, $response['results'][$i - 1]['text']);
@@ -59,7 +54,7 @@ class AutocompleteTest extends AbstractTestCase
             'query' => 21,
         ]);
 
-        $response = \json_decode($this->client->getResponse()->getContent(), true);
+        $response = \json_decode(static::$client->getResponse()->getContent(), true);
         $this->assertSame(
             [
                 ['id' => 21, 'text' => 'Parent Category #21'],

--- a/tests/Controller/BackendErrorsTest.php
+++ b/tests/Controller/BackendErrorsTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class BackendErrorsTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'default_backend']);
-    }
+    protected static $options = ['environment' => 'default_backend'];
 
     public function testUndefinedEntityError()
     {
@@ -20,7 +15,7 @@ class BackendErrorsTest extends AbstractTestCase
             'view' => 'list',
         ]);
 
-        $this->assertSame(404, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(404, static::$client->getResponse()->getStatusCode());
         $this->assertContains('The "InexistentEntity" entity is not defined in the configuration of your backend.', $crawler->filter('head title')->text());
     }
 }

--- a/tests/Controller/BatchActionTest.php
+++ b/tests/Controller/BatchActionTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class BatchActionTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'batch_action']);
-    }
+    protected static $options = ['environment' => 'batch_action'];
 
     public function testBatchActionsForm()
     {

--- a/tests/Controller/CustomEntityControllerAsServiceTest.php
+++ b/tests/Controller/CustomEntityControllerAsServiceTest.php
@@ -6,32 +6,27 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class CustomEntityControllerAsServiceTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'custom_entity_controller_service']);
-    }
+    protected static $options = ['environment' => 'custom_entity_controller_service'];
 
     public function testListAction()
     {
         $this->requestListView();
 
-        if (!$this->client->getContainer()->has('request_stack')) {
+        if (!static::$client->getContainer()->has('request_stack')) {
             $this->markTestSkipped('This test is skipped because @request_stack service is not available.');
         }
 
-        $this->assertContains('Overridden list action as a service.', $this->client->getResponse()->getContent());
+        $this->assertContains('Overridden list action as a service.', static::$client->getResponse()->getContent());
     }
 
     public function testShowAction()
     {
         $this->requestShowView();
 
-        if (!$this->client->getContainer()->has('request_stack')) {
+        if (!static::$client->getContainer()->has('request_stack')) {
             $this->markTestSkipped('This test is skipped because @request_stack service is not available.');
         }
 
-        $this->assertContains('Overridden show action as a service.', $this->client->getResponse()->getContent());
+        $this->assertContains('Overridden show action as a service.', static::$client->getResponse()->getContent());
     }
 }

--- a/tests/Controller/CustomEntityControllerTest.php
+++ b/tests/Controller/CustomEntityControllerTest.php
@@ -6,22 +6,17 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class CustomEntityControllerTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'custom_entity_controller']);
-    }
+    protected static $options = ['environment' => 'custom_entity_controller'];
 
     public function testListAction()
     {
         $this->requestListView();
-        $this->assertContains('Overridden list action.', $this->client->getResponse()->getContent());
+        $this->assertContains('Overridden list action.', static::$client->getResponse()->getContent());
     }
 
     public function testShowAction()
     {
         $this->requestShowView();
-        $this->assertContains('Overridden show action.', $this->client->getResponse()->getContent());
+        $this->assertContains('Overridden show action.', static::$client->getResponse()->getContent());
     }
 }

--- a/tests/Controller/CustomFieldTemplateTest.php
+++ b/tests/Controller/CustomFieldTemplateTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class CustomFieldTemplateTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'custom_field_template']);
-    }
+    protected static $options = ['environment' => 'custom_field_template'];
 
     /**
      * @group legacy

--- a/tests/Controller/CustomMenuTest.php
+++ b/tests/Controller/CustomMenuTest.php
@@ -6,23 +6,18 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class CustomMenuTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'custom_menu']);
-    }
+    protected static $options = ['environment' => 'custom_menu'];
 
     public function testCustomBackendHomepage()
     {
-        $this->client->request('GET', '/admin/');
+        static::$client->request('GET', '/admin/');
 
         $this->assertSame(
             '/admin/?action=list&entity=Category&menuIndex=0&submenuIndex=3',
-            $this->client->getResponse()->headers->get('location')
+            static::$client->getResponse()->headers->get('location')
         );
 
-        $crawler = $this->client->followRedirect();
+        $crawler = static::$client->followRedirect();
 
         $this->assertSame(
             'Products',
@@ -38,7 +33,7 @@ class CustomMenuTest extends AbstractTestCase
     public function testBackendHomepageConfig()
     {
         $this->getBackendHomepage();
-        $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
+        $backendConfig = static::$client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
         $this->assertArraySubset([
             'route' => 'easyadmin',
@@ -49,7 +44,7 @@ class CustomMenuTest extends AbstractTestCase
     public function testDefaultMenuItem()
     {
         $this->getBackendHomepage();
-        $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
+        $backendConfig = static::$client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
         $this->assertArraySubset([
             'label' => 'Categories',
@@ -233,7 +228,7 @@ class CustomMenuTest extends AbstractTestCase
         $expectedTypesSubMenu = ['entity', 'entity', 'divider', 'entity', 'link'];
 
         $this->getBackendHomepage();
-        $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
+        $backendConfig = static::$client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
         $menuConfig = $backendConfig['design']['menu'];
 
         foreach ($menuConfig as $i => $itemConfig) {
@@ -265,11 +260,11 @@ class CustomMenuTest extends AbstractTestCase
         // 1. visit the homepage and click on the menu entry with custom parameters
         $crawler = $this->getBackendHomepage();
         $link = $crawler->filter('.sidebar-menu li:contains("Purchases") a')->eq(0)->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         // 2. click on the 'Edit' link of the first item
         $link = $crawler->filter('td.actions a:contains("Edit")')->eq(0)->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         // 3. the 'referer' parameter should contain the custom query string param
         $refererUrl = $crawler->filter('.form-actions a:contains("Back to listing")')->attr('href');

--- a/tests/Controller/CustomTemplateParametersTest.php
+++ b/tests/Controller/CustomTemplateParametersTest.php
@@ -6,45 +6,40 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class CustomTemplateParametersTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'custom_template_parameters']);
-    }
+    protected static $options = ['environment' => 'custom_template_parameters'];
 
     public function testListViewCustomParameters()
     {
         $this->requestListView();
 
-        $this->assertContains('My custom template parameter is "list"', $this->client->getResponse()->getContent());
+        $this->assertContains('My custom template parameter is "list"', static::$client->getResponse()->getContent());
     }
 
     public function testShowViewCustomParameters()
     {
         $this->requestShowView();
 
-        $this->assertContains('My custom template parameter is "show"', $this->client->getResponse()->getContent());
+        $this->assertContains('My custom template parameter is "show"', static::$client->getResponse()->getContent());
     }
 
     public function testSearchViewCustomParameters()
     {
         $this->requestSearchView();
 
-        $this->assertContains('My custom template parameter is "search"', $this->client->getResponse()->getContent());
+        $this->assertContains('My custom template parameter is "search"', static::$client->getResponse()->getContent());
     }
 
     public function testEditViewCustomParameters()
     {
         $this->requestEditView();
 
-        $this->assertContains('My custom template parameter is "edit"', $this->client->getResponse()->getContent());
+        $this->assertContains('My custom template parameter is "edit"', static::$client->getResponse()->getContent());
     }
 
     public function testNewViewCustomParameters()
     {
         $this->requestNewView();
 
-        $this->assertContains('My custom template parameter is "new"', $this->client->getResponse()->getContent());
+        $this->assertContains('My custom template parameter is "new"', static::$client->getResponse()->getContent());
     }
 }

--- a/tests/Controller/CustomTranslationDomainTest.php
+++ b/tests/Controller/CustomTranslationDomainTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class CustomTranslationDomainTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'custom_translation_domain']);
-    }
+    protected static $options = ['environment' => 'custom_translation_domain'];
 
     public function testListView()
     {

--- a/tests/Controller/CustomizedBackendTest.php
+++ b/tests/Controller/CustomizedBackendTest.php
@@ -6,20 +6,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class CustomizedBackendTest extends AbstractTestCase
 {
-    /**
-     * @group legacy
-     */
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'customized_backend']);
-    }
+    protected static $options = ['environment' => 'customized_backend'];
 
     public function testUserMenuForLoggedUsers()
     {
-        $this->client->followRedirects();
-        $crawler = $this->client->request('GET', '/admin', [], [], [
+        static::$client->followRedirects();
+        $crawler = static::$client->request('GET', '/admin', [], [], [
             'PHP_AUTH_USER' => 'admin',
             'PHP_AUTH_PW' => 'pa$$word',
         ]);
@@ -237,7 +229,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         // 2. click on the 'Show' link of the first item
         $link = $crawler->filter('td.actions a:contains("Show")')->eq(0)->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         // 3. the 'referer' parameter should point to the exact same previous 'list' page
         $refererUrl = $crawler->filter('.form-actions a:contains("Back to Category listing")')->attr('href');
@@ -268,11 +260,11 @@ class CustomizedBackendTest extends AbstractTestCase
 
         // 2. click on the 'Show' link of the first item
         $link = $crawler->filter('td.actions a:contains("Show")')->eq(0)->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         // 3. click on the 'Edit' button
         $link = $crawler->filter('.form-actions a:contains("Modify Category")')->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         // 4. the 'referer' parameter should point to the exact same previous 'list' page
         $refererUrl = $crawler->filter('.form-actions a:contains("Return to listing")')->attr('href');
@@ -358,7 +350,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         // 2. click on the 'Edit' link of the first item
         $link = $crawler->filter('td.actions a:contains("Edit")')->eq(0)->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         // 3. the 'referer' parameter should point to the exact same previous 'list' page
         $refererUrl = $crawler->filter('.form-actions a:contains("Return to listing")')->attr('href');
@@ -450,7 +442,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         // 2. click on the 'New' link to browse the 'new' view
         $link = $crawler->filter('.global-actions a:contains("New Category")')->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         // 3. the 'referer' parameter should point to the exact same previous 'list' page
         $refererUrl = $crawler->filter('.form-actions a:contains("Return to listing")')->attr('href');
@@ -462,21 +454,21 @@ class CustomizedBackendTest extends AbstractTestCase
 
     public function testNewCustomFormOptions()
     {
-        $this->client->enableProfiler();
+        static::$client->enableProfiler();
 
         $crawler = $this->requestNewView();
-        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, static::$client->getResponse()->getStatusCode());
 
         // test 'novalidate' attribute
         $this->assertSame('novalidate', $crawler->filter('#new-category-form')->first()->attr('novalidate'));
 
         $form = $crawler->selectButton('Save changes')->form();
         $form->remove('form[name]');
-        $this->client->submit($form);
-        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        static::$client->submit($form);
+        $this->assertSame(200, static::$client->getResponse()->getStatusCode());
 
         // test validation groups
-        $profile = $this->client->getProfile();
+        $profile = static::$client->getProfile();
         $formData = $profile->getCollector('form')->getData();
         $categoryFields = $formData['forms']['category']['children'];
         $this->assertSame($categoryFields['name']['errors'][0]['message'], 'This value should not be null.');
@@ -570,7 +562,7 @@ class CustomizedBackendTest extends AbstractTestCase
 
         // 2. click on the 'Show' action of the first result
         $link = $crawler->filter('td.actions a:contains("Show")')->eq(0)->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         // 3. the 'referer' parameter should point to the previous specific 'search' view page
         $refererUrl = $crawler->filter('.form-actions a:contains("Back to Category listing")')->attr('href');

--- a/tests/Controller/DataTransferObjectTest.php
+++ b/tests/Controller/DataTransferObjectTest.php
@@ -6,17 +6,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class DataTransferObjectTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'data_transfer_object']);
-    }
+    protected static $options = ['environment' => 'data_transfer_object'];
 
     public function testNewProductDTO(): void
     {
         $crawler = $this->requestNewView('Product');
-        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, static::$client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('#main form')->eq(0);
         $this->assertSame('new', \trim($form->attr('data-view')));
@@ -24,13 +19,13 @@ class DataTransferObjectTest extends AbstractTestCase
         $this->assertEmpty($form->attr('data-entity-id'));
 
         $form = $crawler->selectButton('Save changes')->form();
-        $this->client->submit($form, [
+        static::$client->submit($form, [
             'product[name]' => 'Product X',
             'product[description]' => 'Description X',
             'product[price]' => '1000.00',
             'product[ean]' => '4006381333932',
         ]);
-        $this->assertSame(302, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(302, static::$client->getResponse()->getStatusCode());
 
         $crawler = $this->requestListView('Product');
         $this->assertContains('101 results', $crawler->filter('.list-pagination')->text());
@@ -41,7 +36,7 @@ class DataTransferObjectTest extends AbstractTestCase
     public function testEditProductPriceDTO(): void
     {
         $crawler = $this->requestEditView('Product', '1');
-        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, static::$client->getResponse()->getStatusCode());
 
         $form = $crawler->filter('#main form')->eq(0);
         $this->assertSame('edit', \trim($form->attr('data-view')));
@@ -49,10 +44,10 @@ class DataTransferObjectTest extends AbstractTestCase
         $this->assertEmpty($form->attr('data-entity-id'));
 
         $form = $crawler->selectButton('Save changes')->form();
-        $this->client->submit($form, [
+        static::$client->submit($form, [
             'product[name]' => 'Product X',
         ]);
-        $this->assertSame(302, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(302, static::$client->getResponse()->getStatusCode());
 
         $crawler = $this->requestSearchView('Product X', 'Product');
         $this->assertCount(1, $crawler->filter('.table tbody tr'));

--- a/tests/Controller/DefaultMenuTest.php
+++ b/tests/Controller/DefaultMenuTest.php
@@ -6,23 +6,18 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class DefaultMenuTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'default_menu']);
-    }
+    protected static $options = ['environment' => 'default_menu'];
 
     public function testCustomBackendHomepage()
     {
-        $this->client->request('GET', '/admin/');
+        static::$client->request('GET', '/admin/');
 
         $this->assertSame(
             '/admin/?action=list&entity=Category',
-            $this->client->getResponse()->headers->get('location')
+            static::$client->getResponse()->headers->get('location')
         );
 
-        $crawler = $this->client->followRedirect();
+        $crawler = static::$client->followRedirect();
         $this->assertCount(0, $crawler->filter('.sidebar-menu li.active'));
     }
 

--- a/tests/Controller/DisabledActionsTest.php
+++ b/tests/Controller/DisabledActionsTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class DisabledActionsTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'disabled_actions']);
-    }
+    protected static $options = ['environment' => 'disabled_actions'];
 
     public function testAssociationLinksInListView()
     {
@@ -46,7 +41,7 @@ class DisabledActionsTest extends AbstractTestCase
 
         $this->assertContains(
             'The requested &quot;show&quot; action is not allowed for the &quot;User&quot; entity.',
-            $this->client->getResponse()->getContent()
+            static::$client->getResponse()->getContent()
         );
     }
 
@@ -67,9 +62,9 @@ class DisabledActionsTest extends AbstractTestCase
         $form = $crawler->selectButton('Save changes')->form([
             \strtolower($entityName).'[name]' => 'New Category Name',
         ]);
-        $this->client->submit($form);
+        static::$client->submit($form);
 
-        $this->assertContains($expectedRedirectionLocation, $this->client->getResponse()->headers->get('location'));
+        $this->assertContains($expectedRedirectionLocation, static::$client->getResponse()->headers->get('location'));
     }
 
     public function provideRedirections()

--- a/tests/Controller/DqlFilterTest.php
+++ b/tests/Controller/DqlFilterTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class DqlFilterTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'dql_filter']);
-    }
+    protected static $options = ['environment' => 'dql_filter'];
 
     public function testListDqlFilter()
     {

--- a/tests/Controller/EmptyActionLabelsTest.php
+++ b/tests/Controller/EmptyActionLabelsTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class EmptyActionLabelsTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'empty_action_labels']);
-    }
+    protected static $options = ['environment' => 'empty_action_labels'];
 
     public function testBuiltInActionLabels()
     {

--- a/tests/Controller/EmptyBackendTest.php
+++ b/tests/Controller/EmptyBackendTest.php
@@ -9,9 +9,9 @@ class EmptyBackendTest extends AbstractTestCase
     public function testNoEntityHasBeenConfigured()
     {
         $this->initClient(['environment' => 'empty_backend']);
-        $this->client->request('GET', '/admin/');
+        static::$client->request('GET', '/admin/');
 
-        $this->assertSame(500, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('NoEntitiesConfiguredException', $this->client->getResponse()->getContent());
+        $this->assertSame(500, static::$client->getResponse()->getStatusCode());
+        $this->assertContains('NoEntitiesConfiguredException', static::$client->getResponse()->getContent());
     }
 }

--- a/tests/Controller/EntitySortingByAssociationTest.php
+++ b/tests/Controller/EntitySortingByAssociationTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class EntitySortingByAssociationTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'entity_sorting_by_association']);
-    }
+    protected static $options = ['environment' => 'entity_sorting_by_association'];
 
     public function testListViewSorting()
     {

--- a/tests/Controller/EntitySortingTest.php
+++ b/tests/Controller/EntitySortingTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class EntitySortingTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        // parent::setUp();
-
-        $this->initClient(['environment' => 'entity_sorting']);
-    }
+    protected static $options = ['environment' => 'entity_sorting'];
 
     public function testMainMenuSorting()
     {
@@ -26,7 +21,7 @@ class EntitySortingTest extends AbstractTestCase
 
         // click on any menu item to sort contents differently
         $link = $crawler->filter('.sidebar-menu a:contains("Product 2")')->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
 
         $this->assertNotContains('sorted', $crawler->filter('th:contains("Name")')->attr('class'));
         $this->assertContains('sorted', $crawler->filter('th:contains("Price")')->attr('class'));
@@ -43,7 +38,7 @@ class EntitySortingTest extends AbstractTestCase
 
         // click on any other table column to sort contents differently
         $link = $crawler->filter('th:contains("Price") a')->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
         $this->assertNotContains('sorted', $crawler->filter('th:contains("Name")')->attr('class'));
         $this->assertContains('sorted', $crawler->filter('th:contains("Price")')->attr('class'));
         $this->assertContains('fa-arrow-down', $crawler->filter('th:contains("Price") i')->attr('class'));
@@ -59,7 +54,7 @@ class EntitySortingTest extends AbstractTestCase
 
         // click on any other table column to sort contents differently
         $link = $crawler->filter('th:contains("Name") a')->link();
-        $crawler = $this->client->click($link);
+        $crawler = static::$client->click($link);
         $this->assertNotContains('sorted', $crawler->filter('th:contains("Created at")')->attr('class'));
         $this->assertContains('sorted', $crawler->filter('th:contains("Name")')->attr('class'));
         $this->assertContains('fa-arrow-down', $crawler->filter('th:contains("Name") i')->attr('class'));

--- a/tests/Controller/FormViewTest.php
+++ b/tests/Controller/FormViewTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class FormViewTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'form_view']);
-    }
+    protected static $options = ['environment' => 'form_view'];
 
     /**
      * @group legacy

--- a/tests/Controller/InternationalizationTest.php
+++ b/tests/Controller/InternationalizationTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class InternationalizationTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'internationalization']);
-    }
+    protected static $options = ['environment' => 'internationalization'];
 
     public function testLanguageDefinedByLayout()
     {

--- a/tests/Controller/MultipleConfigSyntaxTest.php
+++ b/tests/Controller/MultipleConfigSyntaxTest.php
@@ -9,7 +9,7 @@ class MultipleConfigSyntaxTest extends AbstractTestCase
     public function testConfigurationInDifferentFiles()
     {
         $this->initClient(['environment' => 'multiple_config_syntax']);
-        $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
+        $backendConfig = static::$client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
         $expectedEntityNames = [
             'Product', 'Product2', 'Product3', 'Product4', 'Inventory', 'Product22', 'Product5', 'Inventory2',

--- a/tests/Controller/OverrideEasyAdminControllerTest.php
+++ b/tests/Controller/OverrideEasyAdminControllerTest.php
@@ -6,18 +6,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class OverrideEasyAdminControllerTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'override_controller']);
-    }
+    protected static $options = ['environment' => 'override_controller'];
 
     public function testLayoutIsOverridden()
     {
-        $crawler = $this->client->request('GET', '/override_layout');
+        $crawler = static::$client->request('GET', '/override_layout');
 
-        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame(200, static::$client->getResponse()->getStatusCode());
         $this->assertSame('Layout is overridden.', \trim($crawler->filter('#main')->text()));
     }
 }

--- a/tests/Controller/OverrideTemplatesTest.php
+++ b/tests/Controller/OverrideTemplatesTest.php
@@ -6,21 +6,16 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class OverrideTemplatesTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'override_templates']);
-    }
+    protected static $options = ['environment' => 'override_templates'];
 
     public function testConfigurationOfOverriddenTemplates()
     {
-        $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
+        $backendConfig = static::$client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
         $this->assertSame('@EasyAdmin/default/new.html.twig', $backendConfig['design']['templates']['new']);
         $this->assertSame('override_templates/show.html.twig', $backendConfig['design']['templates']['show']);
 
-        $entityConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getEntityConfig('Category');
+        $entityConfig = static::$client->getContainer()->get('easyadmin.config.manager')->getEntityConfig('Category');
 
         $this->assertSame('@EasyAdmin/default/new.html.twig', $entityConfig['templates']['new']);
         $this->assertSame('override_templates/show.html.twig', $entityConfig['templates']['show']);
@@ -33,7 +28,7 @@ class OverrideTemplatesTest extends AbstractTestCase
 
         $this->assertContains(
             'Simple template used to override the default show.html.twig template.',
-            $this->client->getResponse()->getContent()
+            static::$client->getResponse()->getContent()
         );
     }
 
@@ -43,7 +38,7 @@ class OverrideTemplatesTest extends AbstractTestCase
 
         $this->assertContains(
             'Simple template used to override the default list.html.twig template.',
-            $this->client->getResponse()->getContent()
+            static::$client->getResponse()->getContent()
         );
     }
 
@@ -53,7 +48,7 @@ class OverrideTemplatesTest extends AbstractTestCase
 
         $this->assertContains(
             'Overridden using Symfony\'s template overriding mechanism',
-            $this->client->getResponse()->getContent()
+            static::$client->getResponse()->getContent()
         );
     }
 }

--- a/tests/Controller/RawFieldTest.php
+++ b/tests/Controller/RawFieldTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class RawFieldTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'raw_field']);
-    }
+    protected static $options = ['environment' => 'raw_field'];
 
     public function testListViewRawField()
     {

--- a/tests/Controller/ReadOnlyBackendTest.php
+++ b/tests/Controller/ReadOnlyBackendTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class ReadOnlyBackendTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'read_only_backend']);
-    }
+    protected static $options = ['environment' => 'read_only_backend'];
 
     public function testListViewContainsNoDisabledActions()
     {
@@ -41,15 +36,15 @@ class ReadOnlyBackendTest extends AbstractTestCase
     {
         $this->requestEditView();
 
-        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('The requested &quot;edit&quot; action is not allowed for the &quot;Category&quot; entity. Solution: remove the &quot;edit&quot; action from the &quot;disabled_actions&quot; option, which can be configured globally for the entire backend or locally for the &quot;Category&quot; entity.', $this->client->getResponse()->getContent());
+        $this->assertSame(403, static::$client->getResponse()->getStatusCode());
+        $this->assertContains('The requested &quot;edit&quot; action is not allowed for the &quot;Category&quot; entity. Solution: remove the &quot;edit&quot; action from the &quot;disabled_actions&quot; option, which can be configured globally for the entire backend or locally for the &quot;Category&quot; entity.', static::$client->getResponse()->getContent());
     }
 
     public function testNewActionIsDisabled()
     {
         $this->requestNewView();
 
-        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
-        $this->assertContains('The requested &quot;new&quot; action is not allowed for the &quot;Category&quot; entity. Solution: remove the &quot;new&quot; action from the &quot;disabled_actions&quot; option, which can be configured globally for the entire backend or locally for the &quot;Category&quot; entity.', $this->client->getResponse()->getContent());
+        $this->assertSame(403, static::$client->getResponse()->getStatusCode());
+        $this->assertContains('The requested &quot;new&quot; action is not allowed for the &quot;Category&quot; entity. Solution: remove the &quot;new&quot; action from the &quot;disabled_actions&quot; option, which can be configured globally for the entire backend or locally for the &quot;Category&quot; entity.', static::$client->getResponse()->getContent());
     }
 }

--- a/tests/Controller/RtlTest.php
+++ b/tests/Controller/RtlTest.php
@@ -6,18 +6,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class RtlTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'rtl']);
-    }
+    protected static $options = ['environment' => 'rtl'];
 
     public function testRtlAutodetection()
     {
         $this->getBackendHomepage();
 
-        $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
+        $backendConfig = static::$client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
         $this->assertTrue($backendConfig['design']['rtl'], 'RTL is enabled automatically for the "ar" locale.');
     }
 

--- a/tests/Controller/SplitConfigurationTest.php
+++ b/tests/Controller/SplitConfigurationTest.php
@@ -9,7 +9,7 @@ class SplitConfigurationTest extends AbstractTestCase
     public function testConfigurationInDifferentFiles()
     {
         $this->initClient(['environment' => 'split_configuration']);
-        $backendConfig = $this->client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
+        $backendConfig = static::$client->getContainer()->get('easyadmin.config.manager')->getBackendConfig();
 
         $this->assertSame(['Category', 'Product'], \array_keys($backendConfig['entities']));
 

--- a/tests/Controller/TypeOptionsTest.php
+++ b/tests/Controller/TypeOptionsTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class TypeOptionsTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'type_options']);
-    }
+    protected static $options = ['environment' => 'type_options'];
 
     public function testNewViewTypeOptions()
     {

--- a/tests/DataCollector/EasyAdminDataCollectorTest.php
+++ b/tests/DataCollector/EasyAdminDataCollectorTest.php
@@ -6,26 +6,21 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class EasyAdminDataCollectorTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'default_backend']);
-    }
+    protected static $options = ['environment' => 'default_backend'];
 
     public function testCollectorIsEnabled()
     {
-        $this->client->enableProfiler();
+        static::$client->enableProfiler();
         $this->requestListView();
 
-        $this->assertNotNull($this->client->getProfile()->getCollector('easyadmin'));
+        $this->assertNotNull(static::$client->getProfile()->getCollector('easyadmin'));
     }
 
     public function testCollectorInformationForListView()
     {
-        $this->client->enableProfiler();
+        static::$client->enableProfiler();
         $this->requestListView();
-        $collector = $this->client->getProfile()->getCollector('easyadmin');
+        $collector = static::$client->getProfile()->getCollector('easyadmin');
 
         $this->assertSame(5, $collector->getNumEntities());
 
@@ -47,9 +42,9 @@ class EasyAdminDataCollectorTest extends AbstractTestCase
 
     public function testCollectorInformationForEditView()
     {
-        $this->client->enableProfiler();
+        static::$client->enableProfiler();
         $this->requestEditView();
-        $collector = $this->client->getProfile()->getCollector('easyadmin');
+        $collector = static::$client->getProfile()->getCollector('easyadmin');
 
         $this->assertSame(5, $collector->getNumEntities());
 
@@ -71,9 +66,9 @@ class EasyAdminDataCollectorTest extends AbstractTestCase
 
     public function testCollectorReset()
     {
-        $this->client->enableProfiler();
+        static::$client->enableProfiler();
         $this->requestListView();
-        $collector = $this->client->getProfile()->getCollector('easyadmin');
+        $collector = static::$client->getProfile()->getCollector('easyadmin');
 
         $this->assertSame(5, $collector->getNumEntities());
         $collector->reset();

--- a/tests/Fixtures/AbstractTestCase.php
+++ b/tests/Fixtures/AbstractTestCase.php
@@ -14,7 +14,8 @@ use Symfony\Component\DomCrawler\Crawler;
 abstract class AbstractTestCase extends WebTestCase
 {
     /** @var Client */
-    protected $client;
+    protected static $client;
+    protected static $options = [];
 
     protected function setUp()
     {
@@ -24,7 +25,7 @@ abstract class AbstractTestCase extends WebTestCase
 
     protected function initClient(array $options = [])
     {
-        $this->client = static::createClient($options);
+        static::$client = static::createClient($options + static::$options);
     }
 
     /**
@@ -52,7 +53,7 @@ abstract class AbstractTestCase extends WebTestCase
      */
     protected function getBackendPage(array $queryParameters)
     {
-        return $this->client->request('GET', '/admin/?'.\http_build_query($queryParameters, '', '&'));
+        return static::$client->request('GET', '/admin/?'.\http_build_query($queryParameters, '', '&'));
     }
 
     /**

--- a/tests/Router/EasyAdminRouterTest.php
+++ b/tests/Router/EasyAdminRouterTest.php
@@ -11,6 +11,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
  */
 final class EasyAdminRouterTest extends AbstractTestCase
 {
+    protected static $options = ['environment' => 'default_backend'];
+
     /**
      * @var EasyAdminRouter
      */
@@ -20,9 +22,7 @@ final class EasyAdminRouterTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->initClient(['environment' => 'default_backend']);
-
-        $this->router = $this->client->getContainer()->get('easyadmin.router');
+        $this->router = static::$client->getContainer()->get('easyadmin.router');
     }
 
     /**

--- a/tests/Search/AutocompleteTest.php
+++ b/tests/Search/AutocompleteTest.php
@@ -6,12 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase;
 
 class AutocompleteTest extends AbstractTestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->initClient(['environment' => 'autocomplete']);
-    }
+    protected static $options = ['environment' => 'autocomplete'];
 
     /**
      * @dataProvider provideMissingParameters
@@ -22,7 +17,7 @@ class AutocompleteTest extends AbstractTestCase
 
         $this->assertSame(
             ['results' => []],
-            $this->client->getContainer()->get('easyadmin.autocomplete')->find($entity, $query),
+            static::$client->getContainer()->get('easyadmin.autocomplete')->find($entity, $query),
             'Some of the parameters required for autocomplete are missing.'
         );
     }
@@ -34,14 +29,14 @@ class AutocompleteTest extends AbstractTestCase
     public function testAutocompleteWrongEntity()
     {
         $this->getBackendHomepage();
-        $this->client->getContainer()->get('easyadmin.autocomplete')->find('ThisEntityDoesNotExist', 'John Doe');
+        static::$client->getContainer()->get('easyadmin.autocomplete')->find('ThisEntityDoesNotExist', 'John Doe');
     }
 
     public function testAutocompleteText()
     {
         $this->getBackendHomepage();
         // the query is 'Parent Categ' instead of 'Parent Category' to better test the autocomplete
-        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'Parent Categ');
+        $autocomplete = static::$client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'Parent Categ');
 
         // the results are the first batch of 10 parent categories
         foreach (\range(1, 10) as $i => $n) {
@@ -53,7 +48,7 @@ class AutocompleteTest extends AbstractTestCase
     public function testAutocompleteNumbers()
     {
         $this->getBackendHomepage();
-        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 21);
+        $autocomplete = static::$client->getContainer()->get('easyadmin.autocomplete')->find('Category', 21);
 
         $this->assertSame(
             [
@@ -68,7 +63,7 @@ class AutocompleteTest extends AbstractTestCase
     {
         $this->getBackendHomepage();
         // testing page 2
-        $autocomplete = $this->client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'Parent Categ', 2);
+        $autocomplete = static::$client->getContainer()->get('easyadmin.autocomplete')->find('Category', 'Parent Categ', 2);
 
         // the results are the second batch of 10 parent categories
         foreach (\range(11, 20) as $i => $n) {


### PR DESCRIPTION
Fix: https://travis-ci.org/EasyCorp/EasyAdminBundle/jobs/530998671#L606
```bash
PHP Fatal error:  Cannot redeclare static Symfony\Bundle\FrameworkBundle\Test\WebTestCase::$client as non static EasyCorp\Bundle\EasyAdminBundle\Tests\Fixtures\AbstractTestCase::$client in /home/travis/build/EasyCorp/EasyAdminBundle/tests/Fixtures/AbstractTestCase.php on line 14
```
this allows us to see all Symfony 4.3 deprecations