### PR TITLE
Fix for collection widget

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -39,6 +39,14 @@
                 parentDiv.data('count', ++numItems)
             }
 
+            var counterForRegenerateId = 0;
+
+            $(parentDiv.children('div.form-group')).each(function (i, item) {
+                $('input', item)[0].name = $('input', item)[0].name.replace(/(.+)\[(\d+)\]/, '$1[' + counterForRegenerateId + ']');
+                $('input', item)[0].id = $('input', item)[0].id.replace(/(.+)_(\d+)/, '$1_' + counterForRegenerateId);
+                counterForRegenerateId++;
+            });
+
             if (0 == parentDiv.children().length && 'undefined' !== parentDiv.attr('data-empty-collection')) {
                 $(parentDiv.attr('data-empty-collection')).insertBefore(parentDiv);
             }


### PR DESCRIPTION
When clicking the delete button of collection item widget, its deleting the item but not regenerating the ids.

![Screen Shot 2019-07-01 at 11 50 44](https://user-images.githubusercontent.com/7759682/60424391-e48ab100-9bf8-11e9-8e6d-67f1c6fe3ea4.png)

For this example, if i delete the "b", result will be like that:

![Screen Shot 2019-07-01 at 11 52 09](https://user-images.githubusercontent.com/7759682/60424576-4cd99280-9bf9-11e9-9acc-04a65e7983e5.png)

![Screen Shot 2019-07-01 at 12 11 28](https://user-images.githubusercontent.com/7759682/60424608-5ebb3580-9bf9-11e9-80dc-d49822534eaa.png)

So, it should be like that:

![Screen Shot 2019-07-01 at 12 12 47](https://user-images.githubusercontent.com/7759682/60424692-90340100-9bf9-11e9-904b-04d14858d6cf.png)

This pr is fixing this problem.