### PR TITLE
Display select lists as autocomplete widgets by default

### DIFF
--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -14,10 +14,14 @@ final class AssociationField implements FieldInterface
 
     public const OPTION_AUTOCOMPLETE = 'autocomplete';
     public const OPTION_CRUD_CONTROLLER = 'crudControllerFqcn';
+    public const OPTION_WIDGET = 'widget';
     /** @internal this option is intended for internal use only */
     public const OPTION_RELATED_URL = 'relatedUrl';
     /** @internal this option is intended for internal use only */
     public const OPTION_DOCTRINE_ASSOCIATION_TYPE = 'associationType';
+
+    public const WIDGET_AUTOCOMPLETE = 'autocomplete';
+    public const WIDGET_NATIVE = 'native';
 
     public static function new(string $propertyName, ?string $label = null): self
     {
@@ -29,6 +33,7 @@ final class AssociationField implements FieldInterface
             ->addCssClass('field-association')
             ->setCustomOption(self::OPTION_AUTOCOMPLETE, false)
             ->setCustomOption(self::OPTION_CRUD_CONTROLLER, null)
+            ->setCustomOption(self::OPTION_WIDGET, self::WIDGET_AUTOCOMPLETE)
             ->setCustomOption(self::OPTION_RELATED_URL, null)
             ->setCustomOption(self::OPTION_DOCTRINE_ASSOCIATION_TYPE, null);
     }
@@ -36,6 +41,13 @@ final class AssociationField implements FieldInterface
     public function autocomplete(): self
     {
         $this->setCustomOption(self::OPTION_AUTOCOMPLETE, true);
+
+        return $this;
+    }
+
+    public function renderAsNativeWidget(bool $asNative = true): self
+    {
+        $this->setCustomOption(self::OPTION_WIDGET, $asNative ? self::WIDGET_NATIVE : self::WIDGET_AUTOCOMPLETE);
 
         return $this;
     }

--- a/src/Field/ChoiceField.php
+++ b/src/Field/ChoiceField.php
@@ -17,8 +17,12 @@ final class ChoiceField implements FieldInterface
     public const OPTION_CHOICES = 'choices';
     public const OPTION_RENDER_AS_BADGES = 'renderAsBadges';
     public const OPTION_RENDER_EXPANDED = 'renderExpanded';
+    public const OPTION_WIDGET = 'widget';
 
     public const VALID_BADGE_TYPES = ['success', 'warning', 'danger', 'info', 'primary', 'secondary', 'light', 'dark'];
+
+    public const WIDGET_AUTOCOMPLETE = 'autocomplete';
+    public const WIDGET_NATIVE = 'native';
 
     public static function new(string $propertyName, ?string $label = null): self
     {
@@ -30,7 +34,8 @@ final class ChoiceField implements FieldInterface
             ->addCssClass('field-select')
             ->setCustomOption(self::OPTION_CHOICES, null)
             ->setCustomOption(self::OPTION_RENDER_AS_BADGES, null)
-            ->setCustomOption(self::OPTION_RENDER_EXPANDED, false);
+            ->setCustomOption(self::OPTION_RENDER_EXPANDED, false)
+            ->setCustomOption(self::OPTION_WIDGET, self::WIDGET_AUTOCOMPLETE);
     }
 
     public function allowMultipleChoices(bool $allow = true): self
@@ -83,6 +88,13 @@ final class ChoiceField implements FieldInterface
         }
 
         $this->setCustomOption(self::OPTION_RENDER_AS_BADGES, $badgeSelector);
+
+        return $this;
+    }
+
+    public function renderAsNativeWidget(bool $asNative = true): self
+    {
+        $this->setCustomOption(self::OPTION_WIDGET, $asNative ? self::WIDGET_NATIVE : self::WIDGET_AUTOCOMPLETE);
 
         return $this;
     }

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -48,6 +48,10 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             ?? $context->getCrudControllers()->findCrudFqcnByEntityFqcn($targetEntityFqcn);
         $field->setCustomOption(AssociationField::OPTION_CRUD_CONTROLLER, $targetCrudControllerFqcn);
 
+        if (AssociationField::WIDGET_AUTOCOMPLETE === $field->getCustomOption(AssociationField::OPTION_WIDGET)) {
+            $field->setFormTypeOption('attr.data-widget', 'select2');
+        }
+
         if ($entityDto->isToOneAssociation($propertyName)) {
             $this->configureToOneAssociation($field);
         }
@@ -61,9 +65,6 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             if (null === $targetCrudControllerFqcn) {
                 throw new \RuntimeException(sprintf('The "%s" field cannot be autocompleted because it doesn\'t define the related CRUD controller FQCN with the "setCrudController()" method.', $field->getProperty()));
             }
-
-            // this enables autocompletion for compatible associations
-            $field->setFormTypeOptionIfNotSet('attr.data-widget', 'select2');
 
             $field->setFormType(CrudAutocompleteType::class);
             $autocompleteEndpointUrl = $this->crudUrlGenerator->build()

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -39,8 +39,8 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         $field->setFormTypeOptionIfNotSet('multiple', $field->getCustomOption(ChoiceField::OPTION_ALLOW_MULTIPLE_CHOICES));
         $field->setFormTypeOptionIfNotSet('expanded', $field->getCustomOption(ChoiceField::OPTION_RENDER_EXPANDED));
 
-        if (true === $field->getCustomOption(ChoiceField::OPTION_AUTOCOMPLETE)) {
-            $field->setFormTypeOptionIfNotSet('attr.data-widget', 'select2');
+        if (ChoiceField::WIDGET_AUTOCOMPLETE === $field->getCustomOption(ChoiceField::OPTION_WIDGET)) {
+            $field->setFormTypeOption('attr.data-widget', 'select2');
         }
 
         $fieldValue = $field->getValue();


### PR DESCRIPTION
This continues #3573, but does the opposite change, to make `<select>` be displayed as Select2 autocomplete widgets by default (and you have the option to display them instead as native HTML widgets).