### PR TITLE
Added two new methods to the abstract CRUD controller

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,8 @@
+Upgrade between EasyAdmin 3.x versions
+======================================
+
+EasyAdmin 3.1.0
+---------------
+
+* `CrudControllerInterface` added two new methods: `createEditFormBuilder()` and
+  `createNewFormBuilder()` (and they were implemented in `AbstractCrudController`)

--- a/src/Contracts/Controller/CrudControllerInterface.php
+++ b/src/Contracts/Controller/CrudControllerInterface.php
@@ -15,6 +15,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -69,7 +70,11 @@ interface CrudControllerInterface
 
     public function deleteEntity(EntityManagerInterface $entityManager, $entityInstance): void;
 
+    public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface;
+
     public function createEditForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface;
+
+    public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface;
 
     public function createNewForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface;
 }

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -42,6 +42,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\CrudUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -444,12 +445,22 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function createEditForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
     {
-        return $this->get(FormFactory::class)->createEditForm($entityDto, $formOptions, $context);
+        return $this->createEditFormBuilder($entityDto, $formOptions, $context)->getForm();
+    }
+
+    public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
+    {
+        return $this->get(FormFactory::class)->createEditFormBuilder($entityDto, $formOptions, $context);
     }
 
     public function createNewForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
     {
-        return $this->get(FormFactory::class)->createNewForm($entityDto, $formOptions, $context);
+        return $this->createNewFormBuilder($entityDto, $formOptions, $context)->getForm();
+    }
+
+    public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
+    {
+        return $this->get(FormFactory::class)->createNewFormBuilder($entityDto, $formOptions, $context);
     }
 
     /**

--- a/src/Factory/FormFactory.php
+++ b/src/Factory/FormFactory.php
@@ -10,6 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudBatchActionFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Router\CrudUrlGenerator;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,7 +29,7 @@ final class FormFactory
         $this->crudUrlGenerator = $crudUrlGenerator;
     }
 
-    public function createEditForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
+    public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
     {
         $cssClass = sprintf('ea-%s-form', $context->getCrud()->getCurrentAction());
         $formOptions->set('attr.class', trim(($formOptions->get('attr.class') ?? '').' '.$cssClass));
@@ -36,10 +37,15 @@ final class FormFactory
         $formOptions->set('entityDto', $entityDto);
         $formOptions->setIfNotSet('translation_domain', $context->getI18n()->getTranslationDomain());
 
-        return $this->symfonyFormFactory->createNamedBuilder($entityDto->getName(), CrudFormType::class, $entityDto->getInstance(), $formOptions->all())->getForm();
+        return $this->symfonyFormFactory->createNamedBuilder($entityDto->getName(), CrudFormType::class, $entityDto->getInstance(), $formOptions->all());
     }
 
-    public function createNewForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
+    public function createEditForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
+    {
+        return $this->createEditFormBuilder($entityDto, $formOptions, $context)->getForm();
+    }
+
+    public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
     {
         $cssClass = sprintf('ea-%s-form', $context->getCrud()->getCurrentAction());
         $formOptions->set('attr.class', trim(($formOptions->get('attr.class') ?? '').' '.$cssClass));
@@ -47,7 +53,12 @@ final class FormFactory
         $formOptions->set('entityDto', $entityDto);
         $formOptions->setIfNotSet('translation_domain', $context->getI18n()->getTranslationDomain());
 
-        return $this->symfonyFormFactory->createNamedBuilder($entityDto->getName(), CrudFormType::class, $entityDto->getInstance(), $formOptions->all())->getForm();
+        return $this->symfonyFormFactory->createNamedBuilder($entityDto->getName(), CrudFormType::class, $entityDto->getInstance(), $formOptions->all());
+    }
+
+    public function createNewForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
+    {
+        return $this->createNewFormBuilder($entityDto, $formOptions, $context)->getForm();
     }
 
     public function createBatchActionsForm(): FormInterface


### PR DESCRIPTION
Fixes #3437.

I think this was a mistake in the original design of EA3. It's better that these methods return the builder because some form features (e.g. events) only work with builders, not with form objects.