### PR TITLE
Displays the filter at the correct position when search is disabled

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -46,9 +46,9 @@
 
     {% if has_datagrid_tools %}
         <div class="datagrid-header-tools">
-            <div class="datagrid-search">
-                {% block search %}
-                    {% if has_search %}
+            {% block search %}
+                {% if has_search %}
+                    <div class="datagrid-search">
                         <div class="form-action form-action-search">
                             <form method="get">
                                 {% block search_form %}
@@ -77,9 +77,9 @@
                                 {% endblock %}
                             </form>
                         </div>
-                    {% endif %}
-                {% endblock search %}
-            </div>
+                    </div>
+                {% endif %}
+            {% endblock search %}
 
             <div class="datagrid-filters">
                 {% block filters %}


### PR DESCRIPTION
This fixes the empty search container taking up space left to the filter:
![image](https://user-images.githubusercontent.com/922919/114899655-6f12c380-9e13-11eb-88ab-1f5c29e04e0e.png)

it will become this:
![image](https://user-images.githubusercontent.com/922919/114899727-818cfd00-9e13-11eb-85ed-e7463765ca7d.png)
