### PR TITLE
fix(translations): fix French filters translations

### DIFF
--- a/src/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/src/Resources/translations/EasyAdminBundle.fr.xlf
@@ -267,11 +267,11 @@
             </trans-unit>
             <trans-unit id="filter.label.is_same">
                 <source>filter.label.is_same</source>
-                <target>est le</target>
+                <target>est</target>
             </trans-unit>
             <trans-unit id="filter.label.is_not_same">
                 <source>filter.label.is_not_same</source>
-                <target>n'est pas le</target>
+                <target>n'est pas</target>
             </trans-unit>
             <trans-unit id="filter.label.is_after">
                 <source>filter.label.is_after</source>


### PR DESCRIPTION
As I said in https://github.com/EasyCorp/EasyAdminBundle/pull/2780, the translations for `filter.label.is_same` and `filter.label.is_not_same` were made for dates only.

I just started to use the new filters system (❤️ @yceruto) but I found out those two translations are also used for entities filter. "le" needs to be removed for clarity.