### PR TITLE
Disable spellcheck and autocorrect in search field

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -65,7 +65,7 @@
 
                                     <div class="form-group">
                                         <div class="form-widget">
-                                            <input class="form-control" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ 'action.search'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}">
+                                            <input class="form-control" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ 'action.search'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}" spellcheck="false" autocorrect="false">
 
                                             {% if app.request.get('query') %}
                                                 <a href="{{ ea_url().unset('query') }}" class="action-search-reset">


### PR DESCRIPTION
This might be controversial for some ... but I've thought a lot about this and I think we should do it.

It's common to input non-existing words in the search box (e.g. codes/IDs) and then you wrongly see the spell-checker in action. Same for autocorrect, which can (wrongly) change what you are searching for.

For reference:

* Laravel Nova did this change recently (https://nova.laravel.com/releases/3.20.0)
* Stripe does the same in https://dashboard.stripe.com/