### PR TITLE
Translate default title only if custom title is null

### DIFF
--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -9,9 +9,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set default_title = ea.crud.defaultPageTitle('detail', entity.instance)|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
-        {% set custom_title = ea.crud.customPageTitle('detail', entity.instance) %}
-        {{ custom_title is null ? default_title|raw : custom_title|trans(ea.i18n.translationParameters)|raw }}
+        {{ ea.crud.customPageTitle is null
+            ? (ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle'))|raw
+            : ea.crud.customPageTitle|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -46,9 +46,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set default_title = ea.crud.defaultPageTitle('edit', entity.instance)|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
-        {% set custom_title = ea.crud.customPageTitle('edit', entity.instance) %}
-        {{ custom_title is null ? default_title|raw : custom_title|trans(ea.i18n.translationParameters)|raw }}
+        {{ ea.crud.customPageTitle is null
+            ? (ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle'))|raw
+            : ea.crud.customPageTitle|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 


### PR DESCRIPTION
Edit and detail action sets content_title block with redundant translation call. In some cases it is also trying to translate string which should not be translated.

Consider User entity with __toString() { return $this->email; }. CrudDto::getDefaultPageTitle return some email address as string and template try to translate it with `EasyAdminBundle` translation domain. There is no way to skip this translation.

This PR does not solve the whole problem, but it skips redundant translation call if not neccessary when you have custom title defined.