### PR TITLE
ImageField Multiple - Fix GetImagePath

### DIFF
--- a/src/Field/Configurator/ImageConfigurator.php
+++ b/src/Field/Configurator/ImageConfigurator.php
@@ -30,6 +30,11 @@ final class ImageConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $configuredBasePath = $field->getCustomOption(ImageField::OPTION_BASE_PATH);
+
+        $formattedValue = \is_array($field->getValue())
+            ? $this->getImagesPath($field->getValue(), $configuredBasePath)
+            : $this->getImagePath($field->getValue(), $configuredBasePath);
+
         $formattedValue = $this->getImagePath($field->getValue(), $configuredBasePath);
         $field->setFormattedValue($formattedValue);
 
@@ -51,6 +56,16 @@ final class ImageConfigurator implements FieldConfiguratorInterface
         $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
         $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
         $field->setFormTypeOption('upload_dir', $absoluteUploadDir);
+    }
+
+    private function getImagesPath(?array $images, ?string $basePath): ?array
+    {
+        $collectionsImage = [];
+        foreach ($images as $image) {
+            $collectionsImage[] = $this->getImagePath($image, $basePath);
+        }
+
+        return $collectionsImage;
     }
 
     private function getImagePath(?string $imagePath, ?string $basePath): ?string


### PR DESCRIPTION
Hi,
this patch is used to manage the case of multiple image uploads,
it manage the creation of basePath for an array value

![image](https://user-images.githubusercontent.com/2642040/102511423-0d229700-4089-11eb-806c-008393a7ee22.png)


```php
ImageField::new('images')
        ->setUploadDir('public/uploads/images')
        ->setBasePath('public/uploads/images')
        ->setUploadedFileNamePattern('[year]-[month]-[day]-[contenthash].[extension]')
        ->setFormTypeOption('multiple', true)
```