### PR TITLE
Added some tests for ChoiceField configurator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "symfony/uid": "^5.1"
     },
     "require-dev": {
+        "dg/bypass-finals": "^1.2",
         "psr/log": "~1.0",
         "symfony/browser-kit": "^4.4|^5.0",
         "symfony/css-selector": "^4.4|^5.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,18 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.0/phpunit.xsd"
          colors="true"
          bootstrap="tests/bootstrap.php">
+
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <server name="APP_ENV" value="test" force="true" />
+        <server name="SHELL_VERBOSITY" value="-1" />
+        <server name="KERNEL_CLASS" value="TestApp\Kernel" />
+    </php>
+
+    <extensions>
+        <extension class="EasyCorp\Bundle\EasyAdminBundle\Test\BypassFinalClasses"/>
+    </extensions>
+
     <testsuites>
         <testsuite name="EasyAdmin Test Suite">
             <directory>tests/</directory>

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -86,7 +86,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         } elseif (\is_array($badgeSelector)) {
             $badgeType = $badgeSelector[$value] ?? 'badge-secondary';
         } elseif (\is_callable($badgeSelector)) {
-            $badgeType = $badgeSelector($field);
+            $badgeType = $badgeSelector($value, $field);
             if (!\in_array($badgeType, ChoiceField::VALID_BADGE_TYPES, true)) {
                 throw new \RuntimeException(sprintf('The value returned by the callable passed to the "renderAsBadges()" method must be one of the following valid badge types: "%s" ("%s" given).', implode(', ', ChoiceField::VALID_BADGE_TYPES), $badgeType));
             }

--- a/src/Test/BypassFinalClasses.php
+++ b/src/Test/BypassFinalClasses.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Test;
+
+use DG\BypassFinals;
+use PHPUnit\Runner\BeforeTestHook;
+
+/**
+ * This was copied from: "How to Mock Final Classes in PHPUnit"
+ * https://tomasvotruba.com/blog/2019/03/28/how-to-mock-final-classes-in-phpunit/
+ * (c) Tomáš Votruba (https://github.com/TomasVotruba/)
+ */
+final class BypassFinalClasses implements BeforeTestHook
+{
+    public function executeBeforeTest(string $test): void
+    {
+        BypassFinals::enable();
+    }
+}

--- a/tests/Field/Configurator/ChoiceConfiguratorTest.php
+++ b/tests/Field/Configurator/ChoiceConfiguratorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Configurator;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ChoiceConfigurator;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ChoiceConfiguratorTest extends KernelTestCase
+{
+    private $choices;
+    private $configurator;
+    private $entityDto;
+    private $adminContext;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->choices = ['a' => 1, 'b' => 2, 'c' => 3];
+        $this->configurator = new ChoiceConfigurator(self::$container->get('translator'));
+        $this->entityDto = $this->createMock(EntityDto::class);
+
+        $crudMock = $this->getMockBuilder(CrudDto::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCurrentPage'])
+            ->getMock();
+        $crudMock->method('getCurrentPage')->willReturn(Crud::PAGE_INDEX);
+
+        $i18nMock = $this->getMockBuilder(I18nDto::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getTranslationParameters', 'getTranslationDomain'])
+            ->getMock();
+        $i18nMock->method('getTranslationParameters')->willReturn([]);
+        $i18nMock->method('getTranslationDomain')->willReturn('messages');
+
+        $adminContextMock = $this->getMockBuilder(AdminContext::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCrud', 'getI18n'])
+            ->getMock();
+        $adminContextMock
+            ->expects($this->any())
+            ->method('getCrud')
+            ->willReturn($crudMock);
+        $adminContextMock
+            ->expects($this->any())
+            ->method('getI18n')
+            ->willReturn($i18nMock);
+
+        $this->adminContext = $adminContextMock;
+    }
+
+    public function testFieldWithoutChoices()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $field = ChoiceField::new('foo');
+        $this->configure($field);
+    }
+
+    public function testFieldWithWrongVisualOptions()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $field = ChoiceField::new('foo')->setChoices($this->choices);
+        $field->renderExpanded();
+        $field->renderAsNativeWidget(false);
+        $this->configure($field);
+    }
+
+    public function testDefaultWidget()
+    {
+        $field = ChoiceField::new('foo')->setChoices($this->choices);
+
+        $field->renderExpanded(false);
+        $field->setCustomOption(ChoiceField::OPTION_WIDGET, null);
+        self::assertSame(ChoiceField::WIDGET_AUTOCOMPLETE, $this->configure($field)->getCustomOption(ChoiceField::OPTION_WIDGET));
+
+        $field->renderExpanded(true);
+        $field->setCustomOption(ChoiceField::OPTION_WIDGET, null);
+        $fieldDto = $this->configure($field);
+        self::assertSame(ChoiceField::WIDGET_NATIVE, $fieldDto->getCustomOption(ChoiceField::OPTION_WIDGET));
+        self::assertSame('select2', $fieldDto->getFormTypeOption('attr.data-widget'));
+    }
+
+    public function testFieldFormOptions()
+    {
+        $field = ChoiceField::new('foo')->setChoices($this->choices);
+        $field->renderExpanded();
+        $field->allowMultipleChoices();
+
+        self::assertSame(
+            ['choices' => $this->choices, 'multiple' => true, 'expanded' => true],
+            $this->configure($field)->getFormTypeOptions()
+        );
+    }
+
+    public function testBadges()
+    {
+        $field = ChoiceField::new('foo')->setChoices($this->choices);
+
+        $field->setValue(1);
+        self::assertSame('a', $this->configure($field)->getFormattedValue());
+
+        $field->setValue([1, 3]);
+        self::assertSame('a, c', $this->configure($field)->getFormattedValue());
+
+        $field->setValue(1)->renderAsBadges();
+        self::assertSame('<span class="badge badge-pill badge-secondary">a</span>', $this->configure($field)->getFormattedValue());
+
+        $field->setValue([1, 3])->renderAsBadges();
+        self::assertSame('<span class="badge badge-pill badge-secondary">a</span><span class="badge badge-pill badge-secondary">c</span>', $this->configure($field)->getFormattedValue());
+
+        $field->setValue(1)->renderAsBadges([1 => 'warning', '3' => 'danger']);
+        self::assertSame('<span class="badge badge-pill badge-warning">a</span>', $this->configure($field)->getFormattedValue());
+
+        $field->setValue([1, 3])->renderAsBadges([1 => 'warning', '3' => 'danger']);
+        self::assertSame('<span class="badge badge-pill badge-warning">a</span><span class="badge badge-pill badge-danger">c</span>', $this->configure($field)->getFormattedValue());
+
+        $field->setValue(1)->renderAsBadges(function ($value) { return $value > 1 ? 'success' : 'primary'; });
+        self::assertSame('<span class="badge badge-pill badge-primary">a</span>', $this->configure($field)->getFormattedValue());
+
+        $field->setValue([1, 3])->renderAsBadges(function ($value) { return $value > 1 ? 'success' : 'primary'; });
+        self::assertSame('<span class="badge badge-pill badge-primary">a</span><span class="badge badge-pill badge-success">c</span>', $this->configure($field)->getFormattedValue());
+    }
+
+    private function configure(FieldInterface $field): FieldDto
+    {
+        $fieldDto = $field->getAsDto();
+        $this->configurator->configure($fieldDto, $this->entityDto, $this->adminContext);
+
+        return $fieldDto;
+    }
+}

--- a/tests/Field/FieldTraitTest.php
+++ b/tests/Field/FieldTraitTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
I'm starting to add more tests for complex features. This PR adds for one of the most complex configurators. While adding tests, I found a bug when using a closure in the `renderAsBadges()` method.

Thanks to @TomasVotruba for publishing https://tomasvotruba.com/blog/2018/05/17/how-to-test-private-services-in-symfony/ which allowed me to test `final` classes without going crazy!