### PR TITLE
Fix #4188

### DIFF
--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -204,10 +204,6 @@ class AdminRouterSubscriber implements EventSubscriberInterface
             $controllerFqcn = \get_class($controller);
         }
 
-        if (null === $controllerFqcn) {
-            throw new \InvalidArgumentException('The type of the _controller request attribute is not supported (it must be a string, an array or an object).');
-        }
-
         return is_subclass_of($controllerFqcn, DashboardControllerInterface::class) ? $controllerFqcn : null;
     }
 


### PR DESCRIPTION
Fix #4188 by not throwing an exception when the controller is null to avoid some conflicts with LexikJWTAuthenticationBundle for example.

At this time we don't know why/how/when this happens as said by javiereguiluz in the issue...