### PR TITLE
Replaced some magic strings by constants

### DIFF
--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\PaginatorDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
@@ -192,8 +193,8 @@ class Crud
     {
         $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);
         foreach ($sortFieldsAndOrder as $sortField => $sortOrder) {
-            if (!\in_array($sortOrder, ['ASC', 'DESC'])) {
-                throw new \InvalidArgumentException(sprintf('The sort order can be only "ASC" or "DESC", "%s" given.', $sortOrder));
+            if (!\in_array($sortOrder, [SortOrder::ASC, SortOrder::DESC], true)) {
+                throw new \InvalidArgumentException(sprintf('The sort order can be only "%s" or "%s", "%s" given.', SortOrder::ASC, SortOrder::DESC, $sortOrder));
             }
 
             if (!\is_string($sortField)) {

--- a/src/Config/Dashboard.php
+++ b/src/Config/Dashboard.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextDirection;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\DashboardDto;
 
 /**
@@ -47,8 +48,8 @@ final class Dashboard
 
     public function setTextDirection(string $direction): self
     {
-        if (!\in_array($direction, ['ltr', 'rtl'], true)) {
-            throw new \InvalidArgumentException(sprintf('The "%s" value given to the textDirection option is not valid. It can only be "ltr" or "rtl"', $direction));
+        if (!\in_array($direction, [TextDirection::LTR, TextDirection::RTL], true)) {
+            throw new \InvalidArgumentException(sprintf('The "%s" value given to the textDirection option is not valid. It can only be "%s" or "%s"', $direction, TextDirection::LTR, TextDirection::RTL));
         }
 
         $this->dto->setTextDirection($direction);

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -2,6 +2,8 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 
@@ -22,10 +24,10 @@ final class CrudMenuItem implements MenuItemInterface
         $this->dto->setLabel($label);
         $this->dto->setIcon($icon);
         $this->dto->setRouteParameters([
-            'crudAction' => 'index',
-            'crudId' => null,
-            'entityFqcn' => $entityFqcn,
-            'entityId' => null,
+            EA::CRUD_ACTION => 'index',
+            EA::CRUD_ID => null,
+            EA::ENTITY_FQCN => $entityFqcn,
+            EA::ENTITY_ID => null,
         ]);
     }
 
@@ -33,7 +35,7 @@ final class CrudMenuItem implements MenuItemInterface
     {
         $this->dto->setRouteParameters(array_merge(
             $this->dto->getRouteParameters(),
-            ['crudControllerFqcn' => $controllerFqcn]
+            [EA::CRUD_CONTROLLER_FQCN => $controllerFqcn]
         ));
 
         return $this;
@@ -43,7 +45,7 @@ final class CrudMenuItem implements MenuItemInterface
     {
         $this->dto->setRouteParameters(array_merge(
             $this->dto->getRouteParameters(),
-            ['crudAction' => $actionName]
+            [EA::CRUD_ACTION => $actionName]
         ));
 
         return $this;
@@ -53,7 +55,7 @@ final class CrudMenuItem implements MenuItemInterface
     {
         $this->dto->setRouteParameters(array_merge(
             $this->dto->getRouteParameters(),
-            ['entityId' => $entityId]
+            [EA::ENTITY_ID => $entityId]
         ));
 
         return $this;
@@ -66,7 +68,7 @@ final class CrudMenuItem implements MenuItemInterface
     {
         $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);
         foreach ($sortFieldsAndOrder as $sortField => $sortOrder) {
-            if (!\in_array($sortOrder, ['ASC', 'DESC'])) {
+            if (!\in_array($sortOrder, [SortOrder::ASC, SortOrder::DESC])) {
                 throw new \InvalidArgumentException(sprintf('The sort order can be only "ASC" or "DESC", "%s" given.', $sortOrder));
             }
 
@@ -77,7 +79,7 @@ final class CrudMenuItem implements MenuItemInterface
 
         $this->dto->setRouteParameters(array_merge(
             $this->dto->getRouteParameters(),
-            ['sort' => $sortFieldsAndOrder]
+            [EA::SORT => $sortFieldsAndOrder]
         ));
 
         return $this;

--- a/src/Config/Option/EA.php
+++ b/src/Config/Option/EA.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Config\Option;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class EA
+{
+    public const CONTEXT_NAME = 'eaContext';
+    public const MENU_INDEX = 'menuIndex';
+    public const SUBMENU_INDEX = 'submenuIndex';
+    public const QUERY = 'query';
+    public const FILTERS = 'filters';
+    public const SORT = 'sort';
+    public const REFERRER = 'referrer';
+    public const DASHBOARD_CONTROLLER_FQCN = 'dashboardControllerFqcn';
+    public const CRUD_CONTROLLER_FQCN = 'crudControllerFqcn';
+    public const CRUD_ACTION = 'crudAction';
+    public const CRUD_ID = 'crudId';
+    public const ENTITY_FQCN = 'entityFqcn';
+    public const ENTITY_ID = 'entityId';
+}

--- a/src/Config/Option/Size.php
+++ b/src/Config/Option/Size.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Config\Option;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class Size
+{
+    public const SM = 'sm';
+    public const MD = 'md';
+    public const LG = 'lg';
+    public const XL = 'xl';
+}

--- a/src/Config/Option/SortOrder.php
+++ b/src/Config/Option/SortOrder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Config\Option;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class SortOrder
+{
+    public const ASC = 'ASC';
+    public const DESC = 'DESC';
+}

--- a/src/Config/Option/TextAlign.php
+++ b/src/Config/Option/TextAlign.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Config\Option;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class TextAlign
+{
+    public const LEFT = 'left';
+    public const CENTER = 'center';
+    public const RIGHT = 'right';
+}

--- a/src/Config/Option/TextDirection.php
+++ b/src/Config/Option/TextDirection.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Config\Option;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class TextDirection
+{
+    public const LTR = 'ltr';
+    public const RTL = 'rtl';
+}

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Context;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetsDto;
@@ -63,7 +64,7 @@ final class AdminContext
 
     public function getReferrer(): ?string
     {
-        return $this->request->query->get('referrer');
+        return $this->request->query->get(EA::REFERRER);
     }
 
     public function getI18n(): I18nDto
@@ -129,8 +130,8 @@ final class AdminContext
 
         $configuredMenuItems = $this->dashboardControllerInstance->configureMenuItems();
         $mainMenuItems = \is_array($configuredMenuItems) ? $configuredMenuItems : iterator_to_array($configuredMenuItems, false);
-        $selectedMenuIndex = $this->request->query->getInt('menuIndex', -1);
-        $selectedMenuSubIndex = $this->request->query->getInt('submenuIndex', -1);
+        $selectedMenuIndex = $this->request->query->getInt(EA::MENU_INDEX, -1);
+        $selectedMenuSubIndex = $this->request->query->getInt(EA::SUBMENU_INDEX, -1);
 
         return $this->mainMenuDto = $this->menuFactory->createMainMenu($mainMenuItems, $selectedMenuIndex, $selectedMenuSubIndex);
     }

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -13,6 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -392,7 +393,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $this->redirect($referrer);
         }
 
-        return $this->redirect($this->get(CrudUrlGenerator::class)->build()->setAction('index')->unset('entityId')->generateUrl());
+        return $this->redirect($this->get(CrudUrlGenerator::class)->build()->setAction(Action::INDEX)->unset(EA::ENTITY_ID)->generateUrl());
     }
 
     public function autocomplete(AdminContext $context): JsonResponse
@@ -402,7 +403,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $autocompleteContext = $context->getRequest()->get(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT);
 
         /** @var CrudControllerInterface $controller */
-        $controller = $this->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext['crudId'], Action::INDEX, $context->getRequest());
+        $controller = $this->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext[EA::CRUD_ID], Action::INDEX, $context->getRequest());
         /** @var FieldDto $field */
         $field = FieldCollection::new($controller->configureFields($autocompleteContext['originatingPage']))->get($autocompleteContext['propertyName']);
         /** @var \Closure|null $queryBuilderCallable */
@@ -431,7 +432,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         /** @var FiltersFormType $filtersForm */
         $filtersForm = $this->get(FormFactory::class)->createFiltersForm($filters, $context->getRequest());
         $formActionParts = parse_url($filtersForm->getConfig()->getAction());
-        $queryString = $formActionParts['query'] ?? [];
+        $queryString = $formActionParts[EA::QUERY] ?? [];
         parse_str($queryString, $queryStringAsArray);
 
         $responseParameters = KeyValueStore::new([

--- a/src/EventListener/AdminContextListener.php
+++ b/src/EventListener/AdminContextListener.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
@@ -34,7 +35,7 @@ class AdminContextListener
 
     public function onKernelController(ControllerEvent $event): void
     {
-        $contextId = $event->getRequest()->query->get('eaContext');
+        $contextId = $event->getRequest()->query->get(EA::CONTEXT_NAME);
         $currentControllerInstance = $this->getCurrentControllerInstance($event);
         if (!$this->isEasyAdminRequest($contextId, $currentControllerInstance)) {
             return;
@@ -50,8 +51,8 @@ class AdminContextListener
             return;
         }
 
-        $crudId = $event->getRequest()->query->get('crudId');
-        $crudAction = $event->getRequest()->query->get('crudAction');
+        $crudId = $event->getRequest()->query->get(EA::CRUD_ID);
+        $crudAction = $event->getRequest()->query->get(EA::CRUD_ACTION);
         $crudControllerInstance = $this->controllerFactory->getCrudControllerInstance($crudId, $crudAction, $event->getRequest());
 
         if (null !== $crudId && null === $dashboardControllerInstance) {
@@ -89,7 +90,7 @@ class AdminContextListener
      * Request is associated to EasyAdmin if one of these conditions meet:
      *  * current controller is an instance of DashboardControllerInterface (the single point of
      *    entry for all requests directly served by EasyAdmin)
-     *  * the contextId passed via the 'eaContext' query string parameter is not null
+     *  * the contextId passed via the EA::CONTEXT_NAME query string parameter is not null
      *    (that's used in menu items that link to Symfony routes not served by EasyAdmin, so
      *    those routes can still be associated with some EasyAdmin dashboard to display the menu, etc.).
      */

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\ActionCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionConfigDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -145,21 +146,21 @@ final class ActionFactory
                 $routeParameters = $routeParameters($entityInstance);
             }
 
-            $routeParameters = array_merge(['eaContext' => $adminContextId], $routeParameters);
+            $routeParameters = array_merge([EA::CONTEXT_NAME => $adminContextId], $routeParameters);
 
             return $this->urlGenerator->generate($routeName, $routeParameters);
         }
 
         $requestParameters = [
-            'crudId' => $request->query->get('crudId'),
-            'crudAction' => $actionDto->getCrudActionName(),
-            'referrer' => $this->generateReferrerUrl($request, $actionDto, $currentAction),
+            EA::CRUD_ID => $request->query->get(EA::CRUD_ID),
+            EA::CRUD_ACTION => $actionDto->getCrudActionName(),
+            EA::REFERRER => $this->generateReferrerUrl($request, $actionDto, $currentAction),
         ];
 
         if (\in_array($actionDto->getName(), [Action::INDEX, Action::NEW], true)) {
-            $requestParameters['entityId'] = null;
+            $requestParameters[EA::ENTITY_ID] = null;
         } elseif (null !== $entityDto) {
-            $requestParameters['entityId'] = $entityDto->getPrimaryKeyValueAsString();
+            $requestParameters[EA::ENTITY_ID] = $entityDto->getPrimaryKeyValueAsString();
         }
 
         return $this->crudUrlGenerator->build($requestParameters)->generateUrl();
@@ -183,10 +184,10 @@ final class ActionFactory
             return null;
         }
 
-        $referrer = $request->get('referrer');
+        $referrer = $request->get(EA::REFERRER);
         $referrerParts = parse_url($referrer);
-        parse_str($referrerParts['query'] ?? '', $referrerQueryStringVariables);
-        $referrerCrudAction = $referrerQueryStringVariables['crudAction'] ?? null;
+        parse_str($referrerParts[EA::QUERY] ?? '', $referrerQueryStringVariables);
+        $referrerCrudAction = $referrerQueryStringVariables[EA::CRUD_ACTION] ?? null;
 
         if (Action::EDIT === $currentAction) {
             if (\in_array($referrerCrudAction, [Action::INDEX, Action::DETAIL], true)) {

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -4,6 +4,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use EasyCorp\Bundle\EasyAdminBundle\Cache\CacheWarmer;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextDirection;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
@@ -47,7 +49,7 @@ final class AdminContextFactory
 
     public function create(Request $request, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController): AdminContext
     {
-        $crudAction = $request->query->get('crudAction');
+        $crudAction = $request->query->get(EA::CRUD_ACTION);
         $validPageNames = [Crud::PAGE_INDEX, Crud::PAGE_DETAIL, Crud::PAGE_EDIT, Crud::PAGE_NEW];
         $pageName = \in_array($crudAction, $validPageNames, true) ? $crudAction : null;
 
@@ -166,7 +168,7 @@ final class AdminContextFactory
 
         $configuredTextDirection = $dashboardDto->getTextDirection();
         $localePrefix = strtolower(substr($locale, 0, 2));
-        $defaultTextDirection = \in_array($localePrefix, ['ar', 'fa', 'he']) ? 'rtl' : 'ltr';
+        $defaultTextDirection = \in_array($localePrefix, ['ar', 'fa', 'he']) ? TextDirection::RTL : TextDirection::LTR;
         $textDirection = $configuredTextDirection ?? $defaultTextDirection;
 
         $translationDomain = $dashboardDto->getTranslationDomain();
@@ -174,7 +176,7 @@ final class AdminContextFactory
         $translationParameters = [];
         if (null !== $crudDto) {
             $translationParameters['%entity_name%'] = $entityName = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
-            $translationParameters['%entity_id%'] = $entityId = $request->query->get('entityId');
+            $translationParameters['%entity_id%'] = $entityId = $request->query->get(EA::ENTITY_ID);
             $translationParameters['%entity_short_id%'] = null === $entityId ? null : u((string) $entityId)->truncate(7);
 
             $entityInstance = null === $entityDto ? null : $entityDto->getInstance();
@@ -198,10 +200,10 @@ final class AdminContextFactory
 
         $queryParams = $request->query->all();
         $searchableProperties = $crudDto->getSearchFields();
-        $query = $queryParams['query'] ?? null;
+        $query = $queryParams[EA::QUERY] ?? null;
         $defaultSort = $crudDto->getDefaultSort();
-        $customSort = $queryParams['sort'] ?? [];
-        $appliedFilters = $queryParams['filters'] ?? [];
+        $customSort = $queryParams[EA::SORT] ?? [];
+        $appliedFilters = $queryParams[EA::FILTERS] ?? [];
 
         return new SearchDto($request, $searchableProperties, $query, $defaultSort, $customSort, $appliedFilters);
     }
@@ -225,6 +227,6 @@ final class AdminContextFactory
             return null;
         }
 
-        return $this->entityFactory->create($crudDto->getEntityFqcn(), $request->query->get('entityId'), $crudDto->getEntityPermission());
+        return $this->entityFactory->create($crudDto->getEntityFqcn(), $request->query->get(EA::ENTITY_ID), $crudDto->getEntityPermission());
     }
 }

--- a/src/Factory/FormFactory.php
+++ b/src/Factory/FormFactory.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudBatchActionFormType;
@@ -72,7 +73,7 @@ final class FormFactory
     {
         $filtersForm = $this->symfonyFormFactory->createNamed('filters', FiltersFormType::class, null, [
             'method' => 'GET',
-            'action' => $request->query->get('referrer', ''),
+            'action' => $request->query->get(EA::REFERRER, ''),
             'ea_filters' => $filters,
         ]);
 

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
@@ -130,12 +131,12 @@ final class MenuFactory
             $urlBuilder = $this->crudUrlGenerator->build()->unsetAll();
 
             // add the index and subIndex query parameters to display the selected menu item
-            $urlBuilder->set('menuIndex', $index)->set('submenuIndex', $subIndex);
+            $urlBuilder->set(EA::MENU_INDEX, $index)->set(EA::SUBMENU_INDEX, $subIndex);
 
             $urlBuilder->setAll($routeParameters);
 
-            $entityFqcn = $routeParameters['entityFqcn'] ?? null;
-            $crudControllerFqcn = $routeParameters['crudControllerFqcn'] ?? null;
+            $entityFqcn = $routeParameters[EA::ENTITY_FQCN] ?? null;
+            $crudControllerFqcn = $routeParameters[EA::CRUD_CONTROLLER_FQCN] ?? null;
             if (null === $entityFqcn && null === $crudControllerFqcn) {
                 throw new \RuntimeException(sprintf('The CRUD menu item with label "%s" must define either the entity FQCN (using the third constructor argument) or the CRUD Controller FQCN (using the "setController()" method).', $menuItemDto->getLabel()));
             }
@@ -151,19 +152,19 @@ final class MenuFactory
                 }
 
                 $urlBuilder->setController($controllerFqcn);
-                $urlBuilder->unset('entityFqcn');
+                $urlBuilder->unset(EA::ENTITY_FQCN);
             }
 
             return $urlBuilder->generateUrl();
         }
 
         if (MenuItemDto::TYPE_DASHBOARD === $menuItemType) {
-            return $this->urlGenerator->generate($dashboardRouteName, ['menuIndex' => $index, 'submenuIndex' => $subIndex]);
+            return $this->urlGenerator->generate($dashboardRouteName, [EA::MENU_INDEX => $index, EA::SUBMENU_INDEX => $subIndex]);
         }
 
         if (MenuItemDto::TYPE_ROUTE === $menuItemType) {
             return $this->urlGenerator->generate($menuItemDto->getRouteName(), array_merge(
-                ['menuIndex' => $index, 'submenuIndex' => $subIndex, 'eaContext' => $adminContextId],
+                [EA::MENU_INDEX => $index, EA::SUBMENU_INDEX => $subIndex, EA::CONTEXT_NAME => $adminContextId],
                 $menuItemDto->getRouteParameters()
             ));
         }

--- a/src/Field/AvatarField.php
+++ b/src/Field/AvatarField.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\Size;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
@@ -29,7 +30,7 @@ final class AvatarField implements FieldInterface
 
     public function setHeight($heightInPixels): self
     {
-        $semanticHeights = ['sm' => 18, 'md' => 24, 'lg' => 48, 'xl' => 96];
+        $semanticHeights = [Size::SM => 18, Size::MD => 24, Size::LG => 48, Size::XL => 96];
 
         if (!\is_int($heightInPixels) && !\array_key_exists($heightInPixels, $semanticHeights)) {
             throw new \InvalidArgumentException(sprintf('The argument of the "%s()" method must be either an integer (the height in pixels) or one of these string values: %s (%d given).', __METHOD__, implode(', ', $semanticHeights), $heightInPixels));

--- a/src/Field/BooleanField.php
+++ b/src/Field/BooleanField.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
@@ -22,7 +23,7 @@ final class BooleanField implements FieldInterface
             ->setTemplateName('crud/field/boolean')
             ->setFormType(CheckboxType::class)
             ->addCssClass('field-boolean')
-            ->setTextAlign('center')
+            ->setTextAlign(TextAlign::CENTER)
             ->setCustomOption(self::OPTION_RENDER_AS_SWITCH, true);
     }
 

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -5,6 +5,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\PersistentCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -72,9 +74,9 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ->setController($field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER))
                 ->setAction('autocomplete')
                 ->setEntityId(null)
-                ->unset('sort') // Avoid passing the 'sort' param from the current entity to the autocompleted one
+                ->unset(EA::SORT) // Avoid passing the 'sort' param from the current entity to the autocompleted one
                 ->set(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT, [
-                    'crudId' => $context->getRequest()->query->get('crudId'),
+                    EA::CRUD_ID => $context->getRequest()->query->get(EA::CRUD_ID),
                     'propertyName' => $propertyName,
                     'originatingPage' => $context->getCrud()->getCurrentPage(),
                 ])
@@ -129,7 +131,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         $field->setFormTypeOptionIfNotSet('class', $field->getDoctrineMetadata()->get('targetEntity'));
 
         if (null === $field->getTextAlign()) {
-            $field->setTextAlign('right');
+            $field->setTextAlign(TextAlign::RIGHT);
         }
 
         $field->setFormattedValue($this->countNumElements($field->getValue()));
@@ -163,8 +165,8 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             ->setController($crudController)
             ->setAction(Action::DETAIL)
             ->setEntityId($entityDto->getPrimaryKeyValue())
-            ->unset('menuIndex')
-            ->unset('submenuIndex')
+            ->unset(EA::MENU_INDEX)
+            ->unset(EA::SUBMENU_INDEX)
             ->includeReferrer()
             ->generateUrl();
     }

--- a/src/Field/Configurator/CountryConfigurator.php
+++ b/src/Field/Configurator/CountryConfigurator.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -59,7 +60,7 @@ final class CountryConfigurator implements FieldConfiguratorInterface
         $field->setFormattedValue($this->getCountryName($field->getValue(), $countryCodeFormat));
 
         if (null === $field->getTextAlign() && false === $field->getCustomOption(CountryField::OPTION_SHOW_NAME)) {
-            $field->setTextAlign('center');
+            $field->setTextAlign(TextAlign::CENTER);
         }
 
         if (\in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_EDIT, Crud::PAGE_NEW], true)) {

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 
 /**
@@ -128,7 +129,7 @@ trait FieldTrait
      */
     public function setTextAlign(string $textAlign): self
     {
-        $validOptions = ['left', 'center', 'right'];
+        $validOptions = [TextAlign::LEFT, TextAlign::CENTER, TextAlign::RIGHT];
         if (!\in_array($textAlign, $validOptions, true)) {
             throw new \InvalidArgumentException(sprintf('The value of the "textAlign" option can only be one of these: "%s" ("%s" was given).', implode(',', $validOptions), $textAlign));
         }

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
 
@@ -24,7 +25,7 @@ final class ImageField implements FieldInterface
             ->setTemplateName('crud/field/image')
             ->setFormType(FileUploadType::class)
             ->addCssClass('field-image')
-            ->setTextAlign('center')
+            ->setTextAlign(TextAlign::CENTER)
             ->setCustomOption(self::OPTION_BASE_PATH, null)
             ->setCustomOption(self::OPTION_UPLOAD_DIR, null)
             ->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, '[name].[extension]');

--- a/src/Field/MoneyField.php
+++ b/src/Field/MoneyField.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Intl\Currencies;
@@ -26,7 +27,7 @@ final class MoneyField implements FieldInterface
             ->setTemplateName('crud/field/money')
             ->setFormType(MoneyType::class)
             ->addCssClass('field-money')
-            ->setTextAlign('right')
+            ->setTextAlign(TextAlign::RIGHT)
             ->setCustomOption(self::OPTION_CURRENCY, null)
             ->setCustomOption(self::OPTION_CURRENCY_PROPERTY_PATH, null)
             ->setCustomOption(self::OPTION_NUM_DECIMALS, 2)

--- a/src/Field/PercentField.php
+++ b/src/Field/PercentField.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\DataTransformer\NumberToLocalizedStringTransformer;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
@@ -26,7 +27,7 @@ final class PercentField implements FieldInterface
             ->setTemplateName('crud/field/percent')
             ->setFormType(PercentType::class)
             ->addCssClass('field-percent')
-            ->setTextAlign('right')
+            ->setTextAlign(TextAlign::RIGHT)
             ->setCustomOption(self::OPTION_NUM_DECIMALS, 0)
             ->setCustomOption(self::OPTION_STORED_AS_FRACTIONAL, true)
             ->setCustomOption(self::OPTION_SYMBOL, '%')

--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Inspector;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -61,11 +62,11 @@ class DataCollector extends BaseDataCollector
     private function collectData(AdminContext $context): array
     {
         return [
-            'CRUD ID' => $context->getRequest()->get('crudId'),
+            'CRUD ID' => $context->getRequest()->get(EA::CRUD_ID),
             'CRUD Controller FQCN' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
-            'CRUD Action' => $context->getRequest()->get('crudAction'),
-            'Entity ID' => $context->getRequest()->get('entityId'),
-            'Sort' => $context->getRequest()->get('sort'),
+            'CRUD Action' => $context->getRequest()->get(EA::CRUD_ACTION),
+            'Entity ID' => $context->getRequest()->get(EA::ENTITY_ID),
+            'Sort' => $context->getRequest()->get(EA::SORT),
         ];
     }
 

--- a/src/Orm/EntityPaginator.php
+++ b/src/Orm/EntityPaginator.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityPaginatorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\PaginatorDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
@@ -124,7 +125,7 @@ final class EntityPaginator implements EntityPaginatorInterface
             $entityDto = $this->entityFactory->createForEntityInstance($entityInstance);
 
             $jsonResult['results'][] = [
-                'entityId' => $entityDto->getPrimaryKeyValueAsString(),
+                EA::ENTITY_ID => $entityDto->getPrimaryKeyValueAsString(),
                 'entityAsString' => $entityDto->toString(),
             ];
         }

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -110,10 +110,12 @@
                             <th width="1px"><span><input type="checkbox" class="form-batch-checkbox-all"></span></th>
                         {% endif %}
 
+                        {% set ea_sort_asc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::ASC') %}
+                        {% set ea_sort_desc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::DESC') %}
                         {% for field in entities|first.fields ?? [] %}
                             {% set is_sorting_field = ea.search.isSortingField(field.property) %}
-                            {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.property) == 'DESC' ? 'ASC' : 'DESC') : 'DESC' %}
-                            {% set column_icon = is_sorting_field ? (next_sort_direction == 'DESC' ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
+                            {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
+                            {% set column_icon = is_sorting_field ? (next_sort_direction == ea_sort_desc ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
 
                             <th class="{{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} text-{{ field.textAlign }}" dir="{{ ea.i18n.textDirection }}">
                                 {% if field.isSortable %}

--- a/src/Router/CrudUrlBuilder.php
+++ b/src/Router/CrudUrlBuilder.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Router;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
@@ -32,7 +33,7 @@ class CrudUrlBuilder
         $this->urlGenerator = $urlGenerator;
 
         $currentRouteParameters = $currentRouteParametersCopy = null === $adminContext ? [] : $adminContext->getRequest()->query->all();
-        unset($currentRouteParametersCopy['referrer']);
+        unset($currentRouteParametersCopy[EA::REFERRER]);
         $currentPageReferrer = null === $adminContext ? null : sprintf('%s?%s', $adminContext->getRequest()->getPathInfo(), http_build_query($currentRouteParametersCopy));
         $this->currentPageReferrer = $currentPageReferrer;
 
@@ -48,28 +49,28 @@ class CrudUrlBuilder
 
     public function setCrudId(string $crudId): self
     {
-        $this->setRouteParameter('crudId', $crudId);
+        $this->setRouteParameter(EA::CRUD_ID, $crudId);
 
         return $this;
     }
 
     public function setController(string $crudControllerFqcn): self
     {
-        $this->setRouteParameter('crudControllerFqcn', $crudControllerFqcn);
+        $this->setRouteParameter(EA::CRUD_CONTROLLER_FQCN, $crudControllerFqcn);
 
         return $this;
     }
 
     public function setAction(string $action): self
     {
-        $this->setRouteParameter('crudAction', $action);
+        $this->setRouteParameter(EA::CRUD_ACTION, $action);
 
         return $this;
     }
 
     public function setEntityId($entityId): self
     {
-        $this->setRouteParameter('entityId', $entityId);
+        $this->setRouteParameter(EA::ENTITY_ID, $entityId);
 
         return $this;
     }
@@ -132,37 +133,37 @@ class CrudUrlBuilder
     public function generateUrl(): string
     {
         if (true === $this->includeReferrer) {
-            $this->setRouteParameter('referrer', $this->currentPageReferrer);
+            $this->setRouteParameter(EA::REFERRER, $this->currentPageReferrer);
         }
 
         if (false === $this->includeReferrer) {
-            $this->unset('referrer');
+            $this->unset(EA::REFERRER);
         }
 
         // transform 'crudControllerFqcn' into 'crudId'
-        if (null !== $crudControllerFqcn = $this->get('crudControllerFqcn')) {
+        if (null !== $crudControllerFqcn = $this->get(EA::CRUD_CONTROLLER_FQCN)) {
             if (null === $crudId = $this->crudControllers->findCrudIdByCrudFqcn($crudControllerFqcn)) {
                 throw new \InvalidArgumentException(sprintf('The given "%s" class is not a valid CRUD controller. Make sure it extends from "%s" or implements "%s".', $crudControllerFqcn, AbstractCrudController::class, CrudControllerInterface::class));
             }
 
-            $this->set('crudId', $crudId);
-            $this->unset('crudControllerFqcn');
+            $this->set(EA::CRUD_ID, $crudId);
+            $this->unset(EA::CRUD_CONTROLLER_FQCN);
         }
 
         // this avoids forcing users to always be explicit about the action to execute
-        if (null !== $this->get('crudId') && null === $this->get('crudAction')) {
-            $this->set('crudAction', Action::INDEX);
+        if (null !== $this->get(EA::CRUD_ID) && null === $this->get(EA::CRUD_ACTION)) {
+            $this->set(EA::CRUD_ACTION, Action::INDEX);
         }
 
         // if the Dashboard FQCN is defined, find its route and use it to override
         // the current route (this is needed to allow generating links to different dashboards)
-        if (null !== $dashboardControllerFqcn = $this->get('dashboardControllerFqcn')) {
+        if (null !== $dashboardControllerFqcn = $this->get(EA::DASHBOARD_CONTROLLER_FQCN)) {
             if (null === $dashboardRoute = $this->dashboardControllers->getRouteByControllerFqcn($dashboardControllerFqcn)) {
                 throw new \InvalidArgumentException(sprintf('The given "%s" class is not a valid Dashboard controller. Make sure it extends from "%s" or implements "%s".', $dashboardControllerFqcn, AbstractDashboardController::class, DashboardControllerInterface::class));
             }
 
             $this->dashboardRoute = $dashboardRoute;
-            $this->unset('dashboardControllerFqcn');
+            $this->unset(EA::DASHBOARD_CONTROLLER_FQCN);
         }
 
         // this happens when generating URLs from outside EasyAdmin (AdminContext is null) and


### PR DESCRIPTION
We use DTOs, objects and constants for all the config stuff ... but the arguments of some functions and the keys of some arrays were still using "magic strings". Let's fix that.

In PHP 8.1 we'll probably have Enums, but for now, let's use very simple classes with public constants.

Please note that I don't want to update the docs about this. Let's keep using "magic strings" in docs for now, specially because using constants in Twig is super-verbose, so I don't want readers to think that they should use these long and boring constants in their templates.

#SymfonyHackday