### PR TITLE
Fix bug absolute upload dir on Windows

### DIFF
--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -158,7 +158,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
                 $value .= \DIRECTORY_SEPARATOR;
             }
 
-            if (0 !== mb_strpos($value, \DIRECTORY_SEPARATOR)) {
+            if (0 !== mb_strpos($value, $this->projectDir)) {
                 $value = $this->projectDir.'/'.$value;
             }
 


### PR DESCRIPTION
Hi Javier,

Thanks for that amazing EasyAdminBundle V3. I think normalizer for `FileUploadType` cause problems on Windows due to that OS doesn't follow POSIX standard.

For instance `$value` can be `C:\projects\project\public\upload` and don't start with `DIRECTORY_SEPARATOR`. Maybe we can simply check that starts with `$this->projectDir`.