### PR TITLE
Handle immutable datetime types in DateTime configurator

### DIFF
--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
+use Doctrine\DBAL\Types\Types;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -51,5 +52,11 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
         }
 
         $field->setFormattedValue($formattedValue);
+
+        $doctrineDataType = $entityDto->getPropertyMetadata($field->getProperty())->get('type');
+        $isImmutableDateTime = in_array($doctrineDataType, [Types::DATETIME_MUTABLE, Types::DATE_MUTABLE, Types::TIME_MUTABLE], true);
+        if ($isImmutableDateTime) {
+            $field->setFormTypeOptionIfNotSet('input', 'datetime_immutable');
+        }
     }
 }

--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -10,9 +10,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\EventListener\EasyAdminTabSubscriber;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
-use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
@@ -63,8 +60,6 @@ class CrudFormType extends AbstractType
                 $guessType = $this->doctrineOrmTypeGuesser->guessType($entityDto->getFqcn(), $fieldDto->getProperty());
                 $formFieldType = $guessType->getType();
                 $formFieldOptions = array_merge($guessType->getOptions(), $formFieldOptions);
-            } elseif (in_array($formFieldType, [DateTimeType::class, DateType::class, TimeType::class])) {
-                $formFieldOptions['input'] = 'datetime_immutable';
             }
 
             if (EaFormPanelType::class === $formFieldType) {


### PR DESCRIPTION
The PR #3205 fixed two bugs. This PR proposes a different fix for the second bug. If this solution is equivalent, it would be easier to maintain because we define form types of the other fields in these "configurator classes".