### PR TITLE
Add a method to define the entity FQCN of the CRUD controller

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -65,7 +65,7 @@ CRUD Controller Configuration
 
 The only mandatory config option of a CRUD controller is the FQCN of the
 Doctrine entity being managed by the controller. This is defined as a public
-static property::
+static method::
 
     namespace App\Controller\Admin;
 
@@ -74,8 +74,11 @@ static property::
 
     class ProductCrudController extends AbstractCrudController
     {
-        // this value must be a FQCN (fully-qualified class name) of a Doctrine ORM entity
-        public static $entityFqcn = Product::class;
+        // it must return a FQCN (fully-qualified class name) of a Doctrine ORM entity
+        public static function getEntityFqcn(): string
+        {
+            return Product::class;
+        }
 
         // ...
     }

--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -34,7 +34,10 @@ the list of fields to display::
 
     class ProductCrudController extends AbstractCrudController
     {
-        public static $entityFqcn = Product::class;
+        public static function getEntityFqcn(): string
+        {
+            return Product::class;
+        }
 
         public function configureFields(string $pageName): iterable
         {

--- a/src/Contracts/Controller/CrudControllerInterface.php
+++ b/src/Contracts/Controller/CrudControllerInterface.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 interface CrudControllerInterface
 {
+    public static function getEntityFqcn(): string;
+
     public function configureCrud(Crud $crud): Crud;
 
     public function configureAssets(Assets $assets): Assets;

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -51,6 +51,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 abstract class AbstractCrudController extends AbstractController implements CrudControllerInterface
 {
+    abstract public static function getEntityFqcn(): string;
+
     public function configureCrud(Crud $crud): Crud
     {
         return $crud;

--- a/src/Maker/CodeBuilder.php
+++ b/src/Maker/CodeBuilder.php
@@ -198,6 +198,13 @@ final class CodeBuilder
 
     public function _variableValue(string $value): self
     {
+        $this->code[] = sprintf('%s', $value);
+
+        return $this;
+    }
+
+    public function _variableAssign(string $value): self
+    {
         $this->code[] = sprintf(' = %s', $value);
 
         return $this;

--- a/src/Maker/Migrator.php
+++ b/src/Maker/Migrator.php
@@ -75,7 +75,10 @@ final class Migrator
                 ->_use($entityFqcn)
                 ->_class($crudControllerClassName)->_extends('AbstractCrudController')
                 ->openBrace()
-                    ->_public()->_static()->_variableName('entityFqcn')->_variableValue($entityClassName.'::class')->semiColon();
+                    ->_public()->_static()->_function()->_method('getEntityFqcn', [], 'string')
+                    ->openBrace()
+                        ->_return()->_variableValue($entityClassName.'::class')->semiColon()
+                    ->closeBrace();
 
             $code = $this->addConfigureCrudMethod($code, $entityClassName, $entityConfig);
             $code = $this->addConfigureActionsMethod($code, $entityConfig);

--- a/src/Registry/CrudControllerRegistry.php
+++ b/src/Registry/CrudControllerRegistry.php
@@ -25,15 +25,7 @@ final class CrudControllerRegistry
 
         foreach ($registry->crudControllers as $controller) {
             $controllerFqcn = \get_class($controller);
-
-            try {
-                if (null === $entityFqcn = $controller::$entityFqcn) {
-                    throw new \RuntimeException();
-                }
-                $registry->controllerToEntityMap[$controllerFqcn] = $entityFqcn;
-            } catch (\Throwable $e) {
-                throw new \RuntimeException(sprintf('The "%s" CRUD controller must define a public static field called "entityFqcn" with the FQCN of the Doctrine entity managed by the controller.', \get_class($controller)));
-            }
+            $registry->controllerToEntityMap[$controllerFqcn] = $controller::getEntityFqcn();
         }
 
         // more than one controller can manage the same entity, so this map will

--- a/tests/Maker/fixtures/output/CategoryCrudController.php
+++ b/tests/Maker/fixtures/output/CategoryCrudController.php
@@ -12,7 +12,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class CategoryCrudController extends AbstractCrudController
 {
-    public static $entityFqcn = Category::class;
+    public static function getEntityFqcn(): string
+    {
+        return Category::class;
+    }
 
     public function configureCrud(Crud $crud): Crud
     {

--- a/tests/Maker/fixtures/output/ProductCrudController.php
+++ b/tests/Maker/fixtures/output/ProductCrudController.php
@@ -17,7 +17,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class ProductCrudController extends AbstractCrudController
 {
-    public static $entityFqcn = Product::class;
+    public static function getEntityFqcn(): string
+    {
+        return Product::class;
+    }
 
     public function configureCrud(Crud $crud): Crud
     {

--- a/tests/Maker/fixtures/output/PurchaseCrudController.php
+++ b/tests/Maker/fixtures/output/PurchaseCrudController.php
@@ -16,7 +16,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TimeField;
 
 class PurchaseCrudController extends AbstractCrudController
 {
-    public static $entityFqcn = Purchase::class;
+    public static function getEntityFqcn(): string
+    {
+        return Purchase::class;
+    }
 
     public function configureCrud(Crud $crud): Crud
     {

--- a/tests/Maker/fixtures/output/PurchaseItemCrudController.php
+++ b/tests/Maker/fixtures/output/PurchaseItemCrudController.php
@@ -11,7 +11,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 
 class PurchaseItemCrudController extends AbstractCrudController
 {
-    public static $entityFqcn = PurchaseItem::class;
+    public static function getEntityFqcn(): string
+    {
+        return PurchaseItem::class;
+    }
 
     public function configureCrud(Crud $crud): Crud
     {

--- a/tests/Maker/fixtures/output/UserCrudController.php
+++ b/tests/Maker/fixtures/output/UserCrudController.php
@@ -14,7 +14,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class UserCrudController extends AbstractCrudController
 {
-    public static $entityFqcn = User::class;
+    public static function getEntityFqcn(): string
+    {
+        return User::class;
+    }
 
     public function configureCrud(Crud $crud): Crud
     {


### PR DESCRIPTION
This was a change proposed in Symfony Slack. Most people agree with it. I don't have a strong opinion ... but I like that we can now add this to the interface:

```php
// Before
class ProductCrudController extends AbstractCrudController
{
    public static $entityFqcn =  Product::class;
}

// After
class ProductCrudController extends AbstractCrudController
{
    public static function getEntityFqcn(): string
    {
        return Product::class;
    }

    // ...
}
```