### PR TITLE
Fixed the cloning of FieldDto objects

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -44,6 +44,14 @@ final class FieldDto
         $this->doctrineMetadata = KeyValueStore::new();
     }
 
+    public function __clone()
+    {
+        $this->assets = clone $this->assets;
+        $this->formTypeOptions = clone $this->formTypeOptions;
+        $this->customOptions = clone $this->customOptions;
+        $this->doctrineMetadata = clone $this->doctrineMetadata;
+    }
+
     public function getUniqueId(): string
     {
         if (null !== $this->uniqueId) {


### PR DESCRIPTION
Another error kindly reported via Symfony Slack. Without this fix, the links of the associations weren't generated properly. We do some object cloning in some parts of the code ... and PHP does a "shallow cloning" instead of a "deep/recursive cloning" by default ... so we need to clone objects explicitly.