### PR TITLE
Introduced a Controller registry and improved security

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -283,8 +283,9 @@ automatically (in addition to the optional route parameters defined by you):
 
 * ``menuIndex`` and ``submenuIndex``: they are needed to keep the selected menu
   item when rendering the page of your action (in case you display the main menu);
-* ``eaContext``: an alphanumeric string that identifies the Dashboard controller
-  FQCN related to this action (and which cannot be guessed by malicious users).
+* ``eaContext``: an random-looking alphanumeric string that identifies the
+  Dashboard controller related to this action (this string is generated using
+  the application kernel secret, so it cannot be guessed by malicious users).
   This is needed to load the dashboard configuration used to render the backend
   layout (in case your action uses it). If you don't add this parameter and try
   to use EasyAdmin templates, you'll see errors such as

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -23,7 +23,7 @@ final class CrudMenuItem implements MenuItemInterface
         $this->dto->setIcon($icon);
         $this->dto->setRouteParameters([
             'crudAction' => 'index',
-            'crudController' => null,
+            'crudId' => null,
             'entityFqcn' => $entityFqcn,
             'entityId' => null,
         ]);
@@ -33,7 +33,7 @@ final class CrudMenuItem implements MenuItemInterface
     {
         $this->dto->setRouteParameters(array_merge(
             $this->dto->getRouteParameters(),
-            ['crudController' => $controllerFqcn]
+            ['crudControllerFqcn' => $controllerFqcn]
         ));
 
         return $this;

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -28,7 +28,7 @@ final class AdminContext
     private $request;
     private $user;
     private $i18nDto;
-    private $crudControllerRegistry;
+    private $crudControllers;
     private $entityDto;
     private $dashboardDto;
     private $dashboardControllerInstance;
@@ -40,12 +40,12 @@ final class AdminContext
     private $mainMenuDto;
     private $userMenuDto;
 
-    public function __construct(Request $request, ?UserInterface $user, I18nDto $i18nDto, CrudControllerRegistry $crudControllerRegistry, DashboardDto $dashboardDto, DashboardControllerInterface $dashboardController, AssetsDto $assetDto, ?CrudDto $crudDto, ?EntityDto $entityDto, ?SearchDto $searchDto, MenuFactory $menuFactory, TemplateRegistry $templateRegistry)
+    public function __construct(Request $request, ?UserInterface $user, I18nDto $i18nDto, CrudControllerRegistry $crudControllers, DashboardDto $dashboardDto, DashboardControllerInterface $dashboardController, AssetsDto $assetDto, ?CrudDto $crudDto, ?EntityDto $entityDto, ?SearchDto $searchDto, MenuFactory $menuFactory, TemplateRegistry $templateRegistry)
     {
         $this->request = $request;
         $this->user = $user;
         $this->i18nDto = $i18nDto;
-        $this->crudControllerRegistry = $crudControllerRegistry;
+        $this->crudControllers = $crudControllers;
         $this->dashboardDto = $dashboardDto;
         $this->dashboardControllerInstance = $dashboardController;
         $this->crudDto = $crudDto;
@@ -73,7 +73,7 @@ final class AdminContext
 
     public function getCrudControllers(): CrudControllerRegistry
     {
-        return $this->crudControllerRegistry;
+        return $this->crudControllers;
     }
 
     public function getEntity(): EntityDto

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -39,6 +39,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityUpdater;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\FieldProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Router\CrudUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -10,6 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
  */
 final class CrudDto
 {
+    private $controllerFqcn;
     private $pageName;
     private $actionName;
     /** @var $actions ActionConfigDto */
@@ -58,6 +59,16 @@ final class CrudDto
         $this->newFormOptions = KeyValueStore::new();
         $this->editFormOptions = KeyValueStore::new();
         $this->overriddenTemplates = [];
+    }
+
+    public function getControllerFqcn(): ?string
+    {
+        return $this->controllerFqcn;
+    }
+
+    public function setControllerFqcn(string $fqcn): void
+    {
+        $this->controllerFqcn = $fqcn;
     }
 
     public function getCurrentPage(): ?string

--- a/src/Exception/ForbiddenActionException.php
+++ b/src/Exception/ForbiddenActionException.php
@@ -10,11 +10,11 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\ExceptionContext;
  */
 final class ForbiddenActionException extends BaseException
 {
-    public function __construct(AdminContext $adminContext)
+    public function __construct(AdminContext $context)
     {
         $parameters = [
-            'action' => $adminContext->getCrud()->getCurrentAction(),
-            'crud_controller' => $adminContext->getRequest()->query->get('crudController'),
+            'crud_controller' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
+            'action' => null === $context->getCrud() ? null : $context->getCrud()->getCurrentAction(),
         ];
 
         $exceptionContext = new ExceptionContext(

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -134,7 +134,7 @@ final class ActionFactory
         }
 
         $requestParameters = [
-            'crudController' => $request->query->get('crudController'),
+            'crudId' => $request->query->get('crudId'),
             'crudAction' => $actionDto->getCrudActionName(),
             'referrer' => $this->generateReferrerUrl($request, $actionDto, $currentAction),
         ];

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -33,12 +33,12 @@ final class AdminContextFactory
     private $crudControllers;
     private $entityFactory;
 
-    public function __construct(TranslatorInterface $translator, ?TokenStorageInterface $tokenStorage, MenuFactory $menuFactory, iterable $crudControllers, EntityFactory $entityFactory)
+    public function __construct(TranslatorInterface $translator, ?TokenStorageInterface $tokenStorage, MenuFactory $menuFactory, CrudControllerRegistry $crudControllers, EntityFactory $entityFactory)
     {
         $this->translator = $translator;
         $this->tokenStorage = $tokenStorage;
         $this->menuFactory = $menuFactory;
-        $this->crudControllers = CrudControllerRegistry::new($crudControllers);
+        $this->crudControllers = $crudControllers;
         $this->entityFactory = $entityFactory;
     }
 
@@ -85,7 +85,7 @@ final class AdminContextFactory
         return $crudController->configureAssets($defaultAssets)->getAsDto();
     }
 
-    private function getCrudDto(CrudControllerRegistry $crudControllerRegistry, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ActionConfigDto $actionConfigDto, FilterConfigDto $filters, ?string $crudAction, ?string $pageName): ?CrudDto
+    private function getCrudDto(CrudControllerRegistry $crudControllers, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ActionConfigDto $actionConfigDto, FilterConfigDto $filters, ?string $crudAction, ?string $pageName): ?CrudDto
     {
         if (null === $crudController) {
             return null;
@@ -94,10 +94,10 @@ final class AdminContextFactory
         $defaultCrud = $dashboardController->configureCrud();
         $crudDto = $crudController->configureCrud($defaultCrud)->getAsDto();
 
-        $entityFqcn = $crudControllerRegistry->getEntityFqcnByControllerFqcn(\get_class($crudController));
+        $entityFqcn = $crudControllers->findEntityFqcnByCrudFqcn(\get_class($crudController));
         $entityClassName = basename(str_replace('\\', '/', $entityFqcn));
-        $entityName = empty($entityClassName) ? 'Undefined' : $entityClassName;
 
+        $crudDto->setControllerFqcn(\get_class($crudController));
         $crudDto->setActionsConfig($actionConfigDto);
         $crudDto->setFiltersConfig($filters);
         $crudDto->setCurrentAction($crudAction);

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -45,7 +45,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         $targetEntityFqcn = $field->getDoctrineMetadata()->get('targetEntity');
         // the target CRUD controller can be NULL; in that case, field value doesn't link to the related entity
         $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER)
-            ?? $context->getCrudControllers()->getControllerFqcnByEntityFqcn($targetEntityFqcn);
+            ?? $context->getCrudControllers()->findCrudFqcnByEntityFqcn($targetEntityFqcn);
         $field->setCustomOption(AssociationField::OPTION_CRUD_CONTROLLER, $targetCrudControllerFqcn);
 
         if ($entityDto->isToOneAssociation($propertyName)) {
@@ -67,7 +67,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
             $field->setFormType(CrudAutocompleteType::class);
             $autocompleteEndpointUrl = $this->crudUrlGenerator->build()
-                ->setController($field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER))
+                ->setCrudFqcn($field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER))
                 ->setAction('autocomplete')
                 ->setEntityId(null)
                 ->generateUrl();
@@ -141,7 +141,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
         // TODO: check if user has permission to see the related entity
         return $this->crudUrlGenerator->build()
-            ->setController($crudController)
+            ->setCrudFqcn($crudController)
             ->setAction(Action::DETAIL)
             ->setEntityId($entityDto->getPrimaryKeyValue())
             ->unset('menuIndex')

--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -61,9 +61,10 @@ class DataCollector extends BaseDataCollector
     private function collectData(AdminContext $context): array
     {
         return [
-            'CRUD Controller' => $context->getRequest()->get('crudController'),
+            'CRUD ID' => $context->getRequest()->get('crudId'),
+            'CRUD Controller FQCN' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
             'CRUD Action' => $context->getRequest()->get('crudAction'),
-            'Entity Id' => $context->getRequest()->get('entityId'),
+            'Entity ID' => $context->getRequest()->get('entityId'),
             'Sort' => $context->getRequest()->get('sort'),
         ];
     }

--- a/src/Registry/DashboardControllerRegistry.php
+++ b/src/Registry/DashboardControllerRegistry.php
@@ -8,7 +8,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 final class DashboardControllerRegistry
 {
     private $controllerFqcnToContextIdMap = [];
-    private $contextIdToControllerFqcnMap;
+    private $contextIdToControllerFqcnMap = [];
 
     public function __construct(string $kernelSecret, iterable $dashboardControllers)
     {

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -64,6 +64,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityUpdater;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\FieldProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Router\CrudUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Security\AuthorizationChecker;
@@ -136,8 +137,9 @@ return static function (ContainerConfigurator $container) {
         ->set(AdminContextListener::class)
             ->arg(0, ref(AdminContextFactory::class))
             ->arg(1, ref(DashboardControllerRegistry::class))
-            ->arg(2, ref('controller_resolver'))
-            ->arg(3, ref('twig'))
+            ->arg(2, ref(CrudControllerRegistry::class))
+            ->arg(3, ref('controller_resolver'))
+            ->arg(4, ref('twig'))
             ->tag('kernel.event_listener', ['event' => ControllerEvent::class])
 
         ->set(CrudResponseListener::class)
@@ -149,16 +151,21 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, ref('translator'))
             ->arg(1, ref('security.token_storage')->nullOnInvalid())
             ->arg(2, ref(MenuFactory::class))
-            ->arg(3, tagged_iterator('ea.crud_controller'))
+            ->arg(3, ref(CrudControllerRegistry::class))
             ->arg(4, ref(EntityFactory::class))
 
         ->set(DashboardControllerRegistry::class)
             ->arg(0, '%kernel.secret%')
             ->arg(1, tagged_iterator('ea.dashboard_controller'))
 
+        ->set(CrudControllerRegistry::class)
+            ->arg(0, '%kernel.secret%')
+            ->arg(1, tagged_iterator('ea.crud_controller'))
+
         ->set(CrudUrlGenerator::class)
             ->arg(0, ref(AdminContextProvider::class))
-            ->arg(1, ref('router.default'))
+            ->arg(1, ref(CrudControllerRegistry::class))
+            ->arg(2, ref('router.default'))
 
         ->set(MenuFactory::class)
             ->arg(0, ref(AdminContextProvider::class))

--- a/src/Resources/views/crud/includes/_delete_form.html.twig
+++ b/src/Resources/views/crud/includes/_delete_form.html.twig
@@ -1,6 +1,6 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {% set delete_url = ea_url()
-    .setController(app.request.query.get('crudController'))
+    .setCrudId(app.request.query.get('crudId'))
     .setAction('delete')
     .setEntityId(entity_id ?? '__entityId_placeholder__')
     .removeReferrer() %}

--- a/src/Router/CrudUrlGenerator.php
+++ b/src/Router/CrudUrlGenerator.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Router;
 
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -11,16 +12,18 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 final class CrudUrlGenerator
 {
     private $adminContextProvider;
+    private $crudControllers;
     private $urlGenerator;
 
-    public function __construct(AdminContextProvider $adminContextProvider, UrlGeneratorInterface $urlGenerator)
+    public function __construct(AdminContextProvider $adminContextProvider, CrudControllerRegistry $crudControllers, UrlGeneratorInterface $urlGenerator)
     {
         $this->adminContextProvider = $adminContextProvider;
+        $this->crudControllers = $crudControllers;
         $this->urlGenerator = $urlGenerator;
     }
 
     public function build(array $routeParameters = []): CrudUrlBuilder
     {
-        return new CrudUrlBuilder($this->adminContextProvider->getContext(), $this->urlGenerator, $routeParameters);
+        return new CrudUrlBuilder($this->adminContextProvider->getContext(), $this->crudControllers, $this->urlGenerator, $routeParameters);
     }
 }


### PR DESCRIPTION
This originated from #3257. The problem to solve is: when linking to a Symfony route from an EasyAdmin dashboard, that action must be able to use EasyAdmin pages (e.g. to display the menu) and it must be able to use the EasyAdmin context variable. This helps embedding your custom actions into the dashboards.

To solve that properly ... I had to make many changes ... but none should affect you in any way. Main changes:

1) Before, URLs added the full CRUD controller FQCN in the query string (e.g. `https://127.0.0.1:8000?...&crudController=App\Controller\Admin\FooCrudController`). Now we only include the "CRUD Controller ID" (e.g. `https://127.0.0.1:8000?...&crudId=f105801`). This ID uses the kernel secret to generate it, so it's non-guessable. As a minor added bonus, this doesn't leak your FQCN to end users (although this is backend, so only "trusted" users can access to it).

2) When accessing a Symfony action through an EasyAdmin dashboard, we set the `eaContext` query parameter (e.g. `https://127.0.0.1:8000?...&eaContext=f105801`) to allow the action be linked to some EasyAdmin dashboard. This avoids leaking the Dashboard controller FQCN and, as before, is non-guessable and based on the kernel secret.

3) I also refactored the listener that creates the EasyAdmin context variable. This listener has to decide pretty quickly if it's an EasyAdmin related request or not. Also, it's very important that it doesn't leak that the application uses EasyAdmin (e.g. throwing exceptions when some query params are wrongly set). I think I got this right ... but reviews are very welcome!

