### PR TITLE
Renamed SelectField as ChoiceField

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -255,6 +255,7 @@ These are all the built-in fields provided by EasyAdmin:
 * ``AssociationField``
 * ``AvatarField``
 * ``BooleanField``
+* ``ChoiceField``
 * ``CodeEditorField``
 * ``CollectionField``
 * ``ColorField``
@@ -271,7 +272,6 @@ These are all the built-in fields provided by EasyAdmin:
 * ``MoneyField``
 * ``NumberField``
 * ``PercentField``
-* ``SelectField``
 * ``SlugField``
 * ``TelephoneField``
 * ``TextareaField``

--- a/src/Field/ChoiceField.php
+++ b/src/Field/ChoiceField.php
@@ -8,11 +8,11 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class SelectField implements FieldInterface
+final class ChoiceField implements FieldInterface
 {
     use FieldTrait;
 
-    public const OPTION_ALLOW_MULTIPLE_SELECT = 'allowMultipleSelect';
+    public const OPTION_ALLOW_MULTIPLE_CHOICES = 'allowMultipleChoices';
     public const OPTION_AUTOCOMPLETE = 'autocomplete';
     public const OPTION_CHOICES = 'choices';
     public const OPTION_RENDER_EXPANDED = 'renderExpanded';
@@ -25,14 +25,14 @@ final class SelectField implements FieldInterface
             ->setTemplateName('crud/field/select')
             ->setFormType(ChoiceType::class)
             ->addCssClass('field-select')
-            ->setCustomOption(self::OPTION_ALLOW_MULTIPLE_SELECT, false)
+            ->setCustomOption(self::OPTION_ALLOW_MULTIPLE_CHOICES, false)
             ->setCustomOption(self::OPTION_CHOICES, null)
             ->setCustomOption(self::OPTION_RENDER_EXPANDED, false);
     }
 
-    public function allowMultipleSelect(bool $allow = true): self
+    public function allowMultipleChoices(bool $allow = true): self
     {
-        $this->setCustomOption(self::OPTION_ALLOW_MULTIPLE_SELECT, $allow);
+        $this->setCustomOption(self::OPTION_ALLOW_MULTIPLE_CHOICES, $allow);
 
         return $this;
     }

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -6,13 +6,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use EasyCorp\Bundle\EasyAdminBundle\Field\SelectField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class SelectConfigurator implements FieldConfiguratorInterface
+final class ChoiceConfigurator implements FieldConfiguratorInterface
 {
     private $translator;
 
@@ -23,12 +23,12 @@ final class SelectConfigurator implements FieldConfiguratorInterface
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {
-        return SelectField::class === $field->getFieldFqcn();
+        return ChoiceField::class === $field->getFieldFqcn();
     }
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
-        $choices = $field->getCustomOption(SelectField::OPTION_CHOICES);
+        $choices = $field->getCustomOption(ChoiceField::OPTION_CHOICES);
         if (empty($choices)) {
             throw new \InvalidArgumentException(sprintf('The "%s" select field must define its possible choices using the setChoices() method.', $field->getProperty()));
         }
@@ -55,10 +55,10 @@ final class SelectConfigurator implements FieldConfiguratorInterface
             $field->setFormattedValue(implode(', ', $selectedChoices));
         }
 
-        $field->setFormTypeOptionIfNotSet('multiple', $field->getCustomOption(SelectField::OPTION_ALLOW_MULTIPLE_SELECT));
-        $field->setFormTypeOptionIfNotSet('expanded', $field->getCustomOption(SelectField::OPTION_RENDER_EXPANDED));
+        $field->setFormTypeOptionIfNotSet('multiple', $field->getCustomOption(ChoiceField::OPTION_ALLOW_MULTIPLE_CHOICES));
+        $field->setFormTypeOptionIfNotSet('expanded', $field->getCustomOption(ChoiceField::OPTION_RENDER_EXPANDED));
 
-        if (true === $field->getCustomOption(SelectField::OPTION_AUTOCOMPLETE)) {
+        if (true === $field->getCustomOption(ChoiceField::OPTION_AUTOCOMPLETE)) {
             $field->setFormTypeOptionIfNotSet('attr.data-widget', 'select2');
         }
     }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -37,7 +37,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\LocaleConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\MoneyConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\NumberConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\PercentConfigurator;
-use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\SelectConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ChoiceConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\SlugConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\TelephoneConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\TextConfigurator;
@@ -311,7 +311,7 @@ return static function (ContainerConfigurator $container) {
         ->set(PercentConfigurator::class)
             ->tag('ea.field_configurator')
 
-        ->set(SelectConfigurator::class)
+        ->set(ChoiceConfigurator::class)
             ->arg(0, ref('translator'))
             ->tag('ea.field_configurator')
 


### PR DESCRIPTION
This is easier to understand because Symfony's form type is called `ChoiceType`