### PR TITLE
Fix absence of results in fields with autocomplete

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -17,7 +17,7 @@ window.addEventListener('load', function() {
     createNullableControls();
 
     createAutoCompleteFields();
-    document.addEventListener('ea.collection.item-added', function() { createAutoCompleteFields(); });
+    document.addEventListener('ea.collection.item-added', createAutoCompleteFields);
 
     createContentResizer();
     createNavigationToggler();
@@ -44,7 +44,7 @@ function createNullableControls() {
 }
 
 function createAutoCompleteFields() {
-    var autocompleteFields = $('[data-widget="select2"]');
+    var autocompleteFields = $('[data-widget="select2"]:not(.select2-hidden-accessible)');
 
     autocompleteFields.each(function () {
         var $this = $(this),

--- a/src/Resources/views/crud/includes/_select2_widget.html.twig
+++ b/src/Resources/views/crud/includes/_select2_widget.html.twig
@@ -1,21 +1,11 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{% set ea_select2_locales = ['ar', 'az', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'gl', 'he', 'hi', 'hr', 'hu', 'id', 'is', 'it', 'ja', 'km', 'ko', 'lt', 'lv', 'mk', 'ms', 'nb', 'nl', 'pl', 'pt-BR', 'pt', 'ro', 'ru', 'sk', 'sr-Cyrl', 'sr', 'sv', 'th', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW'] %}
-{% set ea_select2_locale = ea_select2_locales[ea.i18n.locale] ?? ea_select2_locales[ea.i18n.language] ?? 'en' %}
+{% set ea_select2_locales = ['af', 'ar', 'az', 'bg', 'bn', 'bs', 'ca', 'cs', 'da', 'de', 'dsb', 'el', 'en', 'es', 'et', 'eu', 'fa', 'fi', 'fr', 'gl', 'he', 'hi', 'hr', 'hsb', 'hu', 'hy', 'id', 'is', 'it', 'ja', 'ka', 'km', 'ko', 'lt', 'lv', 'mk', 'ms', 'nb', 'ne', 'nl', 'pl', 'ps', 'pt', 'pt-BR', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr', 'sr-Cyrl', 'sv', 'th', 'tk', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW'] %}
 
-<script src="{{ asset('bundles/easyadmin/select2/i18n/' ~ ea_select2_locale ~ '.js') }}"></script>
-<script type="text/javascript">
-    $(function() {
-        // Select2 widget is only enabled for the <select> elements which
-        // explicitly ask for it
+{% set ea_select2_locale = ea.i18n.locale in ea_select2_locales
+    ? ea.i18n.locale
+    : ea.i18n.language in ea_select2_locales ? ea.i18n.language : 'en'
+%}
 
-        function init() {
-            $('form select[data-widget="select2"]').select2({
-                theme: 'bootstrap',
-                language: '{{ ea_select2_locale }}'
-            });
-        }
-
-        $(document).on('ea.collection.item-added', init);
-        init();
-    });
-</script>
+{% if ea_select2_locale != 'en' %}
+    <script src="{{ asset('bundles/easyadmin/select2/i18n/' ~ ea_select2_locale ~ '.js') }}"></script>
+{% endif %}


### PR DESCRIPTION
Fixes #3355

This PR removes initialization of select2 from `_select2_widget.html.twig` because it is already initialized in `app.js`. There is no need to set `language` option, select2 can read it from `html` tag with a `lang` attribute.

Additionally this PR:  
- prevent from reinitializing all select2 elements when collection item added
- make available new locales for select2
- do not load select2 localization js for English because English included by default