### PR TITLE
Add DateTimeFilter to cover both types (time and date)

### DIFF
--- a/src/Configuration/PropertyConfigPass.php
+++ b/src/Configuration/PropertyConfigPass.php
@@ -4,13 +4,14 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Configuration;
 
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\BooleanFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\ComparisonFilter;
-use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\DateFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\DateTimeFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\TextFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Util\FormTypeHelper;
-use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormRegistryInterface;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
@@ -93,17 +94,26 @@ class PropertyConfigPass implements ConfigPassInterface
             ],
         ],
         'date' => [
-            'type' => DateFilter::class,
-            'type_options' => [],
-        ],
-        'datetime' => [
-            'type' => ComparisonFilter::class,
+            'type' => DateTimeFilter::class,
             'type_options' => [
-                'value_type' => DateTimeType::class,
+                'value_type' => DateType::class,
                 'value_type_options' => [
                     'widget' => 'single_text',
                 ],
             ],
+        ],
+        'time' => [
+            'type' => DateTimeFilter::class,
+            'type_options' => [
+                'value_type' => TimeType::class,
+                'value_type_options' => [
+                    'widget' => 'single_text',
+                ],
+            ],
+        ],
+        'datetime' => [
+            'type' => DateTimeFilter::class,
+            'type_options' => [],
         ],
         'association' => [
             'type' => EntityFilter::class,

--- a/src/Form/Filter/DateTimeFilter.php
+++ b/src/Form/Filter/DateTimeFilter.php
@@ -4,14 +4,16 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Form\Filter;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
-class DateFilter extends AbstractType
+class DateTimeFilter extends AbstractType
 {
     /**
      * {@inheritdoc}
@@ -20,10 +22,15 @@ class DateFilter extends AbstractType
     {
         $builder->get('value')->addModelTransformer(new CallbackTransformer(
             static function ($data) { return $data; },
-            static function ($data) {
+            static function ($data) use ($options) {
                 if ($data instanceof \DateTime) {
-                    // Don't include time format for date comparison
-                    $data = $data->format('Y-m-d');
+                    if (DateType::class === $options['value_type']) {
+                        // sqlite: Don't include time format for date comparison
+                        $data = $data->format('Y-m-d');
+                    } elseif (TimeType::class === $options['value_type']) {
+                        // sqlite: Don't include date format for time comparison
+                        $data = $data->format('H:i:s');
+                    }
                 }
 
                 return $data;
@@ -37,7 +44,7 @@ class DateFilter extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'value_type' => DateType::class,
+            'value_type' => DateTimeType::class,
             'value_type_options' => [
                 'widget' => 'single_text',
             ],


### PR DESCRIPTION
Continuation of https://github.com/EasyCorp/EasyAdminBundle/pull/2740

This remove the `DateFilter` in favor of `DateTimeFilter` which support `time` fields and transform the given data that will be compared later.

As far as I know, only sqlite database has this problem.