### PR TITLE
Add form_theme_only config option

### DIFF
--- a/doc/book/configuration-reference.rst
+++ b/doc/book/configuration-reference.rst
@@ -24,6 +24,7 @@ config key:
 
   * `brand_color`_
   * `form_theme`_
+  * `form_theme_only`_
 * `assets`_
 
   * `css`_
@@ -270,7 +271,7 @@ form_theme
 **values**: any valid form theme template path)
 
 The form theme used to render the form fields in the ``edit`` and ``new`` views.
-By default forms use the design created by EasyAdmin, buy you can use your own
+By default forms use the design created by EasyAdmin, but you can use your own
 form themes and the default Symfony form theme for Bootstrap 4 too:
 
 .. code-block:: yaml
@@ -285,6 +286,15 @@ form themes and the default Symfony form theme for Bootstrap 4 too:
 
             # using EasyAdmin theme and your own custom theme
             form_theme: ['@EasyAdmin/form/bootstrap_4.html.twig', '@App/custom_form_theme.html.twig']
+
+form_theme_only
+~~~~~~~~~~~~~~~
+
+(**default value**: ``false``, **type**: boolean)
+
+If set to ``true``, only the form themes defined for this bundle will be used
+to render the forms. This is especially useful when you don't want your global
+Twig form themes interfering with your admin forms.
 
 assets
 ~~~~~~

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -156,6 +156,12 @@ class Configuration implements ConfigurationInterface
                             ->validate()->castToArray()->end()
                         ->end()
 
+                        ->booleanNode('form_theme_only')
+                            ->defaultValue(false)
+                            ->treatNullLike(false)
+                            ->info('If true, global Twig form themes will not be used.')
+                        ->end()
+
                         ->arrayNode('assets')
                             ->addDefaultsIfNotSet()
                             ->children()

--- a/src/Resources/views/default/edit.html.twig
+++ b/src/Resources/views/default/edit.html.twig
@@ -1,4 +1,8 @@
-{% form_theme form with easyadmin_config('design.form_theme') %}
+{% if easyadmin_config('design.form_theme_only') %}
+    {% form_theme form with easyadmin_config('design.form_theme') only %}
+{% else %}
+    {% form_theme form with easyadmin_config('design.form_theme') %}
+{% endif %}
 
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
 {% set _entity_id = attribute(entity, _entity_config.primary_key_field_name) %}

--- a/src/Resources/views/default/filters.html.twig
+++ b/src/Resources/views/default/filters.html.twig
@@ -1,4 +1,8 @@
-{% form_theme filters_form with easyadmin_config('design.form_theme') %}
+{% if easyadmin_config('design.form_theme_only') %}
+    {% form_theme filters_form with easyadmin_config('design.form_theme') only %}
+{% else %}
+    {% form_theme filters_form with easyadmin_config('design.form_theme') %}
+{% endif %}
 
 {{ form_start(filters_form, { attr: {'id': filters_form.vars.id} }) }}
     {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -111,7 +111,11 @@
 {% block batch_actions %}
     {% if _has_batch_actions %}
         <div class="batch-actions" style="display: none">
-            {% form_theme batch_form with easyadmin_config('design.form_theme') %}
+            {% if easyadmin_config('design.form_theme_only') %}
+                {% form_theme batch_form with easyadmin_config('design.form_theme') only %}
+            {% else %}
+                {% form_theme batch_form with easyadmin_config('design.form_theme') %}
+            {% endif %}
             {{ form(batch_form) }}
         </div>
     {% endif %}

--- a/src/Resources/views/default/new.html.twig
+++ b/src/Resources/views/default/new.html.twig
@@ -1,4 +1,8 @@
-{% form_theme form with easyadmin_config('design.form_theme') %}
+{% if easyadmin_config('design.form_theme_only') %}
+    {% form_theme form with easyadmin_config('design.form_theme') only %}
+{% else %}
+    {% form_theme form with easyadmin_config('design.form_theme') %}
+{% endif %}
 
 {% set _entity_config = easyadmin_entity(app.request.query.get('entity')) %}
 {% trans_default_domain _entity_config.translation_domain %}


### PR DESCRIPTION
I just had an issue on a project where a form template defined for my site broke something in admin. Basically, whenever your global form theme has a block that is of a higher priority and not explicitly defined in the admin theme, admin will render that block using the global theme. In my case, the block was `checkbox_row`, but that could happen for a ton of other blocks as well.

The only way around this is to have an option which disables the global forms, so that's what I added.

As a temporary workaround, I had to copy the whole edit and new templates with the `only` keyword added. I couldn't just extend the original ones, because the form themes carry on to the extended template, so it had no effect.