### PR TITLE
Adding full path to `variables.scss`

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -279,7 +279,7 @@ Customizing the Backend Design
 
 The design of the backend is created with lots of CSS variables. This makes it
 easier to customize it to your own needs. You'll find all variables in the
-``assets/css/easyadmin-theme/variables.scss`` file. To override any of them,
+``vendor/easycorp/easyadmin-bundle/assets/css/easyadmin-theme/variables.scss`` file. To override any of them,
 create a CSS file and redefine the variable values:
 
 .. code-block:: text
@@ -316,7 +316,7 @@ Then, load this CSS file in your dashboard and/or resource admin::
     Because of how Bootstrap styles are defined, it's not possible to use CSS
     variables to override every style. Sometimes you may need to also override
     the value of some `Sass`_ variables (which are also defined in the same
-    ``assets/css/easyadmin-theme/variables.scss`` file).
+    ``vendor/easycorp/easyadmin-bundle/assets/css/easyadmin-theme/variables.scss`` file).
 
 CSS Selectors
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Questions:
* `--body-max-width` is not included in the mentioned `.scss` file, but rather in its sibling `.css` file, so the code block doesn't really reflect what the text says.
* So how can a scss variable (e.g. `$body-bg`) be overwritten then?
* Specifically, I'm looking for a way to increase `max-width` on each `<input>`.

BTW: The "edit this page" link on https://symfony.com/doc/current/bundles/EasyAdminBundle/design.html is broken.
