### PR TITLE
Add ChoiceFilterType and other simplifications

### DIFF
--- a/src/Form/Filter/Type/BooleanFilterType.php
+++ b/src/Form/Filter/Type/BooleanFilterType.php
@@ -2,9 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type;
 
-use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -17,7 +15,7 @@ class BooleanFilterType extends FilterType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'choices' => [
@@ -33,22 +31,8 @@ class BooleanFilterType extends FilterType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ChoiceType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function filter(QueryBuilder $queryBuilder, FormInterface $form, array $metadata)
-    {
-        $alias = \current($queryBuilder->getRootAliases());
-        $property = $metadata['property'];
-        $paramName = static::createAlias($property);
-        $value = $form->getData();
-
-        $queryBuilder->andWhere(\sprintf('%s.%s = :%s', $alias, $property, $paramName))
-            ->setParameter($paramName, $value);
     }
 }

--- a/src/Form/Filter/Type/ComparisonFilterType.php
+++ b/src/Form/Filter/Type/ComparisonFilterType.php
@@ -32,7 +32,7 @@ class ComparisonFilterType extends FilterType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('comparison', $options['comparison_type'], $options['comparison_type_options']);
         $builder->add('value', FormTypeHelper::getTypeClass($options['value_type']), $options['value_type_options'] + [
@@ -43,7 +43,7 @@ class ComparisonFilterType extends FilterType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setRequired('value_type');
         if (null !== $this->valueType) {

--- a/src/Form/Filter/Type/Configurator/ChoiceFilterTypeConfigurator.php
+++ b/src/Form/Filter/Type/Configurator/ChoiceFilterTypeConfigurator.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\Configurator;
+
+use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ChoiceFilterType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Configurator\TypeConfiguratorInterface;
+use Symfony\Component\Form\FormConfigInterface;
+
+/**
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ */
+class ChoiceFilterTypeConfigurator implements TypeConfiguratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configure($name, array $options, array $metadata, FormConfigInterface $parentConfig): array
+    {
+        if (isset($metadata['expanded'])) {
+            $options['value_type_options']['expanded'] = $metadata['expanded'];
+        }
+        if (isset($metadata['multiple'])) {
+            $options['value_type_options']['multiple'] = $metadata['multiple'];
+        }
+        if (isset($metadata['choices'])) {
+            $options['value_type_options']['choices'] = $metadata['choices'];
+        }
+
+        return $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports($type, array $options, array $metadata): bool
+    {
+        return \in_array($type, ['easyadmin.filter.type.choice', ChoiceFilterType::class], true);
+    }
+}

--- a/src/Form/Filter/Type/DateTimeFilterType.php
+++ b/src/Form/Filter/Type/DateTimeFilterType.php
@@ -25,7 +25,7 @@ class DateTimeFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->get('value')->addModelTransformer(new CallbackTransformer(
             static function ($data) { return $data; },
@@ -48,7 +48,7 @@ class DateTimeFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'comparison_type_options' => ['type' => 'datetime'],
@@ -62,7 +62,7 @@ class DateTimeFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ComparisonFilterType::class;
     }

--- a/src/Form/Filter/Type/EntityFilterType.php
+++ b/src/Form/Filter/Type/EntityFilterType.php
@@ -7,8 +7,6 @@ use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-use Symfony\Component\Form\CallbackTransformer;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -18,38 +16,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class EntityFilterType extends FilterType
 {
     use FilterTypeTrait;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options)
-    {
-        $multiple = $builder->get('value')->getOption('multiple');
-
-        $builder->addModelTransformer(new CallbackTransformer(
-            static function ($data) { return $data; },
-            static function ($data) use ($multiple) {
-                switch ($data['comparison']) {
-                    case ComparisonType::EQ:
-                        if (null === $data['value'] || ($multiple && 0 === \count($data['value']))) {
-                            $data['comparison'] = 'IS NULL';
-                        } else {
-                            $data['comparison'] = $multiple ? 'IN' : '=';
-                        }
-                        break;
-                    case ComparisonType::NEQ:
-                        if (null === $data['value'] || ($multiple && 0 === \count($data['value']))) {
-                            $data['comparison'] = 'IS NOT NULL';
-                        } else {
-                            $data['comparison'] = $multiple ? 'NOT IN' : '!=';
-                        }
-                        break;
-                }
-
-                return $data;
-            }
-        ));
-    }
 
     /**
      * {@inheritdoc}
@@ -67,7 +33,7 @@ class EntityFilterType extends FilterType
      */
     public function getParent(): string
     {
-        return ComparisonFilterType::class;
+        return ChoiceFilterType::class;
     }
 
     /**

--- a/src/Form/Filter/Type/FilterTypeTrait.php
+++ b/src/Form/Filter/Type/FilterTypeTrait.php
@@ -2,6 +2,9 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type;
 
+use Doctrine\ORM\QueryBuilder;
+use Symfony\Component\Form\FormInterface;
+
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
@@ -15,5 +18,19 @@ trait FilterTypeTrait
     protected static function createAlias(string $name): string
     {
         return \str_replace('.', '_', $name).'_'.++static::$uniqueAliasId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function filter(QueryBuilder $queryBuilder, FormInterface $form, array $metadata)
+    {
+        $alias = \current($queryBuilder->getRootAliases());
+        $property = $metadata['property'];
+        $paramName = static::createAlias($property);
+        $value = $form->getData();
+
+        $queryBuilder->andWhere(\sprintf('%s.%s = :%s', $alias, $property, $paramName))
+            ->setParameter($paramName, $value);
     }
 }

--- a/src/Form/Filter/Type/TextFilterType.php
+++ b/src/Form/Filter/Type/TextFilterType.php
@@ -24,7 +24,7 @@ class TextFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->addModelTransformer(new CallbackTransformer(
             static function ($data) { return $data; },
@@ -51,7 +51,7 @@ class TextFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'comparison_type_options' => ['type' => 'text'],
@@ -62,7 +62,7 @@ class TextFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): string
     {
         return ComparisonFilterType::class;
     }

--- a/src/Form/Type/ComparisonType.php
+++ b/src/Form/Type/ComparisonType.php
@@ -70,6 +70,7 @@ class ComparisonType extends AbstractType
                             'filter.label.not_contains' => self::NOT_CONTAINS,
                         ];
                         break;
+                    case 'choice':
                     case 'entity':
                         $choices = [
                             'filter.label.is_same' => self::EQ,
@@ -83,7 +84,7 @@ class ComparisonType extends AbstractType
             'translation_domain' => 'EasyAdminBundle',
         ]);
         $resolver->setAllowedTypes('type', 'string');
-        $resolver->setAllowedValues('type', ['array', 'datetime', 'entity', 'numeric', 'text']);
+        $resolver->setAllowedValues('type', ['array', 'datetime', 'choice', 'entity', 'numeric', 'text']);
     }
 
     /**

--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -50,6 +50,11 @@
             <tag name="easyadmin.form.type.configurator" priority="50" />
         </service>
 
+        <service id="easyadmin.filter.type.configurator.choice"
+                 class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\Configurator\ChoiceFilterTypeConfigurator">
+            <tag name="easyadmin.form.type.configurator" priority="0" />
+        </service>
+
         <service id="easyadmin.form.type.configurator.textarea" public="false"
                  class="EasyCorp\Bundle\EasyAdminBundle\Form\Type\Configurator\TextareaTypeConfigurator">
             <tag name="easyadmin.form.type.configurator" priority="40" />
@@ -153,6 +158,10 @@
                 <argument key="input">string</argument>
             </argument>
             <tag name="easyadmin.filter.type" alias="decimal" />
+        </service>
+
+        <service id="easyadmin.filter.type.choice" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ChoiceFilterType">
+            <tag name="easyadmin.filter.type" alias="choice" />
         </service>
 
         <service id="easyadmin.filter.type.entity" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\EntityFilterType">

--- a/tests/Form/Filter/Type/ChoiceFilterTypeTest.php
+++ b/tests/Form/Filter/Type/ChoiceFilterTypeTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Filter\Type;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\Query\Parameter;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ChoiceFilterType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
+
+class ChoiceFilterTypeTest extends FilterTypeTest
+{
+    protected const FILTER_TYPE = ChoiceFilterType::class;
+
+    /**
+     * @dataProvider getDataProvider
+     */
+    public function testSubmitAndFilter($submittedData, $data, array $options, string $dql, array $params)
+    {
+        $form = $this->factory->create(static::FILTER_TYPE, null, $options);
+        $form->submit($submittedData);
+        $this->assertSame($data, $form->getData());
+        $this->assertSame($submittedData, $form->getViewData());
+        $this->assertEmpty($form->getExtraData());
+        $this->assertTrue($form->isSynchronized());
+
+        $filter = $this->filterRegistry->resolveType($form);
+        $filter->filter($this->qb, $form, ['property' => 'foo']);
+        $this->assertSame(static::FILTER_TYPE, \get_class($filter));
+        $this->assertSame($dql, $this->qb->getDQL());
+        $this->assertEquals($params, $this->qb->getParameters()->toArray());
+    }
+
+    public function getDataProvider(): iterable
+    {
+        yield [
+            ['comparison' => ComparisonType::EQ, 'value' => null],
+            ['comparison' => 'IS NULL', 'value' => null],
+            [
+                'value_type_options' => [
+                    'choices' => ['a', 'b', 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo IS NULL',
+            [],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::NEQ, 'value' => null],
+            ['comparison' => 'IS NOT NULL', 'value' => null],
+            [
+                'value_type_options' => [
+                    'choices' => ['a', 'b', 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo IS NOT NULL',
+            [],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::EQ, 'value' => 'a'],
+            ['comparison' => '=', 'value' => 'a'],
+            [
+                'value_type_options' => [
+                    'choices' => ['a', 'b', 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo = (:foo_1)',
+            [new Parameter('foo_1', 'a', \PDO::PARAM_STR)],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::NEQ, 'value' => 'b'],
+            ['comparison' => '!=', 'value' => 'b'],
+            [
+                'value_type_options' => [
+                    'choices' => ['a', 'b', 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo != (:foo_1) OR o.foo IS NULL',
+            [new Parameter('foo_1', 'b', \PDO::PARAM_STR)],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::EQ, 'value' => []],
+            ['comparison' => 'IS NULL', 'value' => []],
+            [
+                'value_type_options' => [
+                    'multiple' => true,
+                    'choices' => ['a', 'b', 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo IS NULL',
+            [],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::NEQ, 'value' => []],
+            ['comparison' => 'IS NOT NULL', 'value' => []],
+            [
+                'value_type_options' => [
+                    'multiple' => true,
+                    'choices' => ['a', 'b', 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo IS NOT NULL',
+            [],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::EQ, 'value' => ['a', 'b']],
+            ['comparison' => 'IN', 'value' => ['a', 'b']],
+            [
+                'value_type_options' => [
+                    'multiple' => true,
+                    'choices' => ['a', 'b', 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo IN (:foo_1)',
+            [new Parameter('foo_1', ['a', 'b'], Connection::PARAM_STR_ARRAY)],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::NEQ, 'value' => ['b', 'c']],
+            ['comparison' => 'NOT IN', 'value' => ['b', 'c']],
+            [
+                'value_type_options' => [
+                    'multiple' => true,
+                    'choices' => ['a', 'b', 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo NOT IN (:foo_1)',
+            [new Parameter('foo_1', ['b', 'c'], Connection::PARAM_STR_ARRAY)],
+        ];
+    }
+}

--- a/tests/Form/Filter/Type/DateTimeFilterTypeTest.php
+++ b/tests/Form/Filter/Type/DateTimeFilterTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Filter\Type;
 
-use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Query\Parameter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\DateTimeFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
@@ -14,47 +14,20 @@ class DateTimeFilterTypeTest extends FilterTypeTest
     /**
      * @dataProvider getDataProvider
      */
-    public function testSubmit($submittedData, $data, $options)
+    public function testSubmitAndFilter($submittedData, $data, $options, string $dql, array $params)
     {
         $form = $this->factory->create(DateTimeFilterType::class, null, $options);
         $form->submit($submittedData);
-
         $this->assertEquals($data, $form->getData());
         $this->assertEquals($data, $form->getViewData());
         $this->assertEmpty($form->getExtraData());
         $this->assertTrue($form->isSynchronized());
-    }
-
-    /**
-     * @dataProvider getDataProvider
-     */
-    public function testFilter($submittedData, $data, $options)
-    {
-        $qb = $this->getMockBuilder(QueryBuilder::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $qb->expects($this->once())
-            ->method('getRootAliases')
-            ->willReturn(['o'])
-        ;
-        $qb->expects($this->once())
-            ->method('andWhere')
-            ->with(\sprintf('o.foo %s :foo_1', $data['comparison']))
-            ->willReturn($qb)
-        ;
-        $qb->expects($this->once())
-            ->method('setParameter')
-            ->with('foo_1', $data['value'])
-        ;
-
-        $form = $this->factory->create(DateTimeFilterType::class, null, $options);
-        $form->submit($submittedData);
 
         $filter = $this->filterRegistry->resolveType($form);
+        $filter->filter($this->qb, $form, ['property' => 'foo']);
         $this->assertSame(ComparisonFilterType::class, \get_class($filter));
-
-        $filter->filter($qb, $form, ['property' => 'foo']);
+        $this->assertSame($dql, $this->qb->getDQL());
+        $this->assertEquals($params, $this->qb->getParameters()->toArray());
     }
 
     public function getDataProvider(): iterable
@@ -63,18 +36,24 @@ class DateTimeFilterTypeTest extends FilterTypeTest
             ['comparison' => ComparisonType::EQ, 'value' => '2019-06-17 14:39:00'],
             ['comparison' => '=', 'value' => new \DateTime('2019-06-17 14:39:00')],
             [],
+            'SELECT o FROM Object o WHERE o.foo = :foo_1',
+            [new Parameter('foo_1', new \DateTime('2019-06-17 14:39:00'), 'datetime')],
         ];
 
         yield [
             ['comparison' => ComparisonType::GT, 'value' => '2019-06-17 14:39:00'],
             ['comparison' => '>', 'value' => '2019-06-17'],
             ['value_type' => DateType::class],
+            'SELECT o FROM Object o WHERE o.foo > :foo_1',
+            [new Parameter('foo_1', '2019-06-17', \PDO::PARAM_STR)],
         ];
 
         yield [
             ['comparison' => ComparisonType::LTE, 'value' => '14:39'],
             ['comparison' => '<=', 'value' => '14:39:00'],
             ['value_type' => TimeType::class],
+            'SELECT o FROM Object o WHERE o.foo <= :foo_1',
+            [new Parameter('foo_1', '14:39:00', \PDO::PARAM_STR)],
         ];
     }
 }

--- a/tests/Form/Filter/Type/FilterTypeTest.php
+++ b/tests/Form/Filter/Type/FilterTypeTest.php
@@ -2,24 +2,40 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Filter\Type;
 
+use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\FilterRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType;
+use Symfony\Bridge\Doctrine\Test\DoctrineTestHelper;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 abstract class FilterTypeTest extends TypeTestCase
 {
+    protected const FILTER_TYPE = ComparisonFilterType::class;
+
     /** @var FilterRegistry */
     protected $filterRegistry;
+    /** @var QueryBuilder */
+    protected $qb;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         // reset counter (only for test purpose)
-        $m = new \ReflectionProperty(ComparisonFilterType::class, 'uniqueAliasId');
+        $m = new \ReflectionProperty(static::FILTER_TYPE, 'uniqueAliasId');
         $m->setAccessible(true);
         $m->setValue(0);
 
         $this->filterRegistry = new FilterRegistry([], []);
+        $this->qb = $this->createQueryBuilder();
+    }
+
+    protected function createQueryBuilder(): QueryBuilder
+    {
+        $em = DoctrineTestHelper::createTestEntityManager();
+        $qb = new QueryBuilder($em);
+        $qb->select('o')->from('Object', 'o');
+
+        return $qb;
     }
 }

--- a/tests/Form/Filter/Type/TextFilterTypeTest.php
+++ b/tests/Form/Filter/Type/TextFilterTypeTest.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Filter\Type;
 
-use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Query\Parameter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\TextFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
@@ -12,47 +12,20 @@ class TextFilterTypeTest extends FilterTypeTest
     /**
      * @dataProvider getDataProvider
      */
-    public function testSubmit($submittedData, $data)
+    public function testSubmitAndFilter($submittedData, $data, string $dql, array $params)
     {
         $form = $this->factory->create(TextFilterType::class);
         $form->submit($submittedData);
-
         $this->assertSame($data, $form->getData());
         $this->assertSame($submittedData, $form->getViewData());
         $this->assertEmpty($form->getExtraData());
         $this->assertTrue($form->isSynchronized());
-    }
-
-    /**
-     * @dataProvider getDataProvider
-     */
-    public function testFilter($submittedData, $data)
-    {
-        $qb = $this->getMockBuilder(QueryBuilder::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-        $qb->expects($this->once())
-            ->method('getRootAliases')
-            ->willReturn(['o'])
-        ;
-        $qb->expects($this->once())
-            ->method('andWhere')
-            ->with(\sprintf('o.foo %s :foo_1', $data['comparison']))
-            ->willReturn($qb)
-        ;
-        $qb->expects($this->once())
-            ->method('setParameter')
-            ->with('foo_1', $data['value'])
-        ;
-
-        $form = $this->factory->create(TextFilterType::class);
-        $form->submit($submittedData);
 
         $filter = $this->filterRegistry->resolveType($form);
+        $filter->filter($this->qb, $form, ['property' => 'foo']);
         $this->assertSame(ComparisonFilterType::class, \get_class($filter));
-
-        $filter->filter($qb, $form, ['property' => 'foo']);
+        $this->assertSame($dql, $this->qb->getDQL());
+        $this->assertEquals($params, $this->qb->getParameters()->toArray());
     }
 
     public function getDataProvider(): iterable
@@ -60,31 +33,43 @@ class TextFilterTypeTest extends FilterTypeTest
         yield [
             ['comparison' => ComparisonType::CONTAINS, 'value' => 'abc'],
             ['comparison' => 'like', 'value' => '%abc%'],
+            'SELECT o FROM Object o WHERE o.foo like :foo_1',
+            [new Parameter('foo_1', '%abc%', \PDO::PARAM_STR)],
         ];
 
         yield [
             ['comparison' => ComparisonType::NOT_CONTAINS, 'value' => 'abc'],
             ['comparison' => 'not like', 'value' => '%abc%'],
+            'SELECT o FROM Object o WHERE o.foo not like :foo_1',
+            [new Parameter('foo_1', '%abc%', \PDO::PARAM_STR)],
         ];
 
         yield [
             ['comparison' => ComparisonType::STARTS_WITH, 'value' => 'abc'],
             ['comparison' => 'like', 'value' => 'abc%'],
+            'SELECT o FROM Object o WHERE o.foo like :foo_1',
+            [new Parameter('foo_1', 'abc%', \PDO::PARAM_STR)],
         ];
 
         yield [
             ['comparison' => ComparisonType::ENDS_WITH, 'value' => 'abc'],
             ['comparison' => 'like', 'value' => '%abc'],
+            'SELECT o FROM Object o WHERE o.foo like :foo_1',
+            [new Parameter('foo_1', '%abc', \PDO::PARAM_STR)],
         ];
 
         yield [
             ['comparison' => ComparisonType::EQ, 'value' => 'abc'],
             ['comparison' => '=', 'value' => 'abc'],
+            'SELECT o FROM Object o WHERE o.foo = :foo_1',
+            [new Parameter('foo_1', 'abc', \PDO::PARAM_STR)],
         ];
 
         yield [
             ['comparison' => ComparisonType::NEQ, 'value' => 'abc'],
             ['comparison' => '!=', 'value' => 'abc'],
+            'SELECT o FROM Object o WHERE o.foo != :foo_1',
+            [new Parameter('foo_1', 'abc', \PDO::PARAM_STR)],
         ];
     }
 }


### PR DESCRIPTION
closes #2798
closes #2797

Example via YAML config:
```yaml
easy_admin:
    entities:
        BlogPost:
            # ...
            list:
                filters:
                    - property: 'status'
                      type: choice
                      type_options:
                          value_type_options:
                              multiple: false # true for multiple selection
                              choices:
                                  'Draf': 'DRAFT'
                                  'Pending': 'PENDING'
                                  'Published': 'PUBLISHED'
```