### PR TITLE
Add symfony/deprecation-contracts to dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "symfony/string": "^5.0",
         "symfony/translation": "^4.4|^5.0",
         "symfony/twig-bundle": "^4.4|^5.0",
-        "symfony/uid": "^5.1"
+        "symfony/uid": "^5.1",
+        "symfony/deprecation-contracts": "^2.0"
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.4",


### PR DESCRIPTION
Fixes `Attempted to call function "trigger_deprecation" from namespace "EasyCorp\Bundle\EasyAdminBundle\Router".`

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
