### PR TITLE
Support for "required" tag attribute in EasyAdminAutocompleteType

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -490,6 +490,7 @@
 {% block easyadmin_autocomplete_widget %}
     {{ form_widget(form.autocomplete, {
         attr: attr|merge({
+            'required': required,
             'data-easyadmin-autocomplete-url' : path('easyadmin', {
                 action: 'autocomplete',
                 entity: autocomplete_entity_name,


### PR DESCRIPTION
I'm not sure this is the right solution, but autocomplete fields do not have their "required" attribute set when the entity field is not nullable (input label is flagged with the red-dot, but form validation on submit ignores the input value). With this change it seems to work as intended.