### PR TITLE
Filter translation fix

### DIFF
--- a/src/Resources/translations/EasyAdminBundle.ar.xlf
+++ b/src/Resources/translations/EasyAdminBundle.ar.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>لا يوجد وصف الوصول لهذه الخاصية أو أنها ليست عامة.</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>لا شيء</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.ca.xlf
+++ b/src/Resources/translations/EasyAdminBundle.ca.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Aquest camp no té un mètode "getter" o la propietat associada no és pública</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Ningú</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.cs.xlf
+++ b/src/Resources/translations/EasyAdminBundle.cs.xlf
@@ -95,6 +95,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Getter metoda pro toto pole neexistuje nebo není veřejná (public)</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Prázdné</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.da.xlf
+++ b/src/Resources/translations/EasyAdminBundle.da.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Der findes ingen getter metode for dette felt eller også er det ikke et tilgængeligt felt</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Ingen</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.de.xlf
+++ b/src/Resources/translations/EasyAdminBundle.de.xlf
@@ -95,6 +95,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Es gibt keine Getter-Methode für diese Eigenschaft oder die Eigenschaft ist nicht public.</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>kein Wert</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.el.xlf
+++ b/src/Resources/translations/EasyAdminBundle.el.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Δεν υπάρχει μέθοδος ανάγνωσης (getter) για αυτό το πεδίο ή η ιδιότητα αυτή δεν είναι προσβάσιμη</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Καμία</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.es.xlf
+++ b/src/Resources/translations/EasyAdminBundle.es.xlf
@@ -95,6 +95,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Este campo no tiene un método getter o la propiedad asociada no es pública</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Ninguno</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">
@@ -237,8 +241,8 @@
                 <source>filter.label.contains</source>
                 <target>contiene</target>
             </trans-unit>
-            <trans-unit id="filter.filter.label.not_contains">
-                <source>filter.filter.label.not_contains</source>
+            <trans-unit id="filter.label.not_contains">
+                <source>filter.label.not_contains</source>
                 <target>no contiene</target>
             </trans-unit>
             <trans-unit id="filter.label.starts_with">

--- a/src/Resources/translations/EasyAdminBundle.fa.xlf
+++ b/src/Resources/translations/EasyAdminBundle.fa.xlf
@@ -91,6 +91,11 @@
                 <source>label.inaccessible.explanation</source>
                 <target>متد Getter برای این فیلد موجود نیست و یا Property عمومی تعریف نشده است</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>هیچ</target>
+            </trans-unit>
+
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.fi.xlf
+++ b/src/Resources/translations/EasyAdminBundle.fi.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Arvo ei ole julkinen, tai sille ei ole asetettu get-metodia</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Ei mitään</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.gl.xlf
+++ b/src/Resources/translations/EasyAdminBundle.gl.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Este campo non ten ningún método getter ou a propiedade asociada non é publica</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Ningún</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.hr.xlf
+++ b/src/Resources/translations/EasyAdminBundle.hr.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Getter metoda ne postoji za ovo polje ili vrijednost svojstva nije javna</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Prazno</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.hu.xlf
+++ b/src/Resources/translations/EasyAdminBundle.hu.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>A getter metódus nem létezik ehhez a mezőhöz vagy a tulajdonság nem publikus.</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Nincs</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.it.xlf
+++ b/src/Resources/translations/EasyAdminBundle.it.xlf
@@ -95,6 +95,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Il metodo getter non esiste per questo campo o la proprietà non è pubblica</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Nessun valore</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.lt.xlf
+++ b/src/Resources/translations/EasyAdminBundle.lt.xlf
@@ -95,6 +95,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Getter metodas neegzistuoja šiame lauke arba nuosavybė nėra vieša</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Nenurodyta</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.pl.xlf
+++ b/src/Resources/translations/EasyAdminBundle.pl.xlf
@@ -95,6 +95,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target><![CDATA[Metoda pobierająca (<i>ang. getter</i>) nie istnieje  dla tego pola lub właściwość (<i>ang. property</i>) nie jest publiczna]]></target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Pusta wartość</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.pt.xlf
+++ b/src/Resources/translations/EasyAdminBundle.pt.xlf
@@ -95,6 +95,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Não existe um método getter para esse campo ou a propriedade não é pública</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Nenhum</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.ro.xlf
+++ b/src/Resources/translations/EasyAdminBundle.ro.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Metoda de tip Get nu există pentru acest câmp sau proprietatea nu e publică</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Gol</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.ru.xlf
+++ b/src/Resources/translations/EasyAdminBundle.ru.xlf
@@ -95,6 +95,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Нет геттера для этого поля или свойство не общедоступно</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Пусто</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.sl.xlf
+++ b/src/Resources/translations/EasyAdminBundle.sl.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Getter metoda ne obstaja za to polje ali pa lastnost ni javna</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Noben</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.sr_RS.xlf
+++ b/src/Resources/translations/EasyAdminBundle.sr_RS.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Getter metoda ne postoji za ovo polje ili je nedostupna</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Prazno</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.uk.xlf
+++ b/src/Resources/translations/EasyAdminBundle.uk.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>Немає геттера для цього поля або поле не публічне</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>Пусто</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">

--- a/src/Resources/translations/EasyAdminBundle.zh_CN.xlf
+++ b/src/Resources/translations/EasyAdminBundle.zh_CN.xlf
@@ -91,6 +91,10 @@
                 <source>label.inaccessible.explanation</source>
                 <target>该字段的Getter方法缺失或该字段不是公共属性</target>
             </trans-unit>
+            <trans-unit id="label.form.empty_value">
+                <source>label.form.empty_value</source>
+                <target>空</target>
+            </trans-unit>
 
             <!-- user -->
             <trans-unit id="user.logged_in_as">


### PR DESCRIPTION
Simple filters feature translation fixes.

* Fixed `label.form.empty_value` missing in many languages. https://github.com/EasyCorp/EasyAdminBundle/issues/2891#issuecomment-520940897
* Fixed typo key for `filter.label.not_contains` in spanish.