### PR TITLE
Including TrixEditor styles into the editor preview

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -521,7 +521,7 @@
 {% block easyadmin_text_editor_widget %}
     {{ form_widget(form, { attr: attr|merge({ 'style': 'display: none' }) }) }}
     <div class="easyadmin-text-editor-wrapper">
-        <trix-editor input="{{ id }}" data-js-url="{{ asset("bundles/easyadmin/form-type-text-editor.js") }}" data-css-url="{{ asset("bundles/easyadmin/form-type-text-editor.css") }}"></trix-editor>
+        <trix-editor input="{{ id }}" class="trix-content" data-js-url="{{ asset("bundles/easyadmin/form-type-text-editor.js") }}" data-css-url="{{ asset("bundles/easyadmin/form-type-text-editor.css") }}"></trix-editor>
     </div>
 {% endblock easyadmin_text_editor_widget %}
 


### PR DESCRIPTION
As stated in the Trix README (https://github.com/basecamp/trix#styling-formatted-content) omitting the `.trix-content` class causes the editor preview to miss proper styling.

I noticed this trying to achieve the same "gallery" alignment as in https://trix-editor.org: on EasyAdmin it looks like you can't arrange attachments side-by-side, but the markup is fine.

Those styles include: 

> bulleted and numbered lists, code blocks, and block quotes