### PR TITLE
Form tabs - handling css_class parameter for form tabs

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -392,7 +392,7 @@
                     </ul>
                     <div class="tab-content">
                         {% for tab_name, tab_config in easyadmin_form_tabs %}
-                            <div id="{{ tab_config['id'] }}" class="tab-pane {% if tab_config.active %}active{% endif %}">
+                            <div id="{{ tab_config['id'] }}" class="tab-pane {% if tab_config.active %}active{% endif %} {{ tab_config['css_class']|default('') }}">
                                 {% if tab_config['help']|default(false) %}
                                     <div class="content-header-help tab-help">
                                         {{ tab_config['help']|trans(domain = _translation_domain)|raw }}


### PR DESCRIPTION
Handling the `css_class` parameter for the form tabs elements.

As mentionned in the doc bellow:
https://symfony.com/doc/master/bundles/EasyAdminBundle/book/edit-new-configuration.html#form-tabs