### PR TITLE
Fixed Dashboard Crud links when using prefixed routes

### DIFF
--- a/src/Cache/CacheWarmer.php
+++ b/src/Cache/CacheWarmer.php
@@ -45,7 +45,9 @@ final class CacheWarmer implements CacheWarmerInterface
                 continue;
             }
 
-            $dashboardRoutes[$controller->toString()] = $routeName;
+            /* Controller names are not unique when locale prefixes are defined, therefore use the unique routename
+             (which is suffixed with .locale) as key, to allow us later to choose the correct localized route */
+            $dashboardRoutes[$routeName] = $controller->toString();
         }
 
         (new Filesystem())->dumpFile(

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -71,10 +71,20 @@ final class AdminContextFactory
         $dashboardControllerRoutes = require $this->cacheDir.'/'.CacheWarmer::DASHBOARD_ROUTES_CACHE;
         $dashboardController = \get_class($dashboardControllerInstance).'::index';
         $dashboardRouteName = null;
-        foreach ($dashboardControllerRoutes as $controller => $routeName) {
+
+        foreach ($dashboardControllerRoutes as $routeName => $controller) {
             if ($controller === $dashboardController) {
                 $dashboardRouteName = $routeName;
-                break;
+
+                //Try to get locale part of the route (e.g. en in 'admin_route.en')
+                $locale = explode('.', $dashboardRouteName)[1] ?? null;
+
+                //If no locale prefix are generated or we found our matching locale we can skip the other iterations
+                if ($locale === null || $locale === $request->getLocale()) {
+                    break;
+                } else { //Otherwise we have to check if we find a better match later
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
Symfony allows to add prefixes to all imported routes, to choose between different languages easily (see https://symfony.com/doc/current/routing.html#localized-routes-i18n).

EasyAdmin 3 had problems when using prefixed routes, because the routes generated for CRUD controllers did not matched the locale the user has selected by the route prefix. Instead, always the last defined route prefix was used.

The reason for this that the controller name (which was used as key by CacheWarmer) is the same for all the different prefixed routes. I changed this behavior and added some logic to determine the right route based on Request object.

Now EasyAdmin should work fine with locale prefixed routes.