### PR TITLE
Improve CRUDController

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -238,7 +238,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
                 return $event->getResponse();
             }
 
-            $submitButtonName = $context->getRequest()->request->get('ea')['newForm']['btn'];
+            $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];
             if (Action::SAVE_AND_CONTINUE === $submitButtonName) {
                 $url = $this->get(AdminUrlGenerator::class)
                     ->setAction(Action::EDIT)
@@ -321,7 +321,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
             $context->getEntity()->setInstance($entityInstance);
 
-            $submitButtonName = $context->getRequest()->request->get('ea')['newForm']['btn'];
+            $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];
             if (Action::SAVE_AND_CONTINUE === $submitButtonName) {
                 $url = $this->get(AdminUrlGenerator::class)
                     ->setAction(Action::EDIT)

--- a/src/Event/AfterEntityDeletedEvent.php
+++ b/src/Event/AfterEntityDeletedEvent.php
@@ -7,6 +7,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
  */
 final class AfterEntityDeletedEvent
 {
+    use StoppableEventTrait;
+
     private $entityInstance;
 
     public function __construct($entityInstance)

--- a/src/Event/AfterEntityFormBuiltEvent.php
+++ b/src/Event/AfterEntityFormBuiltEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Event;
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * @author Gaël BORDAS <g.bordas@boginfo.fr>
+ */
+final class AfterEntityFormBuiltEvent
+{
+    /**
+     * @var ?AdminContext
+     */
+    protected $context;
+
+    /**
+     * @var FormBuilderInterface
+     */
+    protected $form;
+
+    public function __construct(FormBuilderInterface $form, ?AdminContext $context)
+    {
+        $this->form = $form;
+        $this->context = $context;
+    }
+
+    public function getForm(): FormBuilderInterface
+    {
+        return $this->form;
+    }
+
+    public function getContext(): ?AdminContext
+    {
+        return $this->context;
+    }
+}

--- a/src/Event/AfterEntityPersistedEvent.php
+++ b/src/Event/AfterEntityPersistedEvent.php
@@ -7,6 +7,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
  */
 final class AfterEntityPersistedEvent
 {
+    use StoppableEventTrait;
+
     private $entityInstance;
 
     public function __construct($entityInstance)

--- a/src/Event/AfterEntityUpdatedEvent.php
+++ b/src/Event/AfterEntityUpdatedEvent.php
@@ -13,6 +13,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
  */
 final class AfterEntityUpdatedEvent
 {
+    use StoppableEventTrait;
+
     private $entityInstance;
 
     public function __construct($entityInstance)


### PR DESCRIPTION
Some improvements are provided in this PR :

- Allow form submission in ajax (at this time the controller catch submission for single field update management only)

- Improve AfterEntityXxxEvent to implement StoppableEventTrait to allow custom response after entity processed (like AfterCrudAction) for my use case to inject JsonResponse for an ajax request

- Add an event trigger after formBuilder is created and before form is retrieved to allow event subscriber configuration for form.

Issue #4247 is concerned by this fix

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
