### PR TITLE
In Config\Actions class: add missing styles for built-in actions

### DIFF
--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -60,7 +60,7 @@ These are the built-in actions included by default in each page:
 * Page ``Crud::PAGE_EDIT`` (``'edit'``):
 
   * Added by default: ``Action::SAVE_AND_RETURN``, ``Action::SAVE_AND_CONTINUE``
-  * Other available actions: ``Action::DELETE``, ``Action::INDEX``
+  * Other available actions: ``Action::DELETE``, ``Action::DETAIL``, ``Action::INDEX``
 
 * Page ``Crud::PAGE_NEW`` (``'new'``):
 

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -168,17 +168,18 @@ final class Actions
 
         if (Action::DETAIL === $actionName) {
             return Action::new(Action::DETAIL, '__ea__action.detail')
-                ->linkToCrudAction(Action::DETAIL);
+                ->linkToCrudAction(Action::DETAIL)
+                ->addCssClass(Crud::PAGE_EDIT === $pageName ? 'btn btn-secondary' : '');
         }
 
         if (Action::INDEX === $actionName) {
             return Action::new(Action::INDEX, '__ea__action.index')
                 ->linkToCrudAction(Action::INDEX)
-                ->addCssClass(Crud::PAGE_DETAIL === $pageName ? 'btn btn-secondary' : '');
+                ->addCssClass(\in_array($pageName, [Crud::PAGE_DETAIL, Crud::PAGE_EDIT, Crud::PAGE_NEW], true) ? 'btn btn-secondary' : '');
         }
 
         if (Action::DELETE === $actionName) {
-            $cssClass = Crud::PAGE_DETAIL === $pageName ? 'btn btn-link pr-0 text-danger' : 'text-danger';
+            $cssClass = \in_array($pageName, [Crud::PAGE_DETAIL, Crud::PAGE_EDIT], true) ? 'btn btn-link pr-0 text-danger' : 'text-danger';
 
             return Action::new(Action::DELETE, '__ea__action.delete', Crud::PAGE_INDEX === $pageName ? null : 'fa fa-fw fa-trash-o')
                 ->linkToCrudAction(Action::DELETE)


### PR DESCRIPTION
(Even if these actions are not enabled by default)

Indeed, it avoids us to write the following code, just to add the normal styles:

```twig
$actions->add(Crud::PAGE_EDIT, Action::INDEX);
$actions->update(Crud::PAGE_EDIT, Action::INDEX, fn (Action $action) => $action->addCssClass.... etc etc);
```