### PR TITLE
Fix compatibility with PHP7.2

### DIFF
--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -31,6 +31,7 @@ this error message. Check out the following files:
 
 If you need more help, read the EasyAdmin 3 documentation at:
 https://symfony.com/doc/master/bundles/EasyAdminBundle/index.html
-HELP);
+HELP
+	);
     }
 }


### PR DESCRIPTION
Before PHP7.3 Heredoc were parsed differently by PHP and it seems that putting other tokens in the same line as the closing Heredoc causes a syntax error on PHP 7.2:
` In EasyAdminController.php line 37:
    syntax error, unexpected end of file, expecting variable (T_VARIABLE) or heredoc end (T_END_HEREDOC) or ${ (T_DOLLAR_OPEN_CURLY_BRACES) or {$ (T_CURLY_OPEN)`

This minor edit fixes this syntax error and allows EasyAdmin to run on PHP7.2