### PR TITLE
Change the configurator flow

### DIFF
--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -32,10 +32,6 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
-        if (null === $field->getValue()) {
-            return;
-        }
-
         $currencyCode = $this->getCurrency($field, $entityDto);
         if (!$this->isValidCurrencyCode($currencyCode)) {
             throw new \InvalidArgumentException(sprintf('The "%s" value used as the currency of the "%s" money field is not a valid ICU currency code.', $currencyCode, $field->getProperty()));
@@ -43,13 +39,18 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
 
         $numDecimals = $field->getCustomOption(MoneyField::OPTION_NUM_DECIMALS);
         $storedAsCents = $field->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS);
+
+        $field->setFormTypeOption('currency', $field->getCustomOption(MoneyField::OPTION_CURRENCY));
+        $field->setFormTypeOptionIfNotSet('divisor', $storedAsCents ? 100 : 1);
+
+        if (null === $field->getValue()) {
+            return;
+        }
+
         $amount = $storedAsCents ? $field->getValue() / 100 : $field->getValue();
 
         $formattedValue = $this->intlFormatter->formatCurrency($amount, $currencyCode, ['fraction_digit' => $numDecimals]);
         $field->setFormattedValue($formattedValue);
-
-        $field->setFormTypeOption('currency', $field->getCustomOption(MoneyField::OPTION_CURRENCY));
-        $field->setFormTypeOptionIfNotSet('divisor', $storedAsCents ? 100 : 1);
     }
 
     private function getCurrency(FieldDto $field, EntityDto $entityDto): string


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

Fixes #3384, that isn't entirely solved, although it's closed.

Currently the problem is that, because of [the defaults in the MoneyType in Symfony](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php#L54-L66), every time the **field value is NULL**, then it's shown as _Euro by default_, and also the divisor _might_ be wrong in case you want to store the value as cents. This is observed in the following cases:

- Brand new record -> the value is always NULL initially
- If your Money field is nullable, and you decide to submit without a value

Also, the `if (!$this->isValidCurrencyCode($currencyCode)) {` check was not executed in the above occasions.

**So, I propose changing the flow**. This way:

- Money fields can still be nullable -> tried this both on new submission and editing an existing record
- First time submission is correct. With the current behavior if you submit a new record with money value 11.11, that will result in 11, because of the same check exiting the method before the formatting and options are properly set.

p.s.
Apologies for the long description for such a simple change.
