### PR TITLE
[3.0] Fixed deprecations for Symfony 5.1

### DIFF
--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -192,11 +192,12 @@ final class AdminContextFactory
             return null;
         }
 
+        $queryParams = $request->query->all();
         $searchableProperties = $crudDto->getSearchFields();
-        $query = $request->query->get('query');
+        $query = $queryParams['query'] ?? null;
         $defaultSort = $crudDto->getDefaultSort();
-        $customSort = $request->query->get('sort', []);
-        $appliedFilters = $request->query->get('filters', []);
+        $customSort = $queryParams['sort'] ?? [];
+        $appliedFilters = $queryParams['filters'] ?? [];
 
         return new SearchDto($request, $searchableProperties, $query, $defaultSort, $customSort, $appliedFilters);
     }


### PR DESCRIPTION
Hi,

This PR fixes two deprecations that happen with Symfony 5.1:

```User Deprecated: Since symfony/http-foundation 5.1: Passing a non-string value as 2nd argument to "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, pass a string or null instead.```

and

```
User Deprecated: Since symfony/http-foundation 5.1: Retrieving a non-string value from "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, and will throw a "Symfony\Component\HttpFoundation\Exception\BadRequestException" exception in Symfony 6.0, use "Symfony\Component\HttpFoundation\InputBag::all()" instead.
```