### PR TITLE
feat: Make DefaultConfigPass.php php 7.4 compatible

### DIFF
--- a/src/Configuration/DefaultConfigPass.php
+++ b/src/Configuration/DefaultConfigPass.php
@@ -55,7 +55,7 @@ class DefaultConfigPass implements ConfigPassInterface
     {
         $defaultMenuItem = $this->findDefaultMenuItem($backendConfig['design']['menu']);
 
-        if ('empty' === $defaultMenuItem['type']) {
+        if (null !== $defaultMenuItem && 'empty' === $defaultMenuItem['type']) {
             throw new \RuntimeException(sprintf('The "menu" configuration sets "%s" as the default item, which is not possible because its type is "empty" and it cannot redirect to a valid URL.', $defaultMenuItem['label']));
         }
 


### PR DESCRIPTION
When using php 7.4 and having no default menu, the array will be null and an exception will be thrown at this place