### PR TITLE
Fix return type for getFormType

### DIFF
--- a/src/Dto/FilterDto.php
+++ b/src/Dto/FilterDto.php
@@ -32,7 +32,7 @@ final class FilterDto
         $this->fqcn = $fqcn;
     }
 
-    public function getFormType(): string
+    public function getFormType(): ?string
     {
         return $this->formType;
     }


### PR DESCRIPTION
This little PR is given to address a bug I encountered in my current project.

Explanation :

I created a custom Filter to handle deep relation filter management (filter on field -> relation1 -> relationxx -> field)
My filter has a guesser to autoconfigure the form type via a configurator to avoid setting the type each time I use the filter
My problem is that I'd like to allow custom form type set when declaring the filter in my controller and not overwrite it in configurator.
The only way to do it is checking in my configurator if a form type has already been configured.

Pb : return type is expected only a string so calling getFormType before setting it throw an error

Hope you can address this issue and accept this PR

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
