### PR TITLE
Fix PHP 7.2 compatibility, add test for legacy controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .php_cs.cache
 composer.lock
 .phpunit.result.cache
+/phpunit.xml
 vendor/*
 build/
 

--- a/.php_cs
+++ b/.php_cs
@@ -25,7 +25,6 @@ return PhpCsFixer\Config::create()
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced', 'strict' => true],
         // Part of future @Symfony ruleset in PHP-CS-Fixer To be removed from the config file once upgrading
         'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
-        // part of `PHPUnitXYMigration:risky` ruleset, to be enabled when PHPUnit 4.x support will be dropped, as we don't want to rewrite exceptions handling twice
-        'php_unit_no_expectation_annotation' => false,
+        'single_line_throw' => false,
     ))
 ;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,4 +13,10 @@
             <exclude>tests/Form/</exclude>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Command/MakeAdminMigrationCommand.php
+++ b/src/Command/MakeAdminMigrationCommand.php
@@ -29,10 +29,10 @@ class MakeAdminMigrationCommand extends Command
     private $projectDir;
     /** @var InputInterface */
     private $input;
-    /** @var ConsoleSectionOutput $progressSection */
+    /** @var ConsoleSectionOutput */
     private $progressSection;
     private $progressSectionLines = [];
-    /** @var ConsoleSectionOutput $temporarySection */
+    /** @var ConsoleSectionOutput */
     private $temporarySection;
 
     public function __construct(Migrator $migrator, string $projectDir, string $name = null)
@@ -64,7 +64,7 @@ class MakeAdminMigrationCommand extends Command
         $this->addStep('<info>Step 1/3.</info> Find the file with the EasyAdmin 2 config backup.');
         $ea2ConfigBackupPath = $input->getArgument('ea2-backup-file') ?: $this->projectDir.'/easyadmin-config.backup';
 
-        if(!$fs->exists($ea2ConfigBackupPath)) {
+        if (!$fs->exists($ea2ConfigBackupPath)) {
             $this->temporarySection->write(sprintf(
             '<error> ERROR </error> The config backup file was not found in %s. To generate this file, run the <comment>make:admin:migration</comment> command in your application BEFORE upgrading to EasyAdmin 3 (the command must be run while still using EasyAdmin 2).',
             $ea2ConfigBackupPath

--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -14,7 +14,7 @@ class EasyAdminController extends AbstractController
         throw new \RuntimeException(<<<HELP
 If you are seeing this error, you are probably upgrading your application
 from EasyAdmin 2 to EasyAdmin 3. The new version of this bundle is a complete
-refactorization and most of the previous classes have been moved or deleted.
+refactoring and most of the previous classes have been moved or deleted.
  
 One of those removed classes is "EasyAdminController", which was used in EasyAdmin 2
 as the base controller of the entire backend. In EasyAdmin 3 each Doctrine entity has
@@ -31,6 +31,7 @@ this error message. Check out the following files:
 
 If you need more help, read the EasyAdmin 3 documentation at:
 https://symfony.com/doc/master/bundles/EasyAdminBundle/index.html
-HELP);
+HELP
+        );
     }
 }

--- a/src/DependencyInjection/EasyAdminExtension.php
+++ b/src/DependencyInjection/EasyAdminExtension.php
@@ -6,7 +6,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
-use EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -13,7 +13,7 @@ final class CrudDto
     private $controllerFqcn;
     private $pageName;
     private $actionName;
-    /** @var $actions ActionConfigDto */
+    /** @var ActionConfigDto */
     private $actionConfigDto;
     private $filters;
     private $entityFqcn;

--- a/src/Dto/UserMenuDto.php
+++ b/src/Dto/UserMenuDto.php
@@ -13,7 +13,7 @@ final class UserMenuDto
     private $displayAvatar;
     private $name;
     private $avatarUrl;
-    /** @var MenuItem[] $items */
+    /** @var MenuItem[] */
     private $items;
 
     public function __construct()

--- a/src/Field/Configurator/ArrayConfigurator.php
+++ b/src/Field/Configurator/ArrayConfigurator.php
@@ -40,7 +40,7 @@ final class ArrayConfigurator implements FieldConfiguratorInterface
         if (null !== $value && Crud::PAGE_INDEX === $context->getCrud()->getCurrentPage()) {
             $values = $field->getValue();
             if ($values instanceof PersistentCollection) {
-                $values = array_map(function($item) { return (string) $item; }, $values->getValues());
+                $values = array_map(function ($item) { return (string) $item; }, $values->getValues());
             }
 
             $field->setFormattedValue(u(', ')->join($values));

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -83,7 +83,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 $numAssociatedProperties = \count($associatedProperties);
 
                 if ($numAssociatedProperties > 2) {
-                    throw new \RuntimeException(sprintf('Nested associations of more than two levels (e.g. "%s") are not supported yet. We\'ll add support for them in the future, but meanwhile you can only use two-level associations (e.g. "%s")', $propertyName, implode('.', array_slice($associatedProperties, 0, 2))));
+                    throw new \RuntimeException(sprintf('Nested associations of more than two levels (e.g. "%s") are not supported yet. We\'ll add support for them in the future, but meanwhile you can only use two-level associations (e.g. "%s")', $propertyName, implode('.', \array_slice($associatedProperties, 0, 2))));
                 }
 
                 for ($i = 0; $i < $numAssociatedProperties - 1; ++$i) {

--- a/tests/Controller/EasyAdminControllerTest.php
+++ b/tests/Controller/EasyAdminControllerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class EasyAdminControllerTest extends TestCase
+{
+    public function testCall()
+    {
+        $controller = new EasyAdminController();
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('If you are seeing this error, you are probably upgrading your application');
+        $controller->index();
+    }
+}


### PR DESCRIPTION
This change fixes PHP 7.2 compatibility (using NowDoc) and adds test to assure it will not break in future. It also adjusts PHP-CS-Fixer config to avoid this issue again. 

Additional changes include coverage config and code style fixes. 

Replaces #3367
