### PR TITLE
[FIX] autocomplete url can have a wrong 'sort' query parameter

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -71,6 +71,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ->setController($field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER))
                 ->setAction('autocomplete')
                 ->setEntityId(null)
+                ->unset('sort') // Avoid passing the 'sort' param from the current entity to the autocompleted one
                 ->generateUrl();
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);


### PR DESCRIPTION
Hi,

I've encountered a bug while using [easy-admin-demo](https://github.com/javiereguiluz/easy-admin-demo), the autocomplete field of an entity non sortable (`Category` for instance) on a create/edit form for another entity wich has a custom sort (`Product` in that case) was broken. 

It appears that the URL generated for that AJAX call contains a `sort` query parameter taken from the current view (`Product` then), which will somehow be injected in the `SearchDto`, leading to a Doctrine-related error if this field does not exist on the autocompleted entity (`Category`).

To reproduce, you can use easy-admin-demo with an updated database schema, you should get an error while trying to autocomplete a `Category` when editing a `Product`.

I'm not sure it's the way to go to fix this, but I tried to keep things as simple as possible to avoid regressions elsewhere, feedbacks welcomed !

This could be related to #3695 as well.

See ya ;) 
