### PR TITLE
Fix controller to use DataMapper

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -276,10 +276,13 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $context->getEntity()->setInstance($this->createEntity($context->getEntity()->getFqcn()));
         $this->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_NEW)));
         $this->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
-        $entityInstance = $context->getEntity()->getInstance();
 
         $newForm = $this->createNewForm($context->getEntity(), $context->getCrud()->getNewFormOptions(), $context);
         $newForm->handleRequest($context->getRequest());
+
+        $entityInstance = $newForm->getData();
+        $context->getEntity()->setInstance($entityInstance);
+
         if ($newForm->isSubmitted() && $newForm->isValid()) {
             // TODO:
             // $this->processUploadedFiles($newForm);


### PR DESCRIPTION
I have an entity without some setters - field values can only be set through the constructor. I created a DataMapper that creates a new entity instance instead of calling setters. My CrudController looks like this:
```
    public function createEntity(string $entityFqcn)
    {
        return null;
    }

    public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
    {
        $formBuilder = parent::createNewFormBuilder($entityDto, $formOptions, $context);
        $formBuilder->setDataMapper(new PositionDataMapper());
        $formBuilder->setEmptyData(null);

        return $formBuilder;
    }
```
But this does not work as the new value does not end up to $entityInstance in AbstractCrudController::new(). This PR solves this problem.