### PR TITLE
Enable the use of VueJS

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -214,14 +214,14 @@
     {% block delete_form %}
         {{ include('@EasyAdmin/crud/includes/_delete_form.html.twig', with_context = false) }}
     {% endblock delete_form %}
-
-    {% if filters|length > 0 %}
-        {{ include('@EasyAdmin/crud/includes/_filters_modal.html.twig') }}
-    {% endif %}
 {% endblock main %}
 
 {% block body_javascript %}
     {{ parent() }}
+
+    {% if filters|length > 0 %}
+        {{ include('@EasyAdmin/crud/includes/_filters_modal.html.twig') }}
+    {% endif %}
 
     <script type="text/javascript">
         $(function() {


### PR DESCRIPTION
I've been trying to enhance our EasyAdmin with some VueJS.
I want to wrap most of the EasyAdmin HTML into a VueJS App, but one Problem i found was, that the
_filters_modal_html.twig is included quite "deep" into the HTML, which produces warnings when i try
to set up a vue app starting from the .content-wrapper for example.
The main issue is, that that template file contains a script tag with javascript code.
By moving it to the  body_javascript section everything works nicely together.