### PR TITLE
[3.0] Fix searchField() method that was renamed setSearchFields()

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -173,11 +173,11 @@ Search and Pagination Options
         return $crud
             // the names of the Doctrine entity properties where the search is made on
             // (by default it looks for in all properties)
-            ->searchFields(['name', 'description'])
+            ->setSearchFields(['name', 'description'])
             // use dots (e.g. 'seller.email') to search in Doctrine associations
-            ->searchFields(['name', 'description', 'seller.email', 'seller.phone'])
+            ->setSearchFields(['name', 'description', 'seller.email', 'seller.phone'])
             // set it to null to disable and hide the search box
-            ->searchFields(null);
+            ->setSearchFields(null);
 
             // defines the initial sorting applied to the list of entities
             // (user can later change this sorting by clciking on the table columns)

--- a/src/Maker/Migrator.php
+++ b/src/Maker/Migrator.php
@@ -176,7 +176,7 @@ final class Migrator
             }, $searchFieldNames);
             $searchFieldNamesAsString = sprintf('[%s]', implode(', ', $searchFieldVariables));
 
-            $code = $code->_methodCallWithRawArguments('searchFields', [$searchFieldNamesAsString]);
+            $code = $code->_methodCallWithRawArguments('setSearchFields', [$searchFieldNamesAsString]);
         }
 
         if ($definesCustomPagination) {

--- a/tests/Maker/fixtures/output/CategoryCrudController.php
+++ b/tests/Maker/fixtures/output/CategoryCrudController.php
@@ -20,7 +20,7 @@ class CategoryCrudController extends AbstractCrudController
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
-            ->searchFields(['id', 'name']);
+            ->setSearchFields(['id', 'name']);
     }
 
     public function configureFields(string $pageName): iterable

--- a/tests/Maker/fixtures/output/ProductCrudController.php
+++ b/tests/Maker/fixtures/output/ProductCrudController.php
@@ -26,7 +26,7 @@ class ProductCrudController extends AbstractCrudController
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
-            ->searchFields(['id', 'tags', 'ean', 'image', 'features', 'price', 'name', 'description']);
+            ->setSearchFields(['id', 'tags', 'ean', 'image', 'features', 'price', 'name', 'description']);
     }
 
     public function configureFields(string $pageName): iterable

--- a/tests/Maker/fixtures/output/PurchaseCrudController.php
+++ b/tests/Maker/fixtures/output/PurchaseCrudController.php
@@ -26,7 +26,7 @@ class PurchaseCrudController extends AbstractCrudController
         return $crud
             ->setEntityLabelInSingular('Purchase')
             ->setEntityLabelInPlural('Purchase')
-            ->searchFields(['id', 'guid', 'billingAddress']);
+            ->setSearchFields(['id', 'guid', 'billingAddress']);
     }
 
     public function configureActions(Actions $actions): Actions

--- a/tests/Maker/fixtures/output/PurchaseItemCrudController.php
+++ b/tests/Maker/fixtures/output/PurchaseItemCrudController.php
@@ -19,7 +19,7 @@ class PurchaseItemCrudController extends AbstractCrudController
     public function configureCrud(Crud $crud): Crud
     {
         return $crud
-            ->searchFields(['id', 'quantity', 'taxRate']);
+            ->setSearchFields(['id', 'quantity', 'taxRate']);
     }
 
     public function configureFields(string $pageName): iterable

--- a/tests/Maker/fixtures/output/UserCrudController.php
+++ b/tests/Maker/fixtures/output/UserCrudController.php
@@ -24,7 +24,7 @@ class UserCrudController extends AbstractCrudController
         return $crud
             ->setEntityLabelInSingular('User')
             ->setEntityLabelInPlural('User')
-            ->searchFields(['id', 'username', 'email', 'contract']);
+            ->setSearchFields(['id', 'username', 'email', 'contract']);
     }
 
     public function configureFields(string $pageName): iterable


### PR DESCRIPTION
A slight inconsistency fix that I detected when re-migrating my backend
