### PR TITLE
[Doc] Fix 'generate CRUD urls' 404 link

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -104,7 +104,7 @@ XML or PHP config in a separate file. For example, when using YAML:
 
 In practice you won't have to deal with this route or the query string
 parameters in your application because EasyAdmin provides a service to
-`generate CRUD URLs <crud-generate-urls>`_.
+:ref:`generate CRUD URLs <crud-generate-urls>`.
 
 .. note::
 


### PR DESCRIPTION
Hi there,

I've noticed that this reference is broken on the official doc (https://symfony.com/doc/master/bundles/EasyAdminBundle/dashboards.html), it links to https://symfony.com/doc/master/bundles/EasyAdminBundle/crud-generate-urls.html :(

