### PR TITLE
Autocomplete should always retrieve results from the first page

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -67,7 +67,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             }
 
             $field->setFormType(CrudAutocompleteType::class);
-            $autocompleteEndpointUrl = $this->crudUrlGenerator->build()
+            $autocompleteEndpointUrl = $this->crudUrlGenerator->build(['page' => 1]) // The autocomplete should always start on the first page
                 ->setController($field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER))
                 ->setAction('autocomplete')
                 ->setEntityId(null)


### PR DESCRIPTION
The page parameter was taken from the global route leading to missing results in the autocomplete drop-down.
The endpoint now always use 1 as the page and the javascript will still properly increment the page counter whenever required. 

This PR fixes #3707 