### PR TITLE
Excluding the filter type guesser from the form type guessers group

### DIFF
--- a/src/DependencyInjection/Compiler/FilterTypePass.php
+++ b/src/DependencyInjection/Compiler/FilterTypePass.php
@@ -23,6 +23,14 @@ final class FilterTypePass implements CompilerPassInterface
     {
         // type guessers
         $guessers = $this->findAndSortTaggedServices('easyadmin.filter.type_guesser', $container);
+        // the filter type guesser created by the user (in the app side) becomes
+        // a form type guesser too due to autoconfiguration, and that can cause
+        // issues in new/edit forms, so we need to exclude the filter type guesser
+        // from the form type guessers group
+        foreach ($guessers as $guesser) {
+            $container->getDefinition((string) $guesser)
+                ->clearTag('form.type_guesser');
+        }
         // types Map
         $typesMap = [];
         $servicesMap = [];

--- a/src/EasyAdminBundle.php
+++ b/src/EasyAdminBundle.php
@@ -19,7 +19,9 @@ class EasyAdminBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new EasyAdminFormTypePass(), PassConfig::TYPE_BEFORE_REMOVING);
-        $container->addCompilerPass(new FilterTypePass());
+        // this compiler pass must run earlier than FormPass to clear
+        // the 'form.type_guesser' tag for 'easyadmin.filter.type_guesser' services
+        $container->addCompilerPass(new FilterTypePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 10);
         $container->addCompilerPass(new EasyAdminConfigPass());
     }
 }


### PR DESCRIPTION
In the app side, with DI autoconfiguration enabled, a filter type guesser becomes a normal form type guesser as well, because it implements `FormTypeGuesserInterface` and that generates issues in new/edit forms where the filter guessers shouldn't act.