### PR TITLE
Fixed error when there is no crud controller yet

### DIFF
--- a/src/Registry/CrudControllerRegistry.php
+++ b/src/Registry/CrudControllerRegistry.php
@@ -9,7 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface
  */
 final class CrudControllerRegistry
 {
-    private $controllerFqcnToEntityFqcnMap;
+    private $controllerFqcnToEntityFqcnMap = [];
     private $entityFqcnToControllerFqcnMap;
 
     private function __construct()


### PR DESCRIPTION
I just started working on my first EA3 project and learning how it work :) 

I only have one dashboard controller (I don't have any crud controller yet) and I wanted to see how it looked, but this error happened:

![ea3-startup-bug](https://user-images.githubusercontent.com/2028198/82156845-ca2ae780-984b-11ea-8f61-8b6440623644.png)

I'm guessing with this PR that crud controllers aren't mandatory from the start, right?