### PR TITLE
Moved some form logic from Twig template to class

### DIFF
--- a/src/Factory/FormFactory.php
+++ b/src/Factory/FormFactory.php
@@ -30,6 +30,8 @@ final class FormFactory
 
     public function createEditForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
     {
+        $cssClass = sprintf('ea-%s-form', $context->getCrud()->getCurrentAction());
+        $formOptions->set('attr.class', trim(($formOptions->get('attr.class') ?? '').' '.$cssClass));
         $formOptions->set('attr.id', sprintf('edit-%s-form', $entityDto->getName()));
         $formOptions->set('entityDto', $entityDto);
         $formOptions->setIfNotSet('translation_domain', $context->getI18n()->getTranslationDomain());
@@ -39,6 +41,8 @@ final class FormFactory
 
     public function createNewForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
     {
+        $cssClass = sprintf('ea-%s-form', $context->getCrud()->getCurrentAction());
+        $formOptions->set('attr.class', trim(($formOptions->get('attr.class') ?? '').' '.$cssClass));
         $formOptions->set('attr.id', sprintf('new-%s-form', $entityDto->getName()));
         $formOptions->set('entityDto', $entityDto);
         $formOptions->setIfNotSet('translation_domain', $context->getI18n()->getTranslationDomain());

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -2,12 +2,6 @@
 {% use 'bootstrap_4_layout.html.twig' %}
 
 {% block form_start %}
-    {% if ea.crud is not null %}
-        {% set attr = attr|merge({
-            'class': [attr.class|default(''), 'ea-' ~ ea.crud.currentAction ~ '-form']|join(' '),
-        }) %}
-    {% endif %}
-
     {% if form.vars.errors|length > 0 %}
         {{ form_errors(form) }}
     {% endif %}


### PR DESCRIPTION
While merging #3346 by @maczuk I realized that we could move some logic from the Twig template to the PHP factory. We already add several form attributes in PHP, so the CSS class could be another one.