### PR TITLE
Make EasyAdmin 1.x incompatible with Symfony 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
         "symfony/var-dumper": "~2.3|~3.0|^4.0",
         "symfony/yaml": "~2.3|~3.0|^4.0"
     },
+    "conflict": {
+        "symfony/http-kernel": ">=5.0"
+    },
     "config": {
         "sort-packages": true
     },


### PR DESCRIPTION
EasyAdmin 1.x will be frozen soon and won't be compatible with Symfony 5.x.

Should we add this conflict to composer.json to be 100% sure that won't be installed in a 5.x app? Should we add more conflicts? Thanks!