### PR TITLE
Fix bug when using upload_filename with slashes

### DIFF
--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -83,7 +83,12 @@ class FileUploadType extends AbstractType implements DataMapperInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         $uploadNew = static function (UploadedFile $file, string $uploadDir, string $fileName) {
-            $file->move($uploadDir, $fileName);
+            $name = str_replace('\\', '/', $fileName);
+            $pos = strrpos($name, '/');
+            $subDir = false === $pos ? '' : substr($name, 0, $pos);
+            $name = false === $pos ? $name : substr($name, $pos + 1);
+
+            $file->move(rtrim($uploadDir, '/\\').\DIRECTORY_SEPARATOR.$subDir, $name);
         };
 
         $uploadDelete = static function (File $file) {


### PR DESCRIPTION
This PR should fix the poblem described in #3038. Source code is based on `Symfony\Component\HttpFoundation\File\File::getName` method and extracts dirname from upload_filename and joins this extract with upload_dir.

Maybe I could use pathinfo function (https://www.php.net/manual/en/function.pathinfo.php) instead of strpos and substr functions. If you find using of pathinfo() as a better solution then let me know and I will update this fix