### PR TITLE
Throw an error for boolean properties of associated entities

### DIFF
--- a/src/Field/Configurator/BooleanConfigurator.php
+++ b/src/Field/Configurator/BooleanConfigurator.php
@@ -20,8 +20,13 @@ final class BooleanConfigurator implements FieldConfiguratorInterface
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
+        $isRenderedAsSwitch = true === $field->getCustomOption(BooleanField::OPTION_RENDER_AS_SWITCH);
+        if ($isRenderedAsSwitch && false !== strpos($field->getProperty(), '.')) {
+            throw new \InvalidArgumentException('The "%s" property cannot be rendered as a switch because it belongs to an associated entity instead of to the entity itself. Render the property as a normal boolean field.', $field->getProperty());
+        }
+
         // TODO: ask someone who knows Symfony forms well how to make this work
-        if ($field->getCustomOption(BooleanField::OPTION_RENDER_AS_SWITCH)) {
+        if ($isRenderedAsSwitch) {
             // see https://symfony.com/blog/new-in-symfony-4-4-bootstrap-custom-switches
             // $field->setFormTypeOptionIfNotSet('label_attr.class', 'switch-custom');
         }


### PR DESCRIPTION
Fixes #3783. It doesn't really fix it, but it improves the situation.