### PR TITLE
Added imagine_pattern to block vich_image_widget

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -261,21 +261,34 @@
 {% endblock %}
 
 {% block vich_image_widget %}
+    {% set formTypeOptions = ea_crud_form.ea_field.formTypeOptions %}
     <div class="ea-vich-image">
         {% if image_uri|default('') is not empty %}
             {% if download_uri|default('') is empty %}
                 <div class="ea-lightbox-thumbnail">
-                    <img style="cursor: initial" src="{{ asset(image_uri) }}">
+                    {% if formTypeOptions.imagine_pattern is defined and formTypeOptions.imagine_pattern is not empty %}
+                        <img style="cursor: initial" src="{{ asset(image_uri)|imagine_filter(formTypeOptions.imagine_pattern) }}">
+                    {% else %}
+                        <img style="cursor: initial" src="{{ asset(image_uri) }}">
+                    {% endif %}
                 </div>
             {% else %}
                 {% set _lightbox_id = 'ea-lightbox-' ~ id %}
 
                 <a href="#" class="ea-lightbox-thumbnail" data-featherlight="#{{ _lightbox_id }}" data-featherlight-close-on-click="anywhere">
-                    <img src="{{ asset(download_uri) }}">
+                    {% if formTypeOptions.imagine_pattern is defined and formTypeOptions.imagine_pattern is not empty %}
+                        <img src="{{ asset(download_uri)|imagine_filter(formTypeOptions.imagine_pattern) }}">
+                    {% else %}
+                        <img src="{{ asset(download_uri) }}">
+                    {% endif %}
                 </a>
 
                 <div id="{{ _lightbox_id }}" class="ea-lightbox">
-                    <img src="{{ asset(download_uri) }}">
+                    {% if formTypeOptions.imagine_pattern is defined and formTypeOptions.imagine_pattern is not empty %}
+                        <img src="{{ asset(download_uri)|imagine_filter(formTypeOptions.imagine_pattern) }}">
+                    {% else %}
+                        <img src="{{ asset(download_uri) }}">
+                    {% endif %}
                 </div>
             {% endif %}
         {% endif %}


### PR DESCRIPTION
I noticed that using imagine_pattern (a native option exposed by VichImageType) was not useable because the template didn't mention it. In this PR I've implemented the imagine_pattern into the vich_image_widget block.
