### PR TITLE
fix: #3967 Use symfony PropertyAccess to get value of Entity Primary Key

### DIFF
--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -2,12 +2,12 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
-use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Persistence\Mapping\ClassMetadata;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\ActionCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -79,10 +79,11 @@ final class EntityDto
             return $this->primaryKeyValue;
         }
 
-        $r = ClassUtils::newReflectionObject($this->instance);
-        $primaryKeyProperty = $r->getProperty($this->primaryKeyName);
-        $primaryKeyProperty->setAccessible(true);
-        $primaryKeyValue = $primaryKeyProperty->getValue($this->instance);
+        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->enableExceptionOnInvalidIndex()
+            ->getPropertyAccessor();
+
+        $primaryKeyValue = $propertyAccessor->getValue($this->instance, $this->primaryKeyName);
 
         return $this->primaryKeyValue = $primaryKeyValue;
     }


### PR DESCRIPTION
As discussed in linked issue, current implementation of getting the value of primary key in EntityDto fails when using Doctrine Inheritance. Here I used PropertyAccess to get the value, which uses getter method to get value. This works with Doctrine Inheritance. And IMO this is the cleaner way to do it.