### PR TITLE
Allow using Doctrine Common 3 and Persistence 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.1.3",
-        "doctrine/common": "^2.8",
+        "doctrine/common": "^2.8 || ^3.0",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.6.3",
-        "doctrine/persistence": "^1.3.4",
+        "doctrine/persistence": "^1.3.4 || ^2.0",
         "pagerfanta/pagerfanta": "^1.0.1|^2.0",
         "symfony/asset": "^4.2|^5.0",
         "symfony/cache": "^4.2|^5.0",


### PR DESCRIPTION
In EA2 we fixed all deprecations (https://github.com/EasyCorp/EasyAdminBundle/pull/3042) but we only added true support for Doctrine Persistence 2.x in EA3 (https://github.com/EasyCorp/EasyAdminBundle/pull/3698)

This PR will hopefully add Persistence 2 support in EA2 too.