### PR TITLE
Fix pagerfanta deprecation notice

### DIFF
--- a/src/Search/Paginator.php
+++ b/src/Search/Paginator.php
@@ -5,7 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Search;
 use Doctrine\ORM\Query as DoctrineQuery;
 use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 
 /**
@@ -29,7 +29,7 @@ class Paginator
         $query = $this->getQuery($queryOrQueryBuilder);
 
         // don't change the following line (you did that twice in the past and broke everything)
-        $paginator = new Pagerfanta(new DoctrineORMAdapter($query, true, false));
+        $paginator = new Pagerfanta(new QueryAdapter($query, true, false));
         $paginator->setMaxPerPage($maxPerPage);
         $paginator->setCurrentPage($page);
 


### PR DESCRIPTION
Fixes 
```
php.INFO: User Deprecated: Since pagerfanta/pagerfanta 2.4: 
The "Pagerfanta\Adapter\DoctrineORMAdapter" class is deprecated and will be removed in 3.0. 
Use the "Pagerfanta\Doctrine\ORM\QueryAdapter" class from the "pagerfanta/doctrine-orm-adapter" package instead.
```
