### PR TITLE
Custom Entity loading on associations

### DIFF
--- a/src/Configuration/ConfigManager.php
+++ b/src/Configuration/ConfigManager.php
@@ -64,7 +64,7 @@ final class ConfigManager
     {
         $backendConfig = $this->getBackendConfig();
         foreach ($backendConfig['entities'] as $entityName => $entityConfig) {
-            if ($entityConfig['class'] === $fqcn) {
+            if ($entityConfig['class'] === $fqcn || $entityName === $fqcn) {
                 return $entityConfig;
             }
         }


### PR DESCRIPTION
## Context
Currently I have an admin containing 2 configured entities using the same class.
Simple scenario for this is: Same user object, different roles with properties configured.

At the moment when you add a field to the list view like this:
```yml
 - {property: 'user', label: 'Webdeveloper'}
```
EasyAdmin will load the entity config based on the underlaying class.
But, this results into the link being generated for the first found entity which is not the entity I want to load. This is because EasyAdmin loads the entity config based on the first found matching class.

A simple fix for this is allowing the entityConfig loading to match based on the Entity name.
```yml
 - {property: 'user', label: 'Webdeveloper', targetEntity: WebDevelopers}
```

## What has been done
- Added an extra scenario for the entity matching to make it matchable with the entity name.