### PR TITLE
Improved the help message for a common exception

### DIFF
--- a/src/DependencyInjection/EasyAdminExtension.php
+++ b/src/DependencyInjection/EasyAdminExtension.php
@@ -44,10 +44,5 @@ class EasyAdminExtension extends Extension
 
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.php');
-
-        // use EasyAdmin exception listener only in 'dev'
-        if ($container->getParameter('kernel.debug')) {
-            $container->removeDefinition(ExceptionListener::class);
-        }
     }
 }

--- a/src/EventListener/AdminContextListener.php
+++ b/src/EventListener/AdminContextListener.php
@@ -96,7 +96,7 @@ class AdminContextListener
      * Request is associated to EasyAdmin if one of these conditions meet:
      *  * current controller is an instance of DashboardControllerInterface (the single point of
      *    entry for all requests directly served by EasyAdmin)
-     *  * the contextId passed via the query string parameter is not null
+     *  * the contextId passed via the 'eaContext' query string parameter is not null
      *    (that's used in menu items that link to Symfony routes not served by EasyAdmin, so
      *    those routes can still be associated with some EasyAdmin dashboard to display the menu, etc.).
      */

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Twig\Environment;
+use Twig\Error\RuntimeError;
 
 /**
  * This listener allows to display customized error pages in the production
@@ -20,11 +21,13 @@ use Twig\Environment;
  */
 final class ExceptionListener
 {
+    private $kernelDebug;
     private $adminContextProvider;
     private $twig;
 
-    public function __construct(AdminContextProvider $adminContextProvider, Environment $twig)
+    public function __construct(bool $kernelDebug, AdminContextProvider $adminContextProvider, Environment $twig)
     {
+        $this->kernelDebug = $kernelDebug;
         $this->adminContextProvider = $adminContextProvider;
         $this->twig = $twig;
     }
@@ -32,22 +35,47 @@ final class ExceptionListener
     public function onKernelException(ExceptionEvent $event)
     {
         $exception = $event->getThrowable();
-        if (!$exception instanceof BaseException) {
+
+        if ($this->kernelDebug && $exception instanceof RuntimeError && 'Variable "ea" does not exist.' === $exception->getRawMessage()) {
+            $exception->appendMessage($this->getEaVariableExceptionMessage());
+
             return;
         }
 
+        if ($this->kernelDebug || !$exception instanceof BaseException) {
+            return;
+        }
+
+        // TODO: check why these custom error pages don't work
         $event->setResponse($this->createExceptionResponse(FlattenException::create($exception)));
     }
 
     public function createExceptionResponse(FlattenException $exception): Response
     {
         $context = $this->adminContextProvider->getContext();
-        $exceptionTemplatePath = $context->getTemplatePath('exception');
-        $layoutTemplatePath = $context->getTemplatePath('layout');
+        $exceptionTemplatePath = null === $context ? '@EasyAdmin/exception.html.twig' : $context->getTemplatePath('exception');
+        $layoutTemplatePath = null === $context ? '@EasyAdmin/layout.html.twig' : $context->getTemplatePath('layout');
 
         return Response::create($this->twig->render($exceptionTemplatePath, [
             'exception' => $exception,
             'layout_template_path' => $layoutTemplatePath,
         ]), $exception->getStatusCode());
+    }
+
+    private function getEaVariableExceptionMessage(): string
+    {
+        return <<<MESSAGE
+
+
+The "ea" variable stores the admin context (menu items, actions, fields, etc.) and it's created automatically for requests served by EasyAdmin.
+
+If you are seeing this error, you are trying to use some EasyAdmin features in a request not served by EasyAdmin. For example, some of your custom actions may be trying to render or extend from one of the templates provided EasyAdmin.
+
+Your request must meet one of these conditions to be served by EasyAdmin (and to have the "ea" variable defined):
+
+1) It must be run by a controller that implements DashboardControllerInterface. This is done automatically for all actions and CRUD controllers associated to your dashboard.
+
+2) It must contain an "eaContext" query string parameter that identifies the Dashboard associated to this request (this parameter is automatically added by EasyAdmin when creating menu items that link to custom Symfony routes).
+MESSAGE;
     }
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -118,8 +118,9 @@ return static function (ContainerConfigurator $container) {
             ->tag('data_collector', ['id' => 'easyadmin', 'template' => '@EasyAdmin/inspector/data_collector.html.twig'])
 
         ->set(ExceptionListener::class)
-            ->arg(0, new Reference(AdminContextProvider::class))
-            ->arg(1, new Reference('twig'))
+            ->arg(0, '%kernel.debug%')
+            ->arg(1, new Reference(AdminContextProvider::class))
+            ->arg(2, new Reference('twig'))
             ->tag('kernel.event_listener', ['event' => 'kernel.exception', 'priority' => -64])
 
         ->set(EasyAdminTwigExtension::class)


### PR DESCRIPTION
Given the amount of issues and questions related to this, I've decided to improve the exception message about this error:

```
Variable "ea" does not exist.
```

## Before

![before](https://user-images.githubusercontent.com/73419/83967599-7435e680-a8c3-11ea-8ce1-89c501d6e77b.png)

## After

![after](https://user-images.githubusercontent.com/73419/83967600-7730d700-a8c3-11ea-85de-3ebe12d558a2.png)
