### PR TITLE
[3.0] Fix migrator disabled actions

### DIFF
--- a/src/Maker/Migrator.php
+++ b/src/Maker/Migrator.php
@@ -207,7 +207,7 @@ final class Migrator
             ->_public()->_function()->_method('configureActions', ['Actions $actions'], 'Actions')
             ->openBrace()
             ->_return()->_variableName('actions')
-            ->_methodCall('disableActions', [$entityConfig['disabled_actions']])
+            ->_methodCall('disableActions', $entityConfig['disabled_actions'])
             ->semiColon()
             ->closeBrace();
 


### PR DESCRIPTION
`disableActions` accepts variable-length argument list instead of the array.