### PR TITLE
Fixed label functionality of Filters

### DIFF
--- a/src/Dto/FilterDto.php
+++ b/src/Dto/FilterDto.php
@@ -90,6 +90,8 @@ final class FilterDto
      */
     public function setLabel($label): void
     {
+        //We must also apply the label to the form types, or it will not be shown in form
+        $this->setFormTypeOption('label', $label);
         $this->label = $label;
     }
 


### PR DESCRIPTION
Before the label property was not passed to the form used to render the filters, therefore it was not rendered correctly.

Now when setting the "label" filter property of a filter, the "label" property of the FormTypeOptions is set too. 
