### PR TITLE
[3.0] Preventing non-string type from being used as array key

### DIFF
--- a/src/Collection/EntityCollection.php
+++ b/src/Collection/EntityCollection.php
@@ -36,7 +36,7 @@ final class EntityCollection implements CollectionInterface
 
     public function set(EntityDto $newOrUpdatedEntity): void
     {
-        $this->entities[$newOrUpdatedEntity->getPrimaryKeyValue()] = $newOrUpdatedEntity;
+        $this->entities[(string) $newOrUpdatedEntity->getPrimaryKeyValue()] = $newOrUpdatedEntity;
     }
 
     public function offsetExists($offset): bool

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -86,7 +86,7 @@ final class EntityFactory
                 $newEntityDto->markAsInaccessible();
             }
 
-            $entityDtos[$newEntityId] = $newEntityDto;
+            $entityDtos[(string) $newEntityId] = $newEntityDto;
         }
 
         return EntityCollection::new($entityDtos);


### PR DESCRIPTION
I'm running a symfony application where Doctrine is configured to used uuids as primary key. In that scenario entity id is of object type.
This pull request casts ids to strings to prevent the issue.
