### PR TITLE
Create a custom cache pool based on system cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "pagerfanta/pagerfanta": "~1.0,>=1.0.1|~2.0",
         "symfony/asset": "^4.2",
         "symfony/cache": "^4.2",
+        "symfony/cache-contracts": "^1.1",
         "symfony/config": "^4.2",
         "symfony/dependency-injection": "^4.2",
         "symfony/doctrine-bridge": "^4.2",

--- a/src/Configuration/ConfigManager.php
+++ b/src/Configuration/ConfigManager.php
@@ -117,7 +117,7 @@ final class ConfigManager
             return $this->backendConfig = $this->doProcessConfig($this->originalBackendConfig);
         }
 
-        return $this->backendConfig = $this->cache->get(self::CACHE_KEY, function() {
+        return $this->backendConfig = $this->cache->get(self::CACHE_KEY, function () {
             return $this->doProcessConfig($this->originalBackendConfig);
         });
     }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -4,11 +4,21 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="cache.easyadmin" parent="cache.system" public="false">
+            <tag name="cache.pool" />
+        </service>
+
+        <service id="easyadmin.config.manager.cache" class="Symfony\Contracts\Cache\CacheInterface">
+            <factory class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" method="create" />
+            <argument>%kernel.cache_dir%/easyadmin.php</argument>
+            <argument type="service" id="cache.easyadmin" />
+        </service>
+
         <service id="easyadmin.config.manager" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager" public="true">
             <argument>%easyadmin.config%</argument>
             <argument>%kernel.debug%</argument>
             <argument type="service" id="property_accessor" />
-            <argument type="service" id="Psr\Cache\CacheItemPoolInterface" />
+            <argument type="service" id="easyadmin.config.manager.cache" />
         </service>
 
         <service id="easyadmin.query_builder" class="EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder" public="true">

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,17 +8,11 @@
             <tag name="cache.pool" />
         </service>
 
-        <service id="easyadmin.config.manager.cache" class="Symfony\Contracts\Cache\CacheInterface">
-            <factory class="Symfony\Component\Cache\Adapter\PhpArrayAdapter" method="create" />
-            <argument>%kernel.cache_dir%/easyadmin.php</argument>
-            <argument type="service" id="cache.easyadmin" />
-        </service>
-
         <service id="easyadmin.config.manager" class="EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager" public="true">
             <argument>%easyadmin.config%</argument>
             <argument>%kernel.debug%</argument>
             <argument type="service" id="property_accessor" />
-            <argument type="service" id="easyadmin.config.manager.cache" />
+            <argument type="service" id="cache.easyadmin" />
         </service>
 
         <service id="easyadmin.query_builder" class="EasyCorp\Bundle\EasyAdminBundle\Search\QueryBuilder" public="true">


### PR DESCRIPTION
This fixes #2580.

As @antondemanoff said, we were using Symfony's Cache wrongly. I asked @nicolas-grekas directly about this and he confirmed everything. He said that our use case was clearly a "system cache" one, so we must change this. Nico also suggested to take a look at serializer cache, so this PR is based on that (if you are curious, check FrameworkBundle's serializer.xml and cache.xml files).