### PR TITLE
fix get field dto on filter clause

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -198,7 +198,7 @@ final class EntityRepository implements EntityRepositoryInterface
             }
 
             $filterDataDto = FilterDataDto::new($i, $filter, current($queryBuilder->getRootAliases()), $submittedData);
-            $filter->apply($queryBuilder, $filterDataDto, $fields->get($propertyName), $entityDto);
+            $filter->apply($queryBuilder, $filterDataDto, $fields->getByProperty($propertyName), $entityDto);
 
             ++$i;
         }


### PR DESCRIPTION
the fieldDto is always null
![image](https://user-images.githubusercontent.com/3243131/117988952-309df500-b33c-11eb-9888-51dbf50e988f.png)


The filter fails if used with ArrayFilters, only this class use the $fieldDto parameter on apply method
