### PR TITLE
Add PhpStorm attributes

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,6 +21,8 @@ return PhpCsFixer\Config::create()
         'fopen_flags' => false,
         'ordered_imports' => true,
         'protected_to_private' => false,
+        // disable to allow PHP 8 attributes like #[SomeName('...')]
+        'single_line_comment_style' => false,
         // Part of @Symfony:risky in PHP-CS-Fixer 2.13.0. To be removed from the config file once upgrading
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced', 'strict' => true],
         // Part of future @Symfony ruleset in PHP-CS-Fixer To be removed from the config file once upgrading

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,7 +21,7 @@ return PhpCsFixer\Config::create()
         'fopen_flags' => false,
         'ordered_imports' => true,
         'protected_to_private' => false,
-        // disable to allow PHP 8 attributes like #[SomeName('...')]
+        // disabled to allow PHP 8 attributes like #[SomeName('...')]
         'single_line_comment_style' => false,
         // Part of @Symfony:risky in PHP-CS-Fixer 2.13.0. To be removed from the config file once upgrading
         'native_function_invocation' => ['include' => ['@compiler_optimized'], 'scope' => 'namespaced', 'strict' => true],

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -126,7 +126,7 @@ final class Actions
     /**
      * @param array $permissions Syntax: ['actionName' => 'actionPermission', ...]
      */
-    #[ArrayShape([0 => 'string', 1 => 'string'])
+    #[ArrayShape([0 => 'string', 1 => 'string'])]
     public function setPermissions(array $permissions): self
     {
         $this->dto->setActionPermissions($permissions);

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -126,6 +126,7 @@ final class Actions
     /**
      * @param array $permissions Syntax: ['actionName' => 'actionPermission', ...]
      */
+    #[ArrayShape([0 => 'string', 1 => 'string])
     public function setPermissions(array $permissions): self
     {
         $this->dto->setActionPermissions($permissions);

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -126,7 +126,7 @@ final class Actions
     /**
      * @param array $permissions Syntax: ['actionName' => 'actionPermission', ...]
      */
-    #[ArrayShape([0 => 'string', 1 => 'string])
+    #[ArrayShape([0 => 'string', 1 => 'string'])
     public function setPermissions(array $permissions): self
     {
         $this->dto->setActionPermissions($permissions);

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -188,7 +188,7 @@ class Crud
     /**
      * @param array $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
      */
-    #[ArrayShape([0 => 'string', 1 => ['ASC', 'DESC']])
+    #[ArrayShape([0 => 'string', 1 => ['ASC', 'DESC']])]
     public function setDefaultSort(array $sortFieldsAndOrder): self
     {
         $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -188,6 +188,7 @@ class Crud
     /**
      * @param array $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
      */
+    #[ArrayShape([0 => 'string', 1 => ['ASC', 'DESC']])
     public function setDefaultSort(array $sortFieldsAndOrder): self
     {
         $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);

--- a/src/Config/Dashboard.php
+++ b/src/Config/Dashboard.php
@@ -45,6 +45,7 @@ final class Dashboard
         return $this;
     }
 
+    #[ExpectedValues(values: ['ltr', 'rtl'])]
     public function setTextDirection(string $direction): self
     {
         if (!\in_array($direction, ['ltr', 'rtl'], true)) {

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -62,6 +62,7 @@ final class CrudMenuItem implements MenuItemInterface
     /**
      * @param array $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
      */
+    #[ArrayShape([0 => 'string', 1 => ['ASC', 'DESC']])
     public function setDefaultSort(array $sortFieldsAndOrder): self
     {
         $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -62,7 +62,7 @@ final class CrudMenuItem implements MenuItemInterface
     /**
      * @param array $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
      */
-    #[ArrayShape([0 => 'string', 1 => ['ASC', 'DESC']])
+    #[ArrayShape([0 => 'string', 1 => ['ASC', 'DESC']])]
     public function setDefaultSort(array $sortFieldsAndOrder): self
     {
         $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);

--- a/src/Field/CodeEditorField.php
+++ b/src/Field/CodeEditorField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CodeEditorType;
+use JetBrains\PhpStorm\ExpectedValues;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -44,6 +45,7 @@ final class CodeEditorField implements FieldInterface
         return $this;
     }
 
+    #[ExpectedValues(values: self::ALLOWED_LANGUAGES)]
     public function setLanguage(string $language): self
     {
         if (!\in_array($language, self::ALLOWED_LANGUAGES, true)) {

--- a/src/Field/CodeEditorField.php
+++ b/src/Field/CodeEditorField.php
@@ -4,7 +4,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CodeEditorType;
-use JetBrains\PhpStorm\ExpectedValues;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -126,6 +126,7 @@ trait FieldTrait
     /**
      * @param string $textAlign It can be 'left', 'center' or 'right'
      */
+    #[ExpectedValues(values: ['left', 'center', 'right'])]
     public function setTextAlign(string $textAlign): self
     {
         $validOptions = ['left', 'center', 'right'];


### PR DESCRIPTION
As explained here -> https://blog.jetbrains.com/phpstorm/2020/10/phpstorm-2020-3-eap-4/ PhpStorm is going to introduce soon support for some proprietary PHP attributes that will improve code completion a lot.

The good news is that you don't need PHP 8 to use these attributes ... they work with any PHP version as long as you use PHPStorm 2020.3 (which has just been released) or later.

So, I propose to add these attributes as soon as possible. This PR is only a proof of concept. The community will have to provide the rest of the PRs to add attributes everywhere. What do you think about this?