### PR TITLE
Fixed "allowClear" when no "placeholder" is set (AssociationField)

### DIFF
--- a/src/Form/Type/CrudAutocompleteType.php
+++ b/src/Form/Type/CrudAutocompleteType.php
@@ -32,6 +32,11 @@ class CrudAutocompleteType extends AbstractType implements DataMapperInterface
     {
         // Add a custom block prefix to inner field to ease theming:
         array_splice($view['autocomplete']->vars['block_prefixes'], -1, 0, 'ea_autocomplete_inner');
+
+        // allowClear option needs a placeholder value (it can be empty)
+        if ($view->vars['attr']['data-allow-clear'] ?? false && !isset($view->vars['attr']['data-placeholder'])) {
+            $view->vars['attr']['data-placeholder'] = '';
+        }
     }
 
     /**


### PR DESCRIPTION
When trying to clear an AssociationField I get an error from Select2:
<img width="1388" alt="Schermata 2020-11-07 alle 14 45 12" src="https://user-images.githubusercontent.com/1532277/98442948-7a492100-2108-11eb-9bf3-75272a2a9ca8.png">

This seems to be related to: https://stackoverflow.com/questions/49953467/cannot-read-property-id-of-undefined-select2
Select2 doc: https://select2.org/selections#clearable-selections

**My solution:** I simply check if `allowClear` is set (and true), then if `placeholder` is not set I set it to an empty value.

I tried to fix this in a simple way, but maybe you prefer a different solution, let me know.

Thank you for your time.