### PR TITLE
Exclude the actions column from result highlighting

### DIFF
--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -291,7 +291,7 @@
         <script type="text/javascript">
             const _search_query = "{{ app.request.get('query')|default('')|e('js') }}";
             // the original query is prepended to allow matching exact phrases in addition to single words
-            $('#main').find('table tbody').highlight($.merge([_search_query], _search_query.split(' ')));
+            $('#main').find('table tbody td:not(.actions)').highlight($.merge([_search_query], _search_query.split(' ')));
         </script>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Yesterday I saw that the highlighting of search results also highlights the actions column, which looks ugly and is unnecessary:

![image](https://user-images.githubusercontent.com/73419/58630092-a68b2c00-82de-11e9-9e04-3b966400efe6.png)
