### PR TITLE
Fix: sorting by specific field of the AssociatedField #4307

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -105,17 +105,11 @@ final class FieldDto
         $this->propertyName = $propertyName;
     }
 
-    /**
-     * @param string $sortBy
-     */
     public function setSortBy(string $sortBy): void
     {
         $this->sortBy = $sortBy;
     }
 
-    /**
-     * @return string
-     */
     public function getSortBy()
     {
         return $this->sortBy;

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -105,7 +105,7 @@ final class FieldDto
         $this->propertyName = $propertyName;
     }
 
-    public function setSortBy(string $sortBy): void
+    public function setSortBy(?string $sortBy): void
     {
         $this->sortBy = $sortBy;
     }

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -21,6 +21,7 @@ final class FieldDto
     private $formType;
     private $formTypeOptions;
     private $sortable;
+    private $sortBy;
     private $virtual;
     private $permission;
     private $textAlign;
@@ -102,6 +103,22 @@ final class FieldDto
     public function setProperty(string $propertyName): void
     {
         $this->propertyName = $propertyName;
+    }
+
+    /**
+     * @param string $sortBy
+     */
+    public function setSortBy(string $sortBy): void
+    {
+        $this->sortBy = $sortBy;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSortBy()
+    {
+        return $this->sortBy;
     }
 
     /**

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -148,9 +148,9 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         return $entityDto->hasProperty($field->getProperty());
     }
 
-    private function buildSortBy(FieldDto $field): string
+    private function buildSortBy(FieldDto $field): ?string
     {
-        return null !== $field->getSortby() ? $field->getSortby() : 'id';
+        return $field->getSortby();
     }
 
     private function buildVirtualOption(FieldDto $field, EntityDto $entityDto): bool

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -150,7 +150,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
 
     private function buildSortBy(FieldDto $field): string
     {
-        return $field->getSortby() !== null ? $field->getSortby() : 'id';
+        return null !== $field->getSortby() ? $field->getSortby() : 'id';
     }
 
     private function buildVirtualOption(FieldDto $field, EntityDto $entityDto): bool

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -51,6 +51,9 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         $isSortable = $this->buildSortableOption($field, $entityDto);
         $field->setSortable($isSortable);
 
+        $sortableBy = $this->buildSortBy($field);
+        $field->setSortBy($sortableBy);
+
         $isVirtual = $this->buildVirtualOption($field, $entityDto);
         $field->setVirtual($isVirtual);
 
@@ -143,6 +146,11 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         }
 
         return $entityDto->hasProperty($field->getProperty());
+    }
+
+    private function buildSortBy(FieldDto $field): string
+    {
+        return $field->getSortby() !== null ? $field->getSortby() : 'id';
     }
 
     private function buildVirtualOption(FieldDto $field, EntityDto $entityDto): bool

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -116,6 +116,7 @@ trait FieldTrait
 
         return $this;
     }
+
     public function setSortBy(string $sortableBy): self
     {
         $this->dto->setSortBy($sortableBy);

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -117,7 +117,7 @@ trait FieldTrait
         return $this;
     }
 
-    public function setSortBy(string $sortableBy): self
+    public function setSortBy(?string $sortableBy): self
     {
         $this->dto->setSortBy($sortableBy);
 

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -181,6 +181,19 @@ trait FieldTrait
         return $this;
     }
 
+    public function addWebpackEncoreEntries(string ...$entryNames): self
+    {
+        if (!class_exists('Symfony\\WebpackEncoreBundle\\Twig\\EntryFilesTwigExtension')) {
+            throw new \RuntimeException('You are trying to add Webpack Encore entries in a field but Webpack Encore is not installed in your project. Try running "composer req symfony/webpack-encore-bundle"');
+        }
+
+        foreach ($entryNames as $entryName) {
+            $this->dto->addWebpackEncoreEntry($entryName);
+        }
+
+        return $this;
+    }
+
     public function setTemplatePath(string $path): self
     {
         $this->dto->setTemplateName(null);

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -116,6 +116,12 @@ trait FieldTrait
 
         return $this;
     }
+    public function setSortBy(string $sortableBy): self
+    {
+        $this->dto->setSortBy($sortableBy);
+
+        return $this;
+    }
 
     public function setPermission(string $permission): self
     {

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -119,13 +119,13 @@
                         {% set ea_sort_asc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::ASC') %}
                         {% set ea_sort_desc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::DESC') %}
                         {% for field in entities|first.fields ?? [] %}
-                            {% set is_sorting_field = ea.search.isSortingField(field.property) %}
-                            {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
+                            {% set is_sorting_field = ea.search.isSortingField(field.sortableBy ? field.sortableBy : field.property) %}
+                            {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.sortableBy ? field.sortableBy : field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
                             {% set column_icon = is_sorting_field ? (next_sort_direction == ea_sort_desc ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
 
                             <th class="{{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} text-{{ field.textAlign }}" dir="{{ ea.i18n.textDirection }}">
                                 {% if field.isSortable %}
-                                    <a href="{{ ea_url({ page: 1, sort: { (field.property): next_sort_direction } }).includeReferrer() }}">
+                                    <a href="{{ ea_url({ page: 1, sort: { (field.sortableBy ? field.sortableBy : field.property): next_sort_direction } }).includeReferrer() }}">
                                         {{ field.label|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
                                     </a>
                                 {% else %}

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -119,13 +119,13 @@
                         {% set ea_sort_asc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::ASC') %}
                         {% set ea_sort_desc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::DESC') %}
                         {% for field in entities|first.fields ?? [] %}
-                            {% set is_sorting_field = ea.search.isSortingField(field.sortableBy ? field.sortableBy : field.property) %}
-                            {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.sortableBy ? field.sortableBy : field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
+                            {% set is_sorting_field = ea.search.isSortingField(field.sortBy ? field.sortBy : field.property) %}
+                            {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.sortBy ? field.sortBy : field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
                             {% set column_icon = is_sorting_field ? (next_sort_direction == ea_sort_desc ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
 
                             <th class="{{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} text-{{ field.textAlign }}" dir="{{ ea.i18n.textDirection }}">
                                 {% if field.isSortable %}
-                                    <a href="{{ ea_url({ page: 1, sort: { (field.sortableBy ? field.sortableBy : field.property): next_sort_direction } }).includeReferrer() }}">
+                                    <a href="{{ ea_url({ page: 1, sort: { (field.sortBy ? field.sortBy : field.property): next_sort_direction } }).includeReferrer() }}">
                                         {{ field.label|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
                                     </a>
                                 {% else %}


### PR DESCRIPTION
By default, the sorting with AssociatedField is with the ```id```.
This PR introduces sorting by specific field of the AssociatedField.
 
Exemple of usage:
 ```php
 public function configureFields(string $pageName): iterable
    {
        return [
            TextField::new('first', 'Prénom'),
            TextField::new('last', 'Nom'),
            EmailField::new('email', 'Email'),
            AssociationField::new('company', 'Structure')
                ->setSortBy('company.name')
                ->autocomplete()
                ->setRequired(true)
        ]);
    }
 ```
 
 https://user-images.githubusercontent.com/40602497/115112470-fc762500-9f85-11eb-9102-9639b9beaa81.mov
 
 Fix: #4307