### PR TITLE
added permission checks to twig methods that display actions buttons …

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -338,7 +338,8 @@ class EasyAdminTwigExtension extends AbstractExtension
             $entityConfig = $this->configManager->getEntityConfig($entityName);
         } catch (\Exception $e) {
             return false;
-    }
+        }
+        
         $isGranted = (!isset($entityConfig[$action]) || !isset($entityConfig[$action]['item_permission']) || $this->isGranted($entityConfig[$action]['item_permission']));
         return $this->configManager->isActionEnabled($entityName, $view, $action) && $isGranted;
     }

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -324,6 +324,7 @@ class EasyAdminTwigExtension extends AbstractExtension
 
     /**
      * Checks whether the given 'action' is enabled for the given 'entity'.
+     * Also checks if the current user is granted access to this 'action'.
      *
      * @param string $view
      * @param string $action
@@ -333,7 +334,13 @@ class EasyAdminTwigExtension extends AbstractExtension
      */
     public function isActionEnabled($view, $action, $entityName)
     {
-        return $this->configManager->isActionEnabled($entityName, $view, $action);
+        try {
+            $entityConfig = $this->configManager->getEntityConfig($entityName);
+        } catch (\Exception $e) {
+            return false;
+    }
+        $isGranted = (!isset($entityConfig[$action]) || !isset($entityConfig[$action]['item_permission']) || $this->isGranted($entityConfig[$action]['item_permission']));
+        return $this->configManager->isActionEnabled($entityName, $view, $action) && $isGranted;
     }
 
     /**
@@ -354,6 +361,8 @@ class EasyAdminTwigExtension extends AbstractExtension
      * Returns the actions configured for each item displayed in the given view.
      * This method is needed because some actions are displayed globally for the
      * entire view (e.g. 'new' action in 'list' view).
+     * Checks if the current user is granted access to each 'action'.
+     * Forbidden actions will not be returned.
      *
      * @param string $view
      * @param string $entityName
@@ -379,8 +388,10 @@ class EasyAdminTwigExtension extends AbstractExtension
         ];
         $excludedActions = $actionsExcludedForItems[$view];
 
-        return array_filter($viewActions, function ($action) use ($excludedActions, $disabledActions) {
-            return !\in_array($action['name'], $excludedActions) && !\in_array($action['name'], $disabledActions);
+        return array_filter($viewActions, function ($action) use ($excludedActions, $disabledActions, $entityConfig) {
+            return !\in_array($action['name'], $excludedActions)
+                && !\in_array($action['name'], $disabledActions)
+                && (!isset($entityConfig[$action['name']]) || !isset($entityConfig[$action['name']]['item_permission']) || $this->isGranted($entityConfig[$action['name']]['item_permission']));
         });
     }
 

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -339,8 +339,9 @@ class EasyAdminTwigExtension extends AbstractExtension
         } catch (\Exception $e) {
             return false;
         }
-        
+
         $isGranted = (!isset($entityConfig[$action]) || !isset($entityConfig[$action]['item_permission']) || $this->isGranted($entityConfig[$action]['item_permission']));
+
         return $this->configManager->isActionEnabled($entityName, $view, $action) && $isGranted;
     }
 


### PR DESCRIPTION
Partially addresses #2902 

> everywhere we display action's buttons (thanks to easyadmin_get_actions_for_{action]_item()), only display reachable actions

For each action, if permissions are configured, calls isGranted to check if the current user has access. Works for 'global' actions (displayed in header) and 'list' actions.