### PR TITLE
a tiny typographical error solved in docs

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -503,7 +503,7 @@ called ``ea`` (the initials of "EasyAdmin"):
 
     {% for menuItem in ea.mainMenu.items %}
         {# ... #}
-    {% endif %}
+    {% endfor %}
 
 The ``AdminContext`` variable is created dynamically on each request, so you
 can't inject it directly in your services. Instead, use the ``AdminContextProvider``


### PR DESCRIPTION
### Pull Request Type
- [X] Docs

## Description
There is a tiny typographical error in the example code of doc. Just solved it.

Sample screenshot of the existing typo:

![ea](https://user-images.githubusercontent.com/35206101/97209201-3f7cea00-17e6-11eb-915d-973ea758126c.png)

