### PR TITLE
HTTP Basic Auth Documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.confPath": "${workspaceFolder}/vendor/doctrine/orm/docs/en"
+}

--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -355,6 +355,14 @@ URL for the current security firewall automatically::
         ];
     }
 
+.. note::
+
+    The logout menu item will not work under certain authentication schemes like HTTP Basic because they do not have a 
+    default logout path configured due to the nature of how those auth schemes work. If you encounter an error like 
+    ``Unable to find the current firewall LogoutListener, please provide the provider key manually.``, you'll need to 
+    remove the linkToLogout or add a logout provider to your authentication scheme.
+
+
 Exit Impersonation Menu Item
 ............................
 


### PR DESCRIPTION
- Added some documentation around the link to logout
  with limitations around schemes that don't have a
  default logout provider.

Signed-off-by: RJ Garcia <ragboyjr@icloud.com>