### PR TITLE
Reset select2 max-width property

### DIFF
--- a/assets/css/easyadmin-theme/forms.scss
+++ b/assets/css/easyadmin-theme/forms.scss
@@ -121,7 +121,8 @@ label.form-check-label {
 
 .full-width .form-widget input.form-control,
 .full-width .form-widget textarea.form-control,
-.full-width .form-widget select.form-control {
+.full-width .form-widget select.form-control,
+.full-width .form-widget .select2-container--bootstrap .select2-selection {
     max-width: none;
 }
 


### PR DESCRIPTION
I believe this resolves #4242 that select2 max-width property should be imo reseted within .full-width class like the other form elements. Current behaviour makes rendering of select2 broken as the select2-selection__arrow is outside of the element.

