### PR TITLE
Correct block names in welcome page

### DIFF
--- a/src/Resources/views/welcome.html.twig
+++ b/src/Resources/views/welcome.html.twig
@@ -1,9 +1,9 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {% extends '@EasyAdmin/page/content.html.twig' %}
 
-{% block content_title 'Welcome to EasyAdmin 3' %}
+{% block page_title 'Welcome to EasyAdmin 3' %}
 
-{% block content_body %}
+{% block page_content %}
     <style>
         p { max-width: 600px; }
     </style>


### PR DESCRIPTION
Rename blocks in welcome page to respect changes from 4ab2072ecf385f6bb2e8b68ef77d726fe939a001
Fixes #3430
