### PR TITLE
Fixed the dependency injection pass that creates the services

### DIFF
--- a/src/EasyAdminBundle.php
+++ b/src/EasyAdminBundle.php
@@ -17,6 +17,6 @@ class EasyAdminBundle extends Bundle
 
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new CreateControllerRegistriesPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new CreateControllerRegistriesPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
     }
 }


### PR DESCRIPTION
I tried to inject `DashboardControllerRegistry` in a controller and I saw this error:

![image](https://user-images.githubusercontent.com/73419/88535642-97029280-d00a-11ea-86bf-93522084b12c.png)

This change fixes the problem.
