### PR TITLE
Supporting Doctrine Lifecycle Events in batch delete action (fixes #2881)

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -444,16 +444,16 @@ trait AdminControllerTrait
     protected function deleteBatchAction(array $ids): void
     {
         $class = $this->entity['class'];
+        $primaryKey = $this->entity['primary_key_field_name'];
 
-        $this->getDoctrine()->getManagerForClass($class)
-            ->createQueryBuilder()
-            ->delete()
-            ->from($class, 'entity')
-            ->where(sprintf('entity.%s IN (:ids)', $this->entity['primary_key_field_name']))
-            ->setParameter('ids', $ids)
-            ->getQuery()
-            ->execute()
-        ;
+        $entities = $this->em->getRepository($class)
+            ->findBy([$primaryKey => $ids]);
+
+        foreach ($entities as $entity) {
+            $this->em->remove($entity);
+        }
+
+        $this->em->flush();
     }
 
     /**


### PR DESCRIPTION
This PR is a fix suggested by @lorenx in #2881.

### Bug explanation
At the moment the `AdminControllerTrait::deleteBatchAction()` method uses a custom query builder to delete all entities at once. This works, but custom queries bypass Doctrine's [Lifecycle events](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/events.html#lifecycle-events) so no event is fired on batch deletion.

The new implementation makes a single `SELECT` query to fetch all objects, but then runs the `remove()` method for each object to fire proper events.

### How to test
On any project with batch actions enabled, update your entity as follows:

```php
<?php

namespace App\Entity;

use Doctrine\ORM\Mapping as ORM;

/**
 * ...
 * @ORM\HasLifecycleCallbacks
 */
class AnyEntity
{
   // ...

    /** @ORM\PostRemove */
    public function doStuffOnPostRemove()
    {
        dd('PostRemove event!');
    }
}
```

Removing an object should now fail in any circumstance dumping `PostRemove event!`.