### PR TITLE
Allow to define dynamic labels and page titles

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -104,6 +104,8 @@ The rest of CRUD options are configured using the ``configureCrud()`` method::
         }
     }
 
+.. _crud_entity_options:
+
 Entity Options
 ~~~~~~~~~~~~~~
 
@@ -116,6 +118,16 @@ Entity Options
             ->setEntityLabelInSingular('Product')
             ->setEntityLabelInPlural('Products')
 
+            // in addition to a string, the argument of the singular and plural label methods
+            // can be a closure that receives both the current entity instance (which will
+            // be null in 'index' and 'new' pages) and the page name
+            ->setEntityLabelInSingular(
+                fn (?Product $product, string $pageName) => $product ? $product->toString() : 'Product'
+            )
+            ->setEntityLabelInPlural(function (?Category $category, string $pageName) {
+                return 'edit' === $pageName ? $category->getLabel() : 'Categories';
+            })
+
             // the Symfony Security permission needed to manage the entity
             // (none by default, so you can manage all instances of the entity)
             ->setEntityPermission('ROLE_EDITOR')
@@ -125,7 +137,13 @@ Entity Options
 Title and Help Options
 ~~~~~~~~~~~~~~~~~~~~~~
 
-::
+By default, the page titles of the ``index`` and ``new`` pages are based on the
+:ref:`entity option <crud_entity_options>` values defined with the
+``setEntityLabelInSingular()`` and ``setEntityLabelInPlural()`` methods. In the
+``detail`` and ``edit`` pages, EasyAdmin tries first to convert the entity into
+a string representation and falls back to a generic title otherwise.
+
+You can override the default page titles with the following methods::
 
     public function configureCrud(Crud $crud): Crud
     {
@@ -133,6 +151,14 @@ Title and Help Options
             // the visible title at the top of the page and the content of the <title> element
             // it can include these placeholders: %entity_id%, %entity_label_singular%, %entity_label_plural%
             ->setPageTitle('index', '%entity_label_plural% listing')
+
+            // you can pass a PHP closure as the value of the title
+            ->setPageTitle('new', fn () => new \DateTime('now') > new \DateTime('today 13:00') ? 'New dinner' : 'New lunch')
+
+            // in DETAIL and EDIT pages, the closure receives the current entity
+            // as the first argument
+            ->setPageTitle('detail', function(Product $product) => (string) $product)
+            ->setPageTitle('edit', fn (Category $category) => sprintf('Editing <b>%s</b>', $category->getName()))
 
             // the help message displayed to end users (it can contain HTML tags)
             ->setHelp('edit', '...')

--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -140,9 +140,9 @@ final class Action
 
     /**
      * @param array|callable $routeParameters The callable has the signature: function ($entity): array
-     *                                        e.g. ->linkToRoute('invoice_send', function (Invoice $entity) {
-     *                                                 return ['uuid' => $entity->getId()];
-     *                                             });
+     *
+     * Route parameters can be defined as a callable with the signature: function ($entityInstance): array
+     * Example: ->linkToRoute('invoice_send', fn (Invoice $entity) => ['uuid' => $entity->getId()]);
      */
     public function linkToRoute(string $routeName, $routeParameters = []): self
     {

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -35,21 +35,30 @@ class Crud
         return new self($dto);
     }
 
-    public function setEntityLabelInSingular(string $label): self
+    /**
+     * @param string|callable $label The callable signature is: fn ($entityInstance, string $pageName): string
+     */
+    public function setEntityLabelInSingular($label): self
     {
         $this->dto->setEntityLabelInSingular($label);
 
         return $this;
     }
 
-    public function setEntityLabelInPlural(string $label): self
+    /**
+     * @param string|callable $label The callable signature is: fn ($entityInstance, string $pageName): string
+     */
+    public function setEntityLabelInPlural($label): self
     {
         $this->dto->setEntityLabelInPlural($label);
 
         return $this;
     }
 
-    public function setPageTitle(string $pageName, string $title): self
+    /**
+     * @param string|callable $title The callable signature is: fn ($entityInstance): string
+     */
+    public function setPageTitle(string $pageName, $title): self
     {
         if (!\in_array($pageName, $this->getValidPageNames(), true)) {
             throw new \InvalidArgumentException(sprintf('The first argument of the "%s()" method must be one of these valid page names: %s ("%s" given).', __METHOD__, implode(', ', $this->getValidPageNames()), $pageName));

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -92,38 +92,70 @@ final class CrudDto
         $this->entityFqcn = $entityFqcn;
     }
 
-    public function getEntityLabelInSingular(): ?string
+    public function getEntityLabelInSingular($entityInstance = null): ?string
     {
+        if (\is_callable($this->entityLabelInSingular)) {
+            return ($this->entityLabelInSingular)($entityInstance);
+        }
+
         return $this->entityLabelInSingular;
     }
 
-    public function setEntityLabelInSingular(string $label): void
+    /**
+     * @param string|callable $label
+     */
+    public function setEntityLabelInSingular($label): void
     {
         $this->entityLabelInSingular = $label;
     }
 
-    public function getEntityLabelInPlural(): ?string
+    public function getEntityLabelInPlural($entityInstance = null): ?string
     {
+        if (\is_callable($this->entityLabelInPlural)) {
+            return ($this->entityLabelInPlural)($entityInstance);
+        }
+
         return $this->entityLabelInPlural;
     }
 
-    public function setEntityLabelInPlural(string $label): void
+    /**
+     * @param string|callable $label
+     */
+    public function setEntityLabelInPlural($label): void
     {
         $this->entityLabelInPlural = $label;
     }
 
-    public function getCustomPageTitle(string $pageName = null): ?string
+    public function getCustomPageTitle(string $pageName = null, $entityInstance = null): ?string
     {
-        return $this->customPageTitles[$pageName ?? $this->pageName] ?? null;
+        $title = $this->customPageTitles[$pageName ?? $this->pageName];
+        if (\is_callable($title)) {
+            return null !== $entityInstance ? $title($entityInstance) : $title();
+        }
+
+        return $title;
     }
 
-    public function setCustomPageTitle(string $pageName, string $pageTitle): void
+    /**
+     * @param string|callable $pageTitle
+     */
+    public function setCustomPageTitle(string $pageName, $pageTitle): void
     {
         $this->customPageTitles[$pageName] = $pageTitle;
     }
 
-    public function getDefaultPageTitle(string $pageName = null): ?string
+    public function getDefaultPageTitle(string $pageName = null, $entityInstance = null): ?string
     {
+        if (null !== $entityInstance) {
+            if (method_exists($entityInstance, '__toString')) {
+                $entityAsString = (string) $entityInstance;
+
+                if (!empty($entityAsString)) {
+                    return $entityAsString;
+                }
+            }
+        }
+
         return $this->defaultPageTitles[$pageName ?? $this->pageName] ?? null;
     }
 

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -156,7 +156,9 @@ final class ActionFactory
             'referrer' => $this->generateReferrerUrl($request, $actionDto, $currentAction),
         ];
 
-        if (null !== $entityDto && !\in_array($actionDto->getName(), [Action::INDEX, Action::NEW], true)) {
+        if (\in_array($actionDto->getName(), [Action::INDEX, Action::NEW], true)) {
+            $requestParameters['entityId'] = null;
+        } elseif (null !== $entityDto) {
             $requestParameters['entityId'] = $entityDto->getPrimaryKeyValueAsString();
         }
 

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -59,7 +59,7 @@ final class AdminContextFactory
         $crudDto = $this->getCrudDto($this->crudControllers, $dashboardController, $crudController, $actionConfigDto, $filters, $crudAction, $pageName);
         $entityDto = $this->getEntityDto($request, $crudDto);
         $searchDto = $this->getSearchDto($request, $crudDto);
-        $i18nDto = $this->getI18nDto($request, $dashboardDto, $crudDto);
+        $i18nDto = $this->getI18nDto($request, $dashboardDto, $crudDto, $entityDto);
         $templateRegistry = $this->getTemplateRegistry($dashboardController, $crudDto);
         $user = $this->getUser($this->tokenStorage);
 
@@ -159,7 +159,7 @@ final class AdminContextFactory
         return $templateRegistry;
     }
 
-    private function getI18nDto(Request $request, DashboardDto $dashboardDto, ?CrudDto $crudDto): I18nDto
+    private function getI18nDto(Request $request, DashboardDto $dashboardDto, ?CrudDto $crudDto, ?EntityDto $entityDto): I18nDto
     {
         $locale = $request->getLocale();
 
@@ -176,8 +176,9 @@ final class AdminContextFactory
             $translationParameters['%entity_id%'] = $entityId = $request->query->get('entityId');
             $translationParameters['%entity_short_id%'] = null === $entityId ? null : u((string) $entityId)->truncate(7);
 
-            $translatedSingularLabel = $this->translator->trans($crudDto->getEntityLabelInSingular() ?? $entityName, $translationParameters, $translationDomain);
-            $translatedPluralLabel = $this->translator->trans($crudDto->getEntityLabelInPlural() ?? $entityName, $translationParameters, $translationDomain);
+            $entityInstance = null === $entityDto ? null : $entityDto->getInstance();
+            $translatedSingularLabel = $this->translator->trans($crudDto->getEntityLabelInSingular($entityInstance) ?? $entityName, $translationParameters, $translationDomain);
+            $translatedPluralLabel = $this->translator->trans($crudDto->getEntityLabelInPlural($entityInstance) ?? $entityName, $translationParameters, $translationDomain);
             $crudDto->setEntityLabelInSingular($translatedSingularLabel);
             $crudDto->setEntityLabelInPlural($translatedPluralLabel);
 

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -9,8 +9,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set default_title = ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
-        {{ ea.crud.customPageTitle is null ? default_title|raw : ea.crud.customPageTitle|trans(ea.i18n.translationParameters)|raw }}
+        {% set default_title = ea.crud.defaultPageTitle('detail', entity.instance)|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
+        {% set custom_title = ea.crud.customPageTitle('detail', entity.instance) %}
+        {{ custom_title is null ? default_title|raw : custom_title|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -38,8 +38,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set default_title = ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
-        {{ ea.crud.customPageTitle is null ? default_title|raw : ea.crud.customPageTitle|trans(ea.i18n.translationParameters)|raw }}
+        {% set default_title = ea.crud.defaultPageTitle('edit', entity.instance)|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
+        {% set custom_title = ea.crud.customPageTitle('edit', entity.instance) %}
+        {{ custom_title is null ? default_title|raw : custom_title|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -12,8 +12,8 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set default_title = ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
-        {{ ea.crud.customPageTitle is null ? default_title|raw : ea.crud.customPageTitle|trans(ea.i18n.translationParameters)|raw }}
+        {% set default_title = ea.crud.defaultPageTitle('index')|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
+        {{ ea.crud.customPageTitle is null ? default_title|raw : ea.crud.customPageTitle('index')|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -31,8 +31,8 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set default_title = ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
-        {{ ea.crud.customPageTitle is null ? default_title|raw : ea.crud.customPageTitle|trans(ea.i18n.translationParameters)|raw }}
+        {% set default_title = ea.crud.defaultPageTitle('new')|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
+        {{ ea.crud.customPageTitle is null ? default_title|raw : ea.crud.customPageTitle('new')|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/tests/Intl/IntlFormatterTest.php
+++ b/tests/Intl/IntlFormatterTest.php
@@ -22,13 +22,13 @@ class IntlFormatterTest extends TestCase
     /**
      * @dataProvider provideFormatTime
      */
-    public function testFormatTime(?string $expectedResult, ?\DateTimeInterface $date, ?string $timeFormat = 'medium', string $pattern = '', $timezone = null, string $calendar = 'gregorian', string $locale = null)
+    public function testFormatTime(?string $expectedResult, ?\DateTimeInterface $date, ?string $timeFormat = 'medium', string $pattern = '', $timezone = null, string $calendar = 'gregorian', string $locale = null, string $assertMethod = 'assertSame')
     {
         $intlFormatter = new IntlFormatter();
         $formattedTime = $intlFormatter->formatTime($date, $timeFormat, $pattern, $timezone, $calendar, $locale);
         $formattedTimeWithNormalizedSpaces = null === $formattedTime ? $formattedTime : str_replace(' ', ' ', $formattedTime);
 
-        $this->assertSame($expectedResult, $formattedTimeWithNormalizedSpaces);
+        $this->{$assertMethod}($expectedResult, $formattedTimeWithNormalizedSpaces);
     }
 
     /**
@@ -74,8 +74,8 @@ class IntlFormatterTest extends TestCase
     {
         yield [null, null, 'medium', '', null, 'gregorian', null];
 
-        yield ['20201108 03:04 PM', new \DateTime('15:04:05'), 'none', '', null, 'gregorian', 'en'];
-        yield ['20201108 03:04 p. m.', new \DateTime('15:04:05'), 'none', '', null, 'gregorian', 'es'];
+        yield ['03:04 PM', new \DateTime('15:04:05'), 'none', '', null, 'gregorian', 'en', 'assertStringEndsWith'];
+        yield ['03:04 p. m.', new \DateTime('15:04:05'), 'none', '', null, 'gregorian', 'es', 'assertStringEndsWith'];
         yield ['3:04 PM', new \DateTime('15:04:05'), 'short', '', null, 'gregorian', 'en'];
         yield ['15:04', new \DateTime('15:04:05'), 'short', '', null, 'gregorian', 'es'];
         yield ['3:04:05 PM', new \DateTime('15:04:05'), 'medium', '', null, 'gregorian', 'en'];


### PR DESCRIPTION
Fixes #3596.

This was on my TODO list because I like the option to define dynamic page titles based on the current entity.