### PR TITLE
Add section before logout and exit impersonation

### DIFF
--- a/src/Controller/AbstractDashboardController.php
+++ b/src/Controller/AbstractDashboardController.php
@@ -61,7 +61,8 @@ abstract class AbstractDashboardController extends AbstractController implements
 
     public function configureUserMenu(UserInterface $user): UserMenu
     {
-        $userMenuItems = [MenuItem::linkToLogout('__ea__user.sign_out', 'fa-sign-out')];
+        $userMenuItems[] = MenuItem::section();
+        $userMenuItems[] = MenuItem::linkToLogout('__ea__user.sign_out', 'fa-sign-out');
         if ($this->isGranted(Permission::EA_EXIT_IMPERSONATION)) {
             $userMenuItems[] = MenuItem::linkToExitImpersonation('__ea__user.exit_impersonation', 'fa-user-lock');
         }


### PR DESCRIPTION
Hi,

I added section before logout and exit impersonation.

Related #3276

```php
public function configureUserMenu(UserInterface $user): UserMenu
{
    return parent::configureUserMenu($user)
        [...]
        ->addMenuItems([
            MenuItem::linkToRoute('My Profile', 'fa fa-id-card', 'profile_edit'),
            MenuItem::linkToRoute('Settings', 'fa fa-user-cog', 'profile_settings'),
        ]);
}
```

![Capture](https://user-images.githubusercontent.com/12116264/99798073-a5803700-2b30-11eb-9828-3a6602446b19.PNG)
