### PR TITLE
Add support for loading Webpack Encore entries

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -246,6 +246,10 @@ the :doc:`CRUD controllers </crud>` to add your own CSS and JavaScript files::
         public function configureAssets(Assets $assets): Assets
         {
             return $assets
+                // adds the CSS and JS assets associated to the given Webpack Encore entry
+                // it's equivalent to calling encore_entry_link_tags('...') and encore_entry_script_tags('...')
+                ->addWebpackEncoreEntry('admin-app')
+
                 // the argument of these methods is passed to the asset() Twig function
                 // CSS assets are added just before the closing </head> element
                 // and JS assets are added just before the closing </body> element

--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -414,12 +414,20 @@ for a given postal address. This is the class you could create for the field::
             return (new self())
                 ->setProperty($propertyName)
                 ->setLabel($label)
+
                 // this template is used in 'index' and 'detail' pages
                 ->setTemplatePath('admin/field/map.html.twig')
+
                 // this is used in 'edit' and 'new' pages to edit the field contents
                 // you can use your own form types too
                 ->setFormType(TextareaType::class)
                 ->addCssClass('field-map')
+
+                // loads the CSS and JS assets associated to the given Webpack Encore entry
+                // in any CRUD page (index/detail/edit/new). It's equivalent to calling
+                // encore_entry_link_tags('...') and encore_entry_script_tags('...')
+                ->addWebpackEncoreEntry('admin-field-map')
+
                 // these methods allow to define the web assets loaded when the
                 // field is displayed in any CRUD page (index/detail/edit/new)
                 ->addCssFiles('js/admin/field-map.css')

--- a/src/Config/Assets.php
+++ b/src/Config/Assets.php
@@ -24,6 +24,17 @@ final class Assets
         return new self($dto);
     }
 
+    public function addWebpackEncoreEntry(string $entryName): self
+    {
+        if (!class_exists('Symfony\\WebpackEncoreBundle\\Twig\\EntryFilesTwigExtension')) {
+            throw new \RuntimeException('You are trying to add Webpack Encore entries in the backend but Webpack Encore is not installed in your project. Try running "composer req symfony/webpack-encore-bundle"');
+        }
+
+        $this->dto->addWebpackEncoreEntry($entryName);
+
+        return $this;
+    }
+
     public function addCssFile(string $path): self
     {
         $this->dto->addCssFile($path);

--- a/src/Dto/AssetsDto.php
+++ b/src/Dto/AssetsDto.php
@@ -7,6 +7,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
  */
 final class AssetsDto
 {
+    private $webpackEncoreEntries = [];
     private $cssFiles = [];
     private $jsFiles = [];
     private $headContents = [];
@@ -14,6 +15,15 @@ final class AssetsDto
 
     public function __construct()
     {
+    }
+
+    public function addWebpackEncoreEntry(string $entryName): void
+    {
+        if (\in_array($entryName, $this->webpackEncoreEntries, true)) {
+            return;
+        }
+
+        $this->webpackEncoreEntries[] = $entryName;
     }
 
     public function addCssFile(string $path): void
@@ -52,6 +62,11 @@ final class AssetsDto
         $this->bodyContents[] = $htmlContent;
     }
 
+    public function getWebpackEncoreEntries(): array
+    {
+        return $this->webpackEncoreEntries;
+    }
+
     public function getCssFiles(): array
     {
         return $this->cssFiles;
@@ -74,6 +89,7 @@ final class AssetsDto
 
     public function mergeWith(self $assetDto): self
     {
+        $this->webpackEncoreEntries = array_unique(array_merge($this->webpackEncoreEntries, $assetDto->getWebpackEncoreEntries()));
         $this->cssFiles = array_unique(array_merge($this->cssFiles, $assetDto->getCssFiles()));
         $this->jsFiles = array_unique(array_merge($this->jsFiles, $assetDto->getJsFiles()));
         $this->headContents = array_unique(array_merge($this->headContents, $assetDto->getHeadContents()));

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -292,6 +292,11 @@ final class FieldDto
         $this->assets = $assets;
     }
 
+    public function addWebpackEncoreEntry(string $entryName): void
+    {
+        $this->assets->addWebpackEncoreEntry($entryName);
+    }
+
     public function addCssFile(string $cssFilePath): void
     {
         $this->assets->addCssFile($cssFilePath);

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -183,6 +183,19 @@ trait FieldTrait
         return $this;
     }
 
+    public function addWebpackEncoreEntries(string ...$entryNames): self
+    {
+        if (!class_exists('Symfony\\WebpackEncoreBundle\\Twig\\EntryFilesTwigExtension')) {
+            throw new \RuntimeException('You are trying to add Webpack Encore entries in a field but Webpack Encore is not installed in your project. Try running "composer req symfony/webpack-encore-bundle"');
+        }
+
+        foreach ($entryNames as $entryName) {
+            $this->dto->addWebpackEncoreEntry($entryName);
+        }
+
+        return $this;
+    }
+
     public function addCssFiles(string ...$assetPaths): self
     {
         foreach ($assetPaths as $path) {

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -27,12 +27,20 @@
     {% for css_asset in edit_form.vars.ea_crud_form.assets.cssFiles %}
         <link rel="stylesheet" href="{{ asset(css_asset) }}">
     {% endfor %}
+
+    {% for webpack_encore_entry in edit_form.vars.ea_crud_form.assets.webpackEncoreEntries %}
+        {{ ea_call_function_if_exists('encore_entry_link_tags', webpack_encore_entry) }}
+    {% endfor %}
 {% endblock %}
 
 {% block configured_javascripts %}
     {{ parent() }}
     {% for js_asset in edit_form.vars.ea_crud_form.assets.jsFiles %}
         <script src="{{ asset(js_asset) }}"></script>
+    {% endfor %}
+
+    {% for webpack_encore_entry in edit_form.vars.ea_crud_form.assets.webpackEncoreEntries %}
+        {{ ea_call_function_if_exists('encore_entry_script_tags', webpack_encore_entry) }}
     {% endfor %}
 {% endblock %}
 

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -20,12 +20,20 @@
     {% for css_asset in new_form.vars.ea_crud_form.assets.cssFiles %}
         <link rel="stylesheet" href="{{ asset(css_asset) }}">
     {% endfor %}
+
+    {% for webpack_encore_entry in new_form.vars.ea_crud_form.assets.webpackEncoreEntries %}
+        {{ ea_call_function_if_exists('encore_entry_link_tags', webpack_encore_entry) }}
+    {% endfor %}
 {% endblock %}
 
 {% block configured_javascripts %}
     {{ parent() }}
     {% for js_asset in new_form.vars.ea_crud_form.assets.jsFiles %}
         <script src="{{ asset(js_asset) }}"></script>
+    {% endfor %}
+
+    {% for webpack_encore_entry in new_form.vars.ea_crud_form.assets.webpackEncoreEntries %}
+        {{ ea_call_function_if_exists('encore_entry_script_tags', webpack_encore_entry) }}
     {% endfor %}
 {% endblock %}
 

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -22,6 +22,10 @@
         {% for css_asset in ea.assets.cssFiles ?? [] %}
             <link rel="stylesheet" href="{{ asset(css_asset) }}">
         {% endfor %}
+
+        {% for webpack_encore_entry in ea.assets.webpackEncoreEntries ?? [] %}
+            {{ ea_call_function_if_exists('encore_entry_link_tags', webpack_encore_entry) }}
+        {% endfor %}
     {% endblock %}
 
     {% block head_favicon %}
@@ -200,6 +204,10 @@
     {% block configured_javascripts %}
         {% for js_asset in ea.assets.jsFiles ?? [] %}
             <script src="{{ asset(js_asset) }}"></script>
+        {% endfor %}
+
+        {% for webpack_encore_entry in ea.assets.webpackEncoreEntries ?? [] %}
+            {{ ea_call_function_if_exists('encore_entry_script_tags', webpack_encore_entry) }}
         {% endfor %}
     {% endblock %}
 

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -30,6 +30,7 @@ class EasyAdminTwigExtension extends AbstractExtension
     {
         return [
             new TwigFunction('ea_url', [$this, 'getAdminUrlGenerator']),
+            new TwigFunction('ea_call_function_if_exists', [$this, 'callFunctionIfExists'], ['needs_environment' => true, 'is_safe' => ['html' => true]]),
         ];
     }
 
@@ -82,6 +83,15 @@ class EasyAdminTwigExtension extends AbstractExtension
         }
 
         return $filter->getCallable()($value, ...$filterArguments);
+    }
+
+    public function callFunctionIfExists(Environment $environment, string $functionName, ...$functionArguments)
+    {
+        if (false === $function = $environment->getFunction($functionName)) {
+            return '';
+        }
+
+        return $function->getCallable()(...$functionArguments);
     }
 
     public function getAdminUrlGenerator(array $queryParameters = []): AdminUrlGenerator


### PR DESCRIPTION
Fixes #4213.

The method name is a bit long (`addWebpackEncoreEntry()`) but I prefer it because it's completely explicit about its intent.