### PR TITLE
Add option to modify query of AssociationField (with autocomplete)

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -395,12 +395,18 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $queryBuilder = $this->createIndexQueryBuilder($context->getSearch(), $context->getEntity(), FieldCollection::new([]), FilterCollection::new());
 
         $autocompleteContext = $context->getRequest()->get(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT);
-        ['crudId' => $crudId, 'propertyName' => $propertyName] = $autocompleteContext;
 
         /** @var CrudControllerInterface $controller */
-        $controller = $this->get(ControllerFactory::class)->getCrudControllerInstance($crudId, Action::INDEX, $context->getRequest());
+        $controller = $this->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext['crudId'], Action::INDEX, $context->getRequest());
         /** @var FieldDto $field */
-        $field = FieldCollection::new($controller->configureFields(Crud::PAGE_INDEX))->get($propertyName);
+        $field = FieldCollection::new($controller->configureFields(Crud::PAGE_INDEX))->get($autocompleteContext['propertyName']);
+        /** @var \Closure|null $modify */
+        $modify = $field->getCustomOption(AssociationField::OPTION_MODIFY_QUERY);
+
+        if(null !== $modify)
+        {
+            $modify($queryBuilder);
+        }
 
         $paginator = $this->get(PaginatorFactory::class)->create($queryBuilder);
 

--- a/src/Factory/ControllerFactory.php
+++ b/src/Factory/ControllerFactory.php
@@ -47,7 +47,7 @@ final class ControllerFactory
         return $this->getController(DashboardControllerInterface::class, $dashboardControllerFqcn, 'index', $request);
     }
 
-    private function getCrudController(?string $crudControllerFqcn, ?string $crudAction, Request $request): ?CrudControllerInterface
+    public function getCrudController(?string $crudControllerFqcn, ?string $crudAction, Request $request): ?CrudControllerInterface
     {
         return $this->getController(CrudControllerInterface::class, $crudControllerFqcn, $crudAction, $request);
     }

--- a/src/Factory/ControllerFactory.php
+++ b/src/Factory/ControllerFactory.php
@@ -1,0 +1,76 @@
+<?php
+
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
+
+
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @author Lukas Lücke <lukas@luecke.me>
+ */
+final class ControllerFactory
+{
+    private $dashboardControllers;
+    private $crudControllers;
+    private $controllerResolver;
+
+    public function __construct(DashboardControllerRegistry $dashboardControllers, CrudControllerRegistry $crudControllers, ControllerResolverInterface $controllerResolver)
+    {
+        $this->dashboardControllers = $dashboardControllers;
+        $this->crudControllers = $crudControllers;
+        $this->controllerResolver = $controllerResolver;
+    }
+
+    public function getDashboardControllerInstanceFromContextId(string $contextId, Request $request): ?DashboardControllerInterface
+    {
+        return $this->getDashboardController($this->dashboardControllers->getControllerFqcnByContextId($contextId), $request);
+    }
+
+    public function getCrudControllerInstance(?string $crudId, ?string $crudAction, Request $request): ?CrudControllerInterface
+    {
+        if (null === $crudId) {
+            return null;
+        }
+
+        return $this->getCrudController($this->crudControllers->findCrudFqcnByCrudId($crudId), $crudAction, $request);
+    }
+
+    private function getDashboardController(?string $dashboardControllerFqcn, Request $request): ?DashboardControllerInterface
+    {
+        return $this->getController(DashboardControllerInterface::class, $dashboardControllerFqcn, 'index', $request);
+    }
+
+    private function getCrudController(?string $crudControllerFqcn, ?string $crudAction, Request $request): ?CrudControllerInterface
+    {
+        return $this->getController(CrudControllerInterface::class, $crudControllerFqcn, $crudAction, $request);
+    }
+
+    private function getController(string $controllerInterface, ?string $controllerFqcn, ?string $controllerAction, Request $request)
+    {
+        if (null === $controllerFqcn || null === $controllerAction) {
+            return null;
+        }
+
+        $newRequest = $request->duplicate(null, null, ['_controller' => [$controllerFqcn, $controllerAction]]);
+        $controllerCallable = $this->controllerResolver->getController($newRequest);
+
+        if (false === $controllerCallable) {
+            throw new NotFoundHttpException(sprintf('Unable to find the controller "%s::%s".', $controllerFqcn, $controllerAction));
+        }
+
+        if (!\is_array($controllerCallable)) {
+            return null;
+        }
+
+        $controllerInstance = $controllerCallable[0];
+
+        return is_subclass_of($controllerInstance, $controllerInterface) ? $controllerInstance : null;
+    }
+}

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -19,6 +19,9 @@ final class AssociationField implements FieldInterface
     /** @internal this option is intended for internal use only */
     public const OPTION_DOCTRINE_ASSOCIATION_TYPE = 'associationType';
 
+    /** @internal this option is intended for internal use only */
+    public const PARAM_AUTOCOMPLETE_CONTEXT = 'autocompleteContext';
+
     public static function new(string $propertyName, ?string $label = null): self
     {
         return (new self())

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -14,6 +14,7 @@ final class AssociationField implements FieldInterface
 
     public const OPTION_AUTOCOMPLETE = 'autocomplete';
     public const OPTION_CRUD_CONTROLLER = 'crudControllerFqcn';
+    public const OPTION_MODIFY_QUERY = 'modifyQuery';
     /** @internal this option is intended for internal use only */
     public const OPTION_RELATED_URL = 'relatedUrl';
     /** @internal this option is intended for internal use only */
@@ -32,6 +33,7 @@ final class AssociationField implements FieldInterface
             ->addCssClass('field-association')
             ->setCustomOption(self::OPTION_AUTOCOMPLETE, false)
             ->setCustomOption(self::OPTION_CRUD_CONTROLLER, null)
+            ->setCustomOption(self::OPTION_MODIFY_QUERY, null)
             ->setCustomOption(self::OPTION_RELATED_URL, null)
             ->setCustomOption(self::OPTION_DOCTRINE_ASSOCIATION_TYPE, null);
     }
@@ -46,6 +48,13 @@ final class AssociationField implements FieldInterface
     public function setCrudController(string $crudControllerFqcn): self
     {
         $this->setCustomOption(self::OPTION_CRUD_CONTROLLER, $crudControllerFqcn);
+
+        return $this;
+    }
+
+    public function modifyQuery(\Closure $modify): self
+    {
+        $this->setCustomOption(self::OPTION_MODIFY_QUERY, $modify);
 
         return $this;
     }

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\PersistentCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
@@ -77,6 +78,16 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ->generateUrl();
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);
+        } else {
+            $field->setFormTypeOption('query_builder', static function(EntityRepository $repository) use($field) {
+                // TODO: should this use `createIndexQueryBuilder` instead, so we get the default ordering etc.?
+                // it would then be identical to the one used in autocomplete action, but it is a bit complex getting it in here
+                $queryBuilder = $repository->createQueryBuilder('entity');
+                if($modify = $field->getCustomOption(AssociationField::OPTION_MODIFY_QUERY)) {
+                    $modify($queryBuilder);
+                }
+                return $queryBuilder;
+            });
         }
     }
 

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -70,6 +70,10 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ->setController($field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER))
                 ->setAction('autocomplete')
                 ->setEntityId(null)
+                ->set(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT, [
+                    'crudId' => $context->getRequest()->query->get('crudId'),
+                    'propertyName' => $propertyName
+                ])
                 ->generateUrl();
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -15,6 +15,7 @@ use EasyCorp\Bundle\EasyAdminBundle\EventListener\CrudResponseListener;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ActionFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\AdminContextFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FilterFactory;
@@ -150,11 +151,14 @@ return static function (ContainerConfigurator $container) {
 
         ->set(AdminContextListener::class)
             ->arg(0, new Reference(AdminContextFactory::class))
-            ->arg(1, new Reference(DashboardControllerRegistry::class))
-            ->arg(2, new Reference(CrudControllerRegistry::class))
-            ->arg(3, new Reference('controller_resolver'))
-            ->arg(4, new Reference('twig'))
+            ->arg(1, new Reference(ControllerFactory::class))
+            ->arg(2, new Reference('twig'))
             ->tag('kernel.event_listener', ['event' => ControllerEvent::class])
+
+        ->set(ControllerFactory::class)
+            ->arg(0, new Reference(DashboardControllerRegistry::class))
+            ->arg(1, new Reference(CrudControllerRegistry::class))
+            ->arg(2, new Reference('controller_resolver'))
 
         ->set(CrudResponseListener::class)
             ->arg(0, new Reference(AdminContextProvider::class))


### PR DESCRIPTION
Resolves #3476. Depends on #3550.

Works the same for "default" and autocomplete fields.

```php
AssociationField::new('property')
    ->autocomplete() // optional
    ->modifyQuery(fn(QueryBuilder $queryBuilder) => $queryBuilder
        ->where('entity.id > 20')
        ->orderBy('entity.field', 'DESC')
    );
```