### PR TITLE
Improved the IdField used to render primary keys

### DIFF
--- a/src/Field/Configurator/IdConfigurator.php
+++ b/src/Field/Configurator/IdConfigurator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use function Symfony\Component\String\u;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class IdConfigurator implements FieldConfiguratorInterface
+{
+    public function supports(FieldDto $field, EntityDto $entityDto): bool
+    {
+        return IdField::class === $field->getFieldFqcn();
+    }
+
+    public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
+    {
+        $maxLength = $field->getCustomOption(IdField::OPTION_MAX_LENGTH);
+        if (null === $maxLength) {
+            $maxLength = Crud::PAGE_INDEX === $context->getCrud()->getCurrentPage() ? 7 : -1;
+        }
+
+        if (-1 !== $maxLength) {
+            $field->setFormattedValue(u($field->getValue())->truncate($maxLength, '…'));
+        }
+    }
+}

--- a/src/Field/IdField.php
+++ b/src/Field/IdField.php
@@ -12,6 +12,8 @@ final class IdField implements FieldInterface
 {
     use FieldTrait;
 
+    public const OPTION_MAX_LENGTH = 'maxLength';
+
     public static function new(string $propertyName, ?string $label = null): self
     {
         return (new self())
@@ -19,6 +21,21 @@ final class IdField implements FieldInterface
             ->setLabel($label)
             ->setTemplateName('crud/field/id')
             ->setFormType(TextType::class)
-            ->addCssClass('field-id');
+            ->addCssClass('field-id')
+            ->setCustomOption(self::OPTION_MAX_LENGTH, null);
+    }
+
+    /**
+     * Set maxLength to -1 to define an unlimited max length
+     */
+    public function setMaxLength(int $length): self
+    {
+        if (0 === $length) {
+            throw new \InvalidArgumentException(sprintf('The argument of the "%s()" method must be a positive integer or -1 (for unlimited length) (%d given).', __METHOD__, $length));
+        }
+
+        $this->setCustomOption(self::OPTION_MAX_LENGTH, $length);
+
+        return $this;
     }
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -30,6 +30,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CurrencyConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\DateTimeConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\EmailConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\FormConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\IdConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ImageConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\LanguageConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\LocaleConfigurator;
@@ -284,6 +285,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('ea.field_configurator')
 
         ->set(FormConfigurator::class)
+            ->tag('ea.field_configurator')
+
+        ->set(IdConfigurator::class)
             ->tag('ea.field_configurator')
 
         ->set(ImageConfigurator::class)

--- a/src/Resources/views/crud/field/id.html.twig
+++ b/src/Resources/views/crud/field/id.html.twig
@@ -1,5 +1,5 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{# this template is for entity primary keys (don't format those values as numbers) #}
-{{ field.value }}
+{# this template is used to display Doctrine entity primary keys #}
+{{ field.formattedValue }}


### PR DESCRIPTION
UUIDs and ULIDs are increasingly popular for primary keys ... and they are very long ... so they look ugly in listings. This PR makes primary keys 7-char long max by default ... but you can configure it to use any length. 