### PR TITLE
Improve the error message when the image upload dir is not defined

### DIFF
--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -26,7 +26,7 @@ final class ImageField implements FieldInterface
             ->addCssClass('field-image')
             ->setTextAlign('center')
             ->setCustomOption(self::OPTION_BASE_PATH, null)
-            ->setCustomOption(self::OPTION_UPLOAD_DIR, 'public/uploads/files/')
+            ->setCustomOption(self::OPTION_UPLOAD_DIR, null)
             ->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, '[name].[extension]');
     }
 


### PR DESCRIPTION
Fixes #3966 by displaying a better error message:

## Before

![image](https://user-images.githubusercontent.com/73419/99578316-f848da00-29dc-11eb-8da4-52fac3049d91.png)

## After

![image](https://user-images.githubusercontent.com/73419/99578333-fbdc6100-29dc-11eb-8edb-a76f2d7fc136.png)
