### PR TITLE
Simplify translation domain management

### DIFF
--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -78,14 +78,6 @@ final class Action
     {
         $this->dto->setLabel($label);
 
-        // built-in actions use 'EasyAdmin' translation domain by default;
-        // if user updates the label of a built-in action, set the translation
-        // domain to NULL to use instead the domain translation configured in the backend
-        $isBuiltInAction = in_array($this->dto->getName(), [Action::DELETE, Action::DETAIL, Action::EDIT, Action::INDEX, Action::NEW, Action::SAVE_AND_ADD_ANOTHER, Action::SAVE_AND_CONTINUE, Action::SAVE_AND_RETURN], true);
-        if($isBuiltInAction && 'EasyAdminBundle' ===  $this->dto->getTranslationDomain()) {
-            $this->dto->setTranslationDomain(null);
-        }
-
         return $this;
     }
 
@@ -166,16 +158,6 @@ final class Action
     public function linkToUrl($url): self
     {
         $this->dto->setUrl($url);
-
-        return $this;
-    }
-
-    /**
-     * If not defined or set to NULL, actions use the same domain as configured for the entire dashboard.
-     */
-    public function setTranslationDomain(?string $domain): self
-    {
-        $this->dto->setTranslationDomain($domain);
 
         return $this;
     }

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -154,67 +154,59 @@ final class Actions
     private function createBuiltInAction(string $pageName, string $actionName): Action
     {
         if (Action::NEW === $actionName) {
-            return Action::new(Action::NEW, 'action.new', null)
+            return Action::new(Action::NEW, '__ea__action.new', null)
                 ->createAsGlobalAction()
                 ->linkToCrudAction(Action::NEW)
-                ->addCssClass('btn btn-primary')
-                ->setTranslationDomain('EasyAdminBundle');
+                ->addCssClass('btn btn-primary');
         }
 
         if (Action::EDIT === $actionName) {
-            return Action::new(Action::EDIT, 'action.edit', null)
+            return Action::new(Action::EDIT, '__ea__action.edit', null)
                 ->linkToCrudAction(Action::EDIT)
-                ->addCssClass(Crud::PAGE_DETAIL === $pageName ? 'btn btn-primary' : '')
-                ->setTranslationDomain('EasyAdminBundle');
+                ->addCssClass(Crud::PAGE_DETAIL === $pageName ? 'btn btn-primary' : '');
         }
 
         if (Action::DETAIL === $actionName) {
-            return Action::new(Action::DETAIL, 'action.detail')
-                ->linkToCrudAction(Action::DETAIL)
-                ->setTranslationDomain('EasyAdminBundle');
+            return Action::new(Action::DETAIL, '__ea__action.detail')
+                ->linkToCrudAction(Action::DETAIL);
         }
 
         if (Action::INDEX === $actionName) {
-            return Action::new(Action::INDEX, 'action.index')
+            return Action::new(Action::INDEX, '__ea__action.index')
                 ->linkToCrudAction(Action::INDEX)
-                ->addCssClass(Crud::PAGE_DETAIL === $pageName ? 'btn btn-secondary' : '')
-                ->setTranslationDomain('EasyAdminBundle');
+                ->addCssClass(Crud::PAGE_DETAIL === $pageName ? 'btn btn-secondary' : '');
         }
 
         if (Action::DELETE === $actionName) {
             $cssClass = Crud::PAGE_DETAIL === $pageName ? 'btn btn-link pr-0 text-danger' : 'text-danger';
 
-            return Action::new(Action::DELETE, 'action.delete', Crud::PAGE_INDEX === $pageName ? null : 'fa fa-fw fa-trash-o')
+            return Action::new(Action::DELETE, '__ea__action.delete', Crud::PAGE_INDEX === $pageName ? null : 'fa fa-fw fa-trash-o')
                 ->linkToCrudAction(Action::DELETE)
-                ->addCssClass($cssClass)
-                ->setTranslationDomain('EasyAdminBundle');
+                ->addCssClass($cssClass);
         }
 
         if (Action::SAVE_AND_RETURN === $actionName) {
-            return Action::new(Action::SAVE_AND_RETURN, Crud::PAGE_EDIT === $pageName ? 'action.save' : 'action.create')
+            return Action::new(Action::SAVE_AND_RETURN, Crud::PAGE_EDIT === $pageName ? '__ea__action.save' : '__ea__action.create')
                 ->addCssClass('btn btn-primary action-save')
                 ->displayAsButton()
                 ->setHtmlAttributes(['type' => 'submit', 'name' => 'ea[newForm][btn]', 'value' => $actionName])
-                ->linkToCrudAction(Crud::PAGE_EDIT === $pageName ? Action::EDIT : Action::NEW)
-                ->setTranslationDomain('EasyAdminBundle');
+                ->linkToCrudAction(Crud::PAGE_EDIT === $pageName ? Action::EDIT : Action::NEW);
         }
 
         if (Action::SAVE_AND_CONTINUE === $actionName) {
-            return Action::new(Action::SAVE_AND_CONTINUE, Crud::PAGE_EDIT === $pageName ? 'action.save_and_continue' : 'action.create_and_continue', 'far fa-edit')
+            return Action::new(Action::SAVE_AND_CONTINUE, Crud::PAGE_EDIT === $pageName ? '__ea__action.save_and_continue' : '__ea__action.create_and_continue', 'far fa-edit')
                 ->addCssClass('btn btn-secondary action-save')
                 ->displayAsButton()
                 ->setHtmlAttributes(['type' => 'submit', 'name' => 'ea[newForm][btn]', 'value' => $actionName])
-                ->linkToCrudAction(Crud::PAGE_EDIT === $pageName ? Action::EDIT : Action::NEW)
-                ->setTranslationDomain('EasyAdminBundle');
+                ->linkToCrudAction(Crud::PAGE_EDIT === $pageName ? Action::EDIT : Action::NEW);
         }
 
         if (Action::SAVE_AND_ADD_ANOTHER === $actionName) {
-            return Action::new(Action::SAVE_AND_ADD_ANOTHER, 'action.create_and_add_another')
+            return Action::new(Action::SAVE_AND_ADD_ANOTHER, '__ea__action.create_and_add_another')
                 ->addCssClass('btn btn-secondary action-save')
                 ->displayAsButton()
                 ->setHtmlAttributes(['type' => 'submit', 'name' => 'ea[newForm][btn]', 'value' => $actionName])
-                ->linkToCrudAction(Action::NEW)
-                ->setTranslationDomain('EasyAdminBundle');
+                ->linkToCrudAction(Action::NEW);
         }
 
         throw new \InvalidArgumentException(sprintf('The "%s" action is not a built-in action, so you can\'t add or configure it via its name. Either refer to one of the built-in actions or create a custom action called "%s".', $actionName, $actionName));

--- a/src/Config/Menu/MenuItemTrait.php
+++ b/src/Config/Menu/MenuItemTrait.php
@@ -33,16 +33,6 @@ trait MenuItemTrait
         return $this;
     }
 
-    /**
-     * If not defined, menu items use the same domain as configured for the entire dashboard.
-     */
-    public function setTranslationDomain(string $domain): self
-    {
-        $this->dto->setTranslationDomain($domain);
-
-        return $this;
-    }
-
     public function setTranslationParameters(array $parameters): self
     {
         $this->dto->setTranslationParameters($parameters);

--- a/src/Controller/AbstractDashboardController.php
+++ b/src/Controller/AbstractDashboardController.php
@@ -45,14 +45,14 @@ abstract class AbstractDashboardController extends AbstractController implements
 
     public function configureMenuItems(): iterable
     {
-        yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
+        yield MenuItem::linktoDashboard('__ea__page_title.dashboard', 'fa fa-home');
     }
 
     public function configureUserMenu(UserInterface $user): UserMenu
     {
-        $userMenuItems = [MenuItem::linkToLogout('user.sign_out', 'fa-sign-out')->setTranslationDomain('EasyAdminBundle')];
+        $userMenuItems = [MenuItem::linkToLogout('__ea__user.sign_out', 'fa-sign-out')];
         if ($this->isGranted(Permission::EA_EXIT_IMPERSONATION)) {
-            $userMenuItems[] = MenuItem::linkToExitImpersonation('user.exit_impersonation', 'fa-user-lock')->setTranslationDomain('EasyAdminBundle');
+            $userMenuItems[] = MenuItem::linkToExitImpersonation('__ea__user.exit_impersonation', 'fa-user-lock');
         }
 
         return UserMenu::new()

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -22,7 +22,6 @@ final class ActionDto
     private $routeName;
     private $routeParameters;
     private $url;
-    private $translationDomain;
     private $translationParameters;
     private $displayCallable;
 
@@ -199,16 +198,6 @@ final class ActionDto
         $this->url = $url;
     }
 
-    public function getTranslationDomain(): ?string
-    {
-        return $this->translationDomain;
-    }
-
-    public function setTranslationDomain(?string $translationDomain): void
-    {
-        $this->translationDomain = $translationDomain;
-    }
-
     public function getTranslationParameters(): array
     {
         return $this->translationParameters;
@@ -237,7 +226,6 @@ final class ActionDto
         $action = Action::new($this->name, $this->label, $this->icon);
         $action->setCssClass($this->cssClass);
         $action->setHtmlAttributes($this->htmlAttributes);
-        $action->setTranslationDomain($this->translationDomain);
         $action->setTranslationParameters($this->translationParameters);
 
         if (null !== $this->templatePath) {

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -28,7 +28,6 @@ final class MenuItemDto
     private $linkUrl;
     private $linkRel;
     private $linkTarget;
-    private $translationDomain;
     private $translationParameters;
     /** @var MenuItemDto[] */
     private $subItems;
@@ -165,16 +164,6 @@ final class MenuItemDto
     public function setLinkTarget(string $linkTarget): void
     {
         $this->linkTarget = $linkTarget;
-    }
-
-    public function getTranslationDomain(): ?string
-    {
-        return $this->translationDomain;
-    }
-
-    public function setTranslationDomain(?string $translationDomain): void
-    {
-        $this->translationDomain = $translationDomain;
     }
 
     public function getTranslationParameters(): array


### PR DESCRIPTION
Translation domain management in EasyAdmin 3 is very simple:

* We use `messages` by default for all your contents;
* You can define another domain with `->setTranslationDomain()` in the dashboard.

There's only one custom domain per dashboard, because it's a good balance between flexibility and not too much complexity.

-----

However, while working on #3277 I realize that some internal things were leaking: https://github.com/EasyCorp/EasyAdminBundle/pull/3277/files#diff-5d12eb59c3a5430d330385ef8b402417R81

In fact, both actions and menu items allow to define their translation domain. This was added only to deal with our internal translations. E.g. built-in actions have some labels whose translations are defined under the `EasyAdminBundle`, so we cannot use the default backend domain.

This PR removes all that, stops leaking these internal details and instead, it adds an internal marker (`__ea__`) to all labels that must be translated with the bundle domain instead of the backend domain.

No changes are needed in your apps. This just removes some unneeded complexity.