### PR TITLE
feat(form-theme): handle collection compound items removal

### DIFF
--- a/assets/css/easyadmin-theme/forms.scss
+++ b/assets/css/easyadmin-theme/forms.scss
@@ -229,6 +229,18 @@ fieldset .form-group .nullable-control label {
 .form-group.field-collection-action {
     padding-top: 0;
 }
+.field-collection-compound-item-row {
+    display: flex;
+    flex-direction: row;
+
+    > .form-widget-compound {
+        flex: 1;
+    }
+
+    > .field-collection-item-action {
+        top: -2px;
+    }
+}
 .field-collection-item-action {
     font-size: 21px;
     font-weight: bold;

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -45,7 +45,7 @@
         });
         {% endset %}
 
-        <div class="field-collection-item-row">
+        <div class="field-collection-item-row{% if compound %} field-collection-compound-item-row{% endif %}">
             {{ parent() }}
 
             <a class="field-collection-item-action" id="easyadmin-remove-collection-item-{{ form.vars.id }}" href="#" onclick="{{ remove_item_javascript|raw }}; return false;" title="{{ 'action.remove_item'|trans({}, 'EasyAdminBundle') }}">


### PR DESCRIPTION
Fix https://github.com/EasyCorp/EasyAdminBundle/pull/2868#issuecomment-609886325

The goal of this PR is to put the collection removal link at the top right when the collection item is a compound form. Having it at the end is an heavy behavior change for the end users. I think it is better for UX to have the removal link at the beginning of the item. To stay with the spirit of the redesign, we still put it on the right side.

Before:
<img width="953" alt="Screenshot 2020-04-07 at 08 53 03" src="https://user-images.githubusercontent.com/3658119/78638907-60fba000-78ad-11ea-9212-5163140b7caf.png">

After:
<img width="1073" alt="Screenshot 2020-04-07 at 08 51 32" src="https://user-images.githubusercontent.com/3658119/78638922-6527bd80-78ad-11ea-8a78-f3a2c870c520.png">

Tested on Firefox and Chrome.
