### PR TITLE
Allow to upload/remove images in Image fields

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -36,7 +36,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Factory\FilterFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\PaginatorFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Model\FileUploadState;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityUpdater;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
@@ -49,6 +51,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
+use function Symfony\Component\String\u;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -213,8 +216,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $editForm = $this->createEditForm($context->getEntity(), $context->getCrud()->getEditFormOptions(), $context);
         $editForm->handleRequest($context->getRequest());
         if ($editForm->isSubmitted() && $editForm->isValid()) {
-            // TODO:
-            // $this->processUploadedFiles($editForm);
+            $this->processUploadedFiles($editForm);
 
             $event = new BeforeEntityUpdatedEvent($entityInstance);
             $this->get('event_dispatcher')->dispatch($event);
@@ -288,8 +290,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $context->getEntity()->setInstance($entityInstance);
 
         if ($newForm->isSubmitted() && $newForm->isValid()) {
-            // TODO:
-            // $this->processUploadedFiles($newForm);
+            $this->processUploadedFiles($newForm);
 
             $event = new BeforeEntityPersistedEvent($entityInstance);
             $this->get('event_dispatcher')->dispatch($event);
@@ -525,5 +526,46 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $this->get('event_dispatcher')->dispatch($event);
 
         return $event;
+    }
+
+    protected function processUploadedFiles(FormInterface $form): void
+    {
+        /** @var FormInterface $child */
+        foreach ($form as $child) {
+            $config = $child->getConfig();
+
+            if (!$config->getType()->getInnerType() instanceof FileUploadType) {
+                if ($config->getCompound()) {
+                    $this->processUploadedFiles($child);
+                }
+
+                continue;
+            }
+
+            /** @var FileUploadState $state */
+            $state = $config->getAttribute('state');
+
+            if (!$state->isModified()) {
+                continue;
+            }
+
+            $uploadDelete = $config->getOption('upload_delete');
+
+            if ($state->hasCurrentFiles() && ($state->isDelete() || (!$state->isAddAllowed() && $state->hasUploadedFiles()))) {
+                foreach ($state->getCurrentFiles() as $file) {
+                    $uploadDelete($file);
+                }
+                $state->setCurrentFiles([]);
+            }
+
+            $filePaths = (array) $child->getData();
+            $uploadDir = $config->getOption('upload_dir');
+            $uploadNew = $config->getOption('upload_new');
+
+            foreach ($state->getUploadedFiles() as $index => $file) {
+                $fileName = u($filePaths[$index])->after($uploadDir)->toString();
+                $uploadNew($file, $uploadDir, $fileName);
+            }
+        }
     }
 }

--- a/src/Field/Configurator/ImageConfigurator.php
+++ b/src/Field/Configurator/ImageConfigurator.php
@@ -7,12 +7,20 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
+use function Symfony\Component\String\u;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class ImageConfigurator implements FieldConfiguratorInterface
 {
+    private $projectDir;
+
+    public function __construct(string $projectDir)
+    {
+        $this->projectDir = $projectDir;
+    }
+
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {
         return ImageField::class === $field->getFieldFqcn();
@@ -20,10 +28,16 @@ final class ImageConfigurator implements FieldConfiguratorInterface
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
+        $relativeUploadDir = $field->getCustomOption(ImageField::OPTION_UPLOAD_DIR) ?? 'public/uploads/images/';
+        $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
+        $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
+        $field->setFormTypeOption('upload_dir', $absoluteUploadDir);
+
         $configuredBasePath = $field->getCustomOption(ImageField::OPTION_BASE_PATH);
         $formattedValue = $this->getImagePath($field->getValue(), $configuredBasePath);
-
         $field->setFormattedValue($formattedValue);
+
+        $field->setFormTypeOption('upload_filename', $field->getCustomOption(ImageField::OPTION_UPLOADED_FILE_NAME_PATTERN));
 
         // this check is needed to avoid displaying broken images when image properties are optional
         if (empty($formattedValue) || $formattedValue === rtrim($configuredBasePath ?? '', '/')) {
@@ -37,6 +51,9 @@ final class ImageConfigurator implements FieldConfiguratorInterface
         if (null === $imagePath || 0 !== preg_match('/^(http[s]?|\/\/)/i', $imagePath)) {
             return $imagePath;
         }
+
+        // remove project path from filepath
+        $imagePath = str_replace($this->projectDir.\DIRECTORY_SEPARATOR.'public'.\DIRECTORY_SEPARATOR, '', $imagePath);
 
         return isset($basePath)
             ? rtrim($basePath, '/').'/'.ltrim($imagePath, '/')

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -3,7 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
-use Symfony\Component\Form\Extension\Core\Type\FileType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -13,6 +13,8 @@ final class ImageField implements FieldInterface
     use FieldTrait;
 
     public const OPTION_BASE_PATH = 'basePath';
+    public const OPTION_UPLOAD_DIR = 'uploadDir';
+    public const OPTION_UPLOADED_FILE_NAME_PATTERN = 'uploadedFileNamePattern';
 
     public static function new(string $propertyName, ?string $label = null): self
     {
@@ -20,15 +22,49 @@ final class ImageField implements FieldInterface
             ->setProperty($propertyName)
             ->setLabel($label)
             ->setTemplateName('crud/field/image')
-            ->setFormType(FileType::class)
+            ->setFormType(FileUploadType::class)
             ->addCssClass('field-image')
             ->setTextAlign('center')
-            ->setCustomOption(self::OPTION_BASE_PATH, null);
+            ->setCustomOption(self::OPTION_BASE_PATH, null)
+            ->setCustomOption(self::OPTION_UPLOAD_DIR, 'public/uploads/files/')
+            ->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, '[name].[extension]');
     }
 
     public function setBasePath(string $path): self
     {
         $this->setCustomOption(self::OPTION_BASE_PATH, $path);
+
+        return $this;
+    }
+
+    /**
+     * Relative to project's root directory (e.g. use 'public/uploads/' for `<your-project-dir>/public/uploads/`)
+     * Default upload dir: `<your-project-dir>/public/uploads/images/`.
+     */
+    public function setUploadDir(string $uploadDirPath): self
+    {
+        $this->setCustomOption(self::OPTION_UPLOAD_DIR, $uploadDirPath);
+
+        return $this;
+    }
+
+    /**
+     * @param string|\Closure $patternOrCallable
+     *
+     * If it's a string, uploaded files will be renamed according to the given pattern.
+     * The pattern can include the following special values:
+     *   [day] [month] [year] [timestamp]
+     *   [name] [slug] [extension] [contenthash]
+     *   [randomhash] [uuid] [ulid]
+     * (e.g. [year]/[month]/[day]/[slug]-[contenthash].[extension])
+     *
+     * If it's a callable, you will be passed the Symfony's UploadedFile instance and you must
+     * return a string with the new filename.
+     * (e.g. fn(UploadedFile $file) => sprintf('upload_%d_%s.%s', random_int(1, 999), $file->getFilename(), $file->guessExtension()))
+     */
+    public function setUploadedFileNamePattern($patternOrCallable): self
+    {
+        $this->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, $patternOrCallable);
 
         return $this;
     }

--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -76,7 +76,7 @@ class StringToFileTransformer implements DataTransformerInterface
         }
 
         if (\is_string($value)) {
-            return new File($value);
+            return new File($this->uploadDir.$value);
         }
 
         throw new TransformationFailedException('Expected a string or null.');
@@ -93,7 +93,7 @@ class StringToFileTransformer implements DataTransformerInterface
                 throw new TransformationFailedException($value->getErrorMessage());
             }
 
-            $filename = $this->uploadDir.($this->uploadFilename)($value);
+            $filename = ($this->uploadFilename)($value);
 
             return ($this->uploadValidate)($filename);
         }

--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -16,6 +16,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\OptionsResolver\Exception\InvalidArgumentException;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -165,33 +168,26 @@ class FileUploadType extends AbstractType implements DataMapperInterface
 
             return $value;
         });
-        $resolver->setNormalizer('upload_filename', static function (Options $options, $value) {
-            if (\is_callable($value)) {
-                return $value;
+        $resolver->setNormalizer('upload_filename', static function (Options $options, $fileNamePatternOrCallable) {
+            if (\is_callable($fileNamePatternOrCallable)) {
+                return $fileNamePatternOrCallable;
             }
 
-            $generateUuid4 = static function () {
-                return sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-                    random_int(0, 0xffff), random_int(0, 0xffff),
-                    random_int(0, 0xffff),
-                    random_int(0, 0x0fff) | 0x4000,
-                    random_int(0, 0x3fff) | 0x8000,
-                    random_int(0, 0xffff), random_int(0, 0xffff), random_int(0, 0xffff)
-                );
-            };
-
-            return static function (UploadedFile $file) use ($value, $generateUuid4) {
-                return strtr($value, [
+            return static function (UploadedFile $file) use ($fileNamePatternOrCallable) {
+                return strtr($fileNamePatternOrCallable, [
                     '[contenthash]' => sha1_file($file->getRealPath()),
                     '[day]' => date('d'),
                     '[extension]' => $file->guessClientExtension(),
                     '[month]' => date('m'),
                     '[name]' => pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME),
                     '[randomhash]' => bin2hex(random_bytes(20)),
-                    // TODO: remove this by the Symfony String slugger
-                    '[slug]' => transliterator_transliterate('Any-Latin; Latin-ASCII; [^A-Za-z0-9_] remove; Lower()', pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME)),
+                    '[slug]' => (new AsciiSlugger())
+                        ->slug(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))
+                        ->lower()
+                        ->toString(),
                     '[timestamp]' => time(),
-                    '[uuid]' => $generateUuid4(),
+                    '[uuid]' => Uuid::v4()->toRfc4122(),
+                    '[ulid]' => new Ulid(),
                     '[year]' => date('Y'),
                 ]);
             };
@@ -210,7 +206,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
      */
     public function getBlockPrefix(): string
     {
-        return 'easyadmin_fileupload';
+        return 'ea_fileupload';
     }
 
     /**
@@ -219,7 +215,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
     public function mapDataToForms($currentFiles, $forms): void
     {
         /** @var FormInterface $fileForm */
-        $fileForm = current(iterator_to_array($forms, false));
+        $fileForm = current(iterator_to_array($forms));
         $fileForm->setData($currentFiles);
     }
 
@@ -229,7 +225,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
     public function mapFormsToData($forms, &$currentFiles): void
     {
         /** @var FormInterface[] $children */
-        $children = iterator_to_array($forms, false);
+        $children = iterator_to_array($forms);
         $uploadedFiles = $children['file']->getData();
 
         /** @var FileUploadState $state */

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -59,6 +59,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\TextConfigurator as Text
 use EasyCorp\Bundle\EasyAdminBundle\Form\Extension\CollectionTypeExtension;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Extension\EaCrudFormTypeExtension;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Inspector\DataCollector;
 use EasyCorp\Bundle\EasyAdminBundle\Intl\IntlFormatter;
@@ -234,6 +235,10 @@ return static function (ContainerConfigurator $container) {
         ->set(FiltersFormType::class)
             ->tag('form.type', ['alias' => 'ea_filters'])
 
+        ->set(FileUploadType::class)
+            ->arg(0, '%kernel.project_dir%')
+            ->tag('form.type')
+
         ->set(ChoiceFilterConfigurator::class)
 
         ->set(CommonFilterConfigurator::class)
@@ -305,6 +310,7 @@ return static function (ContainerConfigurator $container) {
         ->set(IdConfigurator::class)
 
         ->set(ImageConfigurator::class)
+            ->arg(0, '%kernel.project_dir%')
 
         ->set(LanguageConfigurator::class)
 

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -566,8 +566,8 @@
 {% block ea_fileupload_widget %}
     <div class="ea-fileupload">
         <div class="input-group">
-            {% set placeholder = null %}
-            {% set title = null %}
+            {% set placeholder = '' %}
+            {% set title = '' %}
             {% set filesLabel = 'files'|trans({}, 'EasyAdminBundle') %}
             {% if currentFiles %}
                 {% if multiple %}


### PR DESCRIPTION
This reintroduces the great feature that Yonel (@yceruto) implemented in EasyAdmin 2.x. 

Changes are based completely on the work done by @versh23 in #3511. I can't merge that PR because it includes many unrelated changes in the same PR, so I prefer to create separate PRs.

Please note that in the future (hopefully soon) we'll add a File field and we could refactor some of this code to reuse it for images and files. Also, some of the FileUploadType are not exposed yet as Image field methods ... but we'll do that too in the future.