### PR TITLE
Display the column of actions in index page unconditionally

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -126,11 +126,9 @@
                             </th>
                         {% endfor %}
 
-                        {% if entities|length > 0 and entities|first.actions is not empty %}
-                            <th {% if ea.crud.showEntityActionsAsDropdown %}width="10px"{% endif %} dir="{{ ea.i18n.textDirection }}">
-                                <span class="sr-only">{{ 'action.entity_actions'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}</span>
-                            </th>
-                        {% endif %}
+                        <th {% if ea.crud.showEntityActionsAsDropdown %}width="10px"{% endif %} dir="{{ ea.i18n.textDirection }}">
+                            <span class="sr-only">{{ 'action.entity_actions'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}</span>
+                        </th>
                     </tr>
                 {% endblock table_head %}
                 </thead>
@@ -153,27 +151,25 @@
                                 {% endfor %}
 
                                 {% block entity_actions %}
-                                    {% if entity.actions is not empty %}
-                                        <td class="actions">
-                                            {% if not ea.crud.showEntityActionsAsDropdown %}
-                                                {% for action in entity.actions %}
-                                                    {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea.crud.showEntityActionsAsDropdown }, with_context = false) }}
-                                                {% endfor %}
-                                            {% else %}
-                                                <div class="dropdown dropdown-actions">
-                                                    <a class="dropdown-toggle btn btn-secondary btn-sm" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                                        <i class="fa fa-fw fa-ellipsis-h"></i>
-                                                    </a>
+                                    <td class="actions">
+                                        {% if not ea.crud.showEntityActionsAsDropdown %}
+                                            {% for action in entity.actions %}
+                                                {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea.crud.showEntityActionsAsDropdown }, with_context = false) }}
+                                            {% endfor %}
+                                        {% else %}
+                                            <div class="dropdown dropdown-actions">
+                                                <a class="dropdown-toggle btn btn-secondary btn-sm" href="#" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                    <i class="fa fa-fw fa-ellipsis-h"></i>
+                                                </a>
 
-                                                    <div class="dropdown-menu dropdown-menu-right">
-                                                        {% for action in entity.actions %}
-                                                            {{ include(action.templatePath, { action: action, isIncludedInDropdown: ea.crud.showEntityActionsAsDropdown }, with_context = false) }}
-                                                        {% endfor %}
-                                                    </div>
+                                                <div class="dropdown-menu dropdown-menu-right">
+                                                    {% for action in entity.actions %}
+                                                        {{ include(action.templatePath, { action: action, isIncludedInDropdown: ea.crud.showEntityActionsAsDropdown }, with_context = false) }}
+                                                    {% endfor %}
                                                 </div>
-                                            {% endif %}
-                                        </td>
-                                    {% endif %}
+                                            </div>
+                                        {% endif %}
+                                    </td>
                                 {% endblock entity_actions %}
                             </tr>
 


### PR DESCRIPTION
Note: ignore whitespace when reviewing this PR to see the real change: https://github.com/EasyCorp/EasyAdminBundle/pull/3639/files?w=1

-----

While working on an app which [displays actions conditionally](https://symfony.com/doc/master/bundles/EasyAdminBundle/actions.html#displaying-actions-conditionally) I see this:

![image](https://user-images.githubusercontent.com/73419/88937141-06cf8200-d284-11ea-9a0c-380706bc9b74.png)

It's much worse if the first row doesn't have an action (because the first row is used to decide if the listing has actions or not):

![image](https://user-images.githubusercontent.com/73419/88937211-1f3f9c80-d284-11ea-9c22-2494ef33d90c.png)

This PR proposes to always display this "actions column", no matter if one, many, all or none of the rows have actions. This is how it looks now:

![image](https://user-images.githubusercontent.com/73419/88937322-501fd180-d284-11ea-90b4-3482744e8021.png) ![image](https://user-images.githubusercontent.com/73419/88937332-531ac200-d284-11ea-8a7c-12c391bc9876.png)

This works nicely because browsers are smart and adjust table contents, so if we have lots of contents and no actions, the empty actions column is very small, so we don't waste space:

![image](https://user-images.githubusercontent.com/73419/88937489-80677000-d284-11ea-8266-836e98c9f914.png)
