### PR TITLE
json pretty print

### DIFF
--- a/src/Resources/views/default/field_json.html.twig
+++ b/src/Resources/views/default/field_json.html.twig
@@ -1,10 +1,10 @@
 {% if view == 'show' %}
     {% if value|length > 0 %}
-        <ul>
-            {% for element in value %}
-                <li>{{ element }}</li>
-            {% endfor %}
-        </ul>
+        <div class="large code">
+            <textarea readonly class="form-control">
+                {{ value|json_encode(constant('JSON_PRETTY_PRINT'))|trim }}
+            </textarea>
+        </div>
     {% else %}
         <div class="empty collection-empty">
             {{ include(entity_config.templates.label_empty) }}

--- a/src/Resources/views/default/field_json_array.html.twig
+++ b/src/Resources/views/default/field_json_array.html.twig
@@ -1,10 +1,10 @@
 {% if view == 'show' %}
     {% if value|length > 0 %}
-        <ul>
-            {% for element in value %}
-                <li>{{ element }}</li>
-            {% endfor %}
-        </ul>
+        <div class="large code">
+            <textarea readonly class="form-control">
+                {{ value|json_encode(constant('JSON_PRETTY_PRINT'))|trim }}
+            </textarea>
+        </div>
     {% else %}
         <div class="empty collection-empty">
             {{ include(entity_config.templates.label_empty) }}


### PR DESCRIPTION
When field is json/or json_array it's possible that it will be nested.
So you will get "Array to string conversion" notice

To handle it, we can use `JSON_PRETTY_PRINT` starting from 5.4 (that's way pointing to master)