### PR TITLE
Fixed the handling of the default search sorting

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -366,16 +366,14 @@ trait AdminControllerTrait
         }
 
         $searchableFields = $this->entity['search']['fields'];
-        $defaultSortField = $this->entity['search']['sort']['field'] ?? null;
-        $defaultSortDirection = isset($this->entity['search']['sort']['direction']) ? $this->entity['search']['sort']['direction'] : null;
         $paginator = $this->findBy(
             $this->entity['class'],
             $query,
             $searchableFields,
             $this->request->query->get('page', 1),
             $this->entity['list']['max_results'],
-            $this->request->query->get('sortField', $defaultSortField),
-            $this->request->query->get('sortDirection', $defaultSortDirection),
+            $this->request->query->get('sortField'),
+            $this->request->query->get('sortDirection'),
             $this->entity['search']['dql_filter']
         );
         $fields = $this->entity['list']['fields'];

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -9,8 +9,8 @@
     entity: _entity_config.name,
     menuIndex: app.request.get('menuIndex'),
     submenuIndex: app.request.get('submenuIndex'),
-    sortField: app.request.get('sortField', ''),
-    sortDirection: app.request.get('sortDirection', 'DESC'),
+    sortField: app.request.get('sortField'),
+    sortDirection: app.request.get('sortDirection'),
     page: app.request.get('page', 1),
     referer: null
 }) %}
@@ -18,8 +18,6 @@
 {% if 'search' == app.request.get('action') %}
     {% set _request_parameters = _request_parameters|merge({
         query: app.request.get('query')|default(''),
-        sortField: app.request.get('sortField') ?? _entity_config.search.sort.field ?? '',
-        sortDirection: app.request.get('sortDirection') ?? _entity_config.search.sort.direction ?? 'DESC',
     }) %}
 {% endif %}
 
@@ -51,8 +49,18 @@
                     {% block search_form %}
                         <input type="hidden" name="action" value="search">
                         <input type="hidden" name="entity" value="{{ _request_parameters.entity }}">
-                        <input type="hidden" name="sortField" value="{{ _request_parameters.sortField ?? _entity_config.search.sort.field ?? '' }}">
-                        <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection ?? _entity_config.search.sort.direction ?? 'DESC' }}">
+                        {# if the Request query doesn't define 'sortField' and 'sortDirection', we add them in the
+                           controller (but they don't appear in the request URI). When users click on a column to
+                           sort results, 'sortField' and 'sortDirection' are added to the Request query and they
+                            appear in the request URI too. So, checking if 'sortField' and 'sortDirection' is the
+                            only way to differentiate between sorting made by user and sorting made by us. We only
+                            need to persist the sorting if it's explicitly made by the user. #}
+                        {% if 'sortField' in app.request.uri %}
+                            <input type="hidden" name="sortField" value="{{ _request_parameters.sortField }}">
+                        {% endif %}
+                        {% if 'sortDirection' in app.request.uri %}
+                            <input type="hidden" name="sortDirection" value="{{ _request_parameters.sortDirection }}">
+                        {% endif %}
                         <input type="hidden" name="menuIndex" value="{{ _request_parameters.menuIndex }}">
                         <input type="hidden" name="submenuIndex" value="{{ _request_parameters.submenuIndex }}">
                         <div class="form-group">

--- a/tests/Controller/CustomizedBackendTest.php
+++ b/tests/Controller/CustomizedBackendTest.php
@@ -44,23 +44,16 @@ class CustomizedBackendTest extends AbstractTestCase
     {
         $crawler = $this->requestListView();
 
-        $hiddenParameters = [
-            'action' => 'search',
-            'entity' => 'Category',
-            'sortField' => 'name',
-            'sortDirection' => 'ASC',
-        ];
-
         $this->assertSame('Look for Categories', \trim($crawler->filter('.form-action-search [type="search"]')->attr('placeholder')));
         $this->assertContains('custom_class_search', $crawler->filter('.action-search')->attr('class'));
 
-        $i = 0;
-        foreach ($hiddenParameters as $name => $value) {
-            $this->assertSame($name, $crawler->filter('.action-search input[type=hidden]')->eq($i)->attr('name'));
-            $this->assertSame($value, $crawler->filter('.action-search input[type=hidden]')->eq($i)->attr('value'));
+        $this->assertSame('search', $crawler->filter('.action-search input[type="hidden"][name="action"]')->attr('value'));
+        $this->assertSame('Category', $crawler->filter('.action-search input[type="hidden"][name="entity"]')->attr('value'));
 
-            ++$i;
-        }
+        // the search form doesn't include sort config unless it's explicitly included in the
+        // request URI because the user click on some column to sort results
+        $this->assertCount(0, $crawler->filter('.action-search input[type="hidden"][name="sortField"]'));
+        $this->assertCount(0, $crawler->filter('.action-search input[type="hidden"][name="sortDirection"]'));
     }
 
     public function testListViewNewAction()
@@ -117,6 +110,12 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->assertCount(1, $crawler->filter('.table thead th[class*="sorted"]'), 'Table is sorted only by one column.');
         $this->assertSame('ID', \trim($crawler->filter('.table thead th[class*="sorted"]')->text()), 'By default, table is soreted by ID column.');
         $this->assertSame('fa fa-fw fa-arrow-down', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
+
+        // the search form doesn't include sort config unless it's explicitly included in the
+        // request URI because the user click on some column to sort results
+        $this->assertCount(0, $crawler->filter('.action-search input[type="hidden"][name="sortField"]'));
+        $this->assertCount(0, $crawler->filter('.action-search input[type="hidden"][name="sortDirection"]'));
+
     }
 
     public function testListViewTableContents()
@@ -515,6 +514,11 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->assertCount(1, $crawler->filter('.table thead th[class*="sorted"]'), 'Table is sorted only by one column.');
         $this->assertSame('Label', \trim($crawler->filter('.table thead th[class*="sorted"]')->text()), 'By default, table is soreted by "Label" column (which is the "name" property).');
         $this->assertSame('fa fa-fw fa-arrow-up', $crawler->filter('.table thead th[class*="sorted"] i')->attr('class'), 'The column used to sort results shows the right icon.');
+
+        // the search form doesn't include sort config unless it's explicitly included in the
+        // request URI because the user click on some column to sort results
+        $this->assertCount(0, $crawler->filter('.action-search input[type="hidden"][name="sortField"]'));
+        $this->assertCount(0, $crawler->filter('.action-search input[type="hidden"][name="sortDirection"]'));
     }
 
     public function testSearchViewTableContents()
@@ -585,6 +589,11 @@ class CustomizedBackendTest extends AbstractTestCase
 
         $this->assertSame('user9', \trim($crawler->filter('.table tbody tr td.association')->eq(0)->text()));
         $this->assertContains('sorted', $crawler->filter('.table th.association')->eq(0)->attr('class'));
+
+        // the search form doesn't include sort config unless it's explicitly included in the
+        // request URI because the user click on some column to sort results
+        $this->assertCount(0, $crawler->filter('.action-search input[type="hidden"][name="sortField"]'));
+        $this->assertCount(0, $crawler->filter('.action-search input[type="hidden"][name="sortDirection"]'));
     }
 
     public function testListViewVirtualFields()


### PR DESCRIPTION
This fixes #2738. The trick is to use the request URI to differentiate when the sorting is the default one created by us or the explicit one created by the user when clicking on some column.