### PR TITLE
Update index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -41,7 +41,7 @@ Technical Requirements
 EasyAdmin requires the following:
 
 * PHP 7.2 or higher;
-* Symfony 4.4 or higher;
+* Symfony 4.4 or higher, with [CSRF protection](https://symfony.com/doc/current/security/csrf.html) enabled in `framework.yaml`;
 * Doctrine ORM entities (Doctrine ODM is not supported).
 
 Installation


### PR DESCRIPTION
Mentioning CSRF requirement, see https://github.com/EasyCorp/EasyAdminBundle/issues/3390#issuecomment-650552715

Reason: This might be a show stopper for some people: If I have 100 user forms in my project, and I want them all without CSRF, and I'd need EasyAdmin just for one table, it's easier to create this one admin form manually, than disabling CSRF in the 100 user forms...
