### PR TITLE
[3.0] Allow alpha3 codes for CountryField

### DIFF
--- a/src/Field/Configurator/CountryConfigurator.php
+++ b/src/Field/Configurator/CountryConfigurator.php
@@ -23,16 +23,18 @@ final class CountryConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $field->setFormTypeOptionIfNotSet('attr.data-widget', 'select2');
+        $alpha3 = $field->getCustomOption(CountryField::OPTION_ALPHA3);
 
-        $formattedValue = $this->getCountryName($field->getValue());
+        $formattedValue = $this->getCountryName($field->getValue(), $alpha3);
         $field->setFormattedValue($formattedValue);
+        $field->setFormTypeOption('alpha3', $alpha3);
 
         if (null === $field->getTextAlign() && false === $field->getCustomOption(CountryField::OPTION_SHOW_NAME)) {
             $field->setTextAlign('center');
         }
     }
 
-    private function getCountryName(?string $countryCode): ?string
+    private function getCountryName(?string $countryCode, bool $alpha3): ?string
     {
         if (null === $countryCode) {
             return null;
@@ -44,6 +46,10 @@ final class CountryConfigurator implements FieldConfiguratorInterface
         }
 
         try {
+            if ($alpha3) {
+                return Countries::getAlpha3Name($countryCode);
+            }
+
             return Countries::getName($countryCode);
         } catch (MissingResourceException $e) {
             return null;

--- a/src/Field/CountryField.php
+++ b/src/Field/CountryField.php
@@ -14,6 +14,7 @@ final class CountryField implements FieldInterface
 
     public const OPTION_SHOW_FLAG = 'showFlag';
     public const OPTION_SHOW_NAME = 'showName';
+    public const OPTION_ALPHA3 = 'alpha3';
 
     public static function new(string $propertyName, ?string $label = null): self
     {
@@ -24,7 +25,8 @@ final class CountryField implements FieldInterface
             ->setFormType(CountryType::class)
             ->addCssClass('field-country')
             ->setCustomOption(self::OPTION_SHOW_FLAG, true)
-            ->setCustomOption(self::OPTION_SHOW_NAME, true);
+            ->setCustomOption(self::OPTION_SHOW_NAME, true)
+            ->setCustomOption(self::OPTION_ALPHA3, false);
     }
 
     public function showFlag(bool $isShown = true): self
@@ -37,6 +39,13 @@ final class CountryField implements FieldInterface
     public function showName(bool $isShown = true): self
     {
         $this->setCustomOption(self::OPTION_SHOW_NAME, $isShown);
+
+        return $this;
+    }
+
+    public function alpha3(bool $enable = true): self
+    {
+        $this->setCustomOption(self::OPTION_ALPHA3, $enable);
 
         return $this;
     }

--- a/src/Resources/views/crud/field/country.html.twig
+++ b/src/Resources/views/crud/field/country.html.twig
@@ -2,7 +2,8 @@
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% if field.customOptions.get('showFlag') %}
-    <img class="country-flag" alt="{{ field.formattedValue }}" src="{{ asset('bundles/easyadmin/images/flags/' ~ field.value ~ '.png') }}">
+    {% set country_code = field.customOption('alpha3') ? field.value|ea_country_alpha2_code : field.value %}
+    <img class="country-flag" alt="{{ field.formattedValue }}" src="{{ asset('bundles/easyadmin/images/flags/' ~ country_code ~ '.png') }}">
 {% endif %}
 {% if field.customOptions.get('showName') %}
     {{ field.formattedValue ?? '' }}

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -5,6 +5,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Twig;
 use EasyCorp\Bundle\EasyAdminBundle\Router\CrudUrlBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Router\CrudUrlGenerator;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Intl\Countries;
+use Symfony\Component\Intl\Exception\MissingResourceException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -45,6 +47,7 @@ class EasyAdminTwigExtension extends AbstractExtension
         $filters = [
             new TwigFilter('ea_flatten_array', [$this, 'flattenArray']),
             new TwigFilter('ea_filesize', [$this, 'fileSize']),
+            new TwigFilter('ea_country_alpha2_code', [$this, 'countryAlpha2Code']),
         ];
 
         if (Kernel::VERSION_ID >= 40200) {
@@ -99,5 +102,14 @@ class EasyAdminTwigExtension extends AbstractExtension
         }
 
         return $this->translator->trans($message, array_merge(['%count%' => $count], $arguments), $domain, $locale);
+    }
+
+    public function countryAlpha2Code(string $alpha3Code): ?string
+    {
+        try {
+            return Countries::getAlpha2Code($alpha3Code);
+        } catch (MissingResourceException $e) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Easily configure alpha3 country codes for CountryField.  
Applies to forms & index/detail page.

Fixes #3509