### PR TITLE
[3.x][Fix] Don't call method_exists() for non-objects

### DIFF
--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -69,7 +69,7 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
 
         $collectionItemsAsText = [];
         foreach ($field->getValue() ?? [] as $item) {
-            if (!\is_string($item) && !method_exists($item, '__toString')) {
+            if (!\is_string($item) && !(\is_object($item) && method_exists($item, '__toString'))) {
                 return $this->countNumElements($field->getValue());
             }
 

--- a/src/Field/Configurator/TextConfigurator.php
+++ b/src/Field/Configurator/TextConfigurator.php
@@ -32,7 +32,7 @@ final class TextConfigurator implements FieldConfiguratorInterface
             return;
         }
 
-        if (!\is_string($value) && !method_exists($value, '__toString')) {
+        if (!\is_string($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
             throw new \RuntimeException(sprintf('The value of the "%s" field of the entity with ID = "%s" can\'t be converted into a string, so it cannot be represented by a TextField.', $field->getProperty(), $entityDto->getPrimaryKeyValue()));
         }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

In PHP8 calling `method_exists` on variables which are not `object`or `string` [throws an error](https://github.com/EasyCorp/EasyAdminBundle/issues/3984#issuecomment-791972418)
  