### PR TITLE
Fix form type options when using DateTimeImmutable

### DIFF
--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -10,6 +10,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\EventListener\EasyAdminTabSubscriber;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -57,7 +60,11 @@ class CrudFormType extends AbstractType
             }
 
             if (null === $formFieldType = $fieldDto->getFormType()) {
-                $formFieldType = $this->doctrineOrmTypeGuesser->guessType($entityDto->getFqcn(), $fieldDto->getProperty())->getType();
+                $guessType = $this->doctrineOrmTypeGuesser->guessType($entityDto->getFqcn(), $fieldDto->getProperty());
+                $formFieldType = $guessType->getType();
+                $formFieldOptions = array_merge($guessType->getOptions(), $formFieldOptions);
+            } elseif (in_array($formFieldType, [DateTimeType::class, DateType::class, TimeType::class])) {
+                $formFieldOptions['input'] = 'datetime_immutable';
             }
 
             if (EaFormPanelType::class === $formFieldType) {


### PR DESCRIPTION
When fields are auto-detected by the DoctrineOrmTypeGuesser, it automatically add some options, like `input => datetime_immutable` for date/time types. The first part of the patch is to take these options automatically.

But when fields are set, we need to be explicit, that's the second part of the fix.
