### PR TITLE
Allow to define the form type help message using the type_options config

### DIFF
--- a/doc/book/edit-new-configuration.rst
+++ b/doc/book/edit-new-configuration.rst
@@ -360,7 +360,8 @@ These are the options that you can define for each field:
   form field. The default label is the "humanized" version of the property name
   (e.g. ``published`` is displayed as ``Published`` and ``dateOfBirth`` as
   ``Date of birth``).
-* ``help`` (optional): the help message displayed below the form field.
+* ``help`` (optional): the help message displayed below the form field. You can
+  also define this value via the ``type_options: { help: '...' }`` option.
 * ``css_class`` (optional): the CSS class applied to the parent HTML element
   that contains the entire form field. For example, when using the default
   Bootstrap form theme, this value is applied to the ``<div>`` element which

--- a/src/Configuration/PropertyConfigPass.php
+++ b/src/Configuration/PropertyConfigPass.php
@@ -197,6 +197,17 @@ class PropertyConfigPass implements ConfigPassInterface
                         $normalizedConfig['type_options'] = $this->getFormTypeOptionsOfProperty(
                             $normalizedConfig, $fieldMetadata, $originalFieldConfig
                         );
+
+                        // EasyAdmin defined a 'help' option before Symfony did the same for form types
+                        // Consider the two of them equivalent and copy the 'type_options.help' into 'help'
+                        // to ease further processing of config
+                        if (isset($fieldConfig['help']) && isset($normalizedConfig['type_options']['help'])) {
+                            throw new \RuntimeException(sprintf('The "%s" property in the "%s" view of the "%s" entity defines a help message using both the "help: ..." option from EasyAdmin and the "type_options: { help: ... }" option from Symfony. Remove one of these two help messages.', $normalizedConfig['property'], $view, $entityName));
+                        }
+
+                        if (isset($normalizedConfig['type_options']['help']) && !isset($fieldConfig['help'])) {
+                            $normalizedConfig['help'] = $normalizedConfig['type_options']['help'];
+                        }
                     }
 
                     // special case for the 'list' view: 'boolean' properties are displayed

--- a/src/Configuration/PropertyConfigPass.php
+++ b/src/Configuration/PropertyConfigPass.php
@@ -199,10 +199,10 @@ class PropertyConfigPass implements ConfigPassInterface
                         );
 
                         // EasyAdmin defined a 'help' option before Symfony did the same for form types
-                        // Consider the two of them equivalent and copy the 'type_options.help' into 'help'
+                        // Consider both of them equivalent and copy the 'type_options.help' into 'help'
                         // to ease further processing of config
                         if (isset($fieldConfig['help']) && isset($normalizedConfig['type_options']['help'])) {
-                            throw new \RuntimeException(sprintf('The "%s" property in the "%s" view of the "%s" entity defines a help message using both the "help: ..." option from EasyAdmin and the "type_options: { help: ... }" option from Symfony. Remove one of these two help messages.', $normalizedConfig['property'], $view, $entityName));
+                            throw new \RuntimeException(sprintf('The "%s" property in the "%s" view of the "%s" entity defines a help message using both the "help: ..." option from EasyAdmin and the "type_options: { help: ... }" option from Symfony Forms. These two options are equivalent, but you can only define one of them at the same time. Remove one of these two help messages.', $normalizedConfig['property'], $view, $entityName));
                         }
 
                         if (isset($normalizedConfig['type_options']['help']) && !isset($fieldConfig['help'])) {


### PR DESCRIPTION
This fixes #2795.