### PR TITLE
Fix filters link when page load slowly

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -86,7 +86,7 @@
                     {% if filters|length > 0 %}
                         {% set applied_filters = ea.request.query.all['filters']|default([])|keys %}
                         <div class="btn-group action-filters">
-                            <a href="{{ ea_url().setAction('renderFilters').includeReferrer() }}" class="btn btn-secondary btn-labeled btn-labeled-right action-filters-button {{ applied_filters ? 'action-filters-applied' }}" data-modal="#modal-filters">
+                            <a href="#" data-href="{{ ea_url().setAction('renderFilters').includeReferrer() }}" class="btn btn-secondary btn-labeled btn-labeled-right action-filters-button disabled {{ applied_filters ? 'action-filters-applied' }}" data-modal="#modal-filters">
                                 <i class="fa fa-filter fa-fw"></i> {{ 'filter.title'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}{% if applied_filters %} <span class="text-primary">({{ applied_filters|length }})</span>{% endif %}
                             </a>
                             {% if applied_filters %}
@@ -277,8 +277,8 @@
                 });
             };
 
-            document.querySelector('.action-filters-button').addEventListener('click', function(event) {
-                let filterButton = event.currentTarget;
+            let filterButton = document.querySelector('.action-filters-button');
+            filterButton.addEventListener('click', function(event) {
                 let filterModal = document.querySelector(filterButton.dataset.modal);
                 let filterModalBody = filterModal.querySelector('.modal-body');
 
@@ -292,6 +292,9 @@
                 event.preventDefault();
                 event.stopPropagation();
             });
+            filterButton.setAttribute('href', filterButton.getAttribute('data-href'));
+            filterButton.removeAttribute('data-href');
+            filterButton.classList.remove('disabled');
             {% endif %}
 
 


### PR DESCRIPTION
A workaround appended when your index page is loading slowly (big content, slow connection, . . ).
The filters link is active but not wrapped by event listener so click on it before dom is fully loaded load filter content in browser.

This fix simply disable link until page is fully loaded

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
