### PR TITLE
 #3841 fixed problem with RTL not working correctly

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -2,7 +2,7 @@
 {% trans_default_domain ea.i18n.translationDomain %}
 
 <!DOCTYPE html>
-<html lang="{{ ea.i18n.htmlLocale }}">
+<html lang="{{ ea.i18n.htmlLocale }}" dir="{{ ea.i18n.textDirection }}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -31,7 +31,7 @@
     {% endblock head_javascript %}
 
     {% if 'rtl' == ea.i18n.textDirection %}
-        <link rel="stylesheet" href="{{ asset('bundles/easyadmin/app-rtl.css') }}">
+        <link rel="stylesheet" href="{{ asset('bundles/easyadmin/app.rtl.css') }}">
     {% endif %}
 
     {% block configured_head_contents %}


### PR DESCRIPTION
Related to issue https://github.com/EasyCorp/EasyAdminBundle/issues/3841 . I have described more there.

Still probably would be good if someone who know code base better would check what about app-custom-rtl.css and app-custom-rtl.js as this looks like not included anywhere :thinking:  @javiereguiluz should it be added as well here?

From what I found earlier it was included here as well:
https://github.com/EasyCorp/EasyAdminBundle/commit/b2bda3af08a573ad93bd2c5599e3ed914d82ec96#diff-17ecac8bdee7f4f5de7d7556c4170678R39

There was also earlier test `RtlTest.php` but got removed in https://github.com/EasyCorp/EasyAdminBundle/pull/627. Not sure why...as it does not look like related to PropertyAccessor and it was testing if RTL is working correctly which is in my opinion broken now ( and not detected by tests).
