### PR TITLE
added a check to DateTimeConfigurator

### DIFF
--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -2,6 +2,8 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
+use Symfony\Component\Config\Definition\Exception\Exception;
+
 use Doctrine\DBAL\Types\Types;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
@@ -40,6 +42,9 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
         $timeFormat = null;
         $icuDateTimePattern = '';
         $formattedValue = $field->getValue();
+
+        if($field->getValue() !== DateTimeInterface::class)
+                throw new Exception("Field \"".$field->getProperty()."\" is not an instance of DateTimeInterface (Wrong use of DateTimeField?)");
 
         if (DateTimeField::class === $field->getFieldFqcn()) {
             [$defaultDatePattern, $defaultTimePattern] = $crud->getDateTimePattern();


### PR DESCRIPTION
Add an exception in case one use a wrong entry type.
e.g. If the field is a char/string instead of a DateTime, it just generates an error. 
It would help to display the corresponding property name .

```
Uncaught PHP Exception TypeError: "Argument 1 passed to EasyCorp\Bundle\EasyAdminBundle\Intl\IntlFormatter::formatDateTime() must implement interface DateTimeInterface or be null, string given, called in /var/www/chapaland.com/www/vendor/easycorp/easyadmin-bundle/src/Field/Configurator/DateTimeConfigurator.php on line 60" at /var/www/chapaland.com/www/vendor/easycorp/easyadmin-bundle/src/Intl/IntlFormatter.php line 138
```
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
