### PR TITLE
Fix to make setFieldFqcn() work in configureFields of entity CrudController

### DIFF
--- a/src/Collection/FieldCollection.php
+++ b/src/Collection/FieldCollection.php
@@ -143,7 +143,9 @@ final class FieldCollection implements CollectionInterface
             }
 
             $dto = $field->getAsDto();
-            $dto->setFieldFqcn(\get_class($field));
+            if (null === $dto->getFieldFqcn()) {
+                $dto->setFieldFqcn(\get_class($field));
+            }
             $dtos[$dto->getUniqueId()] = $dto;
         }
 

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -80,7 +80,7 @@ final class FieldDto
         return null !== u($this->getCssClass())->indexOf('field-form_panel');
     }
 
-    public function getFieldFqcn(): string
+    public function getFieldFqcn(): ?string
     {
         return $this->fieldFqcn;
     }


### PR DESCRIPTION
Hi.
The problem:
I have an entity called `Webinar` and it has a field called `partnerLogoImage`, which is another entity called `ImageItem` with `$fileName` and `$altText` fields. `partnerLogoImage` is set as a one-to-one relationship from `Webinar` to `ImageItem`

In my WebinarCrudController.php I am trying to display `partnerLogoImage` via custom form type with this code:
```
public function configureFields(string $pageName): iterable
    {
        return [
            FormField::addPanel('Meta Properties')
                ->collapsible(true),
            Field::new('partnerLogoImage')
                ->setFieldFqcn(ImageItem::class)
                ->setFormType(ImageItemForm::class)
                ->onlyOnForms(),
        ];
    }
```
ImageItemForm.php code:
```
<?php

declare(strict_types=1);

namespace App\Bundle\...\UI\Controller\Admin\Form;

use App\Bundle\...\Domain\Entity\ImageItem;
use App\Bundle\...\Domain\Factory\ImageItemFactoryInterface;
use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\Extension\Core\Type\TextareaType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\Form\FormInterface;
use Symfony\Component\OptionsResolver\OptionsResolver;
use Vich\UploaderBundle\Form\Type\VichImageType;

class ImageItemForm extends AbstractType
{
    private ImageItemFactoryInterface $imageItemFactory;

    public function __construct(ImageItemFactoryInterface $imageItemFactory)
    {
        $this->imageItemFactory = $imageItemFactory;
    }

    public function buildForm(FormBuilderInterface $builder, array $options): void
    {
        $builder
            ->add('file', VichImageType::class, [
                'required' => false,
            ])
            ->add('altText', TextareaType::class, [
                'required' => false,
            ])
        ;
    }

    public function configureOptions(OptionsResolver $resolver): void
    {
        $resolver->setDefaults([
            'data_class' => ImageItem::class,
            'empty_data' => function (FormInterface $form) {
                return $this->imageItemFactory->create('');
            },
        ]);
    }
}
```

And am getting this error:
![image](https://user-images.githubusercontent.com/13430700/108202118-d8939000-714a-11eb-9e90-f745fae9e37d.png)

So i found that setFieldFqcn method in the crud controller
```
            Field::new('partnerLogoImage')
                ->setFieldFqcn(ImageItem::class)
```
is not actually working due to the code in FieldCollection.php which is overwriting the fieldFqcn:
```$dto->setFieldFqcn(\get_class($field));```

Then I've tried to add a condition to that code (see the changes) and the error is gone, the form is displayed on the edit screen.
![image](https://user-images.githubusercontent.com/13430700/108203921-52c51400-714d-11eb-99b0-156b4dcf4c5b.png)


This is my proposed fix for this problem.
