### PR TITLE
Added sortProperty field for Associations

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -14,7 +14,7 @@ final class FieldDto
 {
     private $fieldFqcn;
     private $propertyName;
-    private $sortProperty;
+    private $sortPropertyName;
     private $value;
     private $formattedValue;
     private $formatValueCallable;
@@ -102,15 +102,15 @@ final class FieldDto
         $this->propertyName = $propertyName;
     }
 
-    public function setSortProperty($sortProperty): void
+    public function setSortProperty($sortPropertyName): void
     {
-        $this->sortProperty = $sortProperty;
+        $this->sortPropertyName = $sortPropertyName;
     }
 
 
     public function getSortProperty() :?string
     {
-        return $this->sortProperty;
+        return $this->sortPropertyName;
     }
 
     /**

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -14,6 +14,7 @@ final class FieldDto
 {
     private $fieldFqcn;
     private $propertyName;
+    private $sortProperty;
     private $value;
     private $formattedValue;
     private $formatValueCallable;
@@ -99,6 +100,17 @@ final class FieldDto
     public function setProperty(string $propertyName): void
     {
         $this->propertyName = $propertyName;
+    }
+
+    public function setSortProperty($sortProperty): void
+    {
+        $this->sortProperty = $sortProperty;
+    }
+
+
+    public function getSortProperty() :?string
+    {
+        return $this->sortProperty;
     }
 
     /**

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -43,11 +43,20 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
 
         $targetEntityFqcn = $field->getDoctrineMetadata()->get('targetEntity');
+
+        // get the sort property name which is null by default
         $sortProperty = $field->getSortProperty();
 
+        // if the sort property is set we need to check its a valid property on the associated entity
         if ($sortProperty) {
-            $this->entityFactory->create($targetEntityFqcn)->getPropertyMetadata($sortProperty);
+
+            // create a FieldDto of the associated entity
+            $sortPropertyDto = $this->entityFactory->create($targetEntityFqcn);
+            // checks if the property exists on the associated entity if not it throws an exception
+            // The "$sortProperty" field does not exist in the "$targetEntityFqcn" entity
+            $sortPropertyDto->getPropertyMetadata($sortProperty);
         }
+
         // the target CRUD controller can be NULL; in that case, field value doesn't link to the related entity
         $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER)
             ?? $context->getCrudControllers()->findCrudFqcnByEntityFqcn($targetEntityFqcn);
@@ -79,7 +88,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ->generateUrl();
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);
-            
+
             // If the field is not required we allow clearing out the selection
             if (false === $field->getFormTypeOption('required')) {
                 $field->setFormTypeOption('attr.data-allow-clear', 'true');
@@ -134,7 +143,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
 
         if (method_exists($entityInstance, '__toString')) {
-            return (string) $entityInstance;
+            return (string)$entityInstance;
         }
 
         if (null !== $primaryKeyValue = $entityDto->getPrimaryKeyValue()) {

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -43,6 +43,11 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
 
         $targetEntityFqcn = $field->getDoctrineMetadata()->get('targetEntity');
+        $sortProperty = $field->getSortProperty();
+
+        if ($sortProperty) {
+            $this->entityFactory->create($targetEntityFqcn)->getPropertyMetadata($sortProperty);
+        }
         // the target CRUD controller can be NULL; in that case, field value doesn't link to the related entity
         $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER)
             ?? $context->getCrudControllers()->findCrudFqcnByEntityFqcn($targetEntityFqcn);

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -25,7 +25,11 @@ trait FieldTrait
 
         return $this;
     }
-
+    public function setSortProperty(?string $sortProperty): self
+    {
+        $this->dto->setSortProperty($sortProperty);
+        return $this;
+    }
     public function setProperty(string $propertyName): self
     {
         $this->dto->setProperty($propertyName);

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -25,9 +25,9 @@ trait FieldTrait
 
         return $this;
     }
-    public function setSortProperty(?string $sortProperty): self
+    public function setSortProperty(?string $sortPropertyName): self
     {
-        $this->dto->setSortProperty($sortProperty);
+        $this->dto->setSortProperty($sortPropertyName);
         return $this;
     }
     public function setProperty(string $propertyName): self

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -111,13 +111,14 @@
                         {% endif %}
 
                         {% for field in entities|first.fields ?? [] %}
-                            {% set is_sorting_field = ea.search.isSortingField(field.property) %}
-                            {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.property) == 'DESC' ? 'ASC' : 'DESC') : 'DESC' %}
+                            {% set field_property = (field.sortProperty ? field.property ~'.'~ field.sortProperty : field.property ) %}
+                            {% set is_sorting_field = ea.search.isSortingField(field_property) %}
+                            {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field_property) == 'DESC' ? 'ASC' : 'DESC') : 'DESC' %}
                             {% set column_icon = is_sorting_field ? (next_sort_direction == 'DESC' ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
 
                             <th class="{{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} text-{{ field.textAlign }}" dir="{{ ea.i18n.textDirection }}">
                                 {% if field.isSortable %}
-                                    <a href="{{ ea_url({ page: 1, sort: { (field.property): next_sort_direction } }).includeReferrer() }}">
+                                    <a href="{{ ea_url({ page: 1, sort: { (field_property): next_sort_direction } }).includeReferrer() }}">
                                         {{ field.label|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
                                     </a>
                                 {% else %}


### PR DESCRIPTION
Added a field sort property to fix issue #3379

Checks if the  property is valid or throws an exception.

The twig then appends the property to the parent field property which works for the sorting.

