### PR TITLE
Action permission is also checked with the entity instance

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -118,7 +118,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $event->getResponse();
         }
 
-        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION)) {
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => Action::INDEX, 'entity' => null])) {
             throw new ForbiddenActionException($context);
         }
 
@@ -166,7 +166,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $event->getResponse();
         }
 
-        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION)) {
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => Action::DETAIL, 'entity' => $context->getEntity()])) {
             throw new ForbiddenActionException($context);
         }
 
@@ -200,7 +200,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $event->getResponse();
         }
 
-        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION)) {
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => Action::EDIT, 'entity' => $context->getEntity()])) {
             throw new ForbiddenActionException($context);
         }
 
@@ -283,7 +283,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $event->getResponse();
         }
 
-        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION)) {
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => Action::NEW, 'entity' => null])) {
             throw new ForbiddenActionException($context);
         }
 
@@ -363,7 +363,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $event->getResponse();
         }
 
-        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION)) {
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => Action::DELETE, 'entity' => $context->getEntity()])) {
             throw new ForbiddenActionException($context);
         }
 
@@ -418,10 +418,6 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $event->getResponse();
         }
 
-        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION)) {
-            throw new ForbiddenActionException($context);
-        }
-
         if (!$this->isCsrfTokenValid('ea-batch-action-'.Action::BATCH_DELETE, $batchActionDto->getCsrfToken())) {
             return $this->redirectToRoute($context->getDashboardRouteName());
         }
@@ -431,6 +427,10 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         foreach ($batchActionDto->getEntityIds() as $entityId) {
             $entityInstance = $repository->find($entityId);
             $entityDto = $context->getEntity()->newWithInstance($entityInstance);
+
+            if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => Action::DELETE, 'entity' => $entityDto])) {
+                throw new ForbiddenActionException($context);
+            }
 
             if (!$entityDto->isAccessible()) {
                 throw new InsufficientEntityPermissionException($context);

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -47,11 +47,7 @@ final class ActionFactory
                 continue;
             }
 
-            if (false === $this->authChecker->isGranted(Permission::EA_EXECUTE_ACTION, $actionDto)) {
-                continue;
-            }
-
-            if (false === $this->authChecker->isGranted(Permission::EA_EXECUTE_ACTION_ENTITY, ['action' => $actionDto, 'entity' => $entityDto])) {
+            if (false === $this->authChecker->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => $actionDto, 'entity' => $entityDto])) {
                 continue;
             }
 
@@ -78,7 +74,7 @@ final class ActionFactory
                 continue;
             }
 
-            if (false === $this->authChecker->isGranted(Permission::EA_EXECUTE_ACTION, $actionDto)) {
+            if (false === $this->authChecker->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => $actionDto, 'entity' => null])) {
                 continue;
             }
 

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -51,6 +51,10 @@ final class ActionFactory
                 continue;
             }
 
+            if (false === $this->authChecker->isGranted(Permission::EA_EXECUTE_ACTION_ENTITY, ['action' => $actionDto, 'entity' => $entityDto])) {
+                continue;
+            }
+
             if (false === $actionDto->shouldBeDisplayedFor($entityDto)) {
                 continue;
             }

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -9,7 +9,6 @@ final class Permission
 {
     public const EA_ACCESS_ENTITY = 'EA_ACCESS_ENTITY';
     public const EA_EXECUTE_ACTION = 'EA_EXECUTE_ACTION';
-    public const EA_EXECUTE_ACTION_ENTITY = 'EA_EXECUTE_ACTION_ENTITY';
     public const EA_VIEW_MENU_ITEM = 'EA_VIEW_MENU_ITEM';
     public const EA_VIEW_FIELD = 'EA_VIEW_FIELD';
     public const EA_EXIT_IMPERSONATION = 'EA_EXIT_IMPERSONATION';

--- a/src/Security/Permission.php
+++ b/src/Security/Permission.php
@@ -9,6 +9,7 @@ final class Permission
 {
     public const EA_ACCESS_ENTITY = 'EA_ACCESS_ENTITY';
     public const EA_EXECUTE_ACTION = 'EA_EXECUTE_ACTION';
+    public const EA_EXECUTE_ACTION_ENTITY = 'EA_EXECUTE_ACTION_ENTITY';
     public const EA_VIEW_MENU_ITEM = 'EA_VIEW_MENU_ITEM';
     public const EA_VIEW_FIELD = 'EA_VIEW_FIELD';
     public const EA_EXIT_IMPERSONATION = 'EA_EXIT_IMPERSONATION';

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Security;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -38,11 +39,7 @@ final class SecurityVoter extends Voter
         }
 
         if (Permission::EA_EXECUTE_ACTION === $permissionName) {
-            return $this->voteOnExecuteActionPermission($this->adminContextProvider->getContext()->getCrud(), $subject);
-        }
-
-        if (Permission::EA_EXECUTE_ACTION_ENTITY === $permissionName) {
-            return $this->voteOnExecuteActionEntityPermission($this->adminContextProvider->getContext()->getCrud(), $subject['action'], $subject['entity']);
+            return $this->voteOnExecuteActionPermission($this->adminContextProvider->getContext()->getCrud(), $subject['action'] ?? null, $subject['entity'] ?? null);
         }
 
         if (Permission::EA_VIEW_FIELD === $permissionName) {
@@ -66,28 +63,26 @@ final class SecurityVoter extends Voter
         return $this->authorizationChecker->isGranted($menuItemDto->getPermission());
     }
 
-    private function voteOnExecuteActionPermission(CrudDto $crudDto, ?ActionDto $actionDto): bool
+    /**
+     * @param string|ActionDto $actionNameOrDto
+     */
+    private function voteOnExecuteActionPermission(CrudDto $crudDto, $actionNameOrDto, ?EntityDto $entityDto): bool
     {
         // users can run the Crud action if:
-        // * they have the required permission to execute the action
+        // * they have the required permission to execute the action on the given entity instance
         // * the action is not disabled
-        $actionName = null !== $actionDto ? $actionDto->getName() : $crudDto->getCurrentAction();
+
+        if (!\is_string($actionNameOrDto) && !($actionNameOrDto instanceof ActionDto)) {
+            throw new \RuntimeException(sprintf('When checking the "%s" permission with the isGranted() method, the value of the "action" parameter passed inside the voter $subject must be a string with the action name or a "%s" object.', Permission::EA_EXECUTE_ACTION, Asset::class));
+        }
+        $actionName = \is_string($actionNameOrDto) ? $actionNameOrDto : $actionNameOrDto->getName();
+
         $actionPermission = $crudDto->getActionsConfig()->getActionPermissions()[$actionName] ?? null;
         $disabledActionNames = $crudDto->getActionsConfig()->getDisabledActions();
 
-        return $this->authorizationChecker->isGranted($actionPermission) && !\in_array($actionName, $disabledActionNames, true);
-    }
+        $subject = null === $entityDto ? null : $entityDto->getInstance();
 
-    private function voteOnExecuteActionEntityPermission(CrudDto $crudDto, ActionDto $actionDto, ?EntityDto $entityDto): bool
-    {
-        // users can run the Crud action if:
-        // * they have the required permission to execute the action on an entity instance
-        // * the action is not disabled
-        $actionName = null !== $actionDto ? $actionDto->getName() : $crudDto->getCurrentAction();
-        $actionPermission = $crudDto->getActionsConfig()->getActionPermissions()[$actionName] ?? null;
-        $disabledActionNames = $crudDto->getActionsConfig()->getDisabledActions();
-
-        return $this->authorizationChecker->isGranted($actionPermission, $entityDto->getInstance()) && !\in_array($actionName, $disabledActionNames, true);
+        return $this->authorizationChecker->isGranted($actionPermission, $subject) && !\in_array($actionName, $disabledActionNames, true);
     }
 
     private function voteOnViewPropertyPermission(FieldDto $field): bool


### PR DESCRIPTION
This PR enhance custom voter support for action permission by calling `isGranted()` with the entity instance as subject. 
It will disable the action display and the action execution.

Previously we could easily disable the display of an action but not its execution.

I chose to add a complete separate permission and method for this, but it can also be done in `voteOnExecuteActionPermission` directly

Fix #3459

