### PR TITLE
Fix correct datatype for Code Editor

### DIFF
--- a/assets/js/form-type-code-editor.js
+++ b/assets/js/form-type-code-editor.js
@@ -20,7 +20,7 @@ document.querySelectorAll('[data-easyadmin-code-editor]').forEach(function(codeB
     const editor = CodeMirror.fromTextArea(codeBlock, {
         autocapitalize: false,
         autocorrect: false,
-        indentWithTabs: codeBlock.dataset.indentWithTabs,
+        indentWithTabs: (codeBlock.dataset.indentWithTabs == 'true'),
         lineNumbers: true,
         lineWrapping: true,
         mode: codeBlock.dataset.language,


### PR DESCRIPTION
When using the provided Code editor (CodeMirror) it always defaulted to `indentWithTabs` with a string value.
The JS library sees this as 'true' and thus the default value for this configurable field, according to the docs did not match.

This converts to a proper boolean value, so the configuration can be managed by the developer