### PR TITLE
Use the generic field by default instead of throwing an error

### DIFF
--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -11,10 +11,15 @@ final class Field implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, ?string $label = null, ?string $templateName = null): self
     {
+        if (null === $templateName) {
+            $templateName = 'crud/field/generic';
+        }
+        
         return (new self())
             ->setProperty($propertyName)
-            ->setLabel($label);
+            ->setLabel($label)
+            ->setTemplateName($templateName);
     }
 }


### PR DESCRIPTION
Allows to pass the template name directly in the Field constructor.
If no name is provided the generic template is used to fast track some implementation.

This is more of a convenience feature and also helps in the migration (some of my cruds were broken)