### PR TITLE
Added a new NullFilter option

### DIFF
--- a/doc/filters.rst
+++ b/doc/filters.rst
@@ -70,6 +70,9 @@ These are the built-in filters provided by EasyAdmin:
 * ``EntityFilter``: applied to fields with Doctrine associations (all kinds
   supported). It's rendered as a ``<select>`` list with the condition (equal/not
   equal/etc.) and another ``<select>`` list to choose the comparison value.
+* ``NullFilter``: it's not applied by default to any field. It's useful to
+  filter results depending on the "null" or "not null" value of a property.
+  It's rendered as two radio buttons for the null and not null options.
 * ``NumericFilter``: applied by default to numeric fields.
   It's rendered as a ``<select>`` list with the condition (higher/lower/equal/etc.) and a
   ``<input>`` to define the comparison value.

--- a/src/Filter/Configurator/NullConfigurator.php
+++ b/src/Filter/Configurator/NullConfigurator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\NullFilter;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class NullConfigurator implements FilterConfiguratorInterface
+{
+    public function supports(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): bool
+    {
+        return NullFilter::class === $filterDto->getFqcn();
+    }
+
+    public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
+    {
+        if (empty($filterDto->getFormTypeOption('choices'))) {
+            throw new \InvalidArgumentException(sprintf('The Null filter associated to the "%s" property does not define the labels of the NULL and NOT NULL options. Define them with the setChoiceLabels() method.', $filterDto->getProperty()));
+        }
+    }
+}

--- a/src/Filter/NullFilter.php
+++ b/src/Filter/NullFilter.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Filter;
+
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\NullFilterType;
+
+/**
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class NullFilter implements FilterInterface
+{
+    use FilterTrait;
+
+    private const CHOICE_VALUE_NULL = 'null';
+    private const CHOICE_VALUE_NOT_NULL = 'not_null';
+
+    public static function new(string $propertyName, $label = null): self
+    {
+        return (new self())
+            ->setFilterFqcn(__CLASS__)
+            ->setProperty($propertyName)
+            ->setLabel($label)
+            ->setFormType(NullFilterType::class);
+    }
+
+    public function setChoiceLabels(string $nullChoiceLabel, string $notNullChoiceLabel): self
+    {
+        $this->dto->setFormTypeOption('choices', [
+            $nullChoiceLabel => self::CHOICE_VALUE_NULL,
+            $notNullChoiceLabel => self::CHOICE_VALUE_NOT_NULL,
+        ]);
+
+        return $this;
+    }
+
+    public function apply(QueryBuilder $queryBuilder, FilterDataDto $filterDataDto, ?FieldDto $fieldDto, EntityDto $entityDto): void
+    {
+        $comparison = self::CHOICE_VALUE_NULL === $filterDataDto->getValue() ? 'IS' : 'IS NOT';
+        $queryBuilder
+            ->andWhere(sprintf('%s.%s %s NULL', $filterDataDto->getEntityAlias(), $filterDataDto->getProperty(), $comparison));
+    }
+}

--- a/src/Form/Filter/Type/NullFilterType.php
+++ b/src/Form/Filter/Type/NullFilterType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * @author Yonel Ceruto <yonelceruto@gmail.com>
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class NullFilterType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'expanded' => true,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -54,6 +54,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\CommonConfigurator as Co
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\ComparisonConfigurator as ComparisonFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\DateTimeConfigurator as DateTimeFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\EntityConfigurator as EntityFilterConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\NullConfigurator as NullFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\NumericConfigurator as NumericFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\TextConfigurator as TextFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Extension\CollectionTypeExtension;
@@ -272,6 +273,8 @@ return static function (ContainerConfigurator $container) {
         ->set(DateTimeFilterConfigurator::class)
 
         ->set(EntityFilterConfigurator::class)
+
+        ->set(NullFilterConfigurator::class)
 
         ->set(NumericFilterConfigurator::class)
 


### PR DESCRIPTION
In some of my apps I had to use filters like this, so I thought this could be useful to others. It's like a boolean filter, but instead of true/false, you filter by "null" / "not null". It's used like this:

```php
NullFilter::new('invoice')->setChoiceLabels('Invoice is missing', 'Has invoice')
```