### PR TITLE
Fix bug of date field toggling

### DIFF
--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -157,7 +157,7 @@
             {% if _field_type in ['datetime', 'datetime_immutable', 'date', 'date_immutable', 'dateinterval', 'time', 'time_immutable', 'birthday'] and easyadmin.field.nullable|default(false) %}
                 <div class="nullable-control">
                     <label>
-                        <input type="checkbox" {% if data is null %}checked="checked"{% endif %}>
+                        <input type="checkbox" {% if data is null and valid %}checked="checked"{% endif %}>
                         {{ 'label.nullable_field'|trans({}, 'EasyAdminBundle')}}
                     </label>
                 </div>


### PR DESCRIPTION
After submitting a form with optional field of date/datetime and an invalid value in that field, the "Leave empty" checkbox gets checked and the field is hidden.
Steps to reproduce:
1. Create an entity with a nullable datetime field
2. Add it to easyadmin config
3. Go to "Add <entity>"
4. Uncheck the "Leave empty" checkbox and enter some incomplete date, e.g. only the year.
5. Submit the form
An error message is displayed but the date field is toggled off.

The variable "data" remains null because it can't get assigned an invalid datetime value, so an additional check of data validity fixes this.