### PR TITLE
[Doc] Fixed referencing articles in toctree

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -25,15 +25,15 @@ Table of Contents
 .. toctree::
    :maxdepth: 1
 
-    dashboards
-    crud
-    design
-    fields
-    filters
-    actions
-    security
-    events
-    upgrade
+    /dashboards
+    /crud
+    /design
+    /fields
+    /filters
+    /actions
+    /security
+    /events
+    /upgrade
 
 Technical Requirements
 ----------------------


### PR DESCRIPTION
This fixes the doc errors, and also the missing TOC on the homepage: https://symfony.com/doc/master/bundles/EasyAdminBundle/index.html

I'm not sure why relative paths don't work, but the paragraph above this uses an absolute path and it seems to work fine on symfony.com, so I think this should fix it.

Please note that the version checker is the docs is also a bit of: Visiting the [current docs](https://symfony.com/doc/current/bundles/EasyAdminBundle/index.html) renders 2.x, but the version checker shows 3.x.