### PR TITLE
Fixed a bug and added some tests for MoneyField configurator

### DIFF
--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -36,12 +36,13 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
         if (null !== $currencyCode && !$this->isValidCurrencyCode($currencyCode)) {
             throw new \InvalidArgumentException(sprintf('The "%s" value used as the currency of the "%s" money field is not a valid ICU currency code.', $currencyCode, $field->getProperty()));
         }
+        $field->setFormTypeOption('currency', $currencyCode);
 
         $numDecimals = $field->getCustomOption(MoneyField::OPTION_NUM_DECIMALS);
-        $storedAsCents = $field->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS);
+        $field->setFormTypeOption('scale', $numDecimals);
 
-        $field->setFormTypeOption('currency', $field->getCustomOption(MoneyField::OPTION_CURRENCY));
-        $field->setFormTypeOptionIfNotSet('divisor', $storedAsCents ? 100 : 1);
+        $storedAsCents = $field->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS);
+        $field->setFormTypeOption('divisor', $storedAsCents ? 100 : 1);
 
         if (null === $field->getValue()) {
             return;
@@ -55,7 +56,7 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
 
     private function getCurrency(FieldDto $field, EntityDto $entityDto): ?string
     {
-        if (null === $entityDto->getInstance()) {
+        if (null === $field->getValue()) {
             return null;
         }
 

--- a/tests/Field/AbstractFieldTest.php
+++ b/tests/Field/AbstractFieldTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ChoiceConfigurator;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AbstractFieldTest extends KernelTestCase
+{
+    protected $entityDto;
+    protected $adminContext;
+    protected $configurator;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->entityDto = $this->createMock(EntityDto::class);
+
+        $crudMock = $this->getMockBuilder(CrudDto::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCurrentPage'])
+            ->getMock();
+        $crudMock->method('getCurrentPage')->willReturn(Crud::PAGE_INDEX);
+
+        $i18nMock = $this->getMockBuilder(I18nDto::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getTranslationParameters', 'getTranslationDomain'])
+            ->getMock();
+        $i18nMock->method('getTranslationParameters')->willReturn([]);
+        $i18nMock->method('getTranslationDomain')->willReturn('messages');
+
+        $adminContextMock = $this->getMockBuilder(AdminContext::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCrud', 'getI18n'])
+            ->getMock();
+        $adminContextMock
+            ->expects($this->any())
+            ->method('getCrud')
+            ->willReturn($crudMock);
+        $adminContextMock
+            ->expects($this->any())
+            ->method('getI18n')
+            ->willReturn($i18nMock);
+
+        $this->adminContext = $adminContextMock;
+    }
+
+    protected function configure(FieldInterface $field): FieldDto
+    {
+        $fieldDto = $field->getAsDto();
+        $this->configurator->configure($fieldDto, $this->entityDto, $this->adminContext);
+
+        return $fieldDto;
+    }
+}

--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -1,60 +1,22 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Configurator;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
-use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ChoiceConfigurator;
-use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-class ChoiceConfiguratorTest extends KernelTestCase
+class ChoiceFieldTest extends AbstractFieldTest
 {
     private $choices;
-    private $configurator;
-    private $entityDto;
-    private $adminContext;
 
     protected function setUp(): void
     {
-        self::bootKernel();
+        parent::setUp();
 
         $this->choices = ['a' => 1, 'b' => 2, 'c' => 3];
         $this->configurator = new ChoiceConfigurator(self::$container->get('translator'));
-        $this->entityDto = $this->createMock(EntityDto::class);
-
-        $crudMock = $this->getMockBuilder(CrudDto::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getCurrentPage'])
-            ->getMock();
-        $crudMock->method('getCurrentPage')->willReturn(Crud::PAGE_INDEX);
-
-        $i18nMock = $this->getMockBuilder(I18nDto::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getTranslationParameters', 'getTranslationDomain'])
-            ->getMock();
-        $i18nMock->method('getTranslationParameters')->willReturn([]);
-        $i18nMock->method('getTranslationDomain')->willReturn('messages');
-
-        $adminContextMock = $this->getMockBuilder(AdminContext::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getCrud', 'getI18n'])
-            ->getMock();
-        $adminContextMock
-            ->expects($this->any())
-            ->method('getCrud')
-            ->willReturn($crudMock);
-        $adminContextMock
-            ->expects($this->any())
-            ->method('getI18n')
-            ->willReturn($i18nMock);
-
-        $this->adminContext = $adminContextMock;
     }
 
     public function testFieldWithoutChoices()
@@ -129,13 +91,5 @@ class ChoiceConfiguratorTest extends KernelTestCase
 
         $field->setValue([1, 3])->renderAsBadges(function ($value) { return $value > 1 ? 'success' : 'primary'; });
         self::assertSame('<span class="badge badge-pill badge-primary">a</span><span class="badge badge-pill badge-success">c</span>', $this->configure($field)->getFormattedValue());
-    }
-
-    private function configure(FieldInterface $field): FieldDto
-    {
-        $fieldDto = $field->getAsDto();
-        $this->configurator->configure($fieldDto, $this->entityDto, $this->adminContext);
-
-        return $fieldDto;
     }
 }

--- a/tests/Field/MoneyFieldTest.php
+++ b/tests/Field/MoneyFieldTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\MoneyConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\MoneyField;
+use EasyCorp\Bundle\EasyAdminBundle\Intl\IntlFormatter;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+class MoneyFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $intlFormatterMock = $this->getMockBuilder(IntlFormatter::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['formatCurrency'])
+            ->getMock();
+        $intlFormatterMock->method('formatCurrency')->willReturnCallback(
+            function ($value) { return $value.'€'; }
+        );
+
+        $propertyAccessorMock = $this->getMockBuilder(PropertyAccessor::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['isReadable', 'getValue'])
+            ->getMock();
+        $propertyAccessorMock->method('isReadable')->willReturn(true);
+        $propertyAccessorMock->method('getValue')->willReturn('USD');
+
+        $this->configurator = new MoneyConfigurator($intlFormatterMock, $propertyAccessorMock);
+    }
+
+    public function testFieldWithoutCurrency()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $field = MoneyField::new('foo')->setValue(100);
+        $this->configure($field);
+    }
+
+    public function testFieldWithNullValues()
+    {
+        $field = MoneyField::new('foo')->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getCustomOption(MoneyField::OPTION_CURRENCY));
+    }
+
+    public function testFieldWithWrongCurrency()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $field = MoneyField::new('foo')->setValue(100)->setCurrency('THIS_DOES_NOT_EXIST');
+        $this->configure($field);
+    }
+
+    public function testFieldWithHardcodedCurrency()
+    {
+        $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('EUR', $fieldDto->getCustomOption(MoneyField::OPTION_CURRENCY));
+        self::assertSame('EUR', $fieldDto->getFormTypeOption('currency'));
+    }
+
+    public function testFieldWithPropertyPathCurrency()
+    {
+        $field = MoneyField::new('foo')->setValue(100)->setCurrencyPropertyPath('bar');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('USD', $fieldDto->getFormTypeOption('currency'));
+    }
+
+    public function testFieldDecimals()
+    {
+        $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
+        $fieldDto = $this->configure($field);
+        self::assertSame(2, $fieldDto->getCustomOption('numDecimals'));
+        self::assertSame(2, $fieldDto->getFormTypeOption('scale'));
+
+        $field->setNumDecimals(3);
+        $fieldDto = $this->configure($field);
+        self::assertSame(3, $fieldDto->getCustomOption('numDecimals'));
+        self::assertSame(3, $fieldDto->getFormTypeOption('scale'));
+    }
+
+    public function testFieldCents()
+    {
+        $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
+        $fieldDto = $this->configure($field);
+        self::assertSame('1€', $fieldDto->getFormattedValue());
+        self::assertSame(100, $fieldDto->getFormTypeOption('divisor'));
+
+        $field->setStoredAsCents(false);
+        $fieldDto = $this->configure($field);
+        self::assertSame('100€', $fieldDto->getFormattedValue());
+        self::assertSame(1, $fieldDto->getFormTypeOption('divisor'));
+    }
+}


### PR DESCRIPTION
There was an error when the field value was `null` and the currency was still required to be defined. The PR also contains some unrelated changes to improve field tests.