### PR TITLE
[3.0] Fix template keys error display

### DIFF
--- a/src/Registry/TemplateRegistry.php
+++ b/src/Registry/TemplateRegistry.php
@@ -78,7 +78,7 @@ final class TemplateRegistry
     public function get(string $templateName): string
     {
         if (!$this->has($templateName)) {
-            throw new \InvalidArgumentException(sprintf('The "%s" template is not defined in EasyAdmin. Use one of these allowed template names: %s', $templateName, implode(', ', array_keys($this->getTemplateNames()))));
+            throw new \InvalidArgumentException(sprintf('The "%s" template is not defined in EasyAdmin. Use one of these allowed template names: %s', $templateName, implode(', ', array_keys($this->templates))));
         }
 
         return $this->templates[$templateName];
@@ -87,7 +87,7 @@ final class TemplateRegistry
     public function setTemplate(string $templateName, string $templatePath): void
     {
         if (!$this->has($templateName)) {
-            throw new \InvalidArgumentException(sprintf('The "%s" template is not defined in EasyAdmin. Use one of these allowed template names: %s', $templateName, implode(', ', array_keys($this->getTemplateNames()))));
+            throw new \InvalidArgumentException(sprintf('The "%s" template is not defined in EasyAdmin. Use one of these allowed template names: %s', $templateName, implode(', ', array_keys($this->templates))));
         }
 
         $this->templates[$templateName] = $templatePath;


### PR DESCRIPTION
Example config to reproduce:

```php
public function configureFields(string $pageName): iterable
{
    // ...
    if (Crud::PAGE_NEW === $pageName || Crud::PAGE_EDIT === $pageName) {
        return [
            Field::new('translatedNames')
                ->setTemplateName('inexistent_template')
            ,
        ];
    }
}
```

| Before | After | 
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3369266/81413718-2f912100-9146-11ea-942f-ef95c3ed8705.png) | ![image](https://user-images.githubusercontent.com/3369266/81413759-433c8780-9146-11ea-9aae-05a72a92bc43.png) |

