### PR TITLE
Permission for "delete" action and checks before returning action list.

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -73,7 +73,7 @@ trait AdminControllerTrait
             throw new ForbiddenActionException(['action' => $action, 'entity_name' => $this->entity['name']]);
         }
 
-        if (\in_array($action, ['show', 'edit', 'new'])) {
+        if (\in_array($action, ['show', 'edit', 'new', 'delete'])) {
             $id = $this->request->query->get('id');
             $entity = $this->request->attributes->get('easyadmin')['item'];
             $requiredPermission = $this->entity[$action]['item_permission'];


### PR DESCRIPTION
This proposal :
- answers to this issue: Permission for "delete" action #2986
Reference : EasyCorp/EasyAdminBundle/issues/2986
- integrates improvement from this pull request: added permission checks to twig methods that display actions buttons #2942
(With a bow to @umadesign who did all the real work)
Reference: EasyCorp/EasyAdminBundle/pull/2942
It keeps the item_permission as a reference for permissions in easy_admin.yaml
It prevents error messages for people without the correct permissions.
It allows to block delete for people with just list and show permissions.
You just need to add in the easy_admin.yaml :
```yaml
    EntityXXX:
      ...
      delete:
        item_permission: ['ROLE_XXX','ROLE_YYY']
```
This way the global spirit of permission management is kept,
and the "security hole of delete action is closed.