### PR TITLE
Prevent Panel renderCollapsed and Textarea Autogrow clash

### DIFF
--- a/assets/js/form-type-textarea.js
+++ b/assets/js/form-type-textarea.js
@@ -10,7 +10,9 @@ class Autogrow {
         this.field.style.resize = 'none';
         this.field.style.boxSizing = 'border-box';
         this.field.style.height = 'auto';
-        this.field.style.height = this.field.scrollHeight + 'px';
+        if (this.field.scrollHeight > 0) {
+            this.field.style.height = this.field.scrollHeight + 'px';
+        }
     }
 }
 


### PR DESCRIPTION
When having an autogrow textarea in a collapsed panel, scrollHeight is 0 so field is unusable.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
