### PR TITLE
implements array flattening

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -28,7 +28,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         return ChoiceField::class === $field->getFieldFqcn();
     }
     
-    public function arrayFlatten($array = null)
+    private function arrayFlatten($array = null)
     {
         $result = array();
 

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -32,14 +32,17 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
     {
         $result = array();
 
-        if (!is_array($array)) {
+        if (!\is_array($array)) {
             $array = func_get_args();
         }
 
         foreach ($array as $key => $value) {
 
-            if (is_array($value)) $result = array_merge($result, $this->arrayFlatten($value));
-            else $result = array_merge($result, array($key => $value));
+            if (\is_array($value)) {
+                $result = array_merge($result, $this->arrayFlatten($value));
+            } else {
+                $result = array_merge($result, array($key => $value));
+            }
         }
 
         return $result;

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -27,6 +27,23 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
     {
         return ChoiceField::class === $field->getFieldFqcn();
     }
+    
+    public function arrayFlatten($array = null)
+    {
+        $result = array();
+
+        if (!is_array($array)) {
+            $array = func_get_args();
+        }
+
+        foreach ($array as $key => $value) {
+
+            if (is_array($value)) $result = array_merge($result, $this->arrayFlatten($value));
+            else $result = array_merge($result, array($key => $value));
+        }
+
+        return $result;
+    }
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
@@ -70,7 +87,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         $translationParameters = $context->getI18n()->getTranslationParameters();
         $translationDomain = $context->getI18n()->getTranslationDomain();
         $selectedChoices = [];
-        $flippedChoices = array_flip($choices);
+        $flippedChoices = array_flip($this->arrayFlatten($choices));
         // $value is a scalar for single selections and an array for multiple selections
         foreach (array_values((array) $fieldValue) as $selectedValue) {
             if (null !== $selectedChoice = $flippedChoices[$selectedValue] ?? null) {

--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -35,6 +35,26 @@ class ChoiceFieldTest extends AbstractFieldTest
         self::assertSame('foo', $this->configure($field)->getFormattedValue());
     }
 
+    public function testFieldWithArrayFlattening()
+    {
+        $field = ChoiceField::new('foo')->setChoices([
+            "foo"  => ["A" => "a", "B" => "b"],
+            "bar"  => ["C" => "c", "D" => "d"],
+            "john" => "doe"
+        ]);
+
+        $field->setValue("a");
+        self::assertSame('A', $this->configure($field)->getFormattedValue());
+        $field->setValue("b");
+        self::assertSame('B', $this->configure($field)->getFormattedValue());
+        $field->setValue("c");
+        self::assertSame('C', $this->configure($field)->getFormattedValue());
+        $field->setValue("d");
+        self::assertSame('D', $this->configure($field)->getFormattedValue());
+        $field->setValue("doe");
+        self::assertSame('john', $this->configure($field)->getFormattedValue());
+    }
+
     public function testFieldWithWrongVisualOptions()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -38,20 +38,20 @@ class ChoiceFieldTest extends AbstractFieldTest
     public function testFieldWithArrayFlattening()
     {
         $field = ChoiceField::new('foo')->setChoices([
-            "foo"  => ["A" => "a", "B" => "b"],
-            "bar"  => ["C" => "c", "D" => "d"],
-            "john" => "doe"
+            'foo'  => ['A' => 'a', 'B' => 'b'],
+            'bar'  => ['C' => 'c', 'D' => 'd'],
+            'john' => 'doe'
         ]);
 
-        $field->setValue("a");
+        $field->setValue('a');
         self::assertSame('A', $this->configure($field)->getFormattedValue());
-        $field->setValue("b");
+        $field->setValue('b');
         self::assertSame('B', $this->configure($field)->getFormattedValue());
-        $field->setValue("c");
+        $field->setValue('c');
         self::assertSame('C', $this->configure($field)->getFormattedValue());
-        $field->setValue("d");
+        $field->setValue('d');
         self::assertSame('D', $this->configure($field)->getFormattedValue());
-        $field->setValue("doe");
+        $field->setValue('doe');
         self::assertSame('john', $this->configure($field)->getFormattedValue());
     }
 


### PR DESCRIPTION
array_flip() function returns a "Warning: array_flip(): Can only flip STRING and INTEGER values!" when a nested associative array is passed as argument.
In case of multiple choices selected entries are not retrieved from form.

I flattened the array before flipping to get them
e.g: array("key1" => array("A" => "a", "B" => "b"))
          becomes array("A" => "a", "B" => "b") 
          and then array("a" => "A", "b" => "B") by flipping

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
