### PR TITLE
Fixed the detection of the dashboard route

### DIFF
--- a/src/Cache/CacheWarmer.php
+++ b/src/Cache/CacheWarmer.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Cache;
+
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouterInterface;
+use function Symfony\Component\String\u;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class CacheWarmer implements CacheWarmerInterface
+{
+    public const DASHBOARD_ROUTES_CACHE = 'easyadmin/routes-dashboard.php';
+
+    private $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function isOptional()
+    {
+        return false;
+    }
+
+    public function warmUp($cacheDirectory)
+    {
+        $allRoutes = $this->router->getRouteCollection();
+        $dashboardRoutes = [];
+
+        /** @var Route $route */
+        foreach ($allRoutes as $routeName => $route) {
+            $routeControllerFqcn = u($route->getDefault('_controller') ?? '')->beforeLast('::')->toString();
+
+            try {
+                if (\in_array(DashboardControllerInterface::class, class_implements($routeControllerFqcn))) {
+                    $dashboardRoutes[$routeControllerFqcn] = $routeName;
+                }
+            } catch (\Exception $e) {
+                // ignore these errors that occur for edge-cases like these:
+                // Warning: class_implements(): Class error_controller does not exist and could not be loaded
+            }
+        }
+
+        (new Filesystem())->dumpFile(
+            $cacheDirectory.'/'.self::DASHBOARD_ROUTES_CACHE,
+            '<?php return '.var_export($dashboardRoutes, true).';'
+        );
+    }
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver\AdminContextResolver;
+use EasyCorp\Bundle\EasyAdminBundle\Cache\CacheWarmer;
 use EasyCorp\Bundle\EasyAdminBundle\Command\MakeAdminDashboardCommand;
 use EasyCorp\Bundle\EasyAdminBundle\Command\MakeAdminMigrationCommand;
 use EasyCorp\Bundle\EasyAdminBundle\Command\MakeCrudControllerCommand;
@@ -101,6 +102,10 @@ return static function (ContainerConfigurator $container) {
 
         ->set(Migrator::class)
 
+        ->set(CacheWarmer::class)
+            ->arg(0, ref('router'))
+            ->tag('kernel.cache_warmer')
+
         ->set(DataCollector::class)
             ->arg(0, ref(AdminContextProvider::class))
             ->tag('data_collector', ['id' => 'easyadmin', 'template' => '@EasyAdmin/inspector/data_collector.html.twig'])
@@ -148,11 +153,12 @@ return static function (ContainerConfigurator $container) {
             ->tag('kernel.event_listener', ['event' => ViewEvent::class])
 
         ->set(AdminContextFactory::class)
-            ->arg(0, ref('translator'))
-            ->arg(1, ref('security.token_storage')->nullOnInvalid())
-            ->arg(2, ref(MenuFactory::class))
-            ->arg(3, ref(CrudControllerRegistry::class))
-            ->arg(4, ref(EntityFactory::class))
+            ->arg(0, '%kernel.cache_dir%')
+            ->arg(1, ref('translator'))
+            ->arg(2, ref('security.token_storage')->nullOnInvalid())
+            ->arg(3, ref(MenuFactory::class))
+            ->arg(4, ref(CrudControllerRegistry::class))
+            ->arg(5, ref(EntityFactory::class))
 
         ->set(DashboardControllerRegistry::class)
             ->arg(0, '%kernel.secret%')


### PR DESCRIPTION
Current code was *naïve* and broke whenever you used a Symfony action inside the dashboard. This code works as expected in all cases (at least on my tests).

@wouterj sorry to bother you ... but this code calls to `$route->getRouteCollection();` and if I remember it right, you insisted that the method should not be used. In fact, Symfony Docs say exactly that: https://symfony.com/doc/current/routing.html#checking-if-a-route-exists

However, in my tests this method is fine. It's extremely fast and when looking at the source code: https://github.com/symfony/symfony/blob/466b70d6559e71f32532bfaa624d1917acdcd726/src/Symfony/Component/Routing/Router.php#L190  it looks like everything is cached so it's fast.

Am I missing something here? Thanks!