### PR TITLE
Update FOS_CKEditor for Symfony 4 and 5 use.

### DIFF
--- a/doc/integration/ivoryckeditorbundle.rst
+++ b/doc/integration/ivoryckeditorbundle.rst
@@ -42,16 +42,18 @@ thanks to the `FOSCKEditorBundle`_:
 
     $ php bin/console assets:install --symlink
 
-Finally, add the ``ckeditor_widget.html.twig`` form theme to your Twig
+Finally, add the ``ckeditor_widget.html.twig`` form theme to your EasyAdmin
 configuration so the ``<textarea>`` elements used by the editor are properly
 designed:
 
 .. code-block:: yaml
 
-    # config/packages/twig.yaml
-    twig:
-        form_themes:
-            - '@FOSCKEditor/Form/ckeditor_widget.html.twig'
+    # config/packages/easy_admin.yaml
+    easy_amin:
+        design:
+            form_theme: # Both themes are for ckeditor integration
+                - "@EasyAdmin/form/bootstrap_4.html.twig"
+                - "@FOSCKEditor/Form/ckeditor_widget.html.twig"
 
 Using the Rich Text Editor
 --------------------------


### PR DESCRIPTION
Hello ! It's just an docs update.

First, I don't know how I have to proceed to update the doc for Symfony 4.* to 5.0.*

So, with the last news versions of FOSCKEditor bundle, the ckeditor_widget.html.twig is automatical add to config/packages/fos_ckeditor.yaml.

And thanks to that issue, we know that add on config/package/easy_admin.yaml, the 2 lines of form_theme is necessary and do the job. I test it on my Symfony 5.0 project, it works like this (and with both lines).
https://github.com/FriendsOfSymfony/FOSCKEditorBundle/issues/161#issue-387285347

Bybye ! =)

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
