### PR TITLE
Deprecate CRUD ID in admin URLs

### DIFF
--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -25,7 +25,7 @@ final class CrudMenuItem implements MenuItemInterface
         $this->dto->setIcon($icon);
         $this->dto->setRouteParameters([
             EA::CRUD_ACTION => 'index',
-            EA::CRUD_ID => null,
+            EA::CRUD_CONTROLLER_FQCN => null,
             EA::ENTITY_FQCN => $entityFqcn,
             EA::ENTITY_ID => null,
         ]);

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -405,7 +405,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $autocompleteContext = $context->getRequest()->get(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT);
 
         /** @var CrudControllerInterface $controller */
-        $controller = $this->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext[EA::CRUD_ID], Action::INDEX, $context->getRequest());
+        $controller = $this->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext[EA::CRUD_CONTROLLER_FQCN], Action::INDEX, $context->getRequest());
         /** @var FieldDto $field */
         $field = FieldCollection::new($controller->configureFields($autocompleteContext['originatingPage']))->get($autocompleteContext['propertyName']);
         /** @var \Closure|null $queryBuilderCallable */

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -142,7 +142,7 @@ final class ActionFactory
         }
 
         $requestParameters = [
-            EA::CRUD_ID => $request->query->get(EA::CRUD_ID),
+            EA::CRUD_CONTROLLER_FQCN => $request->query->get(EA::CRUD_CONTROLLER_FQCN),
             EA::CRUD_ACTION => $actionDto->getCrudActionName(),
             EA::REFERRER => $this->generateReferrerUrl($request, $actionDto, $currentAction),
         ];

--- a/src/Factory/ControllerFactory.php
+++ b/src/Factory/ControllerFactory.php
@@ -31,13 +31,13 @@ final class ControllerFactory
         return $this->getDashboardController($controllerFqcn, $request);
     }
 
-    public function getCrudControllerInstance(?string $crudId, ?string $crudAction, Request $request): ?CrudControllerInterface
+    public function getCrudControllerInstance(?string $crudControllerFqcn, ?string $crudAction, Request $request): ?CrudControllerInterface
     {
-        if (null === $crudId) {
+        if (null === $crudControllerFqcn) {
             return null;
         }
 
-        return $this->getCrudController($this->crudControllers->findCrudFqcnByCrudId($crudId), $crudAction, $request);
+        return $this->getCrudController($crudControllerFqcn, $crudAction, $request);
     }
 
     private function getDashboardController(?string $dashboardControllerFqcn, Request $request): ?DashboardControllerInterface

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -77,7 +77,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ->setEntityId(null)
                 ->unset(EA::SORT) // Avoid passing the 'sort' param from the current entity to the autocompleted one
                 ->set(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT, [
-                    EA::CRUD_ID => $context->getRequest()->query->get(EA::CRUD_ID),
+                    EA::CRUD_CONTROLLER_FQCN => $context->getRequest()->query->get(EA::CRUD_CONTROLLER_FQCN),
                     'propertyName' => $propertyName,
                     'originatingPage' => $context->getCrud()->getCurrentPage(),
                 ])

--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -62,7 +62,6 @@ class DataCollector extends BaseDataCollector
     private function collectData(AdminContext $context): array
     {
         return [
-            'CRUD ID' => $context->getRequest()->get(EA::CRUD_ID),
             'CRUD Controller FQCN' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
             'CRUD Action' => $context->getRequest()->get(EA::CRUD_ACTION),
             'Entity ID' => $context->getRequest()->get(EA::ENTITY_ID),

--- a/src/Resources/views/crud/includes/_delete_form.html.twig
+++ b/src/Resources/views/crud/includes/_delete_form.html.twig
@@ -1,6 +1,6 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {% set delete_url = ea_url()
-    .setCrudId(app.request.query.get('crudId'))
+    .setController(app.request.query.get('crudControllerFqcn'))
     .setAction('delete')
     .setEntityId(entity_id ?? '__entityId_placeholder__')
     .removeReferrer() %}


### PR DESCRIPTION
This is the second of the three important changes that I've planned for admin URLs. The first one was #4045.