### PR TITLE
[Search] Allow Searching in nested ORM\Embedded property

### DIFF
--- a/src/Field/Configurator/BooleanConfigurator.php
+++ b/src/Field/Configurator/BooleanConfigurator.php
@@ -21,7 +21,7 @@ final class BooleanConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $isRenderedAsSwitch = true === $field->getCustomOption(BooleanField::OPTION_RENDER_AS_SWITCH);
-        if ($isRenderedAsSwitch && false !== strpos($field->getProperty(), '.')) {
+        if ($isRenderedAsSwitch && $this->isNestedProperty($field) && false === $this->isBoolean($field)) {
             throw new \InvalidArgumentException(sprintf('The "%s" property cannot be rendered as a switch because it belongs to an associated entity instead of to the entity itself. Render the property as a normal boolean field.', $field->getProperty()));
         }
 
@@ -30,5 +30,24 @@ final class BooleanConfigurator implements FieldConfiguratorInterface
             // see https://symfony.com/blog/new-in-symfony-4-4-bootstrap-custom-switches
             // $field->setFormTypeOptionIfNotSet('label_attr.class', 'switch-custom');
         }
+    }
+
+    private function isNestedProperty(FieldDto $field): bool
+    {
+        return false !== strpos($field->getProperty(), '.');
+    }
+
+    private function isBoolean(FieldDto $field): bool
+    {
+        if (false === $field->getDoctrineMetadata()->has('type')) {
+            return false;
+        }
+
+        $doctrineType = $field->getDoctrineMetadata()->get('type');
+        if ('boolean' === $doctrineType) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
#### Pain Point

Thanks to #3864 you can now search on nested entities :rocket:.
But if you try to search on an Entity which has nested Embedable you might have this error
![Screenshot from 2020-10-20 18-52-46](https://user-images.githubusercontent.com/2279794/96618914-d38e1380-1305-11eb-93c1-c8b0e435ce1a.png)

CRUD config:
![Screenshot from 2020-10-20 19-00-34](https://user-images.githubusercontent.com/2279794/96619513-8fe7d980-1306-11eb-92ce-c3ebb0612190.png)

Usecase:
- `property` (ORM\ManyToOne)
  - `landlord` (ORM\ManyToOne)
    - `person1` (**ORM\Embedded**)
      - `firstName`  (string)

![Screenshot from 2020-10-20 18-54-38](https://user-images.githubusercontent.com/2279794/96619121-10f2a100-1306-11eb-9165-c09586a821e7.png)

It fails to find `person1` since only `person1.firstName` is mapped in `landlord`.
![Screenshot from 2020-10-20 18-54-12](https://user-images.githubusercontent.com/2279794/96618968-e0126c00-1305-11eb-893b-55e5baf7d0e5.png)






#### TODO

- [x] Allow searching on nested embeddable
- [ ] Unit Test
