### PR TITLE
Update DateTimeConfigurator.php

### DIFF
--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -84,8 +84,9 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
             $field->setFormTypeOption('widget', 'single_text');
             $field->setFormTypeOption('html5', false);
         }
-
-        $field->setFormattedValue($formattedValue);
+  
+        $formattedStringValue = $formattedValue ?? '';
+        $field->setFormattedValue($formattedStringValue);
 
         $doctrineDataType = $entityDto->getPropertyMetadata($field->getProperty())->get('type');
         $isImmutableDateTime = \in_array($doctrineDataType, [Types::DATETIME_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE], true);


### PR DESCRIPTION
To avoid print the string "null" in an optional datetime column

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
