### PR TITLE
Made the login page independent from Dashboards

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -625,19 +625,36 @@ applications can rely on its default values:
 
                 // OPTIONAL parameters to customize the login form:
 
+                // the translation_domain to use (define this option only if you are
+                // rendering the login template in a regular Symfony controller; when
+                // rendering it from an EasyAdmin Dashboard this is automatically set to
+                // the same domain as the rest of the Dashboard)
+                'translation_domain' => 'admin',
+
+                // the title visible above the login form (define this option only if you are
+                // rendering the login template in a regular Symfony controller; when rendering
+                // it from an EasyAdmin Dashboard this is automatically set as the Dashboard title)
+                'page_title' => 'ACME login',
+
                 // the string used to generate the CSRF token. If you don't define
                 // this parameter, the login form won't include a CSRF token
                 'csrf_token_intention' => 'authenticate',
+
                 // the URL users are redirected to after the login (default: '/admin')
                 'target_path' => $this->generateUrl('admin_dashboard'),
+
                 // the label displayed for the username form field (the |trans filter is applied to it)
                 'username_label' => 'Your username',
+
                 // the label displayed for the password form field (the |trans filter is applied to it)
                 'password_label' => 'Your password',
+
                 // the label displayed for the Sign In form button (the |trans filter is applied to it)
                 'sign_in_label' => 'Log in',
+
                 // the 'name' HTML attribute of the <input> used for the username field (default: '_username')
                 'username_parameter' => 'my_custom_username_field',
+
                 // the 'name' HTML attribute of the <input> used for the password field (default: '_password')
                 'password_parameter' => 'my_custom_password_field',
             ]);

--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -1,10 +1,15 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{% extends ea.templatePath('layout') %}
-{% trans_default_domain ea.i18n.translationDomain %}
+{# This template checks for 'ea' variable existence because it can
+   be used in a EasyAdmin Dashboard controller, where 'ea' is defined
+   or from any other Symfony controller, where 'ea' is not defined #}
+{% extends ea is defined ? ea.templatePath('layout') : '@EasyAdmin/page/login_minimal.html.twig' %}
+{% trans_default_domain ea is defined ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% block body_class 'page-login' %}
+{% block page_title %}{{ page_title is defined ? page_title : (ea is defined ? ea.dashboardTitle : '') }}{% endblock %}
 
 {% block wrapper_wrapper %}
+    {% set page_title = block('page_title') %}
     {% set _username_label = username_label is defined ? username_label|trans : 'login_page.username'|trans({}, 'EasyAdminBundle') %}
     {% set _password_label = password_label is defined ? password_label|trans : 'login_page.password'|trans({}, 'EasyAdminBundle') %}
     {% set _sign_in_label = sign_in_label is defined ? sign_in_label|trans : 'login_page.sign_in'|trans({}, 'EasyAdminBundle') %}
@@ -13,9 +18,17 @@
         <header class="main-header mb-4">
             <div id="header-logo">
                 {% block header_logo %}
-                    <a class="logo {{ ea.dashboardTitle|length > 14 ? 'logo-long' }}" title="{{ ea.dashboardTitle|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
-                        {{ ea.dashboardTitle|raw }}
-                    </a>
+                    {% if page_title %}
+                        {% if ea is defined %}
+                            <a class="logo {{ page_title|length > 14 ? 'logo-long' }}" title="{{ page_title|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
+                                {{ page_title|raw }}
+                            </a>
+                        {% else %}
+                            <div class="logo {{ page_title|length > 14 ? 'logo-long' }}">
+                                {{ page_title|raw }}
+                            </div>
+                        {% endif %}
+                    {% endif %}
                 {% endblock header_logo %}
             </div>
         </header>
@@ -32,7 +45,7 @@
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrf_token_intention) }}">
                 {% endif %}
 
-                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(path(ea.dashboardRouteName)) }}" />
+                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea is defined ? path(ea.dashboardRouteName) : '/') }}" />
 
                 <div class="form-group field-text">
                     <label for="username" class="sr-only form-control-label required">{{ _username_label }}</label>

--- a/src/Resources/views/page/login_minimal.html.twig
+++ b/src/Resources/views/page/login_minimal.html.twig
@@ -1,0 +1,28 @@
+{# This is a template used internally by EasyAdmin. Don't use it
+   directly in your applications. Instead, use the 'login.html.twig' template #}
+{% trans_default_domain translation_domain ?? 'messages' %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noodp, noimageindex, notranslate, nocache" />
+        <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+        <meta name="generator" content="EasyAdmin" />
+
+        <title>{{ block('page_title')|striptags|raw }}</title>
+
+        {% block head_stylesheets %}
+            <link rel="stylesheet" href="{{ asset('bundles/easyadmin/app.css') }}">
+        {% endblock %}
+
+        {% block head_javascript %}
+            <script src="{{ asset('bundles/easyadmin/app.js') }}"></script>
+        {% endblock head_javascript %}
+    </head>
+
+    <body id="{% block body_id %}{% endblock %}" class="ea {% block body_class %}{% endblock %}">
+        {% block wrapper_wrapper %}{% endblock wrapper_wrapper %}
+    </body>
+</html>
+


### PR DESCRIPTION
Fixes #3336.

If you use the login page in a EasyAdmin request, everything keeps working the same ... but if you use it from a regular Symfony controller, you no longer see an error because the `ea` variable is no longer mandatory.