### PR TITLE
Symfony 5 compatible fix

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -633,8 +633,8 @@
 {% block easyadmin_fileupload_widget %}
     <div class="easyadmin-fileupload">
         <div class="input-group">
-            {% set placeholder = null %}
-            {% set title = null %}
+            {% set placeholder = '' %}
+            {% set title = '' %}
             {% set filesLabel = 'files'|trans({}, 'EasyAdminBundle') %}
             {% if currentFiles %}
                 {% if multiple %}


### PR DESCRIPTION
in symfony 5 trans() function does not allow to pass null value

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
