### PR TITLE
Address deprecations from persistence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/common": "^2.8",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.6.3",
-        "doctrine/persistence": "^1.0",
+        "doctrine/persistence": "^1.3.4",
         "pagerfanta/pagerfanta": "^1.0.1|^2.0",
         "symfony/asset": "^4.2|^5.0",
         "symfony/cache": "^4.2|^5.0",

--- a/src/Configuration/MetadataConfigPass.php
+++ b/src/Configuration/MetadataConfigPass.php
@@ -2,8 +2,8 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Configuration;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 
 /**

--- a/src/EventListener/RequestPostInitializeListener.php
+++ b/src/EventListener/RequestPostInitializeListener.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\EntityNotFoundException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/src/Router/EasyAdminRouter.php
+++ b/src/Router/EasyAdminRouter.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Router;
 
-use Doctrine\Common\Persistence\Proxy;
+use Doctrine\Persistence\Proxy;
 use EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigManager;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\UndefinedEntityException;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -2,10 +2,10 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Search;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/tests/Fixtures/AppTestBundle/DataFixtures/AppFixtures.php
+++ b/tests/Fixtures/AppTestBundle/DataFixtures/AppFixtures.php
@@ -8,7 +8,7 @@ use AppTestBundle\Entity\FunctionalTests\Purchase;
 use AppTestBundle\Entity\FunctionalTests\PurchaseItem;
 use AppTestBundle\Entity\FunctionalTests\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 
 class AppFixtures extends Fixture
 {

--- a/tests/Form/Filter/Type/EntityFilterTypeTest.php
+++ b/tests/Form/Filter/Type/EntityFilterTypeTest.php
@@ -3,11 +3,11 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Filter\Type;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ManagerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\EntityFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmExtension;

--- a/tests/Form/Type/EasyAdminAutocompleteTypeTest.php
+++ b/tests/Form/Type/EasyAdminAutocompleteTypeTest.php
@@ -28,7 +28,7 @@ class EasyAdminAutocompleteTypeTest extends TypeTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->classMetadata = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadata')
+        $this->classMetadata = $this->getMockBuilder('Doctrine\Persistence\Mapping\ClassMetadata')
             ->disableOriginalConstructor()
             ->getMock();
         $this->classMetadata


### PR DESCRIPTION
A backwards-compatibility layer has been added to persistence to help
consumers move to the new namespacing. It is based on class aliases,
which means the type declaration changes should not be a BC-break: types
are the same.
See doctrine/persistence#71

This means:
- using the new namespaces
- adding autoload calls for new types to types that may be extended and
use persistence types in type declarations of non-constructor methods,
so that signature compatibility is recognized by old versions of php.
Luckily, none of those were found in this package.

More details on this at
https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf