### PR TITLE
Fix typo for batch action documentation

### DIFF
--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -365,10 +365,10 @@ First, add it to your action configuration using the ``addBatchAction()`` method
         {
             return $actions
                 // ...
-                ->addBatchAction(Action::new('approve', 'Approve Users'))
+                ->addBatchAction(Action::new('approve', 'Approve Users')
                     ->linkToCrudAction('approveUsers')
                     ->addCssClass('btn btn-primary')
-                    ->setIcon('fa fa-user-check')
+                    ->setIcon('fa fa-user-check'))
             ;
         }
     }


### PR DESCRIPTION
Fix the exemple given to illustrate the batch actions as closing parenthesis is not at the right place

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
