### PR TITLE
Add new NumericFilterType and support for between comparison

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -489,6 +489,12 @@ trait AdminControllerTrait
                 continue;
             }
 
+            // if the form filter is not valid then
+            // we should not apply the filter
+            if (!$filterForm->isValid()) {
+                continue;
+            }
+
             // resolve the filter type related to this form field
             $filterType = $filterRegistry->resolveType($filterForm);
 

--- a/src/Form/Filter/Guesser/DoctrineOrmFilterTypeGuesser.php
+++ b/src/Form/Filter/Guesser/DoctrineOrmFilterTypeGuesser.php
@@ -9,12 +9,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\BooleanFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\DateTimeFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\EntityFilterType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\NumericFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\TextFilterType;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser;
 use Symfony\Component\Form\Extension\Core\Type\DateIntervalType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\Guess\Guess;
@@ -93,15 +93,15 @@ class DoctrineOrmFilterTypeGuesser extends DoctrineOrmTypeGuesser
                 return new TypeGuess(DateTimeFilterType::class, self::$defaultOptions + ['value_type' => TimeType::class, 'value_type_options' => ['input' => 'datetime_immutable']], Guess::HIGH_CONFIDENCE);
 
             case Type::DECIMAL:
-                return new TypeGuess(ComparisonFilterType::class, self::$defaultOptions + ['value_type' => NumberType::class, 'value_type_options' => ['input' => 'string']], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess(NumericFilterType::class, self::$defaultOptions + ['value_type_options' => ['input' => 'string']], Guess::MEDIUM_CONFIDENCE);
 
             case Type::FLOAT:
-                return new TypeGuess(ComparisonFilterType::class, self::$defaultOptions + ['value_type' => NumberType::class], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess(NumericFilterType::class, self::$defaultOptions, Guess::MEDIUM_CONFIDENCE);
 
             case Type::BIGINT:
             case Type::INTEGER:
             case Type::SMALLINT:
-                return new TypeGuess(ComparisonFilterType::class, self::$defaultOptions + ['value_type' => IntegerType::class], Guess::MEDIUM_CONFIDENCE);
+                return new TypeGuess(NumericFilterType::class, self::$defaultOptions + ['value_type' => IntegerType::class], Guess::MEDIUM_CONFIDENCE);
 
             case Type::GUID:
             case Type::STRING:

--- a/src/Form/Filter/Type/ComparisonFilterType.php
+++ b/src/Form/Filter/Type/ComparisonFilterType.php
@@ -53,6 +53,7 @@ class ComparisonFilterType extends FilterType
             'comparison_type' => $this->comparisonType,
             'comparison_type_options' => $this->comparisonTypeOptions,
             'value_type_options' => $this->valueTypeOptions,
+            'error_bubbling' => false,
         ]);
         $resolver->setAllowedTypes('comparison_type', 'string');
         $resolver->setAllowedTypes('comparison_type_options', 'array');

--- a/src/Form/Type/ComparisonType.php
+++ b/src/Form/Type/ComparisonType.php
@@ -18,6 +18,7 @@ class ComparisonType extends AbstractType
     public const GTE = '>=';
     public const LT = '<';
     public const LTE = '<=';
+    public const BETWEEN = 'between';
     public const CONTAINS = 'like';
     public const NOT_CONTAINS = 'not like';
     public const STARTS_WITH = 'like*';
@@ -42,6 +43,7 @@ class ComparisonType extends AbstractType
                             'filter.label.is_greater_than_or_equal_to' => self::GTE,
                             'filter.label.is_less_than' => self::LT,
                             'filter.label.is_less_than_or_equal_to' => self::LTE,
+                            'filter.label.is_between' => self::BETWEEN,
                         ];
                         break;
                     case 'text':
@@ -62,6 +64,7 @@ class ComparisonType extends AbstractType
                             'filter.label.is_after_or_same' => self::GTE,
                             'filter.label.is_before' => self::LT,
                             'filter.label.is_before_or_same' => self::LTE,
+                            'filter.label.is_between' => self::BETWEEN,
                         ];
                         break;
                     case 'array':

--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -152,7 +152,7 @@
             <tag name="easyadmin.filter.type" alias="datetime" />
         </service>
 
-        <service id="easyadmin.filter.type.decimal" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType">
+        <service id="easyadmin.filter.type.decimal" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\NumericFilterType">
             <argument type="string">Symfony\Component\Form\Extension\Core\Type\NumberType</argument>
             <argument type="collection">
                 <argument key="input">string</argument>
@@ -168,12 +168,11 @@
             <tag name="easyadmin.filter.type" alias="entity" />
         </service>
 
-        <service id="easyadmin.filter.type.float" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType">
-            <argument type="string">Symfony\Component\Form\Extension\Core\Type\NumberType</argument>
+        <service id="easyadmin.filter.type.float" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\NumericFilterType">
             <tag name="easyadmin.filter.type" alias="float" />
         </service>
 
-        <service id="easyadmin.filter.type.integer" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType">
+        <service id="easyadmin.filter.type.integer" class="EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\NumericFilterType">
             <argument type="string">Symfony\Component\Form\Extension\Core\Type\IntegerType</argument>
             <tag name="easyadmin.filter.type" alias="integer" />
         </service>

--- a/src/Resources/translations/EasyAdminBundle.en.xlf
+++ b/src/Resources/translations/EasyAdminBundle.en.xlf
@@ -241,6 +241,10 @@
                 <source>filter.label.is_less_than_or_equal_to</source>
                 <target>is less than or equal to</target>
             </trans-unit>
+            <trans-unit id="filter.label.is_between">
+                <source>filter.label.is_between</source>
+                <target>is between</target>
+            </trans-unit>
             <trans-unit id="filter.label.contains">
                 <source>filter.label.contains</source>
                 <target>contains</target>

--- a/src/Resources/translations/EasyAdminBundle.es.xlf
+++ b/src/Resources/translations/EasyAdminBundle.es.xlf
@@ -229,6 +229,10 @@
                 <source>filter.label.is_less_than_or_equal_to</source>
                 <target>es menor o igual que</target>
             </trans-unit>
+            <trans-unit id="filter.label.is_between">
+                <source>filter.label.is_between</source>
+                <target>está entre</target>
+            </trans-unit>
             <trans-unit id="filter.label.contains">
                 <source>filter.label.contains</source>
                 <target>contiene</target>

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -578,3 +578,24 @@
 
     {{ include('@EasyAdmin/default/includes/_select2_widget.html.twig') }}
 {% endblock easyadmin_filters_widget %}
+
+{% block easyadmin_numeric_filter_widget %}
+    <div class="form-widget-compound">
+        {{ form_row(form.comparison) }}
+        {{ form_row(form.value) }}
+        <div id="wrapper_{{ form.value2.vars.id }}" {% if form.comparison.vars.value != 'between' %}style="display: none"{% endif %}>
+            {{ form_row(form.value2) }}
+        </div>
+        <script>
+            document.querySelector('#{{ form.comparison.vars.id }}').addEventListener('change', function(event) {
+                const input = document.querySelector('#wrapper_{{ form.value2.vars.id }}');
+                input.style.display = event.currentTarget.value === 'between' ? '' : 'none';
+            });
+        </script>
+    </div>
+    {{- form_errors(form) -}}
+{% endblock  easyadmin_numeric_filter_widget %}
+
+{% block easyadmin_datetime_filter_widget %}
+    {{ block('easyadmin_numeric_filter_widget') }}
+{% endblock  easyadmin_datetime_filter_widget %}

--- a/tests/Configuration/fixtures/configurations/output/config_178.yml
+++ b/tests/Configuration/fixtures/configurations/output/config_178.yml
@@ -3,4 +3,4 @@ easy_admin:
         Category:
             class: AppTestBundle\Entity\UnitTests\Category
             list:
-                filters: { 'id': { property: 'id', type: 'EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType' } }
+                filters: { 'id': { property: 'id', type: 'EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\NumericFilterType' } }

--- a/tests/Form/Filter/Type/DateTimeFilterTypeTest.php
+++ b/tests/Form/Filter/Type/DateTimeFilterTypeTest.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Filter\Type;
 
 use Doctrine\ORM\Query\Parameter;
-use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\ComparisonFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\DateTimeFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
@@ -11,49 +10,86 @@ use Symfony\Component\Form\Extension\Core\Type\TimeType;
 
 class DateTimeFilterTypeTest extends FilterTypeTest
 {
+    protected const FILTER_TYPE = DateTimeFilterType::class;
+
     /**
      * @dataProvider getDataProvider
      */
-    public function testSubmitAndFilter($submittedData, $data, $options, string $dql, array $params)
+    public function testSubmitAndFilter($submittedData, $data, $options, string $dql, array $params, string $expectedError = '')
     {
-        $form = $this->factory->create(DateTimeFilterType::class, null, $options);
+        $form = $this->factory->create(static::FILTER_TYPE, null, $options);
         $form->submit($submittedData);
-        $this->assertEquals($data, $form->getData());
-        $this->assertEquals($data, $form->getViewData());
-        $this->assertEmpty($form->getExtraData());
-        $this->assertTrue($form->isSynchronized());
+        $this->assertTrue($form->isSubmitted());
+        if ($form->isValid()) {
+            $this->assertEquals($data, $form->getData());
+            $this->assertEmpty($form->getExtraData());
+            $this->assertTrue($form->isSynchronized());
 
-        $filter = $this->filterRegistry->resolveType($form);
-        $filter->filter($this->qb, $form, ['property' => 'foo']);
-        $this->assertSame(ComparisonFilterType::class, \get_class($filter));
-        $this->assertSame($dql, $this->qb->getDQL());
-        $this->assertEquals($params, $this->qb->getParameters()->toArray());
+            $filter = $this->filterRegistry->resolveType($form);
+            $filter->filter($this->qb, $form, ['property' => 'foo']);
+            $this->assertSame(static::FILTER_TYPE, \get_class($filter));
+            $this->assertSame($dql, $this->qb->getDQL());
+            $this->assertEquals($params, $this->qb->getParameters()->toArray());
+        } else {
+            $this->assertSame($expectedError, $form->getTransformationFailure()->getMessage());
+        }
     }
 
     public function getDataProvider(): iterable
     {
         yield [
-            ['comparison' => ComparisonType::EQ, 'value' => '2019-06-17 14:39:00'],
-            ['comparison' => '=', 'value' => new \DateTime('2019-06-17 14:39:00')],
+            ['comparison' => ComparisonType::EQ, 'value' => '2019-06-17 14:39:00', 'value2' => null],
+            ['comparison' => '=', 'value' => new \DateTime('2019-06-17 14:39:00'), 'value2' => null],
             [],
             'SELECT o FROM Object o WHERE o.foo = :foo_1',
             [new Parameter('foo_1', new \DateTime('2019-06-17 14:39:00'), 'datetime')],
         ];
 
         yield [
-            ['comparison' => ComparisonType::GT, 'value' => '2019-06-17 14:39:00'],
-            ['comparison' => '>', 'value' => '2019-06-17'],
+            ['comparison' => ComparisonType::GT, 'value' => '2019-06-17 14:39:00', 'value2' => null],
+            ['comparison' => '>', 'value' => '2019-06-17', 'value2' => null],
             ['value_type' => DateType::class],
             'SELECT o FROM Object o WHERE o.foo > :foo_1',
             [new Parameter('foo_1', '2019-06-17', \PDO::PARAM_STR)],
         ];
 
         yield [
-            ['comparison' => ComparisonType::LTE, 'value' => '14:39'],
-            ['comparison' => '<=', 'value' => '14:39:00'],
+            ['comparison' => ComparisonType::LTE, 'value' => '14:39', 'value2' => null],
+            ['comparison' => '<=', 'value' => '14:39:00', 'value2' => null],
             ['value_type' => TimeType::class],
             'SELECT o FROM Object o WHERE o.foo <= :foo_1',
             [new Parameter('foo_1', '14:39:00', \PDO::PARAM_STR)],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::BETWEEN, 'value' => '14:39', 'value2' => '15:00'],
+            ['comparison' => 'between', 'value' => '14:39:00', 'value2' => '15:00:00'],
+            ['value_type' => TimeType::class],
+            'SELECT o FROM Object o WHERE o.foo BETWEEN :foo_1 and :foo_2',
+            [
+                new Parameter('foo_1', '14:39:00', \PDO::PARAM_STR),
+                new Parameter('foo_2', '15:00:00', \PDO::PARAM_STR),
+            ],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::BETWEEN, 'value' => '15:00', 'value2' => '14:39'],
+            ['comparison' => 'between', 'value' => '14:39:00', 'value2' => '15:00:00'],
+            ['value_type' => TimeType::class],
+            'SELECT o FROM Object o WHERE o.foo BETWEEN :foo_1 and :foo_2',
+            [
+                new Parameter('foo_1', '14:39:00', \PDO::PARAM_STR),
+                new Parameter('foo_2', '15:00:00', \PDO::PARAM_STR),
+            ],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::BETWEEN, 'value' => '15:00', 'value2' => null],
+            ['comparison' => 'between', 'value' => '15:00:00', 'value2' => null],
+            ['value_type' => TimeType::class],
+            '',
+            [],
+            'Unable to reverse value for property path "easyadmin_datetime_filter": Two values must be provided when "BETWEEN" comparison is selected.',
         ];
     }
 }

--- a/tests/Form/Filter/Type/NumericFilterTypeTest.php
+++ b/tests/Form/Filter/Type/NumericFilterTypeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Filter\Type;
+
+use Doctrine\ORM\Query\Parameter;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\NumericFilterType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+
+class NumericFilterTypeTest extends FilterTypeTest
+{
+    protected const FILTER_TYPE = NumericFilterType::class;
+
+    /**
+     * @dataProvider getDataProvider
+     */
+    public function testSubmitAndFilter($submittedData, $data, $options, string $dql, array $params, string $expectedError = '')
+    {
+        $form = $this->factory->create(static::FILTER_TYPE, null, $options);
+        $form->submit($submittedData);
+        $this->assertTrue($form->isSubmitted());
+        if ($form->isValid()) {
+            $this->assertEquals($data, $form->getData());
+            $this->assertEmpty($form->getExtraData());
+            $this->assertTrue($form->isSynchronized());
+
+            $filter = $this->filterRegistry->resolveType($form);
+            $filter->filter($this->qb, $form, ['property' => 'foo']);
+            $this->assertSame(static::FILTER_TYPE, \get_class($filter));
+            $this->assertSame($dql, $this->qb->getDQL());
+            $this->assertEquals($params, $this->qb->getParameters()->toArray());
+        } else {
+            $this->assertSame($expectedError, $form->getTransformationFailure()->getMessage());
+        }
+    }
+
+    public function getDataProvider(): iterable
+    {
+        yield [
+            ['comparison' => ComparisonType::EQ, 'value' => '23', 'value2' => null],
+            ['comparison' => '=', 'value' => 23, 'value2' => null],
+            ['value_type' => IntegerType::class],
+            'SELECT o FROM Object o WHERE o.foo = :foo_1',
+            [new Parameter('foo_1', 23, 'integer')],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::GT, 'value' => '23.23', 'value2' => null],
+            ['comparison' => '>', 'value' => 23.23, 'value2' => null],
+            [],
+            'SELECT o FROM Object o WHERE o.foo > :foo_1',
+            [new Parameter('foo_1', 23.23, \PDO::PARAM_STR)],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::BETWEEN, 'value' => '23', 'value2' => '32'],
+            ['comparison' => 'between', 'value' => '23', 'value2' => '32'],
+            ['value_type' => IntegerType::class],
+            'SELECT o FROM Object o WHERE o.foo BETWEEN :foo_1 and :foo_2',
+            [
+                new Parameter('foo_1', 23, 'integer'),
+                new Parameter('foo_2', 32, 'integer'),
+            ],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::BETWEEN, 'value' => '32', 'value2' => '23'],
+            ['comparison' => 'between', 'value' => '23', 'value2' => '32'],
+            ['value_type' => IntegerType::class],
+            'SELECT o FROM Object o WHERE o.foo BETWEEN :foo_1 and :foo_2',
+            [
+                new Parameter('foo_1', 23, 'integer'),
+                new Parameter('foo_2', 32, 'integer'),
+            ],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::BETWEEN, 'value' => '23.32', 'value2' => null],
+            ['comparison' => 'between', 'value' => '23.32', 'value2' => null],
+            [],
+            '',
+            [],
+            'Unable to reverse value for property path "easyadmin_numeric_filter": Two values must be provided when "BETWEEN" comparison is selected.',
+        ];
+    }
+}


### PR DESCRIPTION
![between-comparison](https://user-images.githubusercontent.com/2028198/60454196-3b948400-9c01-11e9-9eb9-62d664531229.gif)

NumericFilterType: default to `decimal`, `float` or `integer` field types.
Added support for `BETWEEN` comparison in `NumericFilterType` and `DateTimeFilterType`.
