### PR TITLE
Tweaked the "confirm action" feature of batch actions

### DIFF
--- a/src/Configuration/ActionConfigPass.php
+++ b/src/Configuration/ActionConfigPass.php
@@ -28,7 +28,7 @@ class ActionConfigPass implements ConfigPassInterface
         'target' => '_self',
         // the value of the template. Will be set in the TemplateConfigPass, if value will stay null.
         'template' => null,
-        // if a confirmation should be asked before the action is executed. For delet
+        // if TRUE, a confirmation message is displayed before executing the batch action
         'ask_confirm' => null,
     ];
 
@@ -384,8 +384,8 @@ class ActionConfigPass implements ConfigPassInterface
                     throw new \InvalidArgumentException(sprintf('The name of the "%s" action defined in the "list" view of the "%s" entity contains invalid characters (allowed: letters, numbers, underscores; the first character cannot be a number).', $actionName, $entityName));
                 }
 
-                if (null !== $actionConfig['ask_confirm'] && !is_bool($actionConfig['ask_confirm'])) {
-                    throw new \InvalidArgumentException(sprintf('Batch actions only bool or null value for "ask_confirm" type, "%s" given.', gettype($actionConfig['ask_confirm'])));
+                if (null !== $actionConfig['ask_confirm'] && !\is_bool($actionConfig['ask_confirm'])) {
+                    throw new \InvalidArgumentException(sprintf('The value of the "ask_confirm" option in the "%s" batch action of the "%s" entity can only be null or boolean, "%s" given.', $actionName, $entityName, \gettype($actionConfig['ask_confirm'])));
                 }
 
                 $backendConfig['entities'][$entityName]['list']['batch_actions'][$actionName] = $actionConfig;

--- a/src/Resources/translations/EasyAdminBundle.en.xlf
+++ b/src/Resources/translations/EasyAdminBundle.en.xlf
@@ -137,15 +137,11 @@
             </trans-unit>
             <trans-unit id="batch_action_modal.title">
                 <source>batch_action_modal.title</source>
-                <target>Do you really want to alter the selected items?</target>
+                <target>You are going to apply the "%action_name%" action to %num_items% item(s).</target>
             </trans-unit>
             <trans-unit id="batch_action_modal.content">
                 <source>batch_action_modal.content</source>
-                <target>There is no undo for this operation.</target>
-            </trans-unit>
-            <trans-unit id="batch_action_modal.action">
-                <source>batch_action_modal.action</source>
-                <target>Proceed</target>
+                <target>You can't undo this action.</target>
             </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>

--- a/src/Resources/translations/EasyAdminBundle.es.xlf
+++ b/src/Resources/translations/EasyAdminBundle.es.xlf
@@ -131,6 +131,14 @@
                 <source>delete_modal.action</source>
                 <target>Borrar</target>
             </trans-unit>
+            <trans-unit id="batch_action_modal.title">
+                <source>batch_action_modal.title</source>
+                <target>Se va a aplicar la acción "%action_name%" a %num_items% elemento(s).</target>
+            </trans-unit>
+            <trans-unit id="batch_action_modal.content">
+                <source>batch_action_modal.content</source>
+                <target>Esta acción no se puede deshacer.</target>
+            </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>
                 <target>Añadir un elemento</target>

--- a/src/Resources/translations/EasyAdminBundle.fr.xlf
+++ b/src/Resources/translations/EasyAdminBundle.fr.xlf
@@ -137,15 +137,11 @@
             </trans-unit>
             <trans-unit id="batch_action_modal.title">
                 <source>batch_action_modal.title</source>
-                <target>Voulez-vous vraiment modifier les éléments sélectionnés?</target>
+                <target>Vous allez appliquer l'action "%action_name%" à %num_items% élément(s).</target>
             </trans-unit>
             <trans-unit id="batch_action_modal.content">
                 <source>batch_action_modal.content</source>
                 <target>Cette action est irréversible.</target>
-            </trans-unit>
-            <trans-unit id="batch_action_modal.action">
-                <source>batch_action_modal.action</source>
-                <target>Procéder</target>
             </trans-unit>
             <trans-unit id="action.add_new_item">
                 <source>action.add_new_item</source>

--- a/src/Resources/translations/messages.en.xlf
+++ b/src/Resources/translations/messages.en.xlf
@@ -27,6 +27,10 @@
                 <source>action.save</source>
                 <target>Save changes</target>
             </trans-unit>
+            <trans-unit id="action.continue">
+                <source>action.continue</source>
+                <target>Continue</target>
+            </trans-unit>
             <trans-unit id="action.cancel">
                 <source>action.cancel</source>
                 <target>Cancel</target>

--- a/src/Resources/translations/messages.es.xlf
+++ b/src/Resources/translations/messages.es.xlf
@@ -31,6 +31,10 @@
                 <source>action.cancel</source>
                 <target>Cancelar</target>
             </trans-unit>
+            <trans-unit id="action.continue">
+                <source>action.continue</source>
+                <target>Continuar</target>
+            </trans-unit>
             <trans-unit id="action.list">
                 <source>action.list</source>
                 <target>Volver al listado</target>

--- a/src/Resources/translations/messages.fr.xlf
+++ b/src/Resources/translations/messages.fr.xlf
@@ -31,6 +31,10 @@
                 <source>action.cancel</source>
                 <target>Annuler</target>
             </trans-unit>
+            <trans-unit id="action.continue">
+                <source>action.continue</source>
+                <target>Continuer</target>
+            </trans-unit>
             <trans-unit id="action.list">
                 <source>action.list</source>
                 <target>Retour à la liste</target>

--- a/src/Resources/views/default/includes/_batch_action_modal.html.twig
+++ b/src/Resources/views/default/includes/_batch_action_modal.html.twig
@@ -2,16 +2,15 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-body">
-                <h4>{{ 'batch_action_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
+                <h4 id="batch-action-confirmation-title">{{ 'batch_action_modal.title'|trans(_trans_parameters, 'EasyAdminBundle') }}</h4>
                 <p>{{ 'batch_action_modal.content'|trans(_trans_parameters, 'EasyAdminBundle') }}</p>
             </div>
             <div class="modal-footer">
                 <button type="button" data-dismiss="modal" class="btn btn-secondary">
                     <span class="btn-label">{{ 'action.cancel'|trans(_trans_parameters, _translation_domain) }}</span>
                 </button>
-                <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-batch-action-button">
-                    <i class="fa fa-fw fa-check"></i>
-                    <span class="btn-label">{{ 'batch_action_modal.action'|trans(_trans_parameters, 'EasyAdminBundle') }}</span>
+                <button type="button" data-dismiss="modal" class="btn btn-primary" id="modal-batch-action-button">
+                    <span class="btn-label">{{ 'action.continue'|trans(_trans_parameters, _translation_domain) }}</span>
                 </button>
             </div>
         </div>

--- a/src/Resources/views/default/list.html.twig
+++ b/src/Resources/views/default/list.html.twig
@@ -369,16 +369,26 @@
                 $content.find('.content-header-title > .title').html(0 === ids.length ? titleContent : '');
             });
 
-            $('button[name="batch_form[name]"].ask-confirm-batch-button').on('click', function (event) {
+            let modalTitle = $('#batch-action-confirmation-title');
+            const titleContentWithPlaceholders = modalTitle.text();
+            $('button[name="batch_form[name]"].batch-action-requires-confirmation').on('click', function (event) {
                 event.preventDefault();
                 event.stopPropagation();
                 let $button = $(this);
+
+                const actionName = $button.text();
+                const numberOfSelectedItems = $('input[type="checkbox"].form-batch-checkbox:checked').length;
+                modalTitle.text(titleContentWithPlaceholders
+                    .replace('%action_name%', actionName)
+                    .replace('%num_items%', numberOfSelectedItems));
 
                 $('#modal-batch-action').modal({ backdrop : true, keyboard : true })
                     .off('click', '#modal-batch-action-button')
                     .on('click', '#modal-batch-action-button', function () {
                         $button.unbind('click');
                         $button.trigger('click');
+
+                        modalTitle.text(titleContentWithPlaceholders);
                     });
             });
             {% endif %}

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -548,7 +548,7 @@
     {{ form_widget(form.ids) }}
     <button type="button" class="btn btn-link deselect-batch-button">{{ 'action.deselect'|trans(_trans_parameters, _translation_domain) }}</button>
     {% for action in batch_actions %}
-        <button type="submit" class="btn {{ action.css_class|default('btn-secondary') }} {% if action.ask_confirm %}ask-confirm-batch-button{% endif -%}" title="{{ action.title|default('') is empty ? '' : action.title|trans(_trans_parameters) }}" name="{{ form.name.vars.full_name }}" value="{{ action.name }}">
+        <button type="submit" class="btn {{ action.css_class|default('btn-secondary') }} {% if action.ask_confirm %}batch-action-requires-confirmation{% endif %}" title="{{ action.title|default('') is empty ? '' : action.title|trans(_trans_parameters) }}" name="{{ form.name.vars.full_name }}" value="{{ action.name }}">
             {%- if action.icon %}<i class="fa fa-fw fa-{{ action.icon }}"></i> {% endif -%}
             {%- if action.label is defined and not action.label is empty -%}
                 {{ action.label|trans(_trans_parameters, _translation_domain) }}

--- a/tests/Configuration/fixtures/exceptions/batch_action_ask_confirm_invalid_type.yml
+++ b/tests/Configuration/fixtures/exceptions/batch_action_ask_confirm_invalid_type.yml
@@ -1,10 +1,10 @@
 # TEST
-# the "ask_confirm" item of the batch actions cannot contain non boolean value
+# the "ask_confirm" option of batch actions can only be null or a boolean value
 
 # EXCEPTION
 expected_exception:
     class: InvalidArgumentException
-    message_string: 'Batch actions only bool or null value for "ask_confirm" type, "string" given.'
+    message_string: 'The value of the "ask_confirm" option in the "delete" batch action of the "TestEntity" entity can only be null or boolean, "string" given.'
 
 # CONFIGURATION
 easy_admin:

--- a/tests/Controller/CustomizedBackendTest.php
+++ b/tests/Controller/CustomizedBackendTest.php
@@ -635,4 +635,13 @@ class CustomizedBackendTest extends AbstractTestCase
         $this->assertSame('<i class="fa fa-fw fa-foo"></i><span><b>foo</b></span>', $crawler->filter('form#new-category-form .form-group')->eq(2)->filter('.input-group-prepend .input-group-text')->html());
         $this->assertSame('<i class="fa fa-fw fa-bar"></i><span><span>bar</span></span>', $crawler->filter('form#new-category-form .form-group')->eq(2)->filter('.input-group-append .input-group-text')->html());
     }
+
+    public function testBatchActions()
+    {
+        $crawler = $this->requestListView('Product');
+
+        $this->assertSame('Delete', $crawler->filter('button.batch-action-requires-confirmation')->text());
+        $this->assertCount(1, $crawler->filter('input[type="hidden"]#batch_form__token'));
+        $this->assertCount(15, $crawler->filter('input[type="checkbox"].form-batch-checkbox'));
+    }
 }

--- a/tests/Fixtures/App/config/config_customized_backend.yml
+++ b/tests/Fixtures/App/config/config_customized_backend.yml
@@ -150,6 +150,7 @@ easy_admin:
             class: AppTestBundle\Entity\FunctionalTests\Product
             label: 'Products'
             list:
+                batch_actions: ['delete']
                 collapse_actions: true
                 fields:
                     - id


### PR DESCRIPTION
This continues #2943. Most of the changes are very minor ... but the messages of the confirmation window has been reworded entirely to look like this:

![image](https://user-images.githubusercontent.com/73419/66719837-077e5100-edf5-11e9-9306-fcac4771f421.png)

The message is dynamically translatable via JavaScript. I think it's worth it because the needed code is tiny and that way the message is easier to understand for users.