### PR TITLE
Fixed locale consistency when generating urls

### DIFF
--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -75,13 +75,9 @@ final class AdminContextFactory
         foreach ($dashboardControllerRoutes as $routeName => $controller) {
             if ($controller === $dashboardController) {
                 // needed for i18n routes, whose name follows the pattern "route_name.locale"
-                $routeLocale = explode('.', $dashboardRouteName)[1] ?? null;
+                $dashboardRouteName = explode('.', $routeName, 2)[0];
 
-                if (null === $routeLocale || $routeLocale === $request->getLocale()) {
-                    $dashboardRouteName = $routeName;
-
-                    break;
-                }
+                break;
             }
         }
 

--- a/src/Router/CrudUrlBuilder.php
+++ b/src/Router/CrudUrlBuilder.php
@@ -181,6 +181,9 @@ class CrudUrlBuilder
         });
         ksort($routeParameters);
 
+        // needed for i18n routes, whose name follows the pattern "route_name.locale"
+        $this->dashboardRoute = explode('.', $this->dashboardRoute, 2)[0];
+
         return $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, UrlGeneratorInterface::ABSOLUTE_URL);
     }
 


### PR DESCRIPTION
I think this is just a little bug in a really useful feature from **@jbtronics:** the `$dashboardRouteName` is used instead of `$routeName` and it's always `null`, so the first available route is matched ignoring the current locale.

This was a bit tricky to spot because it just depends on which localized route is found first while looping.

# Further considerations
While this PR fixes the issue, I'm tagging the original author to suggest another solution: according to the Symfony Blog (https://symfony.com/blog/new-in-symfony-4-1-internationalized-routing) using localized route names works, but it's not recommended.

```php
// ignores the current request locale and generates '/stuur-ons-een-email'
$url = $urlGenerator->generate('contact', ['_locale' => 'nl']);
// this would also work, but it's not recommended:
// $url = $urlGenerator->generate('contact.nl');
```

It also forces the locale value preventing anyone from overriding it using the `_locale` route parameter. Since the original code is already preserving the `_locale` route parameter I would suggest dropping the locale suffix and use the "clean" route name to generate the URL.

This solution would provide the following enhancements:
- localized routes generation will work as expected (same as before if we merge my fix)
- developers will be able to override the locale by passing a standard `_locale` route parameter (an example use case may be implementing a language chooser where you need to generate URLs with a different locale from the current one)

If @jbtronics (or @javiereguiluz) approve my proposal I can update this PR.

Thank you for your time.