### PR TITLE
fix(composer): remove symfony/cache-contracts dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "pagerfanta/pagerfanta": "~1.0,>=1.0.1|~2.0",
         "symfony/asset": "^4.2",
         "symfony/cache": "^4.2",
-        "symfony/cache-contracts": "^1.1",
         "symfony/config": "^4.2",
         "symfony/dependency-injection": "^4.2",
         "symfony/doctrine-bridge": "^4.2",


### PR DESCRIPTION
Requiring `symfony/cache-contracts` is useless since `symfony/contracts` is already required by our lowest supported `symfony/cache` version.

I have checked that our lowest supported `symfony/contracts` version (so through `symfony/cache`) already includes the only interface (`CacheInterface`) we use in EasyAdmin, so it should makes no difference.

Fixing this because requiring it triggers warning on composer autoload dump : 
<img width="987" alt="Screen Shot 2019-07-05 at 12 19 49" src="https://user-images.githubusercontent.com/3658119/60716309-53307d00-9f1f-11e9-81f6-ec55c266715e.png">