### PR TITLE
Docs Bug: Missing font-awesome attribute

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -177,7 +177,7 @@ the look and behavior of each menu item::
         public function configureMenuItems(): iterable
         {
             return [
-                MenuItem::linkToDashboard('Dashboard', 'fa-home'),
+                MenuItem::linkToDashboard('Dashboard', 'fa fa-home'),
 
                 MenuItem::section('Blog'),
                 MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class),


### PR DESCRIPTION
In the first reference to MenuItem::linkToDashboard(...), the 'fa' is missing, resulting in the home icon not appearing.
