### PR TITLE
Add block page_actions in content.html.twig

### DIFF
--- a/src/Resources/views/page/content.html.twig
+++ b/src/Resources/views/page/content.html.twig
@@ -19,6 +19,10 @@
                                 <div class="content-header-title">
                                     <h1 class="title">{% block content_title %}{% endblock %}</h1>
                                 </div>
+                                
+                                {% block page_actions_wrapper %}
+                                    <div class="page-actions">{% block page_actions %}{% endblock %}</div>
+                                {% endblock %}
                             </div>
                         {% endif %}
 


### PR DESCRIPTION
Hi,

I propose the possibility of adding or not block page_actions in the content.html.twig with the example below:

With block page_actions :
```twig
{% extends '@EasyAdmin/page/content.html.twig' %}

{% block content_body %}
    {{ form_start(form, {'attr': {'id': form.vars.id}}) }}
        {{ form_row(form.firstName) }}
        {{ form_row(form.lastName) }}
    {{ form_end(form) }}
{% endblock %}

{% block page_actions %}
    <button type="submit" class="btn btn-primary" form="{{ form.vars.id }}">
        <span class="btn-label">{{ 'action.save'|trans }}</span>
    </button>
{% endblock %}
```
Without block page_actions :
```twig
{% extends '@EasyAdmin/page/content.html.twig' %}

{% block page_actions_wrapper '' %}

{% block content_body %}
    {{ form_start(form) }}
        {{ form_row(form.currentPassword) }}
        {{ form_row(form.newPassword) }}
        <button type="submit" class="btn btn-primary">
            <span class="btn-label">{{ 'action.save'|trans }}</span>
        </button>
    {{ form_end(form) }}
{% endblock %}
```
Like that, the style could look like the form page with the buttons at the top right.