### PR TITLE
Improve file_upload documentation

### DIFF
--- a/doc/book/edit-new-configuration.rst
+++ b/doc/book/edit-new-configuration.rst
@@ -679,6 +679,21 @@ This type defines the following configuration options:
   before moving them to their final destination. By default it checks duplicated
   files and renames them. It's useful in complex scenarios such as validating
   files that will be moved to some cloud service.
+  
+You must declare configuration options within the ``type_options`` key:
+
+.. code-block:: yaml
+
+    # config/packages/easy_admin.yaml
+    easy_admin:
+        entities:
+            User:
+                class: App\Entity\User
+                form:
+                    fields:
+                        - { property: 'photo', type: 'file_upload', type_options: { upload_dir: 'public/uploads/photos/' } }
+                        # ...
+        # ...
 
 This form type uses a `form data transformer`_ to manage the file resource to
 file path conversion. This means that only the file path/s is/are stored in the


### PR DESCRIPTION
Hi folks, 

I added an example about file_upload type_options key.

Explaining type options in "Autocomplete" part then inlined options in "Code Editor" makes it confusing which one we should use in "File Upload".

Moreover, we use these expressions to talk about the options :
- "If you prefer to define it explicitly, do it in the type options" in "Autocomplete"
- "This type defines the following configuration options:" in "Code Editor"
- "This type defines the following configuration options:" in "File Upload"

Therefore it made me confused and I guess some other people may be.

Should I change the third expression to match the first one, as the configuration process is the same ? Or maybe change the order and put "Autocomplete", then "File Upload", then "Code Editor" ?

Regards,

Guillaume