### PR TITLE
Display a gray separator line with menu sections

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -90,10 +90,14 @@
                                 {% if ea.userMenu.items|length > 0 %}
                                     <div class="popover-content-section user-menu">
                                         {% for item in ea.userMenu.items %}
-                                            <a href="{{ item.linkUrl }}" class="user-action {{ item.cssClass }}" target="{{ item.linkTarget }}" rel="{{ item.linkRel }}" referrerpolicy="origin-when-cross-origin">
-                                                {% if item.icon is not empty %}<i class="fa fa-fw {{ item.icon }}"></i>{% endif %}
-                                                <span>{{ item.label }}</span>
-                                            </a>
+                                            {% if item.isMenuSection %}
+                                                <hr class="m-0" />
+                                            {% else %}
+                                                <a href="{{ item.linkUrl }}" class="user-action {{ item.cssClass }}" target="{{ item.linkTarget }}" rel="{{ item.linkRel }}" referrerpolicy="origin-when-cross-origin">
+                                                    {% if item.icon is not empty %}<i class="fa fa-fw {{ item.icon }}"></i>{% endif %}
+                                                    <span>{{ item.label }}</span>
+                                                </a>
+                                            {% endif %}
                                         {% endfor %}
                                     </div>
                                 {% endif %}


### PR DESCRIPTION
Hi,

I have a gray separator line with menu sections:

![Capture](https://user-images.githubusercontent.com/12116264/99792274-25090880-2b27-11eb-977e-34c36246f7c8.PNG)


```php
public function configureUserMenu(UserInterface $user): UserMenu
{
    return UserMenu::new()
        [...]
        ->addMenuItems([
            MenuItem::linkToRoute('My Profile', 'fa fa-id-card', 'profile_edit'),
            MenuItem::linkToRoute('Settings', 'fa fa-user-cog', 'profile_settings'),
            MenuItem::section(),
            MenuItem::linkToLogout('Logout', 'fa fa-sign-out'),
        ]);
}
```

Related #3276
