### PR TITLE
Making "easyadmin.filter.registry" service as public.

### DIFF
--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -92,11 +92,11 @@
 
         <!-- Type Configurators -->
 
-        <service id="easyadmin.filter.registry" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\FilterRegistry">
+        <service id="easyadmin.filter.registry" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\FilterRegistry" public="true">
             <argument type="collection" /> <!-- filter types map -->
             <argument type="iterator" /> <!-- filter types guessers -->
         </service>
-        <service id="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\FilterRegistry" alias="easyadmin.filter.registry" />
+        <service id="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\FilterRegistry" alias="easyadmin.filter.registry" public="true" />
 
         <service id="easyadmin.filter.extension" class="Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension">
             <argument /><!-- All services with tag "easyadmin.filter.type" are stored in a service locator -->


### PR DESCRIPTION
To fix a bug mentioned in #2740.