### PR TITLE
Restrict the actions that can be run in a CRUD controller

### DIFF
--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -116,6 +116,21 @@ final class ActionConfigDto
         return $this->disabledActions;
     }
 
+    public function getCustomCrudActions(): array
+    {
+        $controllerActions = [];
+        /** @var ActionDto[] $actions */
+        foreach ($this->actions as $pageName => $actions) {
+            foreach ($actions as $action) {
+                if (null !== $action->getCrudActionName()) {
+                    $controllerActions[$action->getCrudActionName()] = $action;
+                }
+            }
+        }
+
+        return $controllerActions;
+    }
+
     public function getActionPermissions(): array
     {
         return $this->actionPermissions;

--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -96,7 +96,11 @@ final class ActionConfigDto
      */
     public function getActions()
     {
-        return null === $this->pageName ? $this->actions : ActionCollection::new($this->actions[$this->pageName]);
+        if (null === $this->pageName) {
+            return $this->actions;
+        }
+
+        return !isset($this->actions[$this->pageName]) ? [] : ActionCollection::new($this->actions[$this->pageName]);
     }
 
     /**

--- a/src/EventListener/AdminContextListener.php
+++ b/src/EventListener/AdminContextListener.php
@@ -63,10 +63,12 @@ class AdminContextListener
             return;
         }
 
+        // if a CRUD action is requested, check if it's one of the built-in actions or one of the custom actions
+        // defined as CRUD controller actions. Otherwise, a malicious user could execute any public method of the
+        // CRUD controller just by changing the 'crudAction' query parameter
         $allowedBuiltInActions = [Crud::PAGE_INDEX, Crud::PAGE_DETAIL, Crud::PAGE_NEW, Crud::PAGE_EDIT, 'autocomplete', 'delete', 'renderFilters'];
-        $allowedCustomActions = null === $crudControllerInstance ? [] : $crudControllerInstance->configureActions($dashboardControllerInstance->configureActions())->getAsDto($crudAction)->getActions();
-        $allowedCustomActions = \is_array($allowedCustomActions) ? $allowedCustomActions : array_keys($allowedCustomActions->all());
-        if (!\in_array($crudAction, $allowedBuiltInActions) && !\in_array($crudAction, $allowedCustomActions)) {
+        $allowedCustomActions = null === $crudControllerInstance ? [] : array_keys($crudControllerInstance->configureActions($dashboardControllerInstance->configureActions())->getAsDto($crudAction)->getCustomCrudActions());
+        if (null !== $crudAction && !\in_array($crudAction, $allowedBuiltInActions) && !\in_array($crudAction, $allowedCustomActions)) {
             throw new ForbiddenActionException();
         }
 

--- a/src/Exception/ForbiddenActionException.php
+++ b/src/Exception/ForbiddenActionException.php
@@ -10,8 +10,14 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\ExceptionContext;
  */
 final class ForbiddenActionException extends BaseException
 {
-    public function __construct(AdminContext $context)
+    public function __construct(?AdminContext $context = null)
     {
+        if (null === $context) {
+            parent::__construct(new ExceptionContext('exception.forbidden_action', sprintf('You can\'t run this action.'), [], 403));
+
+            return;
+        }
+
         $parameters = [
             'crud_controller' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
             'action' => null === $context->getCrud() ? null : $context->getCrud()->getCurrentAction(),


### PR DESCRIPTION
In a comment of some issue someone asked if it was a security problem the fact that you can run any public method of a controller by changing the `crudAction` query param in the URL. This tries to restrict the actions to be executed to a few built-in actions (new, edit, etc.) and all the custom actions defined by the user. (Later each action is checked again to see if the user has permissions to run it ... but this PR adds an initial protection).