### PR TITLE
Improve the way Symfony actions are integrated with EasyAdmin

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -278,6 +278,23 @@ It links to any of the Symfony application routes::
         ];
     }
 
+When using route menu items, EasyAdmin adds the following route parameters
+automatically (in addition to the optional route parameters defined by you):
+
+* ``menuIndex`` and ``submenuIndex``: they are needed to keep the selected menu
+  item when rendering the page of your action (in case you display the main menu);
+* ``eaContext``: an alphanumeric string that identifies the Dashboard controller
+  FQCN related to this action (and which cannot be guessed by malicious users).
+  This is needed to load the dashboard configuration used to render the backend
+  layout (in case your action uses it). If you don't add this parameter and try
+  to use EasyAdmin templates, you'll see errors such as
+  *"Variable "ea" does not exist."* (which is related to the :ref:`admin context <admin-context>`).
+
+.. note::
+
+    The path of your route probably doesn't include these parameters added by
+    EasyAdmin, but that's fine (you'll see them as query string parameters).
+
 URL Menu Item
 .............
 

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -101,6 +101,11 @@ final class AdminContext
         return $this->dashboardDto->getFaviconPath();
     }
 
+    public function getDashboardControllerFqcn(): string
+    {
+        return \get_class($this->dashboardControllerInstance);
+    }
+
     public function getDashboardRouteName(): string
     {
         return $this->dashboardDto->getRouteName();
@@ -113,7 +118,7 @@ final class AdminContext
         }
 
         $configuredMenuItems = $this->dashboardControllerInstance->configureMenuItems();
-        $mainMenuItems = is_array($configuredMenuItems) ? $configuredMenuItems : iterator_to_array($configuredMenuItems, false);
+        $mainMenuItems = \is_array($configuredMenuItems) ? $configuredMenuItems : iterator_to_array($configuredMenuItems, false);
         $selectedMenuIndex = $this->request->query->getInt('menuIndex', -1);
         $selectedMenuSubIndex = $this->request->query->getInt('submenuIndex', -1);
 

--- a/src/DependencyInjection/EasyAdminExtension.php
+++ b/src/DependencyInjection/EasyAdminExtension.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\DependencyInjection;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -19,6 +20,10 @@ class EasyAdminExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        $container->registerForAutoconfiguration(DashboardControllerInterface::class)
+            ->addTag('ea.dashboard_controller')
+        ;
+
         $container->registerForAutoconfiguration(CrudControllerInterface::class)
             ->addTag('ea.crud_controller')
         ;

--- a/src/Registry/DashboardControllerRegistry.php
+++ b/src/Registry/DashboardControllerRegistry.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class DashboardControllerRegistry
+{
+    private $controllerFqcnToContextIdMap = [];
+    private $contextIdToControllerFqcnMap;
+
+    public function __construct(string $kernelSecret, iterable $dashboardControllers)
+    {
+        foreach (iterator_to_array($dashboardControllers, false) as $controller) {
+            $controllerFqcn = \get_class($controller);
+            $this->controllerFqcnToContextIdMap[$controllerFqcn] = substr(sha1($kernelSecret.$controllerFqcn), 0, 7);
+        }
+
+        $this->contextIdToControllerFqcnMap = array_flip($this->controllerFqcnToContextIdMap);
+    }
+
+    public function getControllerFqcnByContextId(string $contextId): ?string
+    {
+        return $this->contextIdToControllerFqcnMap[$contextId] ?? null;
+    }
+
+    public function getContextIdByControllerFqcn(string $controllerFqcn): ?string
+    {
+        return $this->controllerFqcnToContextIdMap[$controllerFqcn] ?? null;
+    }
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -64,6 +64,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityUpdater;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\FieldProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Router\CrudUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Security\AuthorizationChecker;
 use EasyCorp\Bundle\EasyAdminBundle\Security\SecurityVoter;
@@ -134,8 +135,9 @@ return static function (ContainerConfigurator $container) {
 
         ->set(AdminContextListener::class)
             ->arg(0, ref(AdminContextFactory::class))
-            ->arg(1, ref('controller_resolver'))
-            ->arg(2, ref('twig'))
+            ->arg(1, ref(DashboardControllerRegistry::class))
+            ->arg(2, ref('controller_resolver'))
+            ->arg(3, ref('twig'))
             ->tag('kernel.event_listener', ['event' => ControllerEvent::class])
 
         ->set(CrudResponseListener::class)
@@ -150,17 +152,22 @@ return static function (ContainerConfigurator $container) {
             ->arg(3, tagged_iterator('ea.crud_controller'))
             ->arg(4, ref(EntityFactory::class))
 
+        ->set(DashboardControllerRegistry::class)
+            ->arg(0, '%kernel.secret%')
+            ->arg(1, tagged_iterator('ea.dashboard_controller'))
+
         ->set(CrudUrlGenerator::class)
             ->arg(0, ref(AdminContextProvider::class))
             ->arg(1, ref('router.default'))
 
         ->set(MenuFactory::class)
             ->arg(0, ref(AdminContextProvider::class))
-            ->arg(1, ref(AuthorizationChecker::class))
-            ->arg(2, ref('translator'))
-            ->arg(3, ref('router'))
-            ->arg(4, ref('security.logout_url_generator'))
-            ->arg(5, ref(CrudUrlGenerator::class))
+            ->arg(1, ref(DashboardControllerRegistry::class))
+            ->arg(2, ref(AuthorizationChecker::class))
+            ->arg(3, ref('translator'))
+            ->arg(4, ref('router'))
+            ->arg(5, ref('security.logout_url_generator'))
+            ->arg(6, ref(CrudUrlGenerator::class))
 
         ->set(EntityRepository::class)
             ->arg(0, ref(AdminContextProvider::class))


### PR DESCRIPTION
This was one of the weakest points of EasyAdmin 3:

What you want to do: link to a normal Symfony route ... but make it look as if it were an EasyAdmin action (use the same page design, display the full dashboard menu, etc.)

You couldn't do that easily until now (so you had to define the actions in your CRUD controllers to reuse the backend layout, menu, etc.) Thanks to this feature, all this will no longer be necessary.