### PR TITLE
[3.0] Fixed JavaScript for New/Edit forms

### DIFF
--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -64,7 +64,7 @@
 
     <script type="text/javascript">
         $(function() {
-            $('.edit-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans({}, 'EasyAdminBundle')|e('js') }}' });
+            $('.ea-edit-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans({}, 'EasyAdminBundle')|e('js') }}' });
 
             const entityForm = document.querySelector('form.ea-edit-form');
             const inputFieldsSelector = 'input,select,textarea';

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -53,16 +53,15 @@
 
     <script type="text/javascript">
         $(function() {
-            $('.new-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans({}, 'EasyAdminBundle')|e('js') }}' });
+            $('.ea-new-form').areYouSure({ 'message': '{{ 'form.are_you_sure'|trans({}, 'EasyAdminBundle')|e('js') }}' });
 
-            const entityForm = document.querySelector('form.new-form');
-            const formSubmitButton = entityForm.querySelector('button[type="submit"]');
+            const entityForm = document.querySelector('form.ea-new-form');
             const inputFieldsSelector = 'input,select,textarea';
 
             // Adding visual feedback for invalid fields: any ".form-group" with invalid fields
             // receives "has-error" class. The class is removed on click on the ".form-group"
             // itself to support custom/complex fields.
-            formSubmitButton.addEventListener('click', function() {
+            entityForm.addEventListener('submit', function() {
                 entityForm.querySelectorAll(inputFieldsSelector).forEach(function (input) {
                     if (!input.validity.valid) {
                         const formGroup = input.closest('div.form-group');
@@ -83,7 +82,7 @@
             // So, the user clicks on Submit button, the form is not submitted and the error
             // is not displayed. This JavaScript code ensures that each tab shows a badge with
             // the number of errors in it.
-            formSubmitButton.addEventListener('click', function() {
+            entityForm.addEventListener('submit', function() {
                 const formTabPanes = entityForm.querySelectorAll('.tab-pane');
                 if (0 === formTabPanes.length) {
                     return;


### PR DESCRIPTION
Hi,

This PR is here to fix two things:

* Fixed class name to select the form to display the "are you sure?" message on new & edit forms
* Fixed JS for the new form when listening to submit events (retrieved the same code as on the edit form)
