### PR TITLE
AssociationField: RELATED_URL new features

### DIFF
--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -186,6 +186,20 @@ final class EntityDto
         return \in_array($associationType, [ClassMetadataInfo::ONE_TO_MANY, ClassMetadataInfo::MANY_TO_MANY], true);
     }
 
+    public function isOneToAssociation(string $propertyName): bool
+    {
+        $associationType = $this->getPropertyMetadata($propertyName)->get('type');
+
+        return \in_array($associationType, [ClassMetadataInfo::ONE_TO_ONE, ClassMetadataInfo::ONE_TO_MANY], true);
+    }
+
+    public function isManyToAssociation(string $propertyName): bool
+    {
+        $associationType = $this->getPropertyMetadata($propertyName)->get('type');
+
+        return \in_array($associationType, [ClassMetadataInfo::MANY_TO_ONE, ClassMetadataInfo::MANY_TO_MANY], true);
+    }
+
     public function isEmbeddedClassProperty(string $propertyName): bool
     {
         $propertyNameParts = explode('.', $propertyName, 2);

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -82,6 +82,6 @@ final class AssociationField implements FieldInterface
 
     public function disableRelatedUrl(bool $disable = true): self
     {
-        return $this->enableRelatedUrl(! $disable);
+        return $this->enableRelatedUrl(!$disable);
     }
 }

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -16,6 +16,7 @@ final class AssociationField implements FieldInterface
     public const OPTION_CRUD_CONTROLLER = 'crudControllerFqcn';
     public const OPTION_WIDGET = 'widget';
     public const OPTION_QUERY_BUILDER_CALLABLE = 'queryBuilderCallable';
+    public const OPTION_ENABLE_RELATED_URL = 'enableRelatedUrl';
     /** @internal this option is intended for internal use only */
     public const OPTION_RELATED_URL = 'relatedUrl';
     /** @internal this option is intended for internal use only */
@@ -39,6 +40,7 @@ final class AssociationField implements FieldInterface
             ->setCustomOption(self::OPTION_CRUD_CONTROLLER, null)
             ->setCustomOption(self::OPTION_WIDGET, self::WIDGET_AUTOCOMPLETE)
             ->setCustomOption(self::OPTION_QUERY_BUILDER_CALLABLE, null)
+            ->setCustomOption(self::OPTION_ENABLE_RELATED_URL, null)
             ->setCustomOption(self::OPTION_RELATED_URL, null)
             ->setCustomOption(self::OPTION_DOCTRINE_ASSOCIATION_TYPE, null);
     }
@@ -69,5 +71,17 @@ final class AssociationField implements FieldInterface
         $this->setCustomOption(self::OPTION_QUERY_BUILDER_CALLABLE, $queryBuilderCallable);
 
         return $this;
+    }
+
+    public function enableRelatedUrl(bool $enable = true): self
+    {
+        $this->setCustomOption(self::OPTION_ENABLE_RELATED_URL, $enable);
+
+        return $this;
+    }
+
+    public function disableRelatedUrl(bool $disable = true): self
+    {
+        return $this->enableRelatedUrl(! $disable);
     }
 }

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -48,8 +48,8 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
          * -> generate the link for a toOne association
          * -> DO NOT generate the link for a toMany association
          */
-        if (null === $this->getCustomOption(AssociationField::OPTION_ENABLE_RELATED_URL)) {
-            $this->setCustomOption(AssociationField::OPTION_ENABLE_RELATED_URL, $entityDto->isToOneAssociation($propertyName));
+        if (null === $field->getCustomOption(AssociationField::OPTION_ENABLE_RELATED_URL)) {
+            $field->setCustomOption(AssociationField::OPTION_ENABLE_RELATED_URL, $entityDto->isToOneAssociation($propertyName));
         }
 
         $targetEntityFqcn = $field->getDoctrineMetadata()->get('targetEntity');

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -43,7 +43,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             throw new \RuntimeException(sprintf('The "%s" field is not a Doctrine association, so it cannot be used as an association field.', $propertyName));
         }
 
-        /**
+        /*
          * Default behavior if not defined:
          * -> generate the link for a toOne association
          * -> DO NOT generate the link for a toMany association

--- a/src/Resources/views/crud/field/association.html.twig
+++ b/src/Resources/views/crud/field/association.html.twig
@@ -2,7 +2,13 @@
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% if 'toMany' == field.customOptions.get('associationType') %}
-    <span class="badge badge-secondary">{{ field.formattedValue }}</span>
+    <span class="badge badge-secondary">
+    {% if field.customOptions.get('relatedUrl') is not null %}
+        <a href="{{ field.customOptions.get('relatedUrl') }}">{{ field.formattedValue }}</a>
+    {% else %}
+        {{ field.formattedValue }}
+    {% endif %}
+    </span>
 {% else %}
     {% if field.customOptions.get('relatedUrl') is not null %}
         <a href="{{ field.customOptions.get('relatedUrl') }}">{{ field.formattedValue }}</a>


### PR DESCRIPTION
Two new features:

1. Add the ability to **enable or disable** the generation of the RELATED_URL (actually, this URL is always generated, even if we don't want)

2. Manage this RELATED_URL also for the ToMany associations. In this case, the URL doesn't point on a DETAIL page, but on a INDEX page **filtered** by the actual EntityDto.

I kept the default behaviors:
* For ToOne associations, the url is generated.
* For ToMany assocaitions, no url is generated.


