### PR TITLE
[3.0] Fixed crud index toggler on refresh for Firefox

### DIFF
--- a/src/Resources/views/crud/field/boolean.html.twig
+++ b/src/Resources/views/crud/field/boolean.html.twig
@@ -9,7 +9,7 @@
     </span>
 {% else %}
     <div class="custom-control custom-switch custom-switch-lg" data-fieldname="{{ field.property }}">
-        <input type="checkbox" class="custom-control-input" id="{{ field.uniqueId }}" {{ field.value == true ? 'checked' }}>
+        <input type="checkbox" class="custom-control-input" id="{{ field.uniqueId }}" {{ field.value == true ? 'checked' }} autocomplete="off">
         <label class="custom-control-label" for="{{ field.uniqueId }}"></label>
     </div>
 {% endif %}


### PR DESCRIPTION
Hi,

I'll try to explain as clearly as I can this bugfix.

I have an Article Crud controller. These articles are sorted by publication status (boolean field, 0 is first) and then by publication date.

Let's say I unpublish an article. Clicking on the toggler works, the ajax request is sent & the toggler goes to "off" status. However, using Firefox, when I refresh the page, the line where the given article was sees its toggler in "off" status, whether the article is published or not.

This is due to Firefox keeping form data between page refreshes. Fixed it by adding a simple `autocomplete="off"` attribute on the input.