### PR TITLE
Supporting multiple tab groups in form validation (fixes #2882)

### DIFF
--- a/src/Resources/views/default/edit.html.twig
+++ b/src/Resources/views/default/edit.html.twig
@@ -79,7 +79,7 @@
 
                 let firstNavTabItemWithError = null;
 
-                formTabPanes.forEach(function (tabPane, tabIndex) {
+                formTabPanes.forEach(function (tabPane) {
                     let tabPaneNumErrors = 0;
                     tabPane.querySelectorAll(inputFieldsSelector).forEach(function (input) {
                         if (!input.validity.valid) {
@@ -87,7 +87,7 @@
                         }
                     });
 
-                    let navTabItem = entityForm.querySelector('.nav-item:nth-child(' + (tabIndex + 1) + ') a');
+                    let navTabItem = entityForm.querySelector('.nav-item a[href="#' + tabPane.id + '"]');
                     let existingErrorBadge = navTabItem.querySelector('span.badge.badge-danger');
                     if (null !== existingErrorBadge) {
                         navTabItem.removeChild(existingErrorBadge);

--- a/src/Resources/views/default/new.html.twig
+++ b/src/Resources/views/default/new.html.twig
@@ -67,7 +67,7 @@
 
                 let firstNavTabItemWithError = null;
 
-                formTabPanes.forEach(function (tabPane, tabIndex) {
+                formTabPanes.forEach(function (tabPane) {
                     let tabPaneNumErrors = 0;
                     tabPane.querySelectorAll(inputFieldsSelector).forEach(function (input) {
                         if (!input.validity.valid) {
@@ -75,7 +75,7 @@
                         }
                     });
 
-                    let navTabItem = entityForm.querySelector('.nav-item:nth-child(' + (tabIndex + 1) + ') a');
+                    let navTabItem = entityForm.querySelector('.nav-item a[href="#' + tabPane.id + '"]');
                     let existingErrorBadge = navTabItem.querySelector('span.badge.badge-danger');
                     if (null !== existingErrorBadge) {
                         navTabItem.removeChild(existingErrorBadge);


### PR DESCRIPTION
This PR is a fix by @lorenx and me (discussed in #2882).

### Bug description
Live demo: https://codepen.io/Liarco/pen/QeOoxv?editors=1011

The demo shows _(on console)_ how the following code
```js
let navTabItem = entityForm.querySelector('.nav-item:nth-child(' + (tabIndex + 1) + ') a');
```
fails when there are multiple tab groups in the same page. The reason is that `tabIndex` is an absolute index while `.nav-item:nth-child(...) a` accepts an index relative to each `.nav.nav-tabs`.

Using
```js
let navTabItem = entityForm.querySelector('.nav-item a[href="#' + tabPane.id + '"]');
```
should work with any number of tab groups. This new selector also relies the way Bootstrap works (tabs and tab-panes are matched by _href -> element id_) and not on elements order. I think that this may be safer in complex form structures.

I've tested this PR on **Chrome**, **Firefox**, **Safari** and **Opera** (on macOS).

### References
- [Attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors#Browser_compatibility) are compatible with all major browsers