### PR TITLE
Enhances the append/prepend_* input-group styling - Fixes #2971

### DIFF
--- a/assets/css/easyadmin-theme/forms.scss
+++ b/assets/css/easyadmin-theme/forms.scss
@@ -57,7 +57,9 @@
 
 .form-widget input.form-control,
 .form-widget textarea.form-control,
-.form-widget select.form-control {
+.form-widget select.form-control,
+.form-widget .input-group-append,
+.form-widget .input-group-prepend {
     border: 0;
     padding: 3px 7px 5px;
     box-shadow: 0 0 0 1px rgba(43, 45, 80, .16), 0 0 0 1px rgba(6, 122, 184, 0), 0 0 0 2px rgba(6, 122, 184, 0), 0 1px 1px rgba(0, 0, 0, .08);
@@ -90,6 +92,23 @@
 
 .form-widget select[multiple].form-control {
     height: auto;
+}
+
+// Since we are using the form-control styling for our group, we need to remove the inner border
+.form-widget .input-group .input-group-text {
+	border: none;
+}
+
+.form-widget .input-group-append {
+    border-top-right-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
+    margin-left: 2px;
+}
+
+.form-widget .input-group-prepend {
+    border-top-left-radius: var(--border-radius);
+    border-bottom-left-radius: var(--border-radius);
+    margin-right: 2px;
 }
 
 // Checkbox widgets


### PR DESCRIPTION
Here is my first attempt in enhancing the input-group append/prepend styling (as reported in issue #2971 ).

It now looks like this:
![grafik](https://user-images.githubusercontent.com/137896/67762262-56f38c80-fa45-11e9-9101-9cc97415d401.png)
![grafik](https://user-images.githubusercontent.com/137896/67762268-5b1faa00-fa45-11e9-9a83-6e969a3faa22.png)
![grafik](https://user-images.githubusercontent.com/137896/67762281-62df4e80-fa45-11e9-98df-f65c683b8db3.png)

Why I've added a margin-left/right to the group?
Without margin the box-shadows overlap and creates the following darker corners:
![grafik](https://user-images.githubusercontent.com/137896/67762046-cf0d8280-fa44-11e9-9492-1821f89ee55b.png)

I've experimented with 1px and 2px and personally I liked the 2px version more.
1px:
![grafik](https://user-images.githubusercontent.com/137896/67762144-10059700-fa45-11e9-8b2d-53d24b217cca.png)

2px:
![grafik](https://user-images.githubusercontent.com/137896/67762151-1267f100-fa45-11e9-9579-8d3ef64c2ae3.png)
