### PR TITLE
url_encode referer in delete_form instead of from callers

### DIFF
--- a/src/Resources/views/default/includes/_delete_form.html.twig
+++ b/src/Resources/views/default/includes/_delete_form.html.twig
@@ -1,6 +1,6 @@
 {{
     form(delete_form, {
-        action: delete_form.vars.action ~ ('?' in delete_form.vars.action ? '&' : '?') ~ 'referer=' ~ referer,
+        action: delete_form.vars.action ~ ('?' in delete_form.vars.action ? '&' : '?') ~ 'referer=' ~ referer|url_encode,
         method: 'DELETE',
         attr: { id: 'delete-form', style: 'display: none' }
     })

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -188,7 +188,7 @@
 
         {{ include('@EasyAdmin/default/includes/_delete_form.html.twig', {
             view: 'list',
-            referer: referer|url_encode,
+            referer: referer,
             delete_form: delete_form_template,
             _translation_domain: _entity_config.translation_domain,
             _trans_parameters: _trans_parameters,


### PR DESCRIPTION
Referer passed to `_delete_form` template was only URL encoded from `list`, not form `edit`, neither `show`.

If the referer contained another entity than the one that is deleted from an edit view => the deletion of the entity from the referer was attempted !

This PR uniformizes the URL encoding of the referer by applying url_encode filter in `_delete_form` template and removing from caller (only list did).