### PR TITLE
Fixed an issue in MoneyFields associated to null entities

### DIFF
--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -33,7 +33,7 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $currencyCode = $this->getCurrency($field, $entityDto);
-        if (!$this->isValidCurrencyCode($currencyCode)) {
+        if (null !== $currencyCode && !$this->isValidCurrencyCode($currencyCode)) {
             throw new \InvalidArgumentException(sprintf('The "%s" value used as the currency of the "%s" money field is not a valid ICU currency code.', $currencyCode, $field->getProperty()));
         }
 
@@ -53,8 +53,12 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
         $field->setFormattedValue($formattedValue);
     }
 
-    private function getCurrency(FieldDto $field, EntityDto $entityDto): string
+    private function getCurrency(FieldDto $field, EntityDto $entityDto): ?string
     {
+        if (null === $entityDto->getInstance()) {
+            return null;
+        }
+
         if (null !== $currencyCode = $field->getCustomOption(MoneyField::OPTION_CURRENCY)) {
             return $currencyCode;
         }


### PR DESCRIPTION
This happens when using filters for entities which have money fields (when configuring those fields for the filters, the entity is null, so the currency is null ... but it's OK in this case).