### PR TITLE
Fix issue in CommonPostConfigurator

### DIFF
--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -34,8 +34,7 @@ final class CommonPostConfigurator implements FieldConfiguratorInterface
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
-        // form pages don't use he formatted value, so don't compute it
-        if (false === \in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_NEW, Crud::PAGE_EDIT], true)) {
+        if (\in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_INDEX, Crud::PAGE_DETAIL], true)) {
             $formattedValue = $this->buildFormattedValueOption($field->getFormattedValue(), $field, $entityDto);
             $field->setFormattedValue($formattedValue);
         }


### PR DESCRIPTION
Oops, I introduced a bug, sorry...
So... I reintroduce the last `if` condition (ie, `getCurrentPage() is 'index' or 'detail'`).
Because, `AbstractCrudController::renderFilters()` calls `...processFields()...` which calls the configurators (whose the CommonPostConfigurator).
And in the case of `renderFilters` action, the `getCurrentPage()` is null.
But in the case of `renderFilters` action, we must **not call** the `formatValueCallable` (because $value and $entity are null).

Well, it's not easy to explain, but I think that you see :-)
It's a pity to not be able to call the `formatValue` callables for custom actions.

So perhaps we have to test that condition? 
```php
        $page = $context->getCrud()->getCurrentPage();
        $action = $context->getCrud()->getCurrentAction();

        // form pages and 'renderFilters' action don't use the formatted value, so don't compute it
        if (false === \in_array($page, [Crud::PAGE_NEW, Crud::PAGE_EDIT], true) && 'renderFilters' !== $action) {
            $formattedValue = $this->buildFormattedValueOption($field->getFormattedValue(), $field, $entityDto);
            $field->setFormattedValue($formattedValue);
        }
```

Thanks

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
