### PR TITLE
Add AfterEntityFormHandledEvent to allow entity modification before calls to `isValid()`

### DIFF
--- a/doc/events.rst
+++ b/doc/events.rst
@@ -38,6 +38,7 @@ All events are triggered using objects instead of event names defined as strings
 * Events related to resource admins:
 
   * ``BeforeCrudActionEvent``
+  * ``AfterEntityFormHandledEvent``
   * ``AfterCrudActionEvent``
 
 Event Subscriber Example

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -19,6 +19,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Event\AfterCrudActionEvent;
 use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntityDeletedEvent;
+use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntityFormHandledEvent;
 use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntityPersistedEvent;
 use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntityUpdatedEvent;
 use EasyCorp\Bundle\EasyAdminBundle\Event\BeforeCrudActionEvent;
@@ -208,6 +209,10 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
         $editForm = $this->createEditForm($context->getEntity(), $context->getCrud()->getEditFormOptions(), $context);
         $editForm->handleRequest($context->getRequest());
+
+	    $event = new AfterEntityFormHandledEvent($entityInstance);
+	    $this->get('event_dispatcher')->dispatch($event);
+        
         if ($editForm->isSubmitted() && $editForm->isValid()) {
             // TODO:
             // $this->processUploadedFiles($editForm);
@@ -279,6 +284,10 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
         $newForm = $this->createNewForm($context->getEntity(), $context->getCrud()->getNewFormOptions(), $context);
         $newForm->handleRequest($context->getRequest());
+        
+	    $event = new AfterEntityFormHandledEvent($entityInstance);
+	    $this->get('event_dispatcher')->dispatch($event);
+	    
         if ($newForm->isSubmitted() && $newForm->isValid()) {
             // TODO:
             // $this->processUploadedFiles($newForm);

--- a/src/Event/AfterEntityFormHandledEvent.php
+++ b/src/Event/AfterEntityFormHandledEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Event;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class AfterEntityFormHandledEvent
+{
+    private $entityInstance;
+
+    public function __construct($entityInstance)
+    {
+        $this->entityInstance = $entityInstance;
+    }
+
+    public function getEntityInstance()
+    {
+        return $this->entityInstance;
+    }
+}


### PR DESCRIPTION
Trying to address a case where you need to update an entity after its form data has been handled but before it is validated.