### PR TITLE
Update index.html.twig according to displayIf feature

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -103,6 +103,7 @@
     <div class="content-panel">
         <div class="content-panel-body with-rounded-top with-min-h-250 without-padding {{ not has_footer ? 'without-footer' }}">
             <table class="table datagrid with-rounded-top {{ not has_footer ? 'with-rounded-bottom' }}">
+                {% set has_actions_column = entities|reduce((carry, entity) => carry or entity.actions is not empty, false) %}
                 <thead>
                 {% block table_head %}
                     <tr>
@@ -126,7 +127,7 @@
                             </th>
                         {% endfor %}
 
-                        {% if entities|length > 0 and entities|first.actions is not empty %}
+                        {% if entities|length > 0 and has_actions_column %}
                             <th {% if ea.crud.showEntityActionsAsDropdown %}width="10px"{% endif %} dir="{{ ea.i18n.textDirection }}">
                                 <span class="sr-only">{{ 'action.entity_actions'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}</span>
                             </th>
@@ -153,7 +154,7 @@
                                 {% endfor %}
 
                                 {% block entity_actions %}
-                                    {% if entity.actions is not empty %}
+                                    {% if has_actions_column %}
                                         <td class="actions">
                                             {% if not ea.crud.showEntityActionsAsDropdown %}
                                                 {% for action in entity.actions %}


### PR DESCRIPTION
With conditional displayed actions, some entities could have no actions cell even if there is the actions column.
Moreover, if the first entity has no actions, the column header is not generated even if some entities have their actions cell.
So, the actions cell generation cannot be determined only by the first index entity anymore, but on the whole list now.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
