### PR TITLE
Fix text_editor and code_editor HTML input name

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -478,7 +478,7 @@
 
 {# EasyAdmin's CodeEditor form type #}
 {% block easyadmin_code_editor_widget %}
-    <textarea id="{{ id }}" name="{{ name }}" data-easyadmin-code-editor data-language="{{ language }}" data-tab-size="{{ tabSize }}" data-indent-with-tabs="{{ indentWithTabs ? 'true' : 'false' }}" data-js-url="{{ asset("bundles/easyadmin/form-type-code-editor.js") }}" data-css-url="{{ asset("bundles/easyadmin/form-type-code-editor.css") }}">{{ data }}</textarea>
+    <textarea id="{{ id }}" name="{{ full_name }}" data-easyadmin-code-editor data-language="{{ language }}" data-tab-size="{{ tabSize }}" data-indent-with-tabs="{{ indentWithTabs ? 'true' : 'false' }}" data-js-url="{{ asset("bundles/easyadmin/form-type-code-editor.js") }}" data-css-url="{{ asset("bundles/easyadmin/form-type-code-editor.css") }}">{{ data }}</textarea>
 
     {% if height is not null %}
         <style type="text/css">
@@ -489,7 +489,7 @@
 
 {# EasyAdmin's TextEditor form type #}
 {% block easyadmin_text_editor_widget %}
-    <input id="{{ id }}" value="{{ data }}" type="hidden" name="{{ name }}">
+    <input id="{{ id }}" value="{{ data }}" type="hidden" name="{{ full_name }}">
     <div class="easyadmin-text-editor-wrapper">
         <trix-editor input="{{ id }}" data-js-url="{{ asset("bundles/easyadmin/form-type-text-editor.js") }}" data-css-url="{{ asset("bundles/easyadmin/form-type-text-editor.css") }}"></trix-editor>
     </div>


### PR DESCRIPTION
Fixes #2811

For single forms without parent, the variable `name` is equal to `full_name` (e.g. `description`), but for compound forms `full_name` will contain also the name of the parent form (e.g. `product[description]`).