### PR TITLE
Support DELETE with http_method_override disabled

### DIFF
--- a/src/Controller/AdminControllerTrait.php
+++ b/src/Controller/AdminControllerTrait.php
@@ -338,6 +338,10 @@ trait AdminControllerTrait
     {
         $this->dispatch(EasyAdminEvents::PRE_DELETE);
 
+        if (!Request::getHttpMethodParameterOverride() && 'POST' === $this->request->getMethod() && 'DELETE' === $this->request->request->get('_method')) {
+            $this->request->setMethod('DELETE');
+        }
+
         if ('DELETE' !== $this->request->getMethod()) {
             return $this->redirect($this->generateUrl('easyadmin', ['action' => 'list', 'entity' => $this->entity['name']]));
         }


### PR DESCRIPTION
If the `http_method_override` configuration option is set to `false`, explicitly perform the method override if the override is `DELETE`.

Fixes #3331

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
