### PR TITLE
fix(vich-uploader): fix widget display

### DIFF
--- a/assets/css/easyadmin-theme/forms.scss
+++ b/assets/css/easyadmin-theme/forms.scss
@@ -425,15 +425,18 @@ form .invalid-feedback > .d-block + .d-block {
 
 // this element should use 'display: flex', but that doesn't work with
 // the CSS trick used to customize the <input type="file" /> fields.
-.easyadmin-vich-image-actions,
-.easyadmin-vich-file-actions {
-    overflow: hidden;
-}
 
 .easyadmin-vich-image-actions > div,
 .easyadmin-vich-file-actions > div {
     float: left;
     margin-right: 4px;
+}
+
+.easyadmin-vich-image-actions:after,
+.easyadmin-vich-file-actions:after {
+    clear: left;
+    content: "";
+    display: block;
 }
 
 .easyadmin-vich-image-actions .field-checkbox,

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -112,6 +112,15 @@
     {% endif %}
 {%- endblock %}
 
+{% block file_widget -%}
+    {% if vich|default(false) %}
+        {%- set type = type|default('file') -%}
+        {{- block('form_widget_simple') -}}
+    {% else %}
+        {{- parent() -}}
+    {% endif %}
+{%- endblock %}
+
 {# Rows #}
 
 {% block form_row -%}
@@ -268,7 +277,7 @@
             {# the container element is needed to allow customizing the <input type="file" /> #}
             <div class="btn btn-secondary input-file-container">
                 <i class="fa fa-fw fa-upload"></i> {{ 'action.choose_file'|trans({}, 'EasyAdminBundle') }}
-                <span class="btn-label">{{ form_widget(form.file, { 'attr': { 'onchange': file_upload_js }}) }}</span>
+                {{ form_widget(form.file, { 'attr': { 'onchange': file_upload_js }, vich: true}) }}
             </div>
 
             {% if form.delete is defined %}
@@ -315,7 +324,7 @@
             {# the container element is needed to allow customizing the <input type="file" /> #}
             <div class="btn btn-secondary input-file-container">
                 <i class="fa fa-fw fa-upload"></i> {{ 'action.choose_file'|trans({}, 'EasyAdminBundle') }}
-                <span class="btn-label">{{ form_widget(form.file, { 'attr': { 'onchange': file_upload_js }}) }}</span>
+                {{ form_widget(form.file, { 'attr': { 'onchange': file_upload_js }, vich: true}) }}
             </div>
 
             {% if form.delete is defined %}


### PR DESCRIPTION
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/2534

Before : 
<img width="411" alt="Screen Shot 2019-06-05 at 10 51 11" src="https://user-images.githubusercontent.com/3658119/58945190-ab8b2800-8783-11e9-9d84-25c104d38cad.png">

After : 
<img width="363" alt="Screen Shot 2019-06-05 at 10 51 59" src="https://user-images.githubusercontent.com/3658119/58945211-b3e36300-8783-11e9-9211-2ead50f22401.png">

Basically, when we render this field, we don't want to use the bootstrap style, so we don't need to render the input as it is defined in Symfony bootstrap theme file. We just need and want a plain file input. However, we still want to call the `form_widget` function in case an EasyAdmin end user wants to override it (or already does).

Tested on Firefox and Chrome, with and without the "delete" option.
