### PR TITLE
Fixed #3652 - ajaxEdit will allow changing properties that are not mapped by doctrine

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -478,10 +478,6 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     private function ajaxEdit(EntityDto $entityDto, ?string $propertyName, bool $newValue): AfterCrudActionEvent
     {
-        if (!$entityDto->hasProperty($propertyName)) {
-            throw new \RuntimeException(sprintf('The "%s" boolean field cannot be changed because it doesn\'t exist in the "%s" entity.', $propertyName, $entityDto->getName()));
-        }
-
         $this->get(EntityUpdater::class)->updateProperty($entityDto, $propertyName, $newValue);
 
         $event = new BeforeEntityUpdatedEvent($entityDto->getInstance());


### PR DESCRIPTION
- Fixed #3652: ajaxEdit will not check if it's a doctrine property anymore, the property will be validated through PropertyAccess's isWritable shortly after


No breaking changes