### PR TITLE
fix #3894: set label to false to not display it

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -138,13 +138,25 @@ final class FieldDto
         $this->formatValueCallable = $callable;
     }
 
-    public function getLabel(): ?string
+    public function getLabel()
     {
         return $this->label;
     }
 
-    public function setLabel(?string $label): void
+    /**
+     * Set the label to NULL or TRUE to autogenerate it (e.g. 'firstName' -> 'First Name').
+     * Set the label to FALSE to not display any label for this field.
+     * Otherwise (string case), set it explicitly.
+
+     * @param string|null|bool
+     */
+    public function setLabel($label): void
     {
+        // Cases equivalent to null
+        if (true === $label || false === (is_string($label) || is_null($label) || is_bool($label))) {
+            $label = null;
+        }
+
         $this->label = $label;
     }
 

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -147,13 +147,13 @@ final class FieldDto
      * Set the label to NULL or TRUE to autogenerate it (e.g. 'firstName' -> 'First Name').
      * Set the label to FALSE to not display any label for this field.
      * Otherwise (string case), set it explicitly.
-
-     * @param string|null|bool
+     *
+     * @param string|bool|null
      */
     public function setLabel($label): void
     {
         // Cases equivalent to null
-        if (true === $label || false === (is_string($label) || is_null($label) || is_bool($label))) {
+        if (true === $label || false === (\is_string($label) || null === $label || \is_bool($label))) {
             $label = null;
         }
 

--- a/src/Field/ArrayField.php
+++ b/src/Field/ArrayField.php
@@ -12,7 +12,7 @@ final class ArrayField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -23,7 +23,7 @@ final class AssociationField implements FieldInterface
     public const WIDGET_AUTOCOMPLETE = 'autocomplete';
     public const WIDGET_NATIVE = 'native';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/AvatarField.php
+++ b/src/Field/AvatarField.php
@@ -15,7 +15,7 @@ final class AvatarField implements FieldInterface
     public const OPTION_IS_GRAVATAR_EMAIL = 'isGravatarEmail';
     public const OPTION_HEIGHT = 'height';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/BooleanField.php
+++ b/src/Field/BooleanField.php
@@ -14,7 +14,7 @@ final class BooleanField implements FieldInterface
 
     public const OPTION_RENDER_AS_SWITCH = 'renderAsSwitch';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/ChoiceField.php
+++ b/src/Field/ChoiceField.php
@@ -24,7 +24,7 @@ final class ChoiceField implements FieldInterface
     public const WIDGET_AUTOCOMPLETE = 'autocomplete';
     public const WIDGET_NATIVE = 'native';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/CodeEditorField.php
+++ b/src/Field/CodeEditorField.php
@@ -20,7 +20,7 @@ final class CodeEditorField implements FieldInterface
 
     private const ALLOWED_LANGUAGES = ['css', 'dockerfile', 'js', 'markdown', 'nginx', 'php', 'shell', 'sql', 'twig', 'xml', 'yaml-frontmatter', 'yaml'];
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/CollectionField.php
+++ b/src/Field/CollectionField.php
@@ -18,7 +18,7 @@ final class CollectionField implements FieldInterface
     public const OPTION_ENTRY_TYPE = 'entryType';
     public const OPTION_SHOW_ENTRY_LABEL = 'showEntryLabel';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/ColorField.php
+++ b/src/Field/ColorField.php
@@ -15,7 +15,7 @@ final class ColorField implements FieldInterface
     public const OPTION_SHOW_SAMPLE = 'showSample';
     public const OPTION_SHOW_VALUE = 'showValue';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -102,13 +102,18 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         return $this->translator->trans($help, $field->getTranslationParameters(), $translationDomain);
     }
 
-    private function buildLabelOption(FieldDto $field, string $translationDomain, ?string $currentPage): ?string
+    /**
+     * @return string|null|bool
+     */
+    private function buildLabelOption(FieldDto $field, string $translationDomain, ?string $currentPage)
     {
         // don't autogenerate a label for these special fields (there's a dedicated configurator for them)
         if (FormField::class === $field->getFieldFqcn()) {
             $label = $field->getLabel();
 
-            return empty($label) ? $label : $this->translator->trans($label, $field->getTranslationParameters(), $translationDomain);
+            return (null === $label || false === $label || '' === $label)
+                ? $label
+                : $this->translator->trans($label, $field->getTranslationParameters(), $translationDomain);
         }
 
         // if an Avatar field doesn't define its label, don't autogenerate it for the 'index' page
@@ -123,7 +128,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
             $label = $this->humanizeString($field->getProperty());
         }
 
-        if (empty($label)) {
+        if (false === $label || '' === $label) {
             return $label;
         }
 

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -103,7 +103,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
     }
 
     /**
-     * @return string|null|bool
+     * @return string|bool|null
      */
     private function buildLabelOption(FieldDto $field, string $translationDomain, ?string $currentPage)
     {

--- a/src/Field/CountryField.php
+++ b/src/Field/CountryField.php
@@ -21,7 +21,7 @@ final class CountryField implements FieldInterface
     /** @internal used to store the code of the flag to use independently from the country code format used */
     public const OPTION_FLAG_CODE = 'flagCode';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/CurrencyField.php
+++ b/src/Field/CurrencyField.php
@@ -16,7 +16,7 @@ final class CurrencyField implements FieldInterface
     public const OPTION_SHOW_NAME = 'showName';
     public const OPTION_SHOW_SYMBOL = 'showSymbol';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/DateField.php
+++ b/src/Field/DateField.php
@@ -15,7 +15,7 @@ final class DateField implements FieldInterface
     public const OPTION_DATE_PATTERN = 'datePattern';
     public const OPTION_WIDGET = 'widget';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/DateTimeField.php
+++ b/src/Field/DateTimeField.php
@@ -45,7 +45,7 @@ final class DateTimeField implements FieldInterface
     public const OPTION_TIMEZONE = 'timezone';
     public const OPTION_WIDGET = 'widget';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/EmailField.php
+++ b/src/Field/EmailField.php
@@ -12,7 +12,7 @@ final class EmailField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -11,7 +11,7 @@ final class Field implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -35,7 +35,8 @@ trait FieldTrait
 
     /**
      * @see EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto::setLabel()
-     * @param string|null|bool
+     *
+     * @param string|bool|null
      */
     public function setLabel($label): self
     {

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -33,7 +33,11 @@ trait FieldTrait
         return $this;
     }
 
-    public function setLabel(?string $label): self
+    /**
+     * @see EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto::setLabel()
+     * @param string|null|bool
+     */
+    public function setLabel($label): self
     {
         $this->dto->setLabel($label);
 

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -76,7 +76,7 @@ final class FormField implements FieldInterface
     private function hasLabelOrIcon(): bool
     {
         // don't use empty() because the label can contain only white spaces (it's a valid edge-case)
-        return (is_string($this->dto->getLabel()) && '' !== $this->dto->getLabel())
+        return (\is_string($this->dto->getLabel()) && '' !== $this->dto->getLabel())
             || null !== $this->dto->getCustomOption(self::OPTION_ICON);
     }
 }

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -20,7 +20,7 @@ final class FormField implements FieldInterface
     /**
      * @internal Use the other named constructors instead (addPanel(), etc.)
      */
-    public static function new(string $propertyName, ?string $label = null)
+    public static function new(string $propertyName, $label = null)
     {
         throw new \RuntimeException('Instead of this method, use the "addPanel()" method.');
     }
@@ -76,7 +76,7 @@ final class FormField implements FieldInterface
     private function hasLabelOrIcon(): bool
     {
         // don't use empty() because the label can contain only white spaces (it's a valid edge-case)
-        return (null !== $this->dto->getLabel() && '' !== $this->dto->getLabel())
+        return (is_string($this->dto->getLabel()) && '' !== $this->dto->getLabel())
             || null !== $this->dto->getCustomOption(self::OPTION_ICON);
     }
 }

--- a/src/Field/HiddenField.php
+++ b/src/Field/HiddenField.php
@@ -12,7 +12,7 @@ final class HiddenField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/IdField.php
+++ b/src/Field/IdField.php
@@ -14,7 +14,7 @@ final class IdField implements FieldInterface
 
     public const OPTION_MAX_LENGTH = 'maxLength';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -14,7 +14,7 @@ final class ImageField implements FieldInterface
 
     public const OPTION_BASE_PATH = 'basePath';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/IntegerField.php
+++ b/src/Field/IntegerField.php
@@ -12,7 +12,7 @@ final class IntegerField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/LanguageField.php
+++ b/src/Field/LanguageField.php
@@ -15,7 +15,7 @@ final class LanguageField implements FieldInterface
     public const OPTION_SHOW_CODE = 'showCode';
     public const OPTION_SHOW_NAME = 'showName';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/LocaleField.php
+++ b/src/Field/LocaleField.php
@@ -15,7 +15,7 @@ final class LocaleField implements FieldInterface
     public const OPTION_SHOW_CODE = 'showCode';
     public const OPTION_SHOW_NAME = 'showName';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/MoneyField.php
+++ b/src/Field/MoneyField.php
@@ -18,7 +18,7 @@ final class MoneyField implements FieldInterface
     public const OPTION_NUM_DECIMALS = 'numDecimals';
     public const OPTION_STORED_AS_CENTS = 'storedAsCents';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/NumberField.php
+++ b/src/Field/NumberField.php
@@ -17,7 +17,7 @@ final class NumberField implements FieldInterface
     public const OPTION_ROUNDING_MODE = 'roundingMode';
     public const OPTION_STORED_AS_STRING = 'storedAsString';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/PercentField.php
+++ b/src/Field/PercentField.php
@@ -18,7 +18,7 @@ final class PercentField implements FieldInterface
     public const OPTION_SYMBOL = 'symbol';
     public const OPTION_ROUNDING_MODE = 'roundingMode';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/SlugField.php
+++ b/src/Field/SlugField.php
@@ -15,7 +15,7 @@ final class SlugField implements FieldInterface
     public const OPTION_TARGET_FIELD_NAME = 'targetFieldName';
     public const OPTION_UNLOCK_CONFIRMATION_MESSAGE = 'unlockConfirmationMessage';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/TelephoneField.php
+++ b/src/Field/TelephoneField.php
@@ -12,7 +12,7 @@ final class TelephoneField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/TextEditorField.php
+++ b/src/Field/TextEditorField.php
@@ -14,7 +14,7 @@ final class TextEditorField implements FieldInterface
 
     public const OPTION_NUM_OF_ROWS = 'numOfRows';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/TextField.php
+++ b/src/Field/TextField.php
@@ -15,7 +15,7 @@ final class TextField implements FieldInterface
     public const OPTION_MAX_LENGTH = 'maxLength';
     public const OPTION_RENDER_AS_HTML = 'renderAsHtml';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/TextareaField.php
+++ b/src/Field/TextareaField.php
@@ -16,7 +16,7 @@ final class TextareaField implements FieldInterface
     public const OPTION_NUM_OF_ROWS = 'numOfRows';
     public const OPTION_RENDER_AS_HTML = 'renderAsHtml';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/TimeField.php
+++ b/src/Field/TimeField.php
@@ -15,7 +15,7 @@ final class TimeField implements FieldInterface
     public const OPTION_TIME_PATTERN = 'timePattern';
     public const OPTION_WIDGET = 'widget';
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/TimezoneField.php
+++ b/src/Field/TimezoneField.php
@@ -12,7 +12,7 @@ final class TimezoneField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Field/UrlField.php
+++ b/src/Field/UrlField.php
@@ -12,7 +12,7 @@ final class UrlField implements FieldInterface
 {
     use FieldTrait;
 
-    public static function new(string $propertyName, ?string $label = null): self
+    public static function new(string $propertyName, $label = null): self
     {
         return (new self())
             ->setProperty($propertyName)

--- a/src/Filter/Configurator/CommonConfigurator.php
+++ b/src/Filter/Configurator/CommonConfigurator.php
@@ -23,7 +23,7 @@ final class CommonConfigurator implements FilterConfiguratorInterface
     {
         if (null === $filterDto->getLabel()) {
             $fieldLabel = null !== $fieldDto ? $fieldDto->getLabel() : null;
-            $label = $fieldLabel ?? u($filterDto->getProperty())->title()->toString();
+            $label = is_string($fieldLabel) ? $fieldLabel : u($filterDto->getProperty())->title()->toString();
             $filterDto->setLabel($label);
         }
     }

--- a/src/Filter/Configurator/CommonConfigurator.php
+++ b/src/Filter/Configurator/CommonConfigurator.php
@@ -23,7 +23,7 @@ final class CommonConfigurator implements FilterConfiguratorInterface
     {
         if (null === $filterDto->getLabel()) {
             $fieldLabel = null !== $fieldDto ? $fieldDto->getLabel() : null;
-            $label = is_string($fieldLabel) ? $fieldLabel : u($filterDto->getProperty())->title()->toString();
+            $label = \is_string($fieldLabel) ? $fieldLabel : u($filterDto->getProperty())->title()->toString();
             $filterDto->setLabel($label);
         }
     }


### PR DESCRIPTION
Now the label can have the `false` value and then it is not displayed.