### PR TITLE
Doc: Add missing Symfony Response use statements

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -52,6 +52,7 @@ dashboard with the ``make:admin:dashboard`` command, the route is defined using
 
         use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
         use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class DashboardController extends AbstractDashboardController
@@ -74,6 +75,7 @@ dashboard with the ``make:admin:dashboard`` command, the route is defined using
 
         use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
         use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class DashboardController extends AbstractDashboardController
@@ -105,6 +107,7 @@ application, you can define an explicit route name to simplify your code:
 
         use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
         use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class DashboardController extends AbstractDashboardController
@@ -127,6 +130,7 @@ application, you can define an explicit route name to simplify your code:
 
         use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
         use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+        use Symfony\Component\HttpFoundation\Response;
         use Symfony\Component\Routing\Annotation\Route;
 
         class DashboardController extends AbstractDashboardController


### PR DESCRIPTION
Symfony Response class was missing from use statements so the examples weren't copy/pastable without modification