### PR TITLE
Re-enable persist in updateEntity()

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -410,9 +410,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
     {
-        // there's no need to persist the entity explicitly again because it's already
-        // managed by Doctrine. The instance is passed to the method in case the
-        // user application needs to make decisions
+        $entityManager->persist($entityInstance);
         $entityManager->flush();
     }
 


### PR DESCRIPTION
Even though `$em->persist($entity)` does nothing for entities that are already managed by the EntityManager when they're fetched from a Repository or via a join, it is still mandatory to execute `persist()` on it for projects that use a different tracking policy: https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/change-tracking-policies.html

My side-project [Compotes](https://github.com/Orbitale/Compotes) uses this, and I noted a good impact in terms of performances and memory in dev (not benchmarked though) because a `flush()` doesn't need to check for **all** the entities in the memory, only the ones that were manually persisted.

And to make this work, an entity must be re-persisted if you want to update it in the database. Hence this PR.