### PR TITLE
[Doc] Fix override template property type

### DIFF
--- a/doc/tutorials/custom-property-options.rst
+++ b/doc/tutorials/custom-property-options.rst
@@ -70,14 +70,12 @@ and ``domain`` options:
 .. code-block:: twig
 
     {# templates/bundles/EasyAdminBundle/default/field_string.html.twig #}
-    {% extends '@!EasyAdminBundle/default/field_string.html.twig' %}
-
     {% if field_options.trans|default(false) %}
         {# translate fields defined as "translatable" #}
         {{ value|trans({}, field_options.domain|default('messages')) }}
     {% else %}
         {# if not translatable, simply include the default template #}
-        {{ parent() }}
+        {{ include('@!EasyAdmin/default/field_string.html.twig') }}
     {% endif %}
 
 If the custom logic is too complex, it may be better to render the property with


### PR DESCRIPTION
Hi Javier,

A little type on documentation to override field template. Maybe block was defined on v1, I don't know. But on v2, we must to include directly the parent template to keep default template behavior.
