### PR TITLE
Add a signature to all backend URLs

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -153,6 +153,12 @@ explained later)::
                 // set this option if you prefer the sidebar (which contains the main menu)
                 // to be displayed as a narrow column instead of the default expanded design
                 ->renderSidebarMinimized()
+
+                // by default, all backend URLs include a signature hash. If a user changes any
+                // query parameter (to "hack" the backend) the signature won't match and EasyAdmin
+                // triggers an error. If this causes any issue in your backend, call this method
+                // to disable this feature and remove all URL signature checks
+                ->disableUrlSignatures()
             ;
         }
     }

--- a/src/Config/Dashboard.php
+++ b/src/Config/Dashboard.php
@@ -71,6 +71,13 @@ final class Dashboard
         return $this;
     }
 
+    public function disableUrlSignatures(bool $disableSignatures = true): self
+    {
+        $this->dto->setSignedUrls(!$disableSignatures);
+
+        return $this;
+    }
+
     public function getAsDto(): DashboardDto
     {
         return $this->dto;

--- a/src/Config/Option/EA.php
+++ b/src/Config/Option/EA.php
@@ -17,10 +17,12 @@ final class EA
     public const ENTITY_ID = 'entityId';
     public const FILTERS = 'filters';
     public const MENU_INDEX = 'menuIndex';
+    public const PAGE = 'page';
     public const QUERY = 'query';
     public const REFERRER = 'referrer';
     public const ROUTE_NAME = 'routeName';
     public const ROUTE_PARAMS = 'routeParams';
     public const SORT = 'sort';
     public const SUBMENU_INDEX = 'submenuIndex';
+    public const URL_SIGNATURE = 'signature';
 }

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -92,6 +92,11 @@ final class AdminContext
         return $this->assetDto;
     }
 
+    public function getSignedUrls(): bool
+    {
+        return $this->dashboardDto->getSignedUrls();
+    }
+
     public function getDashboardTitle(): string
     {
         return $this->dashboardDto->getTitle();

--- a/src/Dto/DashboardDto.php
+++ b/src/Dto/DashboardDto.php
@@ -16,6 +16,7 @@ final class DashboardDto
     private $textDirection;
     private $contentWidth;
     private $sidebarWidth;
+    private $signedUrls;
 
     public function __construct()
     {
@@ -24,6 +25,7 @@ final class DashboardDto
         $this->translationDomain = 'messages';
         $this->contentWidth = Crud::LAYOUT_CONTENT_DEFAULT;
         $this->sidebarWidth = Crud::LAYOUT_SIDEBAR_DEFAULT;
+        $this->signedUrls = true;
     }
 
     public function getRouteName(): string
@@ -94,5 +96,17 @@ final class DashboardDto
     public function setSidebarWidth(string $sidebarWidth): void
     {
         $this->sidebarWidth = $sidebarWidth;
+    }
+
+    public function getSignedUrls(): bool
+    {
+        return $this->signedUrls;
+    }
+
+    public function setSignedUrls(bool $signedUrls): self
+    {
+        $this->signedUrls = $signedUrls;
+
+        return $this;
     }
 }

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -119,6 +119,14 @@ final class ActionFactory
             $actionDto->setHtmlAttribute('form', sprintf('%s-%s-form', $pageName, $entityDto->getName()));
         }
 
+        if (Action::DELETE === $actionDto->getName()) {
+            $actionDto->setHtmlAttributes([
+                'formaction' => $this->adminUrlGenerator->setAction(Action::DELETE)->setEntityId($entityDto->getPrimaryKeyValue())->removeReferrer()->generateUrl(),
+                'data-toggle' => 'modal',
+                'data-target' => '#modal-delete',
+            ]);
+        }
+
         return $actionDto;
     }
 

--- a/src/Orm/EntityPaginator.php
+++ b/src/Orm/EntityPaginator.php
@@ -66,7 +66,7 @@ final class EntityPaginator implements EntityPaginatorInterface
 
     public function generateUrlForPage(int $page): string
     {
-        return $this->adminUrlGenerator->set('page', $page)->includeReferrer()->generateUrl();
+        return $this->adminUrlGenerator->set(EA::PAGE, $page)->includeReferrer()->generateUrl();
     }
 
     public function getCurrentPage(): int

--- a/src/Resources/views/crud/includes/_delete_form.html.twig
+++ b/src/Resources/views/crud/includes/_delete_form.html.twig
@@ -1,11 +1,5 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{% set delete_url = ea_url()
-    .setController(app.request.query.get('crudControllerFqcn'))
-    .setAction('delete')
-    .setEntityId(entity_id ?? '__entityId_placeholder__')
-    .removeReferrer() %}
-
-<form action="{{ delete_url }}" method="post" id="delete-form" style="display: none">
+<form method="post" id="delete-form" style="display: none">
     <input type="hidden" name="token" value="{{ csrf_token('ea-delete') }}" />
 </form>
 
@@ -21,7 +15,7 @@
                     <span class="btn-label">{{ 'action.cancel'|trans([], 'EasyAdminBundle') }}</span>
                 </button>
 
-                <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button" formtarget="delete-form">
+                <button type="button" data-dismiss="modal" class="btn btn-danger" id="modal-delete-button" form="delete-form">
                     <span class="btn-label">{{ 'action.delete'|trans([], 'EasyAdminBundle') }}</span>
                 </button>
             </div>

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -247,14 +247,14 @@
 
             $('.action-delete').on('click', function(e) {
                 e.preventDefault();
-                const id = $(this).parents('[data-id]').first().data('id');
+                const formAction = $(this).attr('formaction');
 
                 $('#modal-delete').modal({ backdrop: true, keyboard: true })
                     .off('click', '#modal-delete-button')
                     .on('click', '#modal-delete-button', function () {
                         let deleteForm = $('#delete-form');
-                        deleteForm.attr('action', deleteForm.attr('action').replace('__entityId_placeholder__', id));
-                        deleteForm.trigger('submit');
+                        deleteForm.attr('action', formAction);
+                        deleteForm.submit();
                     });
             });
 

--- a/src/Router/CrudUrlGenerator.php
+++ b/src/Router/CrudUrlGenerator.php
@@ -14,13 +14,15 @@ final class CrudUrlGenerator
 {
     private $adminContextProvider;
     private $urlGenerator;
+    private $urlSigner;
     private $dashboardControllerRegistry;
     private $crudControllerRegistry;
 
-    public function __construct(AdminContextProvider $adminContextProvider, UrlGeneratorInterface $urlGenerator, DashboardControllerRegistry $dashboardControllerRegistry, CrudControllerRegistry $crudControllerRegistry)
+    public function __construct(AdminContextProvider $adminContextProvider, UrlGeneratorInterface $urlGenerator, UrlSigner $urlSigner, DashboardControllerRegistry $dashboardControllerRegistry, CrudControllerRegistry $crudControllerRegistry)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->urlGenerator = $urlGenerator;
+        $this->urlSigner = $urlSigner;
         $this->dashboardControllerRegistry = $dashboardControllerRegistry;
         $this->crudControllerRegistry = $crudControllerRegistry;
     }
@@ -29,6 +31,6 @@ final class CrudUrlGenerator
     {
         trigger_deprecation('easycorp/easyadmin-bundle', '3.2.0', 'The "%s" class/service is deprecated, use "%s()" instead.', __CLASS__, AdminUrlGenerator::class);
 
-        return new CrudUrlBuilder($this->adminContextProvider->getContext(), $this->urlGenerator, $this->dashboardControllerRegistry, $this->crudControllerRegistry, $routeParameters);
+        return new CrudUrlBuilder($this->adminContextProvider->getContext(), $this->urlGenerator, $this->dashboardControllerRegistry, $this->crudControllerRegistry, $this->urlSigner, $routeParameters);
     }
 }

--- a/src/Router/UrlSigner.php
+++ b/src/Router/UrlSigner.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Router;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+
+/**
+ * This class is entirely based on Symfony\Component\HttpKernel\UriSigner.
+ * (c) Fabien Potencier <fabien@symfony.com> - MIT License.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class UrlSigner
+{
+    private $kernelSecret;
+
+    public function __construct(string $kernelSecret)
+    {
+        $this->kernelSecret = $kernelSecret;
+    }
+
+    /**
+     * Signs a URL adding a query parameter with a hash generated
+     * with the values of some of the URL query parameters.
+     */
+    public function sign(string $url): string
+    {
+        $urlParts = parse_url($url);
+        if (isset($urlParts['query'])) {
+            parse_str($urlParts['query'], $queryParams);
+        } else {
+            $queryParams = [];
+        }
+
+        $queryParams[EA::URL_SIGNATURE] = $this->computeHash($this->getQueryParamsToSign($queryParams));
+
+        return $this->buildUrl($urlParts, $queryParams);
+    }
+
+    /**
+     * Checks that a URL contains a valid signature.
+     */
+    public function check(string $url): bool
+    {
+        $urlParts = parse_url($url);
+        if (isset($urlParts['query'])) {
+            parse_str($urlParts['query'], $queryParams);
+        } else {
+            $queryParams = [];
+        }
+
+        // this differs from Symfony's UriSigner behavior: if the URL doesn't contain any
+        // query parameters, then consider that the signature is OK (even if there's no signature)
+        if ([] === $queryParams) {
+            return true;
+        }
+
+        if (!isset($queryParams[EA::URL_SIGNATURE]) || empty($queryParams[EA::URL_SIGNATURE])) {
+            return false;
+        }
+
+        $expectedHash = $queryParams[EA::URL_SIGNATURE];
+        $calculatedHash = $this->computeHash($this->getQueryParamsToSign($queryParams));
+
+        return hash_equals($calculatedHash, $expectedHash);
+    }
+
+    private function computeHash(array $queryParameters): string
+    {
+        // Base64 hashes include some characters which are not compatible with
+        // query strings, so we replace them to avoid encoding them in the query string
+        return str_replace(
+            ['+', '/', '='],
+            ['-', '_', ''],
+            base64_encode(hash_hmac('sha256', http_build_query($queryParameters), $this->kernelSecret, true))
+        );
+    }
+
+    /**
+     * Instead of signing the entire URL, including all its query parameters,
+     * sign only a few parameters that can be used to attack a backend by:.
+     *
+     *   * Enumerating all entities of certain type (EA::ENTITY_ID)
+     *   * Accessing all application entities (EA::CRUD_CONTROLLER_FQCN)
+     *   * Accessing any CRUD controller method (EA::CRUD_ACTION)
+     *   * Accessing any application route (EA::ROUTE_NAME)
+     *   * Meddling with the parameters of any application route (EA::ROUTE_PARAMS)
+     *
+     * The rest of query parameters are not relevant for the signature (EA::PAGE, EA::SORT, etc.)
+     * or are dynamically set by the user (EA::QUERY, EA::FILTERS, etc.) so they can't be
+     * included in a signature calculated before providing that data.
+     */
+    private function getQueryParamsToSign(array $queryParams): array
+    {
+        $signableQueryParams = array_intersect_key($queryParams, [
+            EA::CRUD_ACTION => 0,
+            EA::CRUD_CONTROLLER_FQCN => 1,
+            EA::ENTITY_ID => 2,
+            EA::ROUTE_NAME => 3,
+            EA::ROUTE_PARAMS => 4,
+        ]);
+
+        ksort($signableQueryParams, SORT_STRING);
+
+        return $signableQueryParams;
+    }
+
+    private function buildUrl(array $urlParts, array $queryParams = []): string
+    {
+        ksort($queryParams, SORT_STRING);
+        $urlParts['query'] = http_build_query($queryParams, '', '&');
+
+        $scheme = isset($urlParts['scheme']) ? $urlParts['scheme'].'://' : '';
+        $host = $urlParts['host'] ?? '';
+        $port = isset($urlParts['port']) ? ':'.$urlParts['port'] : '';
+        $user = $urlParts['user'] ?? '';
+        $pass = isset($urlParts['pass']) ? ':'.$urlParts['pass'] : '';
+        $pass = ($user || $pass) ? "$pass@" : '';
+        $path = $urlParts['path'] ?? '';
+        $query = isset($urlParts['query']) && $urlParts['query'] ? '?'.$urlParts['query'] : '';
+        $fragment = isset($urlParts['fragment']) ? '#'.$urlParts['fragment'] : '';
+
+        return $scheme.$user.$pass.$host.$port.$path.$query.$fragment;
+    }
+}

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Twig;
 
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -15,11 +16,11 @@ use Twig\TwigFunction;
  */
 class EasyAdminTwigExtension extends AbstractExtension
 {
-    private $adminUrlGenerator;
+    private $serviceLocator;
 
-    public function __construct(AdminUrlGenerator $adminUrlGenerator)
+    public function __construct(ServiceLocator $serviceLocator)
     {
-        $this->adminUrlGenerator = $adminUrlGenerator;
+        $this->serviceLocator = $serviceLocator;
     }
 
     /**
@@ -85,6 +86,6 @@ class EasyAdminTwigExtension extends AbstractExtension
 
     public function getAdminUrlGenerator(array $queryParameters = []): AdminUrlGenerator
     {
-        return $this->adminUrlGenerator->setAll($queryParameters);
+        return $this->serviceLocator->get(AdminUrlGenerator::class)->setAll($queryParameters);
     }
 }

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Router;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Router\UrlSigner;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class AdminUrlGeneratorTest extends WebTestCase
+{
+    use ExpectDeprecationTrait;
+
+    private $adminUrlGenerator;
+    private $adminUrlGeneratorWithSignedUrls;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $adminContext = $this->getMockBuilder(AdminContext::class)->disableOriginalConstructor()->getMock();
+        $adminContext->method('getDashboardRouteName')->willReturn('admin');
+        $adminContext->method('getSignedUrls')->willReturn(false);
+        $adminContext->method('getRequest')->willReturn(new Request(['foo' => 'bar']));
+
+        $adminContextProvider = $this->getMockBuilder(AdminContextProvider::class)->disableOriginalConstructor()->getMock();
+        $adminContextProvider->method('getContext')->willReturn($adminContext);
+
+        $adminContextWithSignedUrls = $this->getMockBuilder(AdminContext::class)->disableOriginalConstructor()->getMock();
+        $adminContextWithSignedUrls->method('getDashboardRouteName')->willReturn('admin');
+        $adminContextWithSignedUrls->method('getSignedUrls')->willReturn(true);
+        $adminContextWithSignedUrls->method('getRequest')->willReturn(new Request(['foo' => 'bar']));
+
+        $adminContextProviderWithSignedUrls = $this->getMockBuilder(AdminContextProvider::class)->disableOriginalConstructor()->getMock();
+        $adminContextProviderWithSignedUrls->method('getContext')->willReturn($adminContextWithSignedUrls);
+
+        $dashboardControllerRegistry = $this->getMockBuilder(DashboardControllerRegistry::class)->disableOriginalConstructor()->getMock();
+        $dashboardControllerRegistry->method('getRouteByControllerFqcn')->willReturnMap([
+            ['App\Controller\Admin\SomeDashboardController', 'another_admin'],
+        ]);
+        $dashboardControllerRegistry->method('getNumberOfDashboards')->willReturn(2);
+        $dashboardControllerRegistry->method('getFirstDashboardRoute')->willReturn('admin');
+
+        $crudControllerRegistry = $this->getMockBuilder(CrudControllerRegistry::class)->disableOriginalConstructor()->getMock();
+        $crudControllerRegistry->method('findCrudFqcnByCrudId')->willReturnMap([
+            ['a1b2c3', 'App\Controller\Admin\SomeCrudController'],
+        ]);
+
+        $this->adminUrlGenerator = new AdminUrlGenerator(
+            $adminContextProvider,
+            self::$container->get('router'),
+            $dashboardControllerRegistry,
+            $crudControllerRegistry,
+            new UrlSigner('abc123')
+        );
+
+        $this->adminUrlGeneratorWithSignedUrls = new AdminUrlGenerator(
+            $adminContextProviderWithSignedUrls,
+            self::$container->get('router'),
+            $dashboardControllerRegistry,
+            $crudControllerRegistry,
+            new UrlSigner('abc123')
+        );
+    }
+
+    public function testGenerateEmptyUrl()
+    {
+        // the foo=bar query params come from the current request (defined in the mock of the setUp() method)
+        $this->assertSame('http://localhost/admin?foo=bar', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testGetRouteParameters()
+    {
+        $this->assertSame('bar', $this->adminUrlGenerator->get('foo'));
+        $this->assertNull($this->adminUrlGenerator->get('this_query_param_does_not_exist'));
+    }
+
+    public function testSetRouteParameters()
+    {
+        $this->adminUrlGenerator->set('foo', 'not_bar');
+        $this->assertSame('http://localhost/admin?foo=not_bar', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testNullParameters()
+    {
+        $this->adminUrlGenerator->set('param1', null);
+        $this->adminUrlGenerator->set('param2', 'null');
+        $this->assertSame('http://localhost/admin?foo=bar&param2=null', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testSetAll()
+    {
+        $this->adminUrlGenerator->setAll(['foo1' => 'bar1', 'foo2' => 'bar2']);
+        $this->assertSame('http://localhost/admin?foo=bar&foo1=bar1&foo2=bar2', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testUnsetAll()
+    {
+        $this->adminUrlGenerator->set('foo1', 'bar1');
+        $this->adminUrlGenerator->unsetAll();
+        $this->assertSame('http://localhost/admin', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testUnsetAllExcept()
+    {
+        $this->adminUrlGenerator->setAll(['foo1' => 'bar1', 'foo2' => 'bar2', 'foo3' => 'bar3', 'foo4' => 'bar4']);
+        $this->adminUrlGenerator->unsetAllExcept('foo3', 'foo2');
+        $this->assertSame('http://localhost/admin?foo2=bar2&foo3=bar3', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testParametersAreSorted()
+    {
+        $this->adminUrlGenerator->setAll(['1_foo' => 'bar', 'a_foo' => 'bar', '2_foo' => 'bar']);
+        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $this->adminUrlGenerator->generateUrl());
+
+        $this->adminUrlGenerator->setAll(['2_foo' => 'bar', 'a_foo' => 'bar', '1_foo' => 'bar']);
+        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $this->adminUrlGenerator->generateUrl());
+
+        $this->adminUrlGenerator->setAll(['a_foo' => 'bar', '2_foo' => 'bar', '1_foo' => 'bar']);
+        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testUrlParametersDontAffectOtherUrls()
+    {
+        $this->adminUrlGenerator->set('page', '1');
+        $this->adminUrlGenerator->set('sort', ['id' => 'ASC']);
+        $this->assertSame('http://localhost/admin?foo=bar&page=1&sort%5Bid%5D=ASC', $this->adminUrlGenerator->generateUrl());
+
+        $this->assertSame('http://localhost/admin?foo=bar', $this->adminUrlGenerator->generateUrl());
+
+        $this->adminUrlGenerator->set('page', '2');
+        $this->assertSame('http://localhost/admin?foo=bar&page=2', $this->adminUrlGenerator->generateUrl());
+        $this->assertNull($this->adminUrlGenerator->get('sort'));
+    }
+
+    public function testExplicitDashboardController()
+    {
+        $this->adminUrlGenerator->setDashboard('App\Controller\Admin\SomeDashboardController');
+        $this->assertSame('http://localhost/another_admin?foo=bar', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testUnknownExplicitDashboardController()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given "ThisDashboardControllerDoesNotExist" class is not a valid Dashboard controller. Make sure it extends from "EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController" or implements "EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface".');
+
+        $this->adminUrlGenerator->setDashboard('ThisDashboardControllerDoesNotExist');
+        $this->adminUrlGenerator->generateUrl();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCrudIdMethodIsTransformedIntoCrudFqcn()
+    {
+        $this->adminUrlGenerator->setCrudId('a1b2c3');
+        // The following assert should work, but it fails for some unknown reason ("Failed asserting that string matches format description.")
+        // $this->expectDeprecation("Since easycorp/easyadmin-bundle 3.2.0: The \"setCrudId()\" method of the \"EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator\" service and the related \"crudId\" query parameter are deprecated. Instead, use the CRUD Controller FQCN and the \"setController()\" method like this: ->setController('App\Controller\Admin\SomeCrudController').");
+
+        $this->assertNull($this->adminUrlGenerator->get(EA::CRUD_ID));
+        $this->assertSame('App\Controller\Admin\SomeCrudController', $this->adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
+    }
+
+    public function testCrudIdParameterIsTransformedIntoCrudFqcn()
+    {
+        // don't use setCrudId() because it transforms the crudId into crudFqcn automatically
+        $this->adminUrlGenerator->set(EA::CRUD_ID, 'a1b2c3');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testUnknowCrudId()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given "this_id_does_not_exist" value is not a valid CRUD ID. Instead of dealing with CRUD controller IDs when generating admin URLs, use the "setController()" method to set the CRUD controller FQCN.');
+
+        // don't use setCrudId() because it transforms the crudId into crudFqcn automatically
+        $this->adminUrlGenerator->set(EA::CRUD_ID, 'this_id_does_not_exist');
+        $this->adminUrlGenerator->generateUrl();
+    }
+
+    public function testDefaultCrudAction()
+    {
+        $this->adminUrlGenerator->setController('FooController');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=FooController&foo=bar', $this->adminUrlGenerator->generateUrl());
+
+        $this->adminUrlGenerator->setController('FooController');
+        $this->adminUrlGenerator->setAction(Action::NEW);
+        $this->assertSame('http://localhost/admin?crudAction=new&crudControllerFqcn=FooController&foo=bar', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testControllerParameterRemovesRouteParameters()
+    {
+        $this->adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_NAME));
+        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_PARAMS));
+
+        $this->adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+        $this->adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_NAME));
+        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_PARAMS));
+    }
+
+    public function testActionParameterRemovesRouteParameters()
+    {
+        $this->adminUrlGenerator->setAction(Action::INDEX);
+        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_NAME));
+        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_PARAMS));
+
+        $this->adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+        $this->adminUrlGenerator->setAction(Action::INDEX);
+        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_NAME));
+        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_PARAMS));
+    }
+
+    public function testRouteParametersRemoveOtherParameters()
+    {
+        $this->adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+        $this->assertNull($this->adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
+
+        $this->adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->adminUrlGenerator->set(EA::MENU_INDEX, 3);
+        $this->adminUrlGenerator->set('foo', 'bar');
+        $this->adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+
+        $this->assertNull($this->adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
+        $this->assertNull($this->adminUrlGenerator->get('foo'));
+        $this->assertSame(3, $this->adminUrlGenerator->get(EA::MENU_INDEX));
+    }
+
+    public function testIncludeReferrer()
+    {
+        $this->adminUrlGenerator->includeReferrer();
+        $this->assertSame('http://localhost/admin?foo=bar&referrer=/?foo%3Dbar', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testRemoveReferrer()
+    {
+        $this->adminUrlGenerator->removeReferrer();
+        $this->assertSame('http://localhost/admin?foo=bar', $this->adminUrlGenerator->generateUrl());
+
+        $this->adminUrlGenerator->set(EA::REFERRER, 'https://example.com/foo');
+        $this->adminUrlGenerator->removeReferrer();
+        $this->assertSame('http://localhost/admin?foo=bar', $this->adminUrlGenerator->generateUrl());
+    }
+
+    public function testSignedUrls()
+    {
+        $this->adminUrlGeneratorWithSignedUrls->set('foo1', 'bar1');
+        $this->adminUrlGeneratorWithSignedUrls->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1&signature=yGwN-pwX_xBtCMu87wfD0wyXQm-v4QO_IjCiB6cMvRw', $this->adminUrlGeneratorWithSignedUrls->generateUrl());
+    }
+}

--- a/tests/Router/UrlSignerTest.php
+++ b/tests/Router/UrlSignerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Router;
+
+use EasyCorp\Bundle\EasyAdminBundle\Router\UrlSigner;
+use PHPUnit\Framework\TestCase;
+
+class UrlSignerTest extends TestCase
+{
+    private const KERNEL_SECRET = 'abc123';
+
+    /**
+     * @dataProvider provideSignData
+     */
+    public function testSign(string $url, string $expectedResult)
+    {
+        $urlSigner = new UrlSigner(self::KERNEL_SECRET);
+
+        $this->assertSame($expectedResult, $urlSigner->sign($url));
+    }
+
+    /**
+     * @dataProvider provideCheckData
+     */
+    public function testCheck(string $url, bool $expectedResult)
+    {
+        $urlSigner = new UrlSigner(self::KERNEL_SECRET);
+
+        $this->assertSame($expectedResult, $urlSigner->check($url));
+    }
+
+    public function provideSignData()
+    {
+        // the host/user/pass/port URL parts don't affect the signature
+        yield ['https://example.com/', 'https://example.com/?signature=bS2fxhAzf4E6G4WGnsIUEplAhgVDrQQwjYc1f2wBM_Y'];
+        yield ['https://example.com:8080/', 'https://example.com:8080/?signature=bS2fxhAzf4E6G4WGnsIUEplAhgVDrQQwjYc1f2wBM_Y'];
+        yield ['https://user@example.com/', 'https://user@example.com/?signature=bS2fxhAzf4E6G4WGnsIUEplAhgVDrQQwjYc1f2wBM_Y'];
+        yield ['https://user:pass@example.com/', 'https://user:pass@example.com/?signature=bS2fxhAzf4E6G4WGnsIUEplAhgVDrQQwjYc1f2wBM_Y'];
+        yield ['https://user:pass@example.com:8080/', 'https://user:pass@example.com:8080/?signature=bS2fxhAzf4E6G4WGnsIUEplAhgVDrQQwjYc1f2wBM_Y'];
+        yield ['https://example.com/foo/bar', 'https://example.com/foo/bar?signature=bS2fxhAzf4E6G4WGnsIUEplAhgVDrQQwjYc1f2wBM_Y'];
+
+        // changing the order of query params should produce the same signed URL
+        yield ['https://example.com/foo/bar?crudAction=a&crudControllerFqcn=b', 'https://example.com/foo/bar?crudAction=a&crudControllerFqcn=b&signature=7h96f4SF2XMSviJatMSD7WYOIhYr6MGac2ATPWtrwng'];
+        yield ['https://example.com/foo/bar?crudControllerFqcn=b&crudAction=a', 'https://example.com/foo/bar?crudAction=a&crudControllerFqcn=b&signature=7h96f4SF2XMSviJatMSD7WYOIhYr6MGac2ATPWtrwng'];
+
+        // only certain query params are used for the signature
+        yield ['https://example.com/foo/bar?crudAction=a', 'https://example.com/foo/bar?crudAction=a&signature=-2POpHMuFDWuaQAjqZEsVsQL062p5D9Pg7k6fSOitHA'];
+        yield ['https://example.com/foo/bar?crudAction=a&page=2', 'https://example.com/foo/bar?crudAction=a&page=2&signature=-2POpHMuFDWuaQAjqZEsVsQL062p5D9Pg7k6fSOitHA'];
+    }
+
+    public function provideCheckData()
+    {
+        // if URL doesn't contain any query param, it's OK to not have a signature either
+        yield ['https://example.com/', true];
+
+        // if URL contains at least one query param, then it must have a signature too
+        yield ['https://example.com/?foo=bar', false];
+        yield ['https://example.com/?foo=bar&signature=bS2fxhAzf4E6G4WGnsIUEplAhgVDrQQwjYc1f2wBM_Y', true];
+
+        // it's not enough to have a signature query param; it must have the right value
+        yield ['https://example.com/?foo=bar&signature=', false];
+
+        // the order of query params doesn't affect to the signature check
+        yield ['https://example.com/foo/bar?crudAction=a&crudControllerFqcn=b&signature=7h96f4SF2XMSviJatMSD7WYOIhYr6MGac2ATPWtrwng', true];
+        yield ['https://example.com/foo/bar?crudControllerFqcn=b&crudAction=a&signature=7h96f4SF2XMSviJatMSD7WYOIhYr6MGac2ATPWtrwng', true];
+    }
+}

--- a/tests/TestApplication/src/Controller/AnotherDashboardController.php
+++ b/tests/TestApplication/src/Controller/AnotherDashboardController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class AnotherDashboardController extends AbstractDashboardController
+{
+    /**
+     * @Route("/another_admin", name="another_admin")
+     */
+    public function index(): Response
+    {
+        return parent::index();
+    }
+
+    public function configureDashboard(): Dashboard
+    {
+        return Dashboard::new()
+            ->setTitle('EasyAdmin Tests');
+    }
+
+    public function configureMenuItems(): iterable
+    {
+        yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
+        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+    }
+}


### PR DESCRIPTION
This is the third PR related to routing after #4045 and #4054.

This adds a new `signature=...` query parameter calculated based on the values of other query parameters. This improves security because if a user tries to "hack" the backend by changing any query parameter, they'll see an exception.

### Explanation

In the backend, a user can do the following:

* Change the `entityId` or `crudControllerFqcn`/`crudAction` to see other entities or run other actions (including any CRUD controller method).
* Change the `routeName` to execute any application route.

This may sound bad ... but in practice it's not that problematic:

* Backends are most of the times protected by Symfony security, so nobody except trusted users can reach your backend.
* If a user is already in your backend and has permissions to see "Foo entity with ID = 30", it's probably OK to see "Foo entity with ID = 31" if they change the query parameter option (if they don't have permission, remember that EasyAdmin allows to set a permission per entity, so you can run some voter to decide if they can access the entity or not)
* If a user is running action "foo", it's probably OK if they can run action "bar" too ... because if "bar" is protected or special in any way, you already set a special permission for it, and the user won't be able to execute it by changing the query parameter with the action name (they'll see a security exception).

In any case, to avoid any potential issue, this PR implements a new feature to add signatures to URLs. If a user changes any important query parameter value ... 💣💥 they'll see an exception because the URL signature is not valid.

If this feature breaks your backend in any way, you can disable it too 👍   