### PR TITLE
Remove trailing directory separator for namespace

### DIFF
--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -61,7 +61,7 @@ class MakeCrudControllerCommand extends Command
 
         $guessedNamespace = u($controllerDir)->equalsTo('src')
             ? 'App'
-            : u($controllerDir)->replace('/', ' ')->replace('\\', ' ')->replace('src ', 'app ')->title(true)->replace(' ', '\\');
+            : u($controllerDir)->replace('/', ' ')->replace('\\', ' ')->replace('src ', 'app ')->title(true)->replace(' ', '\\')->trimEnd(DIRECTORY_SEPARATOR);
         $namespace = $io->ask('Namespace of the generated CRUD controller', $guessedNamespace, static function(string $namespace) {
             return u($namespace)->replace('/', '\\')->toString();
         });


### PR DESCRIPTION
The namespace created by the Command was incorrect as the trailing / was not removed.

