### PR TITLE
Allow clear on non required association

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -48,7 +48,8 @@ function createAutoCompleteFields() {
 
     autocompleteFields.each(function () {
         var $this = $(this),
-            autocompleteUrl = $this.data('ea-autocomplete-endpoint-url');
+            autocompleteUrl = $this.data('ea-autocomplete-endpoint-url'),
+            allowClear = $this.data('allow-clear');
 
         if (undefined === autocompleteUrl) {
             $this.select2({ theme: 'bootstrap', placeholder: '', allowClear: true });
@@ -76,7 +77,7 @@ function createAutoCompleteFields() {
                     cache: true
                 },
                 placeholder: '',
-                allowClear: false,
+                allowClear: allowClear,
                 minimumInputLength: 1
             });
         }

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -74,6 +74,11 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ->generateUrl();
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);
+            
+            // If the field is not required we allow clearing out the selection
+            if (false === $field->getFormTypeOption('required')) {
+                $field->setFormTypeOption('attr.data-allow-clear', 'true');
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #3649

The select2 should allow to clear the selection on a non required field. 

Non relevant comment, I was unsure how to setup the webpack environment so I created a separate project locally with all the dependencies and then pasted over the generated files for testing. I'd appreciate any guidance on how to do this more efficiently for future PR ❤️ 