### PR TITLE
Add optional batch response to AdminControllerTrait.php

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -398,7 +398,7 @@ trait AdminControllerTrait
     /**
      * The method that is executed when the user performs a 'batch' action to any entity.
      */
-    protected function batchAction(): RedirectResponse
+    protected function batchAction(): Response
     {
         $batchForm = $this->createBatchForm($this->entity['name']);
         $batchForm->handleRequest($this->request);
@@ -407,7 +407,10 @@ trait AdminControllerTrait
             $actionName = $batchForm->get('name')->getData();
             $actionIds = $batchForm->get('ids')->getData();
 
-            $this->executeDynamicMethod($actionName.'<EntityName>BatchAction', [$actionIds, $batchForm]);
+            $methodResult = $this->executeDynamicMethod($actionName.'<EntityName>BatchAction', [$actionIds, $batchForm]);
+            if ($methodResult instanceof Response) {
+                return $methodResult;
+            }
         }
 
         return $this->redirectToReferrer();


### PR DESCRIPTION
Sometimes batch method should return `Response`. E.g. to downloading multiple PDF files wrapped to ZIP with batch.

The PR allows it:

```php
public function certificatesBatchAction(array $ids)
{
    // get all certificates by ids and wrap to zip
 
    return new FileResponse(...);
}
```

See https://github.com/EasyCorp/EasyAdminBundle/pull/2578#issuecomment-495009609 for discussion