### PR TITLE
[3.0] SlugField: don't translate characters & remove special characters

### DIFF
--- a/assets/js/form-type-slug.js
+++ b/assets/js/form-type-slug.js
@@ -1,4 +1,49 @@
 const slugify = require('slugify');
+slugify.extend({
+    "$": "",
+    "%": "",
+    "&": "",
+    "<": "",
+    ">": "",
+    "|": "",
+    "¢": "",
+    "£": "",
+    "¤": "",
+    "¥": "",
+    "₠": "",
+    "₢": "",
+    "₣": "",
+    "₤": "",
+    "₥": "",
+    "₦": "",
+    "₧": "",
+    "₨": "",
+    "₩": "",
+    "₪": "",
+    "₫": "",
+    "€": "",
+    "₭": "",
+    "₮": "",
+    "₯": "",
+    "₰": "",
+    "₱": "",
+    "₲": "",
+    "₳": "",
+    "₴": "",
+    "₵": "",
+    "₸": "",
+    "₹": "",
+    "₽": "",
+    "₿": "",
+    "∂": "",
+    "∆": "",
+    "∑": "",
+    "∞": "",
+    "♥": "",
+    "元": "",
+    "円": "",
+    "﷼": "",
+});
 
 class Slugger {
     constructor(field) {
@@ -75,23 +120,11 @@ class Slugger {
     }
 
     updateValue() {
-        // this is needed because the special char conversion is done first,
-        // so we cannot remove these symbols later with the 'remove' option of slugify()
-        slugify.extend({
-            '$': '',
-            '%': '',
-            '&': '',
-            '<': '',
-            '>': '',
-            '|': '',
-            '¢': '',
-            '£': '',
-            '¥': '',
-            '©': '',
-            '®': '',
+        this.field.value = slugify(this.target.value, {
+            remove: /[^A-Za-z0-9\s-]/g,
+            lower: true,
+            strict: true,
         });
-
-        this.field.value = slugify(this.target.value, { lower: true, strict: true });
     }
 
     /**


### PR DESCRIPTION
Follow-up of Javier's comment: https://github.com/EasyCorp/EasyAdminBundle/pull/3164#issuecomment-622336387

This PR:

* extends (only once) the slugify() function to remove translated symbols (eg. "$" => "dollar")
* uses the "lower" option of slugify instead of .toLowerCase()
* allows only alphanumeric characters (and dashes) in the slug

Could supersede https://github.com/EasyCorp/EasyAdminBundle/commit/ec3c8da9508b063f719783eb87d52faee977487f ?