### PR TITLE
Allow to search using nested associations

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -191,7 +191,8 @@ return static function (ContainerConfigurator $container) {
         ->set(EntityRepository::class)
             ->arg(0, new Reference(AdminContextProvider::class))
             ->arg(1, new Reference('doctrine'))
-            ->arg(2, new Reference(FormFactory::class))
+            ->arg(2, new Reference(EntityFactory::class))
+            ->arg(3, new Reference(FormFactory::class))
 
         ->set(EntityFactory::class)
             ->arg(0, new Reference(FieldFactory::class))


### PR DESCRIPTION
Search in nested fields was always supported (e.g. `user.email`). In EA3 we even improved it to support any number of nested levels. The problem is that it didn't work at all. This PR fixes it for two-level associations ... and I'll improve it later to support any number of levels.