### PR TITLE
Fix ExceptionListener @final deprecation

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -55,9 +55,6 @@
         <service id="easyadmin.listener.exception" class="EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener" public="true">
             <argument type="service" id="twig" />
             <argument>%easyadmin.config%</argument>
-            <argument type="string">easyadmin.listener.exception:showExceptionPageAction</argument>
-            <argument type="service" id="logger" on-invalid="null" />
-            <tag name="monolog.logger" channel="request" />
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" priority="-64" />
         </service>
 

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -42,7 +42,7 @@ class ExceptionListenerTest extends TestCase
         $event = $this->getEventExceptionThatShouldBeCalledOnce($exception);
         $twig = $this->getTwig();
 
-        $listener = new ExceptionListener($twig, [], 'easyadmin.listener.exception:showExceptionPageAction');
+        $listener = new ExceptionListener($twig, []);
         $listener->onKernelException($event);
     }
 
@@ -64,7 +64,7 @@ class ExceptionListenerTest extends TestCase
         $event = $this->getEventExceptionThatShouldNotBeCalled($exception);
         $twig = $this->getTwig();
 
-        $listener = new ExceptionListener($twig, [], 'easyadmin.listener.exception:showExceptionPageAction');
+        $listener = new ExceptionListener($twig, []);
         $listener->onKernelException($event);
     }
 }


### PR DESCRIPTION
https://travis-ci.org/EasyCorp/EasyAdminBundle/jobs/531004595#L817
```bash
  1x: The "Symfony\Component\HttpKernel\EventListener\ExceptionListener" class is considered final since Symfony 4.3. It may change without further notice as of its next major version. You should not extend it from "EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener".
    1x in ExceptionListenerTest::testCatchBaseExceptions from EasyCorp\Bundle\EasyAdminBundle\Tests\EventListener
  1x: The "EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener::onKernelException()" method will require a new "string $eventName" argument in the next major version of its parent class "Symfony\Component\HttpKernel\EventListener\ExceptionListener", not defining it is deprecated.
    1x in ExceptionListenerTest::testCatchBaseExceptions from EasyCorp\Bundle\EasyAdminBundle\Tests\EventListener
  1x: The "EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener::onKernelException()" method will require a new "EventDispatcherInterface $eventDispatcher" argument in the next major version of its parent class "Symfony\Component\HttpKernel\EventListener\ExceptionListener", not defining it is deprecated.
    1x in ExceptionListenerTest::testCatchBaseExceptions from EasyCorp\Bundle\EasyAdminBundle\Tests\EventListener
```
I'm not sure we should care about BC here (it can be simplified even more)
The injection of a custom controller to this class seems like a rare extreme case; most of the time you should override the `@EasyAdmin/default/exception.html.twig` template.