### PR TITLE
Design override docs folder structure bug solve

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -57,7 +57,7 @@ For example::
              │     └─ text.html.twig
              ├─ label/
              │  └─ null.html.twig
-             └─ page/
+             └─ crud/
                 ├─ index.html.twig
                 ├─ form.html.twig
                 └─ paginator.html.twig


### PR DESCRIPTION
- [x] Docs

- In the docs there has to override template need override crud/index.html.twig, crud/form.html.twig, crud/paginator.html.twig but there has no index.html.twig in easyadmin crud folder. That will be page/index.html.twig
