### PR TITLE
CSP: wrap script tags rendered on page load in blocks to allow manual overwrite

### DIFF
--- a/src/Resources/views/crud/includes/_filters_modal.html.twig
+++ b/src/Resources/views/crud/includes/_filters_modal.html.twig
@@ -19,28 +19,31 @@
         </div>
     </div>
 </div>
-<script>
-    const filterModal = document.querySelector('#modal-filters');
 
-    const removeFilter = function(field) {
-        field.closest('form').querySelectorAll('input[name^="filters['+field.dataset.filterProperty+']"]').forEach(hidden => {
-            hidden.remove();
+{% block javascript_filter_modal %}
+    <script>
+        const filterModal = document.querySelector('#modal-filters');
+
+        const removeFilter = function(field) {
+            field.closest('form').querySelectorAll('input[name^="filters['+field.dataset.filterProperty+']"]').forEach(hidden => {
+                hidden.remove();
+            });
+            field.remove();
+        }
+
+        document.querySelector('#modal-clear-button').addEventListener('click', function() {
+            filterModal.querySelectorAll('.filter-field').forEach(filterField => {
+                removeFilter(filterField);
+            });
+
+            filterModal.querySelector('form').submit();
         });
-        field.remove();
-    }
 
-    document.querySelector('#modal-clear-button').addEventListener('click', function() {
-        filterModal.querySelectorAll('.filter-field').forEach(filterField => {
-            removeFilter(filterField);
+        document.querySelector('#modal-apply-button').addEventListener('click', function() {
+            filterModal.querySelectorAll('.filter-checkbox:not(:checked)').forEach(notAppliedFilter => {
+                removeFilter(notAppliedFilter.closest('.filter-field'));
+            });
+            filterModal.querySelector('form').submit();
         });
-
-        filterModal.querySelector('form').submit();
-    });
-
-    document.querySelector('#modal-apply-button').addEventListener('click', function() {
-        filterModal.querySelectorAll('.filter-checkbox:not(:checked)').forEach(notAppliedFilter => {
-            removeFilter(notAppliedFilter.closest('.filter-field'));
-        });
-        filterModal.querySelector('form').submit();
-    });
-</script>
+    </script>
+{% endblock javascript_filter_modal %}

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -44,12 +44,14 @@
 
 {% block body %}
     <body id="{% block body_id %}{% endblock %}" class="ea {% block body_class %}{% endblock %}">
-    <script>
-        document.body.classList.add(
-            'ea-content-width-' + (localStorage.getItem('ea/content/width') || '{{ ea.crud.contentWidth ?? ea.dashboardContentWidth ?? 'normal' }}'),
-            'ea-sidebar-width-' + (localStorage.getItem('ea/sidebar/width') || '{{ ea.crud.sidebarWidth ?? ea.dashboardSidebarWidth ?? 'normal' }}')
-        );
-    </script>
+    {% block javascript_page_layout %}
+        <script>
+            document.body.classList.add(
+                'ea-content-width-' + (localStorage.getItem('ea/content/width') || '{{ ea.crud.contentWidth ?? ea.dashboardContentWidth ?? 'normal' }}'),
+                'ea-sidebar-width-' + (localStorage.getItem('ea/sidebar/width') || '{{ ea.crud.sidebarWidth ?? ea.dashboardSidebarWidth ?? 'normal' }}')
+            );
+        </script>
+    {% endblock javascript_page_layout %}
 
     {% block wrapper_wrapper %}
         {% block flash_messages %}


### PR DESCRIPTION
I saw that implementing CSP has been discussed here several times already. This pull request doesn't attempt to implement CSP in easyadmin but instead provide a way for library users to have CSP enabled and be able to render all pages without any policy violations.

For instance if CSP is implemented via `nelmio/security-bundle` then all that is required is as opposed to having to fully copy and paste the template and add the blocks every time the library is updated.
```
{% extends '@!EasyAdmin/crud/includes/_filters_modal.html.twig' %}

{% block filter_modal_javascript %}
    {% cspscript %}
        {{ parent() }}
    {% endcspscript %}
{% endblock %}

```

Note: this doesn't fully solve the CSP issue. Once the filter modal is opened the JS that is loaded async causes a violation which cannot easily be solved because the content of the JS is dynamic.