### PR TITLE
Fixed the widget option of choice fields

### DIFF
--- a/src/Field/ChoiceField.php
+++ b/src/Field/ChoiceField.php
@@ -35,7 +35,7 @@ final class ChoiceField implements FieldInterface
             ->setCustomOption(self::OPTION_CHOICES, null)
             ->setCustomOption(self::OPTION_RENDER_AS_BADGES, null)
             ->setCustomOption(self::OPTION_RENDER_EXPANDED, false)
-            ->setCustomOption(self::OPTION_WIDGET, self::WIDGET_AUTOCOMPLETE);
+            ->setCustomOption(self::OPTION_WIDGET, null);
     }
 
     public function allowMultipleChoices(bool $allow = true): self


### PR DESCRIPTION
We used a Select2 autocomplete widget by default for ChoiceFields ... but this is wrong when the ChoiceField uses the `expanded` option.