### PR TITLE
[3.0] Migration: fix file name not matching class name

### DIFF
--- a/src/Maker/Migrator.php
+++ b/src/Maker/Migrator.php
@@ -87,7 +87,7 @@ final class Migrator
 
             $code = $code->closeBrace(); // closing for 'class ... {'
 
-            $controllerClassName = $entityClassName.'CrudController.php';
+            $controllerClassName = $crudControllerClassName.'.php';
             $outputFilePath = $this->outputDir.'/'.$controllerClassName;
             $isDumped = $this->dumpCode($code, $outputFilePath);
 


### PR DESCRIPTION
The migration creates classes which do not match the file name if the configuration used names that are not identical to the entity class names.

Example:
```
easy_admin:
  entities:
    Categories:
      class: App\Entity\Category
```

This currently creates a `CategoryCrudController.php` file with a class `CategoriesCrudController`