### PR TITLE
Don't define a name for the default dashboard route

### DIFF
--- a/src/Controller/AbstractDashboardController.php
+++ b/src/Controller/AbstractDashboardController.php
@@ -25,6 +25,14 @@ use Symfony\Component\Security\Core\User\UserInterface;
  */
 abstract class AbstractDashboardController extends AbstractController implements DashboardControllerInterface
 {
+    /**
+     * @Route("/admin")
+     */
+    public function index(): Response
+    {
+        return $this->render('@EasyAdmin/layout.html.twig');
+    }
+
     public function configureDashboard(): Dashboard
     {
         return Dashboard::new();
@@ -82,13 +90,5 @@ abstract class AbstractDashboardController extends AbstractController implements
     public function configureFilters(): Filters
     {
         return Filters::new();
-    }
-
-    /**
-     * @Route("/admin", name="dashboard")
-     */
-    public function index(): Response
-    {
-        return $this->render('@EasyAdmin/layout.html.twig');
     }
 }


### PR DESCRIPTION
We don't need any special route name because the name is obtained dynamically at runtime and all links are generated with it. So, let's remove the route name and let Symfony assign an automatic name to this route.