### PR TITLE
Don't hardcode the --color-primary CSS variable when unneeded

### DIFF
--- a/doc/book/configuration-reference.rst
+++ b/doc/book/configuration-reference.rst
@@ -240,7 +240,7 @@ visual design of the backend.
 brand_color
 ~~~~~~~~~~~
 
-(**default value**: ``'#E67E22'``, **type**: string, **values**: any valid CSS
+(**default value**: ``'hsl(230, 55%, 60%)'``, **type**: string, **values**: any valid CSS
 expression to define a color)
 
 This is the color used to highlight important elements of the backend, such as
@@ -255,6 +255,13 @@ to create a backend that matches your branding perfectly. Example:
             # any valid CSS color syntax can be used
             # brand_color: 'rgba(59, 89, 152, 0.5)'
         # ...
+
+.. seealso::
+
+    This option is useful when the only design change you want to make is to
+    update the main color of the interface. However, if you start changing more
+    design elements, it's better to unset this option and use CSS variables as
+    explained :ref:`in this section <customizing-the-backend-design>`.
 
 form_theme
 ~~~~~~~~~~

--- a/doc/book/design-configuration.rst
+++ b/doc/book/design-configuration.rst
@@ -42,6 +42,13 @@ backend interface:
             # if the color includes a '%', you must double it to escape it in the YAML file
             brand_color: 'hsl(0, 100%%, 50%%);'
 
+.. seealso::
+
+    This option is useful when the only design change you want to make is to
+    update the main color of the interface. However, if you start changing more
+    design elements, it's better to unset this option and use CSS variables as
+    explained :ref:`in this section <customizing-the-backend-design>`.
+
 Adding Custom Web Assets
 ------------------------
 
@@ -158,6 +165,8 @@ Bootstrap feature not included by default.
 Given that the performance gain was minimal, this idea was abandoned and,
 starting from EasyAdmin 2.2.2 the entire Boostrap CSS and JavaScript code is
 loaded by default in all pages.
+
+.. _customizing-the-backend-design:
 
 Customizing the Backend Design
 ------------------------------

--- a/src/Resources/views/default/layout.html.twig
+++ b/src/Resources/views/default/layout.html.twig
@@ -17,9 +17,11 @@
             <link rel="stylesheet" href="{{ asset(css_asset) }}">
         {% endfor %}
 
+        {% if easyadmin_config('design.brand_color') != 'hsl(230, 55%, 60%)' %}
         <style>
             :root { --color-primary: {{ easyadmin_config('design.brand_color') }}; }
         </style>
+        {% endif %}
 
         {% block head_favicon %}
             {% set favicon = easyadmin_config('design.assets.favicon') %}

--- a/tests/Controller/DefaultBackendTest.php
+++ b/tests/Controller/DefaultBackendTest.php
@@ -100,7 +100,11 @@ class DefaultBackendTest extends AbstractTestCase
     {
         $this->getBackendHomepage();
 
-        $this->assertContains('--color-primary: hsl(230, 55%, 60%);', static::$client->getResponse()->getContent(), 'The HTML content includes the value of the default brand color.');
+        // if users define the design.brand_color option, define the --color-primary CSS variable in the
+        // HTML layout to override any other values of the same variable. Otherwise, don't define the
+        // variable in the layout because it's already defined in variables.css and that's simpler to
+        // override for designers.
+        $this->assertNotContains('--color-primary: hsl(230, 55%, 60%);', static::$client->getResponse()->getContent(), 'The --color-primary CSS variable is not hardcoded in the HTML when its value is undefined or the default one.');
     }
 
     public function testListViewTitle()


### PR DESCRIPTION
This fixes #2818.

This doesn't change anything for most people. However, it makes it easier to override the design of the interface.

When `design.brand_color` option has its default value, we no longer hardcode it in the layout HTML, so you can easily override it using CSS variables in your own CSS files.