### PR TITLE
Removing 2 `use`s...

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -299,8 +299,6 @@ create a CSS file and redefine the variable values:
 Then, load this CSS file in your dashboard and/or resource admin::
 
     use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
-    use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
-    use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 
     class DashboardController extends AbstractDashboardController
     {


### PR DESCRIPTION
...cause they are clear anyway (from the above examples). Now the really new and important `use` is standing out more.

BTW: The "edit this page" link on https://symfony.com/doc/current/bundles/EasyAdminBundle/design.html leads to 404 on GitHub.com
