### PR TITLE
Dashboard skeleton: change icon classes

### DIFF
--- a/src/Resources/skeleton/dashboard.tpl
+++ b/src/Resources/skeleton/dashboard.tpl
@@ -27,6 +27,6 @@ class <?= $class_name; ?> extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        // yield MenuItem::linkToCrud('The Label', 'icon class', EntityClass::class);
+        // yield MenuItem::linkToCrud('The Label', 'fa fa-list', EntityClass::class);
     }
 }


### PR DESCRIPTION
Because "icon class" classes don't exist
