### PR TITLE
Remove field help translation already performed

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -99,7 +99,7 @@
             {% endif %}
 
             {% if ea.field.help|default(form.vars.help) != '' %}
-                <small class="form-help">{{ ea.field.help|default(form.vars.help)|trans(domain = form.vars.translation_domain)|raw }}</small>
+                <small class="form-help">{{ ea.field.help|default(form.vars.help)|raw }}</small>
             {% endif %}
 
             {{- form_errors(form) -}}


### PR DESCRIPTION
The field help was translated twice for the form views (in Controller and Twig), throwing a missing translation.
My little fix is OK and consistent with the detail view.
There might be the same case in [form_theme.html.twig#L448](https://github.com/EasyCorp/EasyAdminBundle/blob/master/src/Resources/views/crud/form_theme.html.twig#L448) however I cannot test it in my current project. (Yes, I am too lazy to clone the _easy-admin-demo_ for now...).