### PR TITLE
[3.0] Change route name to "easyadmin_dashboard" to avoid conflicts with other routes

### DIFF
--- a/src/Controller/AbstractDashboardController.php
+++ b/src/Controller/AbstractDashboardController.php
@@ -85,7 +85,7 @@ abstract class AbstractDashboardController extends AbstractController implements
     }
 
     /**
-     * @Route("/admin", name="dashboard")
+     * @Route("/admin", name="easyadmin_dashboard")
      */
     public function index(): Response
     {


### PR DESCRIPTION
EA3 will create tons of BC breaks, so it might be safer to make sure the new routes don't cause conflicts