### PR TITLE
Prevent "Undefined index" notices when adding custom actions.

### DIFF
--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -58,7 +58,7 @@ final class ActionConfigDto
 
     public function appendAction(string $pageName, ActionDto $actionDto): void
     {
-        $this->actions[$pageName] = array_merge([$actionDto->getName() => $actionDto], $this->actions[$pageName]);
+        $this->actions[$pageName] = array_merge([$actionDto->getName() => $actionDto], $this->actions[$pageName] ?? []);
     }
 
     public function setAction(string $pageName, ActionDto $actionDto): void


### PR DESCRIPTION
Related (and explained) with #3364. 

When adding custom action, the `ActionConfigDto::appendAction()` method was trying to retrieve existing action from the array by given key, which (in this case) doesn't exist. Simple null coalescing operator fixed the problem.