### PR TITLE
Make list.html.twig work with older versions of Twig

### DIFF
--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -126,7 +126,7 @@
 {% endblock content_header %}
 
 {% block main %}
-    {% set _fields_visible_by_user = fields|filter((metadata, field) => easyadmin_is_granted(metadata.permission)) %}
+    {% set _fields_visible_by_user = fields|filter((metadata, field) => easyadmin_is_granted(metadata.permission))|slice(0) %}
     {% set _number_of_hidden_results = 0 %}
     {% set _list_item_actions = easyadmin_get_actions_for_list_item(_entity_config.name) %}
 

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -126,7 +126,7 @@
 {% endblock content_header %}
 
 {% block main %}
-    {% set _fields_visible_by_user = fields|filter((metadata, field) => easyadmin_is_granted(metadata.permission))|slice(0) %}
+    {% set _fields_visible_by_user = fields|filter((metadata, field) => easyadmin_is_granted(metadata.permission))|slice(0, null, true) %}
     {% set _number_of_hidden_results = 0 %}
     {% set _list_item_actions = easyadmin_get_actions_for_list_item(_entity_config.name) %}
 


### PR DESCRIPTION
2 of the 4 CI jobs were failing because of a twig issue that was fixed a couple of months ago: https://github.com/twigphp/Twig/issues/3063

list.html.twig throws this error to the crawler:
`An exception has been thrown during the rendering of a template ("Cannot traverse an already closed generator").`

The issue mentioned above is tripped by using the object `_fields_visible_by_user` more than once in the template.

I worked around it by filtering the output of `filter()` through `slice(0, null, true)` which basically calls `iterator_to_array()` on the generator and then doesn't slice anything off the array it gets.

A proper and permanent solution might be to remove all `filter()` uses and not use them until the minimum required version of Twig is the fixed one.