### PR TITLE
#3956 Added support to use callable formats in routing configuration

### DIFF
--- a/src/Cache/CacheWarmer.php
+++ b/src/Cache/CacheWarmer.php
@@ -35,7 +35,16 @@ final class CacheWarmer implements CacheWarmerInterface
 
         /** @var Route $route */
         foreach ($allRoutes as $routeName => $route) {
-            $controller = u($route->getDefault('_controller') ?? '');
+            $controller = $route->getDefault('_controller') ?? '';
+            if (\is_string($controller) && !empty($controller) && class_exists($controller)) {
+                $controller .= '::__invoke';
+            }
+
+            if (\is_array($controller)) {
+                $controller = $controller[0].'::'.($controller[1] ?? '__invoke');
+            }
+
+            $controller = u($controller);
             if (!$controller->endsWith('::index')) {
                 continue;
             }


### PR DESCRIPTION
This is a fix for #3956 allows using routing configuration in different forms of callables:
```php
return static function (RoutingConfigurator $router): void {
    $router
        ->add('admin_dashboard', '/')
            ->controller([DashboardController::class, 'index'])
    ;
};
```
and
```php
return static function (RoutingConfigurator $router): void {
    $router
        ->add('admin_dashboard', '/')
            ->controller(DashboardController::class)
    ;
};
```