### PR TITLE
[3.0] Crud docs: fixed usage of `setCrudFqcn` instead of `setController`

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -433,7 +433,7 @@ service to generate URLs in your PHP code::
 
             // the URL builder provides shortcuts for the most common parameters
             $url = $this->crudUrlGenerator->build()
-                ->setController(SomeController::class)
+                ->setCrudFqcn(SomeController::class)
                 ->setAction('theActionName')
                 ->generateUrl();
 
@@ -454,7 +454,7 @@ method (it will be called automatically for you):
     {% set url = ea_url().set('page', 2) %}
 
     {% set url = ea_url()
-        .setController('App\\Controller\\Admin\\SomeController')
+        .setCrudFqcn('App\\Controller\\Admin\\SomeController')
         .setAction('theActionName') %}
 
 .. _`Symfony controllers`: https://symfony.com/doc/current/controller.html


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
