### PR TITLE
New Paginator based on Doctrine Pagination

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.6,>=2.6.3",
         "doctrine/persistence": "^1.0",
-        "pagerfanta/pagerfanta": "~1.0,>=1.0.1|~2.0",
         "symfony/asset": "^4.2",
         "symfony/cache": "^4.2",
         "symfony/config": "^4.2",

--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -15,7 +15,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\FilterRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminBatchFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminFiltersFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType;
-use Pagerfanta\Pagerfanta;
+use EasyCorp\Bundle\EasyAdminBundle\Search\Paginator;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -615,7 +615,7 @@ trait AdminControllerTrait
      * @param string|null $sortDirection
      * @param string|null $dqlFilter
      *
-     * @return Pagerfanta The paginated query results
+     * @return Paginator The paginated query results
      */
     protected function findAll($entityClass, $page = 1, $maxPerPage = 15, $sortField = null, $sortDirection = null, $dqlFilter = null)
     {
@@ -633,7 +633,7 @@ trait AdminControllerTrait
             'sort_direction' => $sortDirection,
         ]);
 
-        return $this->get('easyadmin.paginator')->createOrmPaginator($queryBuilder, $page, $maxPerPage);
+        return $this->get('easyadmin.paginator')->create($queryBuilder, $page, $maxPerPage);
     }
 
     /**
@@ -664,7 +664,7 @@ trait AdminControllerTrait
      * @param string|null $sortDirection
      * @param string|null $dqlFilter
      *
-     * @return Pagerfanta The paginated query results
+     * @return Paginator The paginated query results
      */
     protected function findBy($entityClass, $searchQuery, array $searchableFields, $page = 1, $maxPerPage = 15, $sortField = null, $sortDirection = null, $dqlFilter = null)
     {
@@ -682,7 +682,7 @@ trait AdminControllerTrait
             'searchable_fields' => $searchableFields,
         ]);
 
-        return $this->get('easyadmin.paginator')->createOrmPaginator($queryBuilder, $page, $maxPerPage);
+        return $this->get('easyadmin.paginator')->create($queryBuilder, $page, $maxPerPage);
     }
 
     /**

--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -16,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminBatchFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminFiltersFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Search\Paginator;
+use EasyCorp\Bundle\EasyAdminBundle\Search\QueryPaginator;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
@@ -615,7 +616,7 @@ trait AdminControllerTrait
      * @param string|null $sortDirection
      * @param string|null $dqlFilter
      *
-     * @return Paginator The paginated query results
+     * @return QueryPaginator The paginated query results
      */
     protected function findAll($entityClass, $page = 1, $maxPerPage = 15, $sortField = null, $sortDirection = null, $dqlFilter = null)
     {
@@ -633,7 +634,7 @@ trait AdminControllerTrait
             'sort_direction' => $sortDirection,
         ]);
 
-        return $this->get('easyadmin.paginator')->create($queryBuilder, $page, $maxPerPage);
+        return new QueryPaginator($queryBuilder, $page, $maxPerPage);
     }
 
     /**
@@ -664,7 +665,7 @@ trait AdminControllerTrait
      * @param string|null $sortDirection
      * @param string|null $dqlFilter
      *
-     * @return Paginator The paginated query results
+     * @return QueryPaginator The paginated query results
      */
     protected function findBy($entityClass, $searchQuery, array $searchableFields, $page = 1, $maxPerPage = 15, $sortField = null, $sortDirection = null, $dqlFilter = null)
     {
@@ -682,7 +683,7 @@ trait AdminControllerTrait
             'searchable_fields' => $searchableFields,
         ]);
 
-        return $this->get('easyadmin.paginator')->create($queryBuilder, $page, $maxPerPage);
+        return new QueryPaginator($queryBuilder, $page, $maxPerPage);
     }
 
     /**

--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -15,7 +15,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\FilterRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminBatchFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminFiltersFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminFormType;
-use EasyCorp\Bundle\EasyAdminBundle\Search\Paginator;
 use EasyCorp\Bundle\EasyAdminBundle\Search\QueryPaginator;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -634,7 +633,7 @@ trait AdminControllerTrait
             'sort_direction' => $sortDirection,
         ]);
 
-        return new QueryPaginator($queryBuilder, $page, $maxPerPage);
+        return (new QueryPaginator($queryBuilder, $maxPerPage))->paginate($page);
     }
 
     /**
@@ -683,7 +682,7 @@ trait AdminControllerTrait
             'searchable_fields' => $searchableFields,
         ]);
 
-        return new QueryPaginator($queryBuilder, $page, $maxPerPage);
+        return (new QueryPaginator($queryBuilder, $maxPerPage))->paginate($page);
     }
 
     /**

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -31,6 +31,7 @@
         </service>
 
         <service id="easyadmin.paginator" class="EasyCorp\Bundle\EasyAdminBundle\Search\Paginator" public="true">
+            <deprecated>The "%service_id%" service is deprecated. Instead of this service, pagination is now managed by an instance of the EasyCorp\Bundle\EasyAdminBundle\Search\QueryPaginator value object.</deprecated>
         </service>
 
         <service id="easyadmin.router" class="EasyCorp\Bundle\EasyAdminBundle\Router\EasyAdminRouter" public="true">

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -32,8 +32,8 @@
 {% block content_title %}
     {% apply spaceless %}
         {% if 'search' == app.request.get('action') %}
-            {% set _default_title = 'search.page_title'|transchoice(paginator.nbResults, {}, 'EasyAdminBundle') %}
-            {{ (_entity_config.search.title is defined ? _entity_config.search.title|transchoice(paginator.nbResults) : _default_title)|raw }}
+            {% set _default_title = 'search.page_title'|transchoice(paginator.numResults, {}, 'EasyAdminBundle') %}
+            {{ (_entity_config.search.title is defined ? _entity_config.search.title|transchoice(paginator.numResults) : _default_title)|raw }}
         {% else %}
             {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
             {{ (_entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title)|raw }}
@@ -166,7 +166,7 @@
 
         <tbody>
         {% block table_body %}
-            {% for item in paginator.currentPageResults %}
+            {% for item in paginator.results %}
                 {% if not easyadmin_is_granted(_entity_config.list.item_permission, item) %}
                     {% set _number_of_hidden_results = _number_of_hidden_results + 1 %}
                 {% else %}
@@ -228,7 +228,7 @@
     </table>
 
     {% block delete_form %}
-        {% set referer = paginator.currentPage == paginator.nbPages and 1 != paginator.currentPage and 1 == paginator.currentPageResults|length
+        {% set referer = paginator.currentPage == paginator.lastPage and 1 != paginator.currentPage and 1 == paginator.results|length
             ? path('easyadmin', app.request.query|merge({ page: app.request.query.get('page') - 1 }))
             : app.request.requestUri
         %}

--- a/src/Resources/views/default/paginator.html.twig
+++ b/src/Resources/views/default/paginator.html.twig
@@ -4,7 +4,7 @@
 
 <div class="list-pagination">
     <div class="list-pagination-counter">
-        {{ 'paginator.results'|transchoice(paginator.nbResults)|raw }}
+        {{ 'paginator.results'|transchoice(paginator.numResults)|raw }}
     </div>
 
     <nav class="pager list-pagination-paginator {{ not paginator.hasPreviousPage ? 'first-page' }} {{ not paginator.hasNextPage ? 'last-page' }}">

--- a/src/Search/Autocomplete.php
+++ b/src/Search/Autocomplete.php
@@ -50,7 +50,7 @@ class Autocomplete
         $paginator = $this->finder->findByAllProperties($backendConfig['entities'][$entity], $query, $page, $backendConfig['show']['max_results']);
 
         return [
-            'results' => $this->processResults($paginator->getCurrentPageResults(), $backendConfig['entities'][$entity]),
+            'results' => $this->processResults($paginator->getResults(), $backendConfig['entities'][$entity]),
             'has_next_page' => $paginator->hasNextPage(),
         ];
     }

--- a/src/Search/Finder.php
+++ b/src/Search/Finder.php
@@ -29,12 +29,12 @@ class Finder
      * @param string $sortField
      * @param string $sortDirection
      *
-     * @return Paginator
+     * @return QueryPaginator
      */
     public function findByAllProperties(array $entityConfig, $searchQuery, $page = 1, $maxResults = self::MAX_RESULTS, $sortField = null, $sortDirection = null)
     {
         $queryBuilder = $this->queryBuilder->createSearchQueryBuilder($entityConfig, $searchQuery, $sortField, $sortDirection);
 
-        return new Paginator($queryBuilder, $page, $maxResults);
+        return new QueryPaginator($queryBuilder, $page, $maxResults);
     }
 }

--- a/src/Search/Finder.php
+++ b/src/Search/Finder.php
@@ -2,8 +2,6 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Search;
 
-use Pagerfanta\Pagerfanta;
-
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
@@ -31,12 +29,12 @@ class Finder
      * @param string $sortField
      * @param string $sortDirection
      *
-     * @return Pagerfanta
+     * @return Paginator
      */
     public function findByAllProperties(array $entityConfig, $searchQuery, $page = 1, $maxResults = self::MAX_RESULTS, $sortField = null, $sortDirection = null)
     {
         $queryBuilder = $this->queryBuilder->createSearchQueryBuilder($entityConfig, $searchQuery, $sortField, $sortDirection);
 
-        return $this->paginator->createOrmPaginator($queryBuilder, $page, $maxResults);
+        return new Paginator($queryBuilder, $page, $maxResults);
     }
 }

--- a/src/Search/Finder.php
+++ b/src/Search/Finder.php
@@ -35,6 +35,6 @@ class Finder
     {
         $queryBuilder = $this->queryBuilder->createSearchQueryBuilder($entityConfig, $searchQuery, $sortField, $sortDirection);
 
-        return new QueryPaginator($queryBuilder, $page, $maxResults);
+        return (new QueryPaginator($queryBuilder, $maxResults))->paginate($page);
     }
 }

--- a/src/Search/Paginator.php
+++ b/src/Search/Paginator.php
@@ -4,115 +4,13 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Search;
 
 use Doctrine\ORM\Query as DoctrineQuery;
 use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
-use Doctrine\ORM\Tools\Pagination\CountWalker;
-use Doctrine\ORM\Tools\Pagination\Paginator as DoctrinePaginator;
 
 /**
+ * @deprecated Use EasyCorp\Bundle\EasyAdminBundle\Search\QueryPaginator
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 class Paginator
 {
-    private const PAGE_SIZE = 15;
-    private $currentPage;
-    private $pageSize;
-    private $results;
-    private $numResults;
-
-    public function create(DoctrineQueryBuilder $queryBuilder, int $currentPage = 1, int $pageSize = self::PAGE_SIZE): Paginator
-    {
-        $this->currentPage = max(1, $currentPage);
-        $this->pageSize = $pageSize;
-        $firstResult = ($this->currentPage - 1) * $pageSize;
-
-        $query = $queryBuilder
-            ->setFirstResult($firstResult)
-            ->setMaxResults($pageSize)
-            ->getQuery();
-
-        if (0 === \count($queryBuilder->getDQLPart('join'))) {
-            $query->setHint(CountWalker::HINT_DISTINCT, false);
-        }
-
-        $paginator = new DoctrinePaginator($query, true);
-        $paginator->setUseOutputWalkers(false);
-
-        $this->results = $paginator->getIterator();
-        $this->numResults = $paginator->count();
-
-        return $this;
-    }
-
-    public function getCurrentPage(): int
-    {
-        return $this->currentPage;
-    }
-
-    public function getNbPages(): int
-    {
-        @trigger_error(sprintf('The "%s" method is deprecated. Use "getLastPage()" instead.', __METHOD__), E_USER_DEPRECATED);
-
-        return $this->getLastPage();
-    }
-
-    public function getLastPage(): int
-    {
-        return (int) ceil($this->numResults / $this->pageSize);
-    }
-
-    public function getPageSize(): int
-    {
-        return $this->pageSize;
-    }
-
-    public function hasPreviousPage(): bool
-    {
-        return $this->currentPage > 1;
-    }
-
-    public function getPreviousPage(): int
-    {
-        return max(1, $this->currentPage - 1);
-    }
-
-    public function hasNextPage(): bool
-    {
-        return $this->currentPage < $this->getLastPage();
-    }
-
-    public function getNextPage(): int
-    {
-        return min($this->getLastPage(), $this->currentPage + 1);
-    }
-
-    public function hasToPaginate(): bool
-    {
-        return $this->numResults > $this->pageSize;
-    }
-
-    public function getNbResults(): int
-    {
-        @trigger_error(sprintf('The "%s" method is deprecated. Use "getNumResults()" instead.', __METHOD__), E_USER_DEPRECATED);
-
-        return $this->getNumResults();
-    }
-
-    public function getNumResults(): int
-    {
-        return $this->numResults;
-    }
-
-    public function getResults(): ?\Traversable
-    {
-        return $this->results;
-    }
-
-    public function getCurrentPageResults(): ?\Traversable
-    {
-        @trigger_error(sprintf('The "%s" method is deprecated. Use "getResults()" instead.', __METHOD__), E_USER_DEPRECATED);
-
-        return $this->getResults();
-    }
-
     /**
      * Creates a Doctrine ORM paginator for the given query builder.
      *
@@ -126,6 +24,6 @@ class Paginator
     {
         @trigger_error(sprintf('The "%s" method is deprecated. Use "new %s()" instead to create the paginator.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
-        return new self($queryBuilder, $page, $maxPerPage);
+        return new QueryPaginator($queryBuilder, $page, $maxPerPage);
     }
 }

--- a/src/Search/Paginator.php
+++ b/src/Search/Paginator.php
@@ -5,15 +5,113 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Search;
 use Doctrine\ORM\Query as DoctrineQuery;
 use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
-use Pagerfanta\Pagerfanta;
+use Doctrine\ORM\Tools\Pagination\Paginator as DoctrinePaginator;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 class Paginator
 {
-    private const MAX_ITEMS = 15;
+    private const PAGE_SIZE = 15;
+    private $currentPage;
+    private $pageSize;
+    private $results;
+    private $numResults;
+
+    public function create(DoctrineQueryBuilder $queryBuilder, int $currentPage = 1, int $pageSize = self::PAGE_SIZE): Paginator
+    {
+        $this->currentPage = max(1, $currentPage);
+        $this->pageSize = $pageSize;
+        $firstResult = ($this->currentPage - 1) * $pageSize;
+
+        $query = $queryBuilder
+            ->setFirstResult($firstResult)
+            ->setMaxResults($pageSize)
+            ->getQuery();
+
+        if (0 === \count($queryBuilder->getDQLPart('join'))) {
+            $query->setHint(CountWalker::HINT_DISTINCT, false);
+        }
+
+        $paginator = new DoctrinePaginator($query, true);
+        $paginator->setUseOutputWalkers(false);
+
+        $this->results = $paginator->getIterator();
+        $this->numResults = $paginator->count();
+
+        return $this;
+    }
+
+    public function getCurrentPage(): int
+    {
+        return $this->currentPage;
+    }
+
+    public function getNbPages(): int
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated. Use "getLastPage()" instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getLastPage();
+    }
+
+    public function getLastPage(): int
+    {
+        return (int) ceil($this->numResults / $this->pageSize);
+    }
+
+    public function getPageSize(): int
+    {
+        return $this->pageSize;
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->currentPage > 1;
+    }
+
+    public function getPreviousPage(): int
+    {
+        return max(1, $this->currentPage - 1);
+    }
+
+    public function hasNextPage(): bool
+    {
+        return $this->currentPage < $this->getLastPage();
+    }
+
+    public function getNextPage(): int
+    {
+        return min($this->getLastPage(), $this->currentPage + 1);
+    }
+
+    public function hasToPaginate(): bool
+    {
+        return $this->numResults > $this->pageSize;
+    }
+
+    public function getNbResults(): int
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated. Use "getNumResults()" instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getNumResults();
+    }
+
+    public function getNumResults(): int
+    {
+        return $this->numResults;
+    }
+
+    public function getResults(): ?\Traversable
+    {
+        return $this->results;
+    }
+
+    public function getCurrentPageResults(): ?\Traversable
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated. Use "getResults()" instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getResults();
+    }
 
     /**
      * Creates a Doctrine ORM paginator for the given query builder.
@@ -22,20 +120,12 @@ class Paginator
      * @param int                                $page
      * @param int                                $maxPerPage
      *
-     * @return Pagerfanta
+     * @return \Traversable
      */
-    public function createOrmPaginator($queryBuilder, $page = 1, $maxPerPage = self::MAX_ITEMS)
+    public function createOrmPaginator($queryBuilder, $page = 1, $maxPerPage = self::PAGE_SIZE)
     {
-        $query = $queryBuilder->getQuery();
-        if (0 === \count($queryBuilder->getDQLPart('join'))) {
-            $query->setHint(CountWalker::HINT_DISTINCT, false);
-        }
+        @trigger_error(sprintf('The "%s" method is deprecated. Use "new %s()" instead to create the paginator.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
-        // don't change the following line (you did that twice in the past and broke everything)
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($query, true, false));
-        $paginator->setMaxPerPage($maxPerPage);
-        $paginator->setCurrentPage($page);
-
-        return $paginator;
+        return new self($queryBuilder, $page, $maxPerPage);
     }
 }

--- a/src/Search/Paginator.php
+++ b/src/Search/Paginator.php
@@ -7,6 +7,7 @@ use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
 
 /**
  * @deprecated Use EasyCorp\Bundle\EasyAdminBundle\Search\QueryPaginator
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 class Paginator
@@ -22,7 +23,7 @@ class Paginator
      */
     public function createOrmPaginator($queryBuilder, $page = 1, $maxPerPage = self::PAGE_SIZE)
     {
-        @trigger_error(sprintf('The "%s" method is deprecated. Use "new %s()" instead to create the paginator.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
+        @\trigger_error(\sprintf('The "%s" method is deprecated. Use "new %s()" instead to create the paginator.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
         return (new QueryPaginator($queryBuilder, $maxPerPage))->paginate($page);
     }

--- a/src/Search/Paginator.php
+++ b/src/Search/Paginator.php
@@ -24,6 +24,6 @@ class Paginator
     {
         @trigger_error(sprintf('The "%s" method is deprecated. Use "new %s()" instead to create the paginator.', __METHOD__, __CLASS__), E_USER_DEPRECATED);
 
-        return new QueryPaginator($queryBuilder, $page, $maxPerPage);
+        return (new QueryPaginator($queryBuilder, $maxPerPage))->paginate($page);
     }
 }

--- a/src/Search/QueryPaginator.php
+++ b/src/Search/QueryPaginator.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Search;
+
+use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
+use Doctrine\ORM\Tools\Pagination\CountWalker;
+use Doctrine\ORM\Tools\Pagination\Paginator as DoctrinePaginator;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class QueryPaginator
+{
+    private const PAGE_SIZE = 15;
+    private $currentPage;
+    private $pageSize;
+    private $results;
+    private $numResults;
+
+    public function __construct(DoctrineQueryBuilder $queryBuilder, int $currentPage = 1, int $pageSize = self::PAGE_SIZE)
+    {
+        $this->currentPage = max(1, $currentPage);
+        $this->pageSize = $pageSize;
+        $firstResult = ($this->currentPage - 1) * $pageSize;
+
+        $query = $queryBuilder
+            ->setFirstResult($firstResult)
+            ->setMaxResults($pageSize)
+            ->getQuery();
+
+        if (0 === \count($queryBuilder->getDQLPart('join'))) {
+            $query->setHint(CountWalker::HINT_DISTINCT, false);
+        }
+
+        $paginator = new DoctrinePaginator($query, true);
+        $paginator->setUseOutputWalkers(false);
+
+        $this->results = $paginator->getIterator();
+        $this->numResults = $paginator->count();
+
+        return $this;
+    }
+
+    public function getCurrentPage(): int
+    {
+        return $this->currentPage;
+    }
+
+    public function getLastPage(): int
+    {
+        return (int) ceil($this->numResults / $this->pageSize);
+    }
+
+    public function getPageSize(): int
+    {
+        return $this->pageSize;
+    }
+
+    public function hasPreviousPage(): bool
+    {
+        return $this->currentPage > 1;
+    }
+
+    public function getPreviousPage(): int
+    {
+        return max(1, $this->currentPage - 1);
+    }
+
+    public function hasNextPage(): bool
+    {
+        return $this->currentPage < $this->getLastPage();
+    }
+
+    public function getNextPage(): int
+    {
+        return min($this->getLastPage(), $this->currentPage + 1);
+    }
+
+    public function hasToPaginate(): bool
+    {
+        return $this->numResults > $this->pageSize;
+    }
+
+    public function getNumResults(): int
+    {
+        return $this->numResults;
+    }
+
+    public function getResults(): ?\Traversable
+    {
+        return $this->results;
+    }
+
+    /**
+     * @deprecated Use getResults()
+     */
+    public function getCurrentPageResults(): ?\Traversable
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated. Use "getResults()" instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getResults();
+    }
+
+    /**
+     * @deprecated Use getLastPage()
+     */
+    public function getNbPages(): int
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated. Use "getLastPage()" instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getLastPage();
+    }
+
+    /**
+     * @deprecated Use getNumResults()
+     */
+    public function getNbResults(): int
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated. Use "getNumResults()" instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return $this->getNumResults();
+    }
+}

--- a/src/Search/QueryPaginator.php
+++ b/src/Search/QueryPaginator.php
@@ -26,7 +26,7 @@ class QueryPaginator
 
     public function paginate(int $page = 1): self
     {
-        $this->currentPage = max(1, $page);
+        $this->currentPage = \max(1, $page);
         $firstResult = ($this->currentPage - 1) * $this->pageSize;
 
         $query = $this->queryBuilder
@@ -56,7 +56,7 @@ class QueryPaginator
 
     public function getLastPage(): int
     {
-        return (int) ceil($this->numResults / $this->pageSize);
+        return (int) \ceil($this->numResults / $this->pageSize);
     }
 
     public function getPageSize(): int
@@ -71,7 +71,7 @@ class QueryPaginator
 
     public function getPreviousPage(): int
     {
-        return max(1, $this->currentPage - 1);
+        return \max(1, $this->currentPage - 1);
     }
 
     public function hasNextPage(): bool
@@ -81,7 +81,7 @@ class QueryPaginator
 
     public function getNextPage(): int
     {
-        return min($this->getLastPage(), $this->currentPage + 1);
+        return \min($this->getLastPage(), $this->currentPage + 1);
     }
 
     public function hasToPaginate(): bool
@@ -104,7 +104,7 @@ class QueryPaginator
      */
     public function getCurrentPageResults(): ?\Traversable
     {
-        @trigger_error(sprintf('The "%s" method is deprecated. Use "getResults()" instead.', __METHOD__), E_USER_DEPRECATED);
+        @\trigger_error(\sprintf('The "%s" method is deprecated. Use "getResults()" instead.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->getResults();
     }
@@ -114,7 +114,7 @@ class QueryPaginator
      */
     public function getNbPages(): int
     {
-        @trigger_error(sprintf('The "%s" method is deprecated. Use "getLastPage()" instead.', __METHOD__), E_USER_DEPRECATED);
+        @\trigger_error(\sprintf('The "%s" method is deprecated. Use "getLastPage()" instead.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->getLastPage();
     }
@@ -124,7 +124,7 @@ class QueryPaginator
      */
     public function getNbResults(): int
     {
-        @trigger_error(sprintf('The "%s" method is deprecated. Use "getNumResults()" instead.', __METHOD__), E_USER_DEPRECATED);
+        @\trigger_error(\sprintf('The "%s" method is deprecated. Use "getNumResults()" instead.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->getNumResults();
     }


### PR DESCRIPTION
The future of the Pagerfanta library looks uncertain (see https://github.com/whiteoctober/Pagerfanta/issues/278). Alos, we don't use almost any of the Pagerfanta features, because we only support Doctrine ORM.

So, let's switch to Doctirne Pager. I've added some deprecated methods in the new `Paginator` class to minimize the errors caused by pagination use from templates. This will be a minor breaking change, but for most developers nothing will change and they won't need to make any change at all in their apps. The other developers will need to change some "use" imports and some type-hints.

What do you think of this proposal? Thanks!