### PR TITLE
[ChoiceField] Allow to define choices using a callback

### DIFF
--- a/src/Field/ChoiceField.php
+++ b/src/Field/ChoiceField.php
@@ -55,10 +55,20 @@ final class ChoiceField implements FieldInterface
     /**
      * Given choices must follow the same format used in Symfony Forms:
      * ['Label visible to users' => 'submitted_value', ...].
+     *
+     * In addition to an array, you can use a PHP callback, which is passed the instance
+     * of the current entity (it can be null) and the FieldDto as the second argument:
+     * ->setChoices(fn () => ['foo' => 1, 'bar' => 2])
+     * ->setChoices(fn (?MyEntity $foo) => $foo->someField()->getChoices())
+     * ->setChoices(fn (?MyEntity $foo, FieldDto $field) => ...)
      */
-    public function setChoices(array $keyValueChoices): self
+    public function setChoices($choiceGenerator): self
     {
-        $this->setCustomOption(self::OPTION_CHOICES, $keyValueChoices);
+        if (!\is_array($choiceGenerator) && !\is_callable($choiceGenerator)) {
+            throw new \InvalidArgumentException(sprintf('The argument of the "%s" method must be an array or a closure ("%s" given).', __METHOD__, \gettype($choiceGenerator)));
+        }
+
+        $this->setCustomOption(self::OPTION_CHOICES, $choiceGenerator);
 
         return $this;
     }

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -31,7 +31,8 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $isExpanded = $field->getCustomOption(ChoiceField::OPTION_RENDER_EXPANDED);
-        $choices = $field->getCustomOption(ChoiceField::OPTION_CHOICES);
+
+        $choices = $this->getChoices($field->getCustomOption(ChoiceField::OPTION_CHOICES), $entityDto, $field);
         if (empty($choices)) {
             throw new \InvalidArgumentException(sprintf('The "%s" choice field must define its possible choices using the setChoices() method.', $field->getProperty()));
         }
@@ -77,6 +78,19 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
             }
         }
         $field->setFormattedValue(implode($isRenderedAsBadge ? '' : ', ', $selectedChoices));
+    }
+
+    private function getChoices($choiceGenerator, EntityDto $entity, FieldDto $field): array
+    {
+        if (null === $choiceGenerator) {
+            return [];
+        }
+
+        if (\is_array($choiceGenerator)) {
+            return $choiceGenerator;
+        }
+
+        return $choiceGenerator($entity->getInstance(), $field);
     }
 
     private function getBadgeCssClass($badgeSelector, $value, FieldDto $field): string

--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -25,6 +25,16 @@ class ChoiceFieldTest extends AbstractFieldTest
         $this->configure($field);
     }
 
+    public function testFieldWithChoiceGeneratorCallback()
+    {
+        $field = ChoiceField::new('foo')->setChoices(static function () { return ['foo' => 1, 'bar' => 2]; });
+
+        self::assertSame(['foo' => 1, 'bar' => 2], $this->configure($field)->getFormTypeOption(ChoiceField::OPTION_CHOICES));
+
+        $field->setValue(1);
+        self::assertSame('foo', $this->configure($field)->getFormattedValue());
+    }
+
     public function testFieldWithWrongVisualOptions()
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
I needed this feature this morning ... and I thought it might be useful for others too. Instead of hardcoding choices as an array, you can now use a PHP callback:

```php
yield ChoiceField::new('foo')->setChoices(['aaa' => 1, 'bbb' => 2]);
yield ChoiceField::new('foo')->setChoices(fn () => ['aaa' => 1, 'bbb' => 2]);
yield ChoiceField::new('foo')->setChoices(fn (Foo $foo) => array_combine($foo->getCategories(), $foo->getCategories()));
yield ChoiceField::new('foo')->setChoices(fn (Foo $foo, FieldDto $field) => [$field->getName() => 0] + $foo->getChoices());
```