### PR TITLE
Fixed the wat date, time and datetime formats/patterns are handled

### DIFF
--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -27,8 +27,8 @@ final class CrudDto
     ];
     private $customPageTitles;
     private $helpMessages;
-    private $dateFormat;
-    private $timeFormat;
+    private $datePattern;
+    private $timePattern;
     private $dateTimePattern;
     private $dateIntervalFormat;
     private $timezone;
@@ -48,9 +48,9 @@ final class CrudDto
     {
         $this->customPageTitles = [Crud::PAGE_DETAIL => null, Crud::PAGE_EDIT => null, Crud::PAGE_INDEX => null, Crud::PAGE_NEW => null];
         $this->helpMessages = [Crud::PAGE_DETAIL => null, Crud::PAGE_EDIT => null, Crud::PAGE_INDEX => null, Crud::PAGE_NEW => null];
-        $this->dateFormat = 'medium';
-        $this->timeFormat = 'medium';
-        $this->dateTimePattern = '';
+        $this->datePattern = 'MMM d, y';
+        $this->timePattern = 'h:mm:ss a';
+        $this->dateTimePattern = 'MMM d, y h:mm:ss a';
         $this->dateIntervalFormat = '%%y Year(s) %%m Month(s) %%d Day(s)';
         $this->defaultSort = [];
         $this->searchFields = [];
@@ -141,24 +141,24 @@ final class CrudDto
         $this->helpMessages[$pageName] = $helpMessage;
     }
 
-    public function getDateFormat(): ?string
+    public function getDatePattern(): ?string
     {
-        return $this->dateFormat;
+        return $this->datePattern;
     }
 
-    public function setDateFormat(?string $format): void
+    public function setDatePattern(?string $format): void
     {
-        $this->dateFormat = $format;
+        $this->datePattern = $format;
     }
 
-    public function getTimeFormat(): ?string
+    public function getTimePattern(): ?string
     {
-        return $this->timeFormat;
+        return $this->timePattern;
     }
 
-    public function setTimeFormat(?string $format): void
+    public function setTimePattern(?string $format): void
     {
-        $this->timeFormat = $format;
+        $this->timePattern = $format;
     }
 
     public function getDateTimePattern(): string

--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -32,23 +32,23 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $crud = $context->getCrud();
-        $defaultDateFormat = $crud->getDateFormat();
-        $defaultTimeFormat = $crud->getTimeFormat();
-        $defaultDateTimePattern = $crud->getDateTimePattern();
-        $defaultTimezone = $crud->getTimezone();
 
-        $dateFormat = $field->getCustomOption(DateTimeField::OPTION_DATE_FORMAT) ?? $defaultDateFormat;
-        $timeFormat = $field->getCustomOption(DateTimeField::OPTION_TIME_FORMAT) ?? $defaultTimeFormat;
-        $dateTimePattern = $field->getCustomOption(DateTimeField::OPTION_DATETIME_PATTERN) ?? $defaultDateTimePattern;
+        $defaultTimezone = $crud->getTimezone();
         $timezone = $field->getCustomOption(DateTimeField::OPTION_TIMEZONE) ?? $defaultTimezone;
 
         $formattedValue = $field->getValue();
         if (DateTimeField::class === $field->getFieldFqcn()) {
-            $formattedValue = $this->intlFormatter->formatDateTime($field->getValue(), $dateFormat, $timeFormat, $dateTimePattern, $timezone);
+            $defaultDateTimePattern = $crud->getDateTimePattern();
+            $dateTimePattern = $field->getCustomOption(DateTimeField::OPTION_DATETIME_PATTERN) ?? $defaultDateTimePattern;
+            $formattedValue = $this->intlFormatter->formatDateTime($field->getValue(), null, null, $dateTimePattern, $timezone);
         } elseif (DateField::class === $field->getFieldFqcn()) {
-            $formattedValue = $this->intlFormatter->formatDate($field->getValue(), $dateFormat, $dateTimePattern, $timezone);
+            $defaultDatePattern = $crud->getDatePattern();
+            $datePattern = $field->getCustomOption(DateField::OPTION_DATE_PATTERN) ?? $defaultDatePattern;
+            $formattedValue = $this->intlFormatter->formatDate($field->getValue(), null, $datePattern, $timezone);
         } elseif (TimeField::class === $field->getFieldFqcn()) {
-            $formattedValue = $this->intlFormatter->formatTime($field->getValue(), $timeFormat, $dateTimePattern, $timezone);
+            $defaultTimePattern = $crud->getTimePattern();
+            $timePattern = $field->getCustomOption(TimeField::OPTION_TIME_PATTERN) ?? $defaultTimePattern;
+            $formattedValue = $this->intlFormatter->formatTime($field->getValue(), null, $timePattern, $timezone);
         }
 
         $field->setFormattedValue($formattedValue);

--- a/src/Field/DateField.php
+++ b/src/Field/DateField.php
@@ -12,6 +12,8 @@ final class DateField implements FieldInterface
 {
     use FieldTrait;
 
+    public const OPTION_DATE_PATTERN = 'datePattern';
+
     public static function new(string $propertyName, ?string $label = null): self
     {
         return (new self())
@@ -21,8 +23,7 @@ final class DateField implements FieldInterface
             ->setFormType(DateType::class)
             ->addCssClass('field-date')
             // the proper default values of these options are set on the Crud class
-            ->setCustomOption(DateTimeField::OPTION_DATE_FORMAT, null)
-            ->setCustomOption(DateTimeField::OPTION_DATETIME_PATTERN, null)
+            ->setCustomOption(self::OPTION_DATE_PATTERN, null)
             ->setCustomOption(DateTimeField::OPTION_TIMEZONE, null);
     }
 
@@ -45,17 +46,16 @@ final class DateField implements FieldInterface
      */
     public function setFormat(string $dateFormatOrPattern): self
     {
-        if ('none' === $dateFormatOrPattern || '' === trim($dateFormatOrPattern)) {
-            throw new \InvalidArgumentException(sprintf('The first argument of the "%s()" method cannot be "none" or an empty string. Define either the date format or the datetime Intl pattern.', __METHOD__));
+        if (DateTimeField::FORMAT_NONE === $dateFormatOrPattern || '' === trim($dateFormatOrPattern)) {
+            $validDateFormatsWithoutNone = array_filter(DateTimeField::VALID_DATE_FORMATS, static function($format) {
+                return DateTimeField::FORMAT_NONE !== $format;
+            });
+
+            throw new \InvalidArgumentException(sprintf('The first argument of the "%s()" method cannot be "%s" or an empty string. Use either the special date formats (%s) or a datetime Intl pattern.',  __METHOD__, DateTimeField::FORMAT_NONE, implode(', ', $validDateFormatsWithoutNone)));
         }
 
-        if (!\in_array($dateFormatOrPattern, DateTimeField::VALID_DATE_FORMATS, true)) {
-            $this->setCustomOption(DateTimeField::OPTION_DATETIME_PATTERN, $dateFormatOrPattern);
-            $this->setCustomOption(DateTimeField::OPTION_DATE_FORMAT, null);
-        } else {
-            $this->setCustomOption(DateTimeField::OPTION_DATETIME_PATTERN, null);
-            $this->setCustomOption(DateTimeField::OPTION_DATE_FORMAT, $dateFormatOrPattern);
-        }
+        $datePattern = DateTimeField::INTL_DATE_PATTERNS[$dateFormatOrPattern] ?? $dateFormatOrPattern;
+        $this->setCustomOption(self::OPTION_DATE_PATTERN, $datePattern);
 
         return $this;
     }

--- a/src/Field/TimeField.php
+++ b/src/Field/TimeField.php
@@ -12,6 +12,8 @@ final class TimeField implements FieldInterface
 {
     use FieldTrait;
 
+    public const OPTION_TIME_PATTERN = 'timePattern';
+
     public static function new(string $propertyName, ?string $label = null): self
     {
         return (new self())
@@ -21,8 +23,7 @@ final class TimeField implements FieldInterface
             ->setFormType(TimeType::class)
             ->addCssClass('field-time')
             // the proper default values of these options are set on the Crud class
-            ->setCustomOption(DateTimeField::OPTION_TIME_FORMAT, null)
-            ->setCustomOption(DateTimeField::OPTION_DATETIME_PATTERN, null)
+            ->setCustomOption(self::OPTION_TIME_PATTERN, null)
             ->setCustomOption(DateTimeField::OPTION_TIMEZONE, null);
     }
 
@@ -45,17 +46,16 @@ final class TimeField implements FieldInterface
      */
     public function setFormat(string $timeFormatOrPattern): self
     {
-        if ('none' === $timeFormatOrPattern || '' === trim($timeFormatOrPattern)) {
-            throw new \InvalidArgumentException(sprintf('The first argument of the "%s()" method cannot be "none" or an empty string. Define either the time format or the datetime Intl pattern.', __METHOD__));
+        if (DateTimeField::FORMAT_NONE === $timeFormatOrPattern || '' === trim($timeFormatOrPattern)) {
+            $validTimeFormatsWithoutNone = array_filter(DateTimeField::VALID_DATE_FORMATS, static function($format) {
+                return DateTimeField::FORMAT_NONE !== $format;
+            });
+
+            throw new \InvalidArgumentException(sprintf('The first argument of the "%s()" method cannot be "%s" or an empty string. Use either the special time formats (%s) or a datetime Intl pattern.',  __METHOD__, DateTimeField::FORMAT_NONE, implode(', ', $validTimeFormatsWithoutNone)));
         }
 
-        if (!\in_array($timeFormatOrPattern, DateTimeField::VALID_DATE_FORMATS, true)) {
-            $this->setCustomOption(DateTimeField::OPTION_DATETIME_PATTERN, $timeFormatOrPattern);
-            $this->setCustomOption(DateTimeField::OPTION_TIME_FORMAT, null);
-        } else {
-            $this->setCustomOption(DateTimeField::OPTION_DATETIME_PATTERN, null);
-            $this->setCustomOption(DateTimeField::OPTION_TIME_FORMAT, $timeFormatOrPattern);
-        }
+        $timePattern = DateTimeField::INTL_TIME_PATTERNS[$timeFormatOrPattern] ?? $timeFormatOrPattern;
+        $this->setCustomOption(self::OPTION_TIME_PATTERN, $timePattern);
 
         return $this;
     }


### PR DESCRIPTION
Fixes #3451.

Basically the datetime formatting was a mess ... because it changed the date and/or time formatting too. Now everything is handled as expected, datetime formatting only affects datetime variables and date or time variables are unchanged.

This can look like a BC break ... but it's not, because it's a massive bug fix, so it's OK to change all the wrong code.