### PR TITLE
Added a sprintf, fixing the "Wrong parameters for InvalidArgumentExce…

### DIFF
--- a/src/Field/Configurator/BooleanConfigurator.php
+++ b/src/Field/Configurator/BooleanConfigurator.php
@@ -22,7 +22,7 @@ final class BooleanConfigurator implements FieldConfiguratorInterface
     {
         $isRenderedAsSwitch = true === $field->getCustomOption(BooleanField::OPTION_RENDER_AS_SWITCH);
         if ($isRenderedAsSwitch && false !== strpos($field->getProperty(), '.')) {
-            throw new \InvalidArgumentException('The "%s" property cannot be rendered as a switch because it belongs to an associated entity instead of to the entity itself. Render the property as a normal boolean field.', $field->getProperty());
+            throw new \InvalidArgumentException(sprintf('The "%s" property cannot be rendered as a switch because it belongs to an associated entity instead of to the entity itself. Render the property as a normal boolean field.', $field->getProperty()));
         }
 
         // TODO: ask someone who knows Symfony forms well how to make this work


### PR DESCRIPTION
In the BooleanConfigurator an InvalidArgumentException is thrown without the correct parameters. 
Triggering an error: "Wrong parameters for InvalidArgumentException([string $message [, long $code [, Throwable $previous = NULL]]])"

%s placeholder was present in the message but no sprintf function was called. Added the sprintf function.