### PR TITLE
Fixed CountryConfigurator edge-case when the flag code is empty

### DIFF
--- a/src/Field/Configurator/CountryConfigurator.php
+++ b/src/Field/Configurator/CountryConfigurator.php
@@ -70,7 +70,7 @@ final class CountryConfigurator implements FieldConfiguratorInterface
                 $flagCode = Countries::getAlpha2Code($flagCode);
             }
 
-            if (strpos(self::SUPPORTED_FLAGS, $flagCode) === false) {
+            if (empty($flagCode) || false === strpos(self::SUPPORTED_FLAGS, $flagCode)) {
                 $flagCode = 'GENERIC';
             }
 


### PR DESCRIPTION
This fixes the following issue:

![image](https://user-images.githubusercontent.com/73419/95014104-f0a7be80-0644-11eb-9f8b-dabb26b8c10d.png)
