### PR TITLE
Added the missing template for LocaleField

### DIFF
--- a/src/Registry/TemplateRegistry.php
+++ b/src/Registry/TemplateRegistry.php
@@ -40,6 +40,7 @@ final class TemplateRegistry
         'crud/field/image' => '@EasyAdmin/crud/field/image.html.twig',
         'crud/field/integer' => '@EasyAdmin/crud/field/integer.html.twig',
         'crud/field/language' => '@EasyAdmin/crud/field/language.html.twig',
+        'crud/field/locale' => '@EasyAdmin/crud/field/locale.html.twig',
         'crud/field/money' => '@EasyAdmin/crud/field/money.html.twig',
         'crud/field/number' => '@EasyAdmin/crud/field/number.html.twig',
         'crud/field/percent' => '@EasyAdmin/crud/field/percent.html.twig',

--- a/src/Resources/views/crud/field/locale.html.twig
+++ b/src/Resources/views/crud/field/locale.html.twig
@@ -1,0 +1,8 @@
+{# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
+{# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
+{% if field.customOptions.get('showCode') %}
+    <span class="badge badge-language" title="{{ field.formattedValue }}">{{ field.value }}</span>
+{% endif %}
+{% if field.customOptions.get('showName') %}
+    {{ field.formattedValue ?? '' }}
+{% endif %}


### PR DESCRIPTION
We use the same content of the `language` template because for now it's identical.