### PR TITLE
Use hyphen in html lang atribute

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -2,7 +2,7 @@
 {% trans_default_domain ea.i18n.translationDomain %}
 
 <!DOCTYPE html>
-<html lang="{{ ea.i18n.locale }}">
+<html lang="{{ ea.i18n.locale|replace({ '_': '-' }) }}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
This should fix #3439

Select2 cannot parse language with underscore. I propose use hyphen as described in [MDN Web Docs ](
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang):

> A language tag is made of hyphen-separated language subtags