### PR TITLE
Fix #3990 - ImageField Filename Erased

### DIFF
--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -99,7 +99,7 @@ class StringToFileTransformer implements DataTransformerInterface
         }
 
         if ($value instanceof File) {
-            return $value->getPathname();
+            return $value->getFilename();
         }
 
         throw new TransformationFailedException('Expected an instance of File or null.');


### PR DESCRIPTION
Hi,
Currently when you modify an entity that already contains an image, the data transform will render the pathname, which causes the filename to be updated in the database and causes an error because it should only render the Filename. 

i described the problem in this issue #3990 :)