### PR TITLE
Add `property` to PRE_UPDATE and POST_UPDATE events

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -597,9 +597,9 @@ trait AdminControllerTrait
 
         $this->get('easyadmin.property_accessor')->setValue($entity, $property, $value);
 
-        $this->dispatch(EasyAdminEvents::PRE_UPDATE, ['entity' => $entity, 'newValue' => $value]);
+        $this->dispatch(EasyAdminEvents::PRE_UPDATE, ['entity' => $entity, 'property' => $property, 'newValue' => $value]);
         $this->executeDynamicMethod('update<EntityName>Entity', [$entity]);
-        $this->dispatch(EasyAdminEvents::POST_UPDATE, ['entity' => $entity, 'newValue' => $value]);
+        $this->dispatch(EasyAdminEvents::POST_UPDATE, ['entity' => $entity, 'property' => $property, 'newValue' => $value]);
 
         $this->dispatch(EasyAdminEvents::POST_EDIT);
     }


### PR DESCRIPTION
Currently, the `PRE_UPDATE` and `POST_UPDATE` events only contain the new changed value, which means you can't add custom logic when only a specific field has changed. (In my case, I need to update a timestamp only when the `active` field has changed).

So I'm proposing to add the property name with the event so that it easier to identify which field has changed in an event listener.