### PR TITLE
[AbstractCrucController] Fix redirect if referrer is empty string

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -231,8 +231,9 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             }
 
             if (Action::SAVE_AND_RETURN === $submitButtonName) {
-                $url = $context->getReferrer()
-                    ?? $this->get(CrudUrlGenerator::class)->build()->setAction(Action::INDEX)->generateUrl();
+                $url = !$context->getReferrer()
+                    ? $this->get(CrudUrlGenerator::class)->build()->setAction(Action::INDEX)->generateUrl()
+                    : $context->getReferrer();
 
                 return $this->redirect($url);
             }


### PR DESCRIPTION
Hello everyone, 

* I have been encountering a problem since a few versions, sometimes, in my query string, the query param `referrer` is not set at all. This results in it being an empty string in the `$context->getRefferer()` method returns

* This entails the check in the following line is `true`:  

```php
$url = $context->getReferrer()
    ?? $this->get(CrudUrlGenerator::class)->build()->setAction(Action::INDEX)->generateUrl();
```

* Thus, the `$url` variable is an empty string and I get a 500 error after saving

* I understand that the referrer variable should not be this empty string in the first place, but I think this change I propose is worth, as checking a boolean feels more reliable to me

Thanks

