### PR TITLE
Make SUCCESS and FAILURE public for Symfony 5.1

### DIFF
--- a/src/Command/MakeAdminMigrationCommand.php
+++ b/src/Command/MakeAdminMigrationCommand.php
@@ -21,8 +21,8 @@ class MakeAdminMigrationCommand extends Command
 {
     protected static $defaultName = 'make:admin:migration';
 
-    private const SUCCESS = 0;
-    private const FAILURE = 1;
+    public const SUCCESS = 0;
+    public const FAILURE = 1;
 
     private $migrator;
     private $projectDir;


### PR DESCRIPTION
Installing easyadmin in the Symfony 5.1 framework fails.
```
!!  PHP Fatal error:  Access level to EasyCorp\Bundle\EasyAdminBundle\Command\MakeAdminMigrationCommand::SUCCESS must be public (as in class Symfony\Component\Console\Command\Command) in /home/tac/formeo-demo/vendor/easycorp/easyadmin-bundle/src/Command/MakeAdminMigrationCommand.php on line 134
!!  Symfony\Component\ErrorHandler\Error\FatalError {#480
!!    -error: array:4 [
!!      "type" => 64
!!      "message" => "Access level to EasyCorp\Bundle\EasyAdminBundle\Command\MakeAdminMigrationCommand::SUCCESS must be public (as in class Symfony\Component\Console\Command\Command)"
!!      "file" => "/home/tac/formeo-demo/vendor/easycorp/easyadmin-bundle/src/Command/MakeAdminMigrationCommand.php"
!!      "line" => 134
!!    ]
!!    #message: "Compile Error: Access level to EasyCorp\Bundle\EasyAdminBundle\Command\MakeAdminMigrationCommand::SUCCESS must be public (as in class Symfony\Component\Console\Command\Command)"
!!    #code: 0
!!    #file: "./vendor/easycorp/easyadmin-bundle/src/Command/MakeAdminMigrationCommand.php"
!!    #line: 134
!!  }
```


