### PR TITLE
Fix ImageField template for multiple images

### DIFF
--- a/src/Resources/views/crud/field/image.html.twig
+++ b/src/Resources/views/crud/field/image.html.twig
@@ -1,11 +1,18 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% set lightbox_content_id = 'ea-lightbox-' ~ field.uniqueId %}
-<a href="#" class="ea-lightbox-thumbnail" data-lightbox-content-selector="#{{ lightbox_content_id }}">
-    <img src="{{ asset(field.formattedValue) }}" class="img-fluid">
-</a>
+{% set images = field.formattedValue %}
+{% if images is not iterable %}
+    {% set images = [images] %}
+{% endif %}
 
-<div id="{{ lightbox_content_id }}" class="ea-lightbox">
-    <img src="{{ asset(field.formattedValue) }}">
-</div>
+{% for image in images %}
+    {% set html_id = 'ea-lightbox-' ~ field.uniqueId ~ '-' ~ loop.index %}
+    <a href="#" class="ea-lightbox-thumbnail" data-featherlight="#{{ html_id }}" data-featherlight-close-on-click="anywhere">
+        <img src="{{ asset(image) }}" class="img-fluid">
+    </a>
+
+    <div id="{{ html_id }}" class="ea-lightbox">
+        <img src="{{ asset(image) }}">
+    </div>
+{% endfor %}


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

I wanted to use the image field with multiple urls, this PR made this possible #4061 but then the render of the field wouldn't work because the formatted value is an array, this PR fixes this.

It adds the loop index the html id in order for the lightbox to work for all images.
