### PR TITLE
Crud index page: add the missing 'search reset' link to clear the current search

### DIFF
--- a/assets/css/easyadmin-theme/datagrids.scss
+++ b/assets/css/easyadmin-theme/datagrids.scss
@@ -134,8 +134,13 @@ table.datagrid {
   background-repeat: no-repeat;
   background-size: 13px 13px;
   background-position: 10px 8px;
-  padding-left: 32px;
+  padding: 0 32px;
   min-width: 100%;
+}
+
+.datagrid-header-tools .datagrid-search a.action-search-reset {
+    margin-left: -20px;
+    margin-right: 10px;
 }
 
 #modal-filters .modal-dialog {

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -72,6 +72,11 @@
                                         <div class="form-widget">
                                             <input class="form-control" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ 'action.search'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}">
                                         </div>
+                                        {% if app.request.get('query') %}
+                                            <a href="{{ ea_url().unset('query') }}" class="action-search-reset">
+                                                <i class="fa fa-close"></i>
+                                            </a>
+                                        {% endif %}
                                     </div>
                                 {% endblock %}
                             </form>


### PR DESCRIPTION
Add a very simple  'close' icon to reset the current search (as EA already does for filters button)

Note: I didn't recompile the changed scss file. Do I do?

