### PR TITLE
Fix formTypeOptions access if ea_field is null

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -261,7 +261,7 @@
 {% endblock %}
 
 {% block vich_image_widget %}
-    {% set formTypeOptions = ea_crud_form.ea_field.formTypeOptions %}
+    {% set formTypeOptions = ea_crud_form.ea_field.formTypeOptions|default %}
     <div class="ea-vich-image">
         {% if image_uri|default('') is not empty %}
             {% if download_uri|default('') is empty %}


### PR DESCRIPTION
Fixes #3818.
If `ea_field` is not defined, then `default` filter will return an empty string.
This will allow these conditions `formTypeOptions.imagine_pattern is defined and formTypeOptions.imagine_pattern is not empty` to be performed.