### PR TITLE
Fixing minor PHPDoc error causing static analysis to fail

### DIFF
--- a/src/Config/UserMenu.php
+++ b/src/Config/UserMenu.php
@@ -72,7 +72,7 @@ final class UserMenu
     }
 
     /**
-     * @param MenuItem[] $items
+     * @param MenuItemInterface[] $items
      */
     public function setMenuItems(array $items): self
     {


### PR DESCRIPTION
Hi,
I'm getting errors from PHPStan when I use the `setMenuItems(...)` method from `EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu` like this:
```php
// My dashboard controller
// ...
    public function configureUserMenu(UserInterface $user): UserMenu
    {
        return parent::configureUserMenu($user)
            ->setName($user->getUsername())
            ->setGravatarEmail($user->getUsername())
            ->setMenuItems([MenuItem::linkToLogout('__ea__user.sign_out', 'fa fa-sign-out')])
        ;
    }
// ...
```

The analysis output says:
```
Parameter #1 $items of method EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu::setMenuItems() expects array<EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem>, array<int, EasyCorp\Bundle\EasyAdminBundle\Config\Menu\LogoutMenuItem> given.
```

I think that this minor PHPDoc change should fix that.

What do you think?