### PR TITLE
Add missing use in custom field example

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -394,6 +394,7 @@ for a given postal address. This is the class you could create for the field::
     namespace App\Admin\Field;
 
     use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+    use EasyCorp\Bundle\EasyAdminBundle\Field\FieldTrait;
     use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 
     final class MapField implements FieldInterface


### PR DESCRIPTION
Add use statement is missing from the exemple "Creating Custom Fields"

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
