### PR TITLE
Add support for unmapped filter fields

### DIFF
--- a/doc/book/list-search-show-configuration.rst
+++ b/doc/book/list-search-show-configuration.rst
@@ -715,6 +715,26 @@ new filter to the field which will use it:
                           # optionally you can pass options to the filter class
                           # type_options: {}
 
+.. tip::
+
+    When configuring filters to entities, all filters are validated. Any filter
+    properties that do not exist on the entity class will cause an exception to be
+    thrown.
+
+    In cases where you need extra filters in the form that will not be mapped to
+    the underlying entity class, you need to set the ``mapped`` option to ``false``::
+
+        # config/packages/easy_admin.yaml
+        easy_admin:
+            entities:
+                Users:
+                    class: App\Entity\User
+                    list:
+                        filters:
+                            - property: 'unmapped'
+                              type: 'App\Form\Filter\CustomFilterType'
+                              mapped: false
+
 If the options passed to the filter are dynamic, you can't define them in the
 YAML config file. Instead, :ref:`create a custom controller <overriding-the-entity-controller>`
 for your entity and override the ``createFiltersForm()`` method::

--- a/tests/Configuration/fixtures/exceptions/filters_unknown_property.yml
+++ b/tests/Configuration/fixtures/exceptions/filters_unknown_property.yml
@@ -4,7 +4,7 @@
 # EXCEPTION
 expected_exception:
     class: \InvalidArgumentException
-    message_string: 'The "this-property-does-not-exist" filter configured in the "list" view of the "Category" entity refers to a property called "this-property-does-not-exist" which is not defined in that entity.'
+    message_string: 'The "this-property-does-not-exist" filter configured in the "list" view of the "Category" entity refers to a property called "this-property-does-not-exist" which is not defined in that entity. Set the "mapped" option to false if it is not intended to be a mapped property.'
 
 # CONFIGURATION
 easy_admin:

--- a/tests/Configuration/fixtures/exceptions/filters_unmapped_without_type.yml
+++ b/tests/Configuration/fixtures/exceptions/filters_unmapped_without_type.yml
@@ -1,0 +1,15 @@
+# TEST
+# items in the 'filters' option must define the 'type' option when they are unmapped
+
+# EXCEPTION
+expected_exception:
+    class: \InvalidArgumentException
+    message_string: 'The "foo" filter defined in the "list" view of the "Category" entity must define its own "type" explicitly because EasyAdmin cannot autoconfigure it.'
+
+# CONFIGURATION
+easy_admin:
+    entities:
+        Category:
+            class: AppTestBundle\Entity\UnitTests\Category
+            list:
+                filters: [{ property: 'foo', mapped: false }]


### PR DESCRIPTION
The current exception is good for DX (typos via the YAML config), but we often need to create a filter that is not directly related to any mapped property.

Now users can achieve this by creating a custom Controller and overriding the `createFiltersForm ()` method, but this proposal also makes it possible through the YAML configuration:
```yaml
easy_admin:
    entities:
        Category:
            # ...
            list:
                filters: [{ property: 'country', type: 'App\Form\Filter\CountryFilterType', mapped: false }]
```
the new option `mapped` allow you to skip this EasyAdmin validation.

Closes #2793