### PR TITLE
renderFilters form action query fix

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -436,6 +436,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $formActionParts = parse_url($filtersForm->getConfig()->getAction());
         $queryString = $formActionParts[EA::QUERY] ?? [];
         parse_str($queryString, $queryStringAsArray);
+        unset($queryStringAsArray[EA::FILTERS], $queryStringAsArray[EA::PAGE]);
 
         $responseParameters = KeyValueStore::new([
             'templateName' => 'crud/filters',


### PR DESCRIPTION
Fixes #3716 and #3999. Also it fixes the pager issue - If you have some filters applied and you are not on first page when you select new filter value you could see empty grid because page param is not reset (new results count could be less than for previous selection).

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
