### PR TITLE
Allow to render the same field more than once in index/detail pages

### DIFF
--- a/src/Collection/FieldCollection.php
+++ b/src/Collection/FieldCollection.php
@@ -26,7 +26,7 @@ final class FieldCollection implements CollectionInterface
     public function __clone()
     {
         foreach ($this->fields as $fieldName => $fieldDto) {
-            $this->fields[$fieldName] = clone $fieldDto;
+            $this->fields[$fieldDto->getUniqueId()] = clone $fieldDto;
         }
     }
 
@@ -38,24 +38,40 @@ final class FieldCollection implements CollectionInterface
         return new self($fields);
     }
 
-    public function get(string $fieldName): ?FieldDto
+    public function get(string $fieldUniqueId): ?FieldDto
     {
-        return $this->fields[$fieldName] ?? null;
+        return $this->fields[$fieldUniqueId] ?? null;
+    }
+
+    /**
+     * It returns the first field with the given name or null if none found.
+     * Some pages (index/detail) can render the same field more than once.
+     * In those cases, this method always returns the first field occurrence.
+     */
+    public function getByName(string $fieldName): ?FieldDto
+    {
+        foreach ($this->fields as $field) {
+            if ($fieldName === $field->getProperty()) {
+                return $field;
+            }
+        }
+
+        return null;
     }
 
     public function set(FieldDto $newOrUpdatedField): void
     {
-        $this->fields[$newOrUpdatedField->getProperty()] = $newOrUpdatedField;
+        $this->fields[$newOrUpdatedField->getUniqueId()] = $newOrUpdatedField;
     }
 
     public function unset(FieldDto $removedField): void
     {
-        unset($this->fields[$removedField->getProperty()]);
+        unset($this->fields[$removedField->getUniqueId()]);
     }
 
     public function prepend(FieldDto $newField): void
     {
-        $this->fields = array_merge([$newField->getProperty() => $newField], $this->fields);
+        $this->fields = array_merge([$newField->getUniqueId() => $newField], $this->fields);
     }
 
     public function first(): ?FieldDto
@@ -124,7 +140,7 @@ final class FieldCollection implements CollectionInterface
 
             $dto = $field->getAsDto();
             $dto->setFieldFqcn(\get_class($field));
-            $dtos[$dto->getProperty()] = $dto;
+            $dtos[$dto->getUniqueId()] = $dto;
         }
 
         return $dtos;

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -39,6 +39,7 @@ final class FieldDto
 
     public function __construct()
     {
+        $this->uniqueId = new Ulid();
         $this->cssClass = '';
         $this->templateName = 'crud/field/text';
         $this->assets = new AssetsDto();
@@ -65,11 +66,7 @@ final class FieldDto
 
     public function getUniqueId(): string
     {
-        if (null !== $this->uniqueId) {
-            return $this->uniqueId;
-        }
-
-        return $this->uniqueId = new Ulid();
+        return $this->uniqueId;
     }
 
     public function isFormDecorationField(): bool

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -105,7 +105,7 @@
         <div class="content-panel">
             <div class="content-panel-header {{ collapsible ? 'collapsible' }} {{ field.help is not empty ? 'with-help' }}">
                 {% if collapsible %}
-                    <a href="#content-{{ field.property }}" data-toggle="collapse" class="content-panel-collapse {{ collapsed ? 'collapsed' }}" aria-expanded="{{ collapsed ? 'false' : 'true' }}" aria-controls="content-{{ field.property }}">
+                    <a href="#content-{{ field.uniqueId }}" data-toggle="collapse" class="content-panel-collapse {{ collapsed ? 'collapsed' }}" aria-expanded="{{ collapsed ? 'false' : 'true' }}" aria-controls="content-{{ field.uniqueId }}">
                         <i class="fas fw fa-chevron-right collapse-icon"></i>
                 {% endif %}
 
@@ -123,7 +123,7 @@
                 {% endif %}
             </div>
 
-            <div id="content-{{ field.property }}" class="content-panel-body without-footer without-padding {{ collapsible ? 'collapse' }} {{ not collapsed ? 'show'}}">
+            <div id="content-{{ field.uniqueId }}" class="content-panel-body without-footer without-padding {{ collapsible ? 'collapse' }} {{ not collapsed ? 'show'}}">
                 <dl class="datalist">
 {% endmacro %}
 


### PR DESCRIPTION
It's an alternative to #4178 and fixes #4178.

This allows to display the same field any number of times, but only in the pages controlled by EasyAdmin (index/detail). In the other pages (edit/new) you can't do that because they are controlled by Symfony Forms and they don't allow to render the same field twice in a single form.