### PR TITLE
Fix an issue when no default menu is set in config

### DIFF
--- a/src/Configuration/DefaultConfigPass.php
+++ b/src/Configuration/DefaultConfigPass.php
@@ -77,6 +77,8 @@ class DefaultConfigPass implements ConfigPassInterface
                 }
             }
         }
+
+        return reset($menuConfig[0]);
     }
 
     /**


### PR DESCRIPTION
If you set a list of menus and don't set any of the elements as default, let's return the first element.

I detected this bug when upgrading to PHP 7.4 with no other change, as I had a `Trying to access array offset on value of type null` error at `DefaultConfigPass.php:49`