### PR TITLE
Minor fix in the design of exception pages

### DIFF
--- a/src/Resources/views/default/exception.html.twig
+++ b/src/Resources/views/default/exception.html.twig
@@ -3,7 +3,8 @@
 {% block body_class 'error' %}
 {% block page_title %}{{ 'errors'|transchoice(1, {}, 'EasyAdminBundle') }}{% endblock %}
 
-{% block content_header '' %}
+{% block content_header_wrapper '' %}
+{% block content_footer_wrapper '' %}
 {% block main %}
     <div class="error-message">
         <h1><i class="fa fa-fw fa-exclamation-circle"></i> {{ block('page_title') }}</h1>


### PR DESCRIPTION
Very minor tweak. Before:

![image](https://user-images.githubusercontent.com/73419/60766825-6a9e7000-a0af-11e9-8f0a-1e408aa26364.png)

After:

![image](https://user-images.githubusercontent.com/73419/60766828-6d00ca00-a0af-11e9-97e1-a56304907102.png)

We now correctly remove the empty header/footer content.