### PR TITLE
feat(filters): only add placeholder for entity type if at least one join column is nullable

### DIFF
--- a/src/Form/Filter/Guesser/DoctrineOrmFilterTypeGuesser.php
+++ b/src/Form/Filter/Guesser/DoctrineOrmFilterTypeGuesser.php
@@ -50,7 +50,12 @@ class DoctrineOrmFilterTypeGuesser extends DoctrineOrmTypeGuesser
                 'multiple' => $multiple,
                 'attr' => ['data-widget' => 'select2'],
             ]];
-            if ($metadata->isSingleValuedAssociation($property)) {
+            // If all join columns are not nullable, the placeholder does not
+            // need to be displayed since an empty filter value would always
+            // returns no result.
+            if ($metadata->isSingleValuedAssociation($property) && \count($mapping['joinColumns']) !== \count(\array_filter($mapping['joinColumns'], function (array $joinColumnMapping): bool {
+                return false === $joinColumnMapping['nullable'] ?? false;
+            }))) {
                 $options['value_type_options']['placeholder'] = 'label.form.empty_value';
             }
 


### PR DESCRIPTION
Considering the following entities : 

```php
class EntityA
{
	
}

class EntityB
{
    /**
     * @ORM\ManyToOne(targetEntity="EntityA")
     * @ORM\JoinColumn(nullable=false)
     */
    private $entityA;
}
```

With this filters configuration for the `EntityB` entity :
```yaml
filters:
    - { label: 'foo', property: 'entityA' } # filter type is guessed
```

When the filter is displayed, the placeholder is still added, thus proposing an invalid "empty value" choice to the final user while the association is mandatory (not nullable). By invalid, I mean that submitting the filter with the "empty value" selected will always return no result.

If all join columns of an association are not nullable, we does not need to add the `placeholder` option.

Currently, the workaround is to do this in the filter configuration :
```yaml
filters:
    - { label: 'foo', property: 'entityA', type: 'entity', type_options: { value_type_options: { class: 'EntityA' } } }
```