### PR TITLE
Fixed the autocomplete feature of association fields

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -403,7 +403,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         /** @var CrudControllerInterface $controller */
         $controller = $this->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext['crudId'], Action::INDEX, $context->getRequest());
         /** @var FieldDto $field */
-        $field = FieldCollection::new($controller->configureFields(Crud::PAGE_INDEX))->get($autocompleteContext['propertyName']);
+        $field = FieldCollection::new($controller->configureFields($autocompleteContext['originatingPage']))->get($autocompleteContext['propertyName']);
         /** @var \Closure|null $queryBuilderCallable */
         $queryBuilderCallable = $field->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE);
 

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -76,6 +76,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ->set(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT, [
                     'crudId' => $context->getRequest()->query->get('crudId'),
                     'propertyName' => $propertyName,
+                    'originatingPage' => $context->getCrud()->getCurrentPage(),
                 ])
                 ->generateUrl();
 


### PR DESCRIPTION
This is related to #3551. Autocomplete stopped working in one of my apps. The reason is that the autocomplete field is not shown on `index/detail` but only on `edit/new` ... so let's not assume that the page where the field is defined is always `index`.