### PR TITLE
Doc: simplify example vich_uploader_image.html.twig by including the original image template

### DIFF
--- a/doc/integration/vichuploaderbundle.rst
+++ b/doc/integration/vichuploaderbundle.rst
@@ -206,15 +206,9 @@ VichUploaderBundle configuration.
     .. code-block:: html+twig
 
         {# templates/vich_uploader_image.html.twig #}
-        <a href="#" class="easyadmin-thumbnail" data-featherlight="#easyadmin-lightbox-{{ item.id }}" data-featherlight-close-on-click="anywhere">
-            {# the second parameter is the name of the property with the UploadableField annotation #}
-            <img src="{{ vich_uploader_asset(item, 'imageFile') }}">
-        </a>
-
-        <div id="easyadmin-lightbox-{{ item.id }}" class="easyadmin-lightbox">
-            {# the second parameter is the name of the property with the UploadableField annotation #}
-            <img src="{{ vich_uploader_asset(item, 'imageFile') }}">
-        </div>
+        {% set value = vich_uploader_asset(item, field_options.fieldName) %}
+        {% set uuid = item.id %}
+        {% include '@EasyAdmin/default/field_image.html.twig' %}
 
 Uploading the Images in the ``edit`` and ``new`` Views
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Instead of copying the contents of the `field_image.html.twig` file, we can override the `value` and `uuid` variables and include the image field template.

Advantages:
- no need for defining a template per image field, this template can be used regardless of the property name
- this template works for null values as well
- when the `field_image.html.twig` contents change, the documentation need not to be updated and developers do not need to update their `vich_uploader_image.html.twig` templates.