### PR TITLE
Fixed deprecated non-string from InputBag::get()

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -83,7 +83,7 @@
             <div class="datagrid-filters">
                 {% block filters %}
                     {% if filters|length > 0 %}
-                        {% set applied_filters = ea.request.query.get('filters')|default([])|keys %}
+                        {% set applied_filters = ea.request.query.all['filters']|default([])|keys %}
                         <div class="btn-group action-filters">
                             <a href="{{ ea_url().setAction('renderFilters').includeReferrer() }}" class="btn btn-secondary btn-labeled btn-labeled-right action-filters-button {{ applied_filters ? 'action-filters-applied' }}" data-modal="#modal-filters">
                                 <i class="fa fa-filter fa-fw"></i> {{ 'filter.title'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}{% if applied_filters %} <span class="text-primary">({{ applied_filters|length }})</span>{% endif %}


### PR DESCRIPTION
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/3822

Note: I used the array syntax because we can't use the `$key` parameter of `InputBag::all($key)` to keep backward compatibility with `ParameterBag` used by Symfony < 5.1
