### PR TITLE
Renamed TextAreaField to TextareaField

### DIFF
--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -13,7 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextAreaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
@@ -29,8 +29,8 @@ final class FieldFactory
     private static $doctrineTypeToFieldFqcn = [
         //Type::TARRAY => 'array',
         Type::BIGINT => TextField::class,
-        Type::BINARY => TextAreaField::class,
-        Type::BLOB => TextAreaField::class,
+        Type::BINARY => TextareaField::class,
+        Type::BLOB => TextareaField::class,
         Type::BOOLEAN => BooleanField::class,
         Type::DATE => DateField::class,
         Type::DATE_IMMUTABLE => DateField::class,
@@ -48,7 +48,7 @@ final class FieldFactory
         //Type::SIMPLE_ARRAY => 'array',
         Type::SMALLINT => IntegerField::class,
         Type::STRING => TextField::class,
-        Type::TEXT => TextAreaField::class,
+        Type::TEXT => TextareaField::class,
         Type::TIME => TimeField::class,
         Type::TIME_IMMUTABLE => TimeField::class,
     ];

--- a/src/Field/Configurator/TextConfigurator.php
+++ b/src/Field/Configurator/TextConfigurator.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextAreaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use function Symfony\Component\String\u;
 
@@ -18,20 +18,20 @@ final class TextConfigurator implements FieldConfiguratorInterface
 {
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {
-        return \in_array($field->getFieldFqcn(), [TextField::class, TextAreaField::class], true);
+        return \in_array($field->getFieldFqcn(), [TextField::class, TextareaField::class], true);
     }
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
-        if ($field instanceof TextAreaField) {
-            $field->setFormTypeOptionIfNotSet('attr.rows', $field->getCustomOption(TextAreaField::OPTION_NUM_OF_ROWS));
+        if ($field instanceof TextareaField) {
+            $field->setFormTypeOptionIfNotSet('attr.rows', $field->getCustomOption(TextareaField::OPTION_NUM_OF_ROWS));
         }
 
         if (null === $field->getValue()) {
             return;
         }
 
-        $configuredMaxLength = $field->getCustomOption(TextAreaField::OPTION_MAX_LENGTH);
+        $configuredMaxLength = $field->getCustomOption(TextareaField::OPTION_MAX_LENGTH);
         $isDetailAction = Action::DETAIL === $context->getCrud()->getCurrentAction();
         $defaultMaxLength = $isDetailAction ? PHP_INT_MAX : 64;
         $formattedValue = u($field->getValue())->truncate($configuredMaxLength ?? $defaultMaxLength, '…');

--- a/src/Field/TextareaField.php
+++ b/src/Field/TextareaField.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class TextAreaField implements FieldInterface
+final class TextareaField implements FieldInterface
 {
     use FieldTrait;
 

--- a/src/Maker/CodeBuilder.php
+++ b/src/Maker/CodeBuilder.php
@@ -231,7 +231,8 @@ final class CodeBuilder
     public function getAsString(): string
     {
         $useStatements = array_unique($this->useStatements);
-        sort($useStatements);
+        // 'natcasesort()' is needed to sort 'TextareaField' before 'TextField'
+        natcasesort($useStatements);
 
         return implode('', $this->beforeCode)
             .' '

--- a/src/Maker/Migrator.php
+++ b/src/Maker/Migrator.php
@@ -25,7 +25,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TelephoneField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextAreaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\UrlField;
@@ -396,8 +396,8 @@ final class Migrator
         $doctrineTypeToFqcn = [
             //Type::TARRAY => 'array',
             Type::BIGINT => TextField::class,
-            Type::BINARY => TextAreaField::class,
-            Type::BLOB => TextAreaField::class,
+            Type::BINARY => TextareaField::class,
+            Type::BLOB => TextareaField::class,
             Type::BOOLEAN => BooleanField::class,
             Type::DATE => DateField::class,
             Type::DATE_IMMUTABLE => DateField::class,
@@ -415,7 +415,7 @@ final class Migrator
             //Type::SIMPLE_ARRAY => 'array',
             Type::SMALLINT => IntegerField::class,
             Type::STRING => TextField::class,
-            Type::TEXT => TextAreaField::class,
+            Type::TEXT => TextareaField::class,
             Type::TIME => TimeField::class,
             Type::TIME_IMMUTABLE => TimeField::class,
         ];

--- a/tests/Maker/fixtures/output/ProductCrudController.php
+++ b/tests/Maker/fixtures/output/ProductCrudController.php
@@ -12,7 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextAreaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class ProductCrudController extends AbstractCrudController
@@ -28,7 +28,7 @@ class ProductCrudController extends AbstractCrudController
     {
         $panel1 = FormField::addPanel('Basic information');
         $name = TextField::new('name');
-        $description = TextAreaField::new('description');
+        $description = TextareaField::new('description');
         $categories = AssociationField::new('categories');
         $panel2 = FormField::addPanel('Product Details');
         $ean = TextField::new('ean');

--- a/tests/Maker/fixtures/output/PurchaseCrudController.php
+++ b/tests/Maker/fixtures/output/PurchaseCrudController.php
@@ -10,7 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextAreaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TimeField;
 
@@ -36,7 +36,7 @@ class PurchaseCrudController extends AbstractCrudController
         $panel1 = FormField::addPanel('Delivery Details');
         $deliveryDate = DateField::new('deliveryDate');
         $deliveryHour = TimeField::new('deliveryHour');
-        $billingAddress = TextAreaField::new('billingAddress');
+        $billingAddress = TextareaField::new('billingAddress');
         $panel2 = FormField::addPanel('Purchase Details');
         $guid = TextField::new('guid');
         $buyer = AssociationField::new('buyer');
@@ -44,7 +44,7 @@ class PurchaseCrudController extends AbstractCrudController
         $createdAt = DateTimeField::new('createdAt');
         $shipping = TextField::new('shipping');
         $purchasedItems = AssociationField::new('purchasedItems');
-        $total = TextAreaField::new('total');
+        $total = TextareaField::new('total');
 
         if (Crud::PAGE_INDEX === $pageName) {
             return [$guid, $buyer, $deliveryDate, $deliveryHour, $billingAddress, $purchasedItems, $total];

--- a/tests/Maker/fixtures/output/UserCrudController.php
+++ b/tests/Maker/fixtures/output/UserCrudController.php
@@ -9,7 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextAreaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class UserCrudController extends AbstractCrudController
@@ -27,7 +27,7 @@ class UserCrudController extends AbstractCrudController
     {
         $panel1 = FormField::addPanel('Account Information');
         $username = TextField::new('username');
-        $isActive = TextAreaField::new('isActive');
+        $isActive = TextareaField::new('isActive');
         $panel2 = FormField::addPanel('Contact Information');
         $email = TextField::new('email');
         $panel3 = FormField::addPanel('Legal Information');


### PR DESCRIPTION
This was suggested in Symfony's Slack to be consistent with Symfony's Form TextareaType.