### PR TITLE
Add `raw` filter in `page_title` block

### DIFF
--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -6,7 +6,7 @@
 {% trans_default_domain ea is defined ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% block body_class 'page-login' %}
-{% block page_title %}{{ page_title is defined ? page_title : (ea is defined ? ea.dashboardTitle : '') }}{% endblock %}
+{% block page_title %}{{ page_title is defined ? page_title|raw : (ea is defined ? ea.dashboardTitle|raw : '') }}{% endblock %}
 
 {% block wrapper_wrapper %}
     {% set page_title = block('page_title') %}


### PR DESCRIPTION
To prevent HTML tags in "logo" link.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
