### PR TITLE
[FIX] Orm/EntityRepository->addOrderClause()

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -144,8 +144,8 @@ final class EntityRepository implements EntityRepositoryInterface
 
     private function addOrderClause(QueryBuilder $queryBuilder, SearchDto $searchDto, EntityDto $entityDto): void
     {
-        $aliases = $queryBuilder->getAllAliases();
         foreach ($searchDto->getSort() as $sortProperty => $sortOrder) {
+            $aliases = $queryBuilder->getAllAliases();
             $sortFieldIsDoctrineAssociation = $entityDto->isAssociation($sortProperty);
 
             if ($sortFieldIsDoctrineAssociation) {


### PR DESCRIPTION
It's necessary to get all aliases inside the for because there are new ones with the leftJoin.
If not, when we order by an asociationField the associated entity is left join twice.

Fixes error: [Semantical Error] line 0, col 105 near '<alias> ORDER': Error: '<alias>' is already defined.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
