### PR TITLE
Update AdminUrlGenerator usage and add a note

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -469,7 +469,8 @@ Generating Admin URLs
 .. versionadded:: 3.2
 
     The ``AdminUrlGenerator`` class was introduced in EasyAdmin 3.2.0. In earlier
-    versions, you had to use the ``CrudUrlGenerator`` class.
+    versions, you had to use the ``CrudUrlGenerator`` class and call the
+    ``build()`` method to start building a URL.
 
 :ref:`As explained <dashboard-route>` in the article about Dashboards, all URLs
 of a given dashboard use the same route and they only differ in the query string


### PR DESCRIPTION
The build method isn't existing and isn't needed anymore and it produces an exception.

Attempted to call an undefined method named "build" of class "EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator"

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
