### PR TITLE
[Doc] Fixed the table of contents of a chapter

### DIFF
--- a/doc/book/edit-new-configuration.rst
+++ b/doc/book/edit-new-configuration.rst
@@ -560,7 +560,7 @@ change this value (globally or per entity):
         # ...
 
 Code Editor
------------
+~~~~~~~~~~~
 
 It displays a JavaScript-based editor for source code. It provides advanced
 features such as code highlighting and smart indenting.
@@ -612,7 +612,7 @@ This type defines the following configuration options:
 .. _form-type-text-editor:
 
 Text Editor
------------
+~~~~~~~~~~~
 
 It displays a JavaScript-based WYSIWYG text editor based on the popular
 `Trix editor`_. You don't need to install any external dependencies because


### PR DESCRIPTION
The TOC was wrong. All form types should be at the same level:

![image](https://user-images.githubusercontent.com/73419/61149122-ac308000-a4e0-11e9-91da-ec11e7a3ef37.png)
