### PR TITLE
feat(theme): add id to collections buttons add and remove

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -47,7 +47,7 @@
 
         <div class="field-collection-item-row">
             <div class="field-collection-item-action">
-                <a href="#" onclick="{{ remove_item_javascript|raw }}; return false;" class="text-danger" title="{{ 'action.remove_item'|trans({}, 'EasyAdminBundle') }}">
+                <a id="easyadmin-remove-collection-item-{{ form.vars.id }}" href="#" onclick="{{ remove_item_javascript|raw }}; return false;" class="text-danger" title="{{ 'action.remove_item'|trans({}, 'EasyAdminBundle') }}">
                     <i class="fa fa-fw fa-window-close"></i>
                 </a>
             </div>
@@ -104,7 +104,7 @@
         {% endset %}
 
         <div class="text-right field-collection-item-action">
-            <a href="#" onclick="{{ remove_item_javascript|raw }}" class="text-danger">
+            <a id="easyadmin-remove-collection-item-{{ form.vars.id }}" href="#" onclick="{{ remove_item_javascript|raw }}" class="text-danger">
                 <i class="fa fa-fw fa-remove"></i>
                 {{ 'action.remove_item'|trans({}, 'EasyAdminBundle') }}
             </a>
@@ -177,7 +177,7 @@
 
         <div class="form-group field-collection-action">
             <div class="form-widget">
-                <a href="#" onclick="{{ js_add_item|raw }}; return false;" class="btn btn-secondary btn-sm">
+                <a id="easyadmin-add-collection-item-{{ form.vars.id }}" href="#" onclick="{{ js_add_item|raw }}; return false;" class="btn btn-secondary btn-sm">
                     <i class="fa fa-fw fa-plus"></i>
                     <span class="btn-label">{{ (form|length == 0 ? 'action.add_new_item' : 'action.add_another_item')|trans({}, 'EasyAdminBundle') }}</span>
                 </a>


### PR DESCRIPTION
When you are testing an EasyAdmin project with end-to-end tests that support JavaScript (with Symfony Panther in my case), it's not easy to simulate click on collections "add" and "remove" buttons because nothing particular identify them.

That means I have to rely on the order of fields of my form instead of their ids for example.

Current selectors in one of my form for an "add" button :
`#new-question-form > div > div:nth-child(3) > fieldset > div > div > div.form-group.field-collection-action > div > a`

With this change :
`#easyadmin-add-question_steps`