### PR TITLE
fix(form-theme): do not display empty collection block when the form is compound and its value is null

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -216,10 +216,11 @@
     <div class="form-widget-compound">
         {# the "is iterable" check is needed because if an object implements __toString() and
            returns an empty string, "is empty" returns true even if it's not a collection #}
-        {% if value is null or (value is iterable and value is empty) %}
+        {% set isIterableAndEmpty = value is iterable and value is empty %}
+        {% if isIterableAndEmpty %}
             {{ block('empty_collection') }}
         {% endif %}
-        {% if value is iterable and value is empty or form.vars.prototype is defined %}
+        {% if isIterableAndEmpty or form.vars.prototype is defined %}
             {% set attr = attr|merge({'data-empty-collection': block('empty_collection') }) %}
         {% endif %}
 


### PR DESCRIPTION
Currently, when you use a sub form, you get the empty collection block displayed because the form is compound. However, having a `null` value in a compound form does not mean it's a collection. It's actually the default value.

The `value is null` check is not on 1.x, so I think it might have been added by mistake on 2.x. Do you remember why you did this @javiereguiluz?