### PR TITLE
Fix wrong check in CacheWarmer

### DIFF
--- a/src/Cache/CacheWarmer.php
+++ b/src/Cache/CacheWarmer.php
@@ -37,13 +37,8 @@ final class CacheWarmer implements CacheWarmerInterface
         foreach ($allRoutes as $routeName => $route) {
             $routeControllerFqcn = u($route->getDefault('_controller') ?? '')->beforeLast('::')->toString();
 
-            try {
-                if (\in_array(DashboardControllerInterface::class, class_implements($routeControllerFqcn))) {
-                    $dashboardRoutes[$routeControllerFqcn] = $routeName;
-                }
-            } catch (\Exception $e) {
-                // ignore these errors that occur for edge-cases like these:
-                // Warning: class_implements(): Class error_controller does not exist and could not be loaded
+            if (is_subclass_of($routeControllerFqcn, DashboardControllerInterface::class)) {
+                $dashboardRoutes[$routeControllerFqcn] = $routeName;
             }
         }
 


### PR DESCRIPTION
A PHP warning is a PHP warning, not an Exception.
Only a custom error handler can turn them into exceptions, and not all apps use error handlers - even Symfony apps.
