### PR TITLE
Removed the twig-extensions dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "symfony/twig-bridge": "^4.2|^5.0",
         "symfony/twig-bundle": "^4.2|^5.0",
         "symfony/validator": "^4.2|^5.0",
-        "twig/extensions": "^1.5",
         "twig/twig": "^2.12|^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
`twig-extensions` repo [is deprecated](https://github.com/twigphp/Twig-extensions) in favor of the new [Twig extras](https://github.com/twigphp?q=extra).

I checked and the only filter we use from `twig-extensions` is `trans` ... but that's also provided by the `twig-bridge` dependency (which is installed indirectly via our `twig-bundle` requirement). So, I think we can safely remove this dependency.