### PR TITLE
Display null when an Id is null

### DIFF
--- a/src/Field/Configurator/IdConfigurator.php
+++ b/src/Field/Configurator/IdConfigurator.php
@@ -27,7 +27,7 @@ final class IdConfigurator implements FieldConfiguratorInterface
             $maxLength = Crud::PAGE_INDEX === $context->getCrud()->getCurrentPage() ? 7 : -1;
         }
 
-        if (-1 !== $maxLength) {
+        if (-1 !== $maxLength && !is_null($field->getValue()) {
             $field->setFormattedValue(u($field->getValue())->truncate($maxLength, '…'));
         }
     }


### PR DESCRIPTION
Add a check to not truncate a null field value. This is useful when displaying id of children which are not necessarily initialized yet.


