### PR TITLE
Re-added the legacy EasyAdminController to avoid errors when upgrading

### DIFF
--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+/**
+ * This file is kept for BC reasons, to avoid errors when upgrading from EasyAdmin 2.
+ */
+class EasyAdminController extends AbstractController
+{
+    public function __call($name, $arguments)
+    {
+        throw new \RuntimeException(<<<HELP
+If you are seeing this error, you are probably upgrading your application
+from EasyAdmin 2 to EasyAdmin 3. The new version of this bundle is a complete
+refactorization and most of the previous classes have been moved or deleted.
+ 
+One of those removed classes is "EasyAdminController", which was used in EasyAdmin 2
+as the base controller of the entire backend. In EasyAdmin 3 each Doctrine entity has
+its own controller, so you can no longer use that base controller.
+
+This file is usually referenced from the "config/routes/easy_admin.yaml" file. Remove
+or update that configuration file to stop using the removed controller class.
+
+If you need more help, read the EasyAdmin 3 documentation at:
+https://symfony.com/doc/master/bundles/EasyAdminBundle/index.html
+HELP
+        );
+    }
+}


### PR DESCRIPTION
When someone upgrades from EA2 to EA3, they keep all the old EA2 config files for a while (they remove them later when EA3 works for them). This can cause lots of errors.

That's why we keep in EA3 the, now unused, configuration class used in EA2: https://github.com/EasyCorp/EasyAdminBundle/blob/master/src/DependencyInjection/Configuration.php. This prevents errors when Symfony tries to load the `easy_admin` semantic config.

Similarly, it's common to face this error when upgrading:

![upgrading-error](https://user-images.githubusercontent.com/73419/81417580-b0065080-914b-11ea-994e-f55471142004.png)

Your config files probably point to the `EasyAdminController`, which no longer exists. So, let's re-add it to avoid errors ... and provide useful error messages if someone tries to use it.