### PR TITLE
[Doc] Fix link to Permission class

### DIFF
--- a/doc/security.rst
+++ b/doc/security.rst
@@ -187,7 +187,7 @@ Custom Security Voters
 
 EasyAdmin implements a Symfony `security voter`_ to check the permissions
 defined for actions, entities, menu items, etc. The actual security permissions
-are defined as constants in the :class:`EasyCorp\\Bundle\\EasyAdminBundle\\Security\\Permission`
+are defined as constants in the `EasyCorp\\Bundle\\EasyAdminBundle\\Security\\Permission`
 class (e.g. ``Permission::EA_EXECUTE_ACTION``, ``Permission::EA_VIEW_MENU_ITEM``, etc.)
 
 If you define a custom security voter for the backend, consider changing the


### PR DESCRIPTION
Not sure this is the right fix to do, but currently, the link to this class is rendered as `https://github.com/symfony/symfony/blob/master/src/EasyCorp/Bundle/EasyAdminBundle/Security/Permission.php` which obviously result in a 404 error (note the symfony/symfony prefix).

You can see this paragraph to spot the error https://symfony.com/doc/master/bundles/EasyAdminBundle/security.html#custom-security-voters.

Note: I couldn't find any other occurences of the `:class:` usage on github because their search had always been broken when looking for specific symbols containing not alphanumeric chars, so there could be other occurences to fix...