### PR TITLE
Add support for datetimetz_immutable configuration

### DIFF
--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -92,7 +92,7 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
             return;
         }
         $doctrineDataType = $entityDto->getPropertyMetadata($field->getProperty())->get('type');
-        $isImmutableDateTime = \in_array($doctrineDataType, [Types::DATETIME_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE], true);
+        $isImmutableDateTime = \in_array($doctrineDataType, [Types::DATETIMETZ_IMMUTABLE, Types::DATETIME_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE], true);
         if ($isImmutableDateTime) {
             $field->setFormTypeOptionIfNotSet('input', 'datetime_immutable');
         }


### PR DESCRIPTION
DateTimeConfigurator's immutable types support introduced in #3208 lacks `datetimetz_immutable` disallowing its usage without manually configuring fields.