### PR TITLE
Display formatted field values as "raw" values in templates

### DIFF
--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -10,6 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use function Symfony\Component\String\u;
+use Twig\Markup;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -17,10 +18,12 @@ use function Symfony\Component\String\u;
 final class CommonPostConfigurator implements FieldConfiguratorInterface
 {
     private $adminContextProvider;
+    private $charset;
 
-    public function __construct(AdminContextProvider $adminContextProvider)
+    public function __construct(AdminContextProvider $adminContextProvider, string $charset)
     {
         $this->adminContextProvider = $adminContextProvider;
+        $this->charset = $charset;
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
@@ -45,7 +48,7 @@ final class CommonPostConfigurator implements FieldConfiguratorInterface
             return $value;
         }
 
-        return $callable($value, $entityDto->getInstance());
+        return new Markup($callable($value, $entityDto->getInstance()), $this->charset);
     }
 
     private function updateFieldTemplate(FieldDto $field): void

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -288,6 +288,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set(CommonPostConfigurator::class)
             ->arg(0, new Reference(AdminContextProvider::class))
+            ->arg(1, '%kernel.charset%')
             ->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR, ['priority' => -9999])
 
         ->set(CommonPreConfigurator::class)


### PR DESCRIPTION
I've faced this limitation many times when using `->formatValue()` to apply a callable to the original field value. 

I think that using Twig's `Markup` is OK in this scenario and it won't introduce any security vulnerability (this is a private backend and you are generating the value). But if I'm missing something, please tell me!