### PR TITLE
CommonPostConfigurator: fix some issues (particularly bring by #3982)

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -133,7 +133,7 @@ final class FieldDto
         return $this->formatValueCallable;
     }
 
-    public function setFormatValueCallable(callable $callable): void
+    public function setFormatValueCallable(?callable $callable): void
     {
         $this->formatValueCallable = $callable;
     }


### PR DESCRIPTION
* **If formatted field value is a string**, display it as "raw" values in templates
* Do not compute formatted value for NEW and EDIT pages (but yes for the others, including the potential custom pages)
* Allow `FieldDto::setFormatValueCallable()` to receive a `null` parameter (to reset the callable)