### PR TITLE
Renamed a security permission related to entities

### DIFF
--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -82,7 +82,7 @@ final class EntityFactory
         foreach ($entityInstances as $entityInstance) {
             $newEntityDto = $entityDto->newWithInstance($entityInstance);
             $newEntityId = $newEntityDto->getPrimaryKeyValueAsString();
-            if (!$this->authorizationChecker->isGranted(Permission::EA_VIEW_ENTITY, $newEntityDto)) {
+            if (!$this->authorizationChecker->isGranted(Permission::EA_ACCESS_ENTITY, $newEntityDto)) {
                 $newEntityDto->markAsInaccessible();
             }
 
@@ -109,7 +109,7 @@ final class EntityFactory
         $entityMetadata = $this->getEntityMetadata($entityFqcn);
         $entityDto = new EntityDto($entityFqcn, $entityMetadata, $entityPermission, $entityInstance);
 
-        if (!$this->authorizationChecker->isGranted(Permission::EA_VIEW_ENTITY, $entityDto)) {
+        if (!$this->authorizationChecker->isGranted(Permission::EA_ACCESS_ENTITY, $entityDto)) {
             $entityDto->markAsInaccessible();
         }
 

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -7,10 +7,10 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Security;
  */
 final class Permission
 {
+    public const EA_ACCESS_ENTITY = 'EA_ACCESS_ENTITY';
     public const EA_EXECUTE_ACTION = 'EA_EXECUTE_ACTION';
     public const EA_VIEW_MENU_ITEM = 'EA_VIEW_MENU_ITEM';
     public const EA_VIEW_FIELD = 'EA_VIEW_FIELD';
-    public const EA_VIEW_ENTITY = 'EA_VIEW_ENTITY';
     public const EA_EXIT_IMPERSONATION = 'EA_EXIT_IMPERSONATION';
 
     public static function exists(?string $permissionName): bool

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -45,7 +45,7 @@ final class SecurityVoter extends Voter
             return $this->voteOnViewPropertyPermission($subject);
         }
 
-        if (Permission::EA_VIEW_ENTITY === $permissionName) {
+        if (Permission::EA_ACCESS_ENTITY === $permissionName) {
             return $this->voteOnViewEntityPermission($subject);
         }
 


### PR DESCRIPTION
We use this permission to check access for index/detail/edit/new pages ... so it's not only about "view entity" but "access to entity" in general. I don't want to introduce different permissions for "view entity", "update entity", etc. because we don't use ACL and if you need that, you can implement it in your own security voter because you always know in which page you are.