### PR TITLE
Fixed conversion of EntityDto to string in batch delete

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -435,7 +435,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             try {
                 $this->deleteEntity($entityManager, $entityInstance);
             } catch (ForeignKeyConstraintViolationException $e) {
-                throw new EntityRemoveException(['entity_name' => $entityDto, 'message' => $e->getMessage()]);
+                throw new EntityRemoveException(['entity_name' => $entityDto->toString(), 'message' => $e->getMessage()]);
             }
 
             $this->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));

--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -36,6 +36,11 @@ final class EntityDto
         $this->permission = $entityPermission;
     }
 
+    public function __toString(): string
+    {
+        return $this->toString();
+    }
+
     public function getFqcn(): string
     {
         return $this->fqcn;


### PR DESCRIPTION
This continues the work started in #4354 but proposes a different solution.