### PR TITLE
Updated the way text contents with HTML tags are displayed

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,20 @@ Upgrade between EasyAdmin 3.x versions
 EasyAdmin 3.4.0
 ---------------
 
+Text fields and Textarea fields no longer strip tags in INDEX page.
+Use the new `stripTags()` method to keep the previous behavior:
+
+```php
+// before
+yield TextField::new('someField');
+
+// after
+yield TextField::new('someField')->stripTags();
+```
+
+EasyAdmin 3.3.2
+---------------
+
 ### CSS, JavaScript and Webpack Entries are passed as assets
 
 This is an internal change that only affects you if your application has

--- a/src/Field/TextField.php
+++ b/src/Field/TextField.php
@@ -14,6 +14,7 @@ final class TextField implements FieldInterface
 
     public const OPTION_MAX_LENGTH = 'maxLength';
     public const OPTION_RENDER_AS_HTML = 'renderAsHtml';
+    public const OPTION_STRIP_TAGS = 'stripTags';
 
     /**
      * @param string|false|null $label
@@ -27,9 +28,14 @@ final class TextField implements FieldInterface
             ->setFormType(TextType::class)
             ->addCssClass('field-text')
             ->setCustomOption(self::OPTION_MAX_LENGTH, null)
-            ->setCustomOption(self::OPTION_RENDER_AS_HTML, false);
+            ->setCustomOption(self::OPTION_RENDER_AS_HTML, false)
+            ->setCustomOption(self::OPTION_STRIP_TAGS, false);
     }
 
+    /**
+     * This option is ignored when using 'renderAsHtml()' to avoid
+     * truncating contents in the middle of an HTML tag.
+     */
     public function setMaxLength(int $length): self
     {
         if ($length < 1) {
@@ -44,6 +50,13 @@ final class TextField implements FieldInterface
     public function renderAsHtml(bool $asHtml = true): self
     {
         $this->setCustomOption(self::OPTION_RENDER_AS_HTML, $asHtml);
+
+        return $this;
+    }
+
+    public function stripTags(bool $stripTags = true): self
+    {
+        $this->setCustomOption(self::OPTION_STRIP_TAGS, $stripTags);
 
         return $this;
     }

--- a/src/Field/TextareaField.php
+++ b/src/Field/TextareaField.php
@@ -12,9 +12,10 @@ final class TextareaField implements FieldInterface
 {
     use FieldTrait;
 
-    public const OPTION_MAX_LENGTH = 'maxLength';
+    public const OPTION_MAX_LENGTH = TextField::OPTION_MAX_LENGTH;
     public const OPTION_NUM_OF_ROWS = 'numOfRows';
-    public const OPTION_RENDER_AS_HTML = 'renderAsHtml';
+    public const OPTION_RENDER_AS_HTML = TextField::OPTION_RENDER_AS_HTML;
+    public const OPTION_STRIP_TAGS = TextField::OPTION_STRIP_TAGS;
 
     /**
      * @param string|false|null $label
@@ -30,9 +31,14 @@ final class TextareaField implements FieldInterface
             ->addJsFiles('bundles/easyadmin/form-type-textarea.js')
             ->setCustomOption(self::OPTION_MAX_LENGTH, null)
             ->setCustomOption(self::OPTION_NUM_OF_ROWS, 5)
-            ->setCustomOption(self::OPTION_RENDER_AS_HTML, false);
+            ->setCustomOption(self::OPTION_RENDER_AS_HTML, false)
+            ->setCustomOption(self::OPTION_STRIP_TAGS, false);
     }
 
+    /**
+     * This option is ignored when using 'renderAsHtml()' to avoid
+     * truncating contents in the middle of an HTML tag.
+     */
     public function setMaxLength(int $length): self
     {
         if ($length < 1) {
@@ -58,6 +64,13 @@ final class TextareaField implements FieldInterface
     public function renderAsHtml(bool $asHtml = true): self
     {
         $this->setCustomOption(self::OPTION_RENDER_AS_HTML, $asHtml);
+
+        return $this;
+    }
+
+    public function stripTags(bool $stripTags = true): self
+    {
+        $this->setCustomOption(self::OPTION_STRIP_TAGS, $stripTags);
 
         return $this;
     }

--- a/src/Resources/views/crud/field/text.html.twig
+++ b/src/Resources/views/crud/field/text.html.twig
@@ -1,13 +1,8 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% set render_as_html = field.customOptions.get('renderAsHtml') %}
 {% if ea.crud.currentAction == 'detail' %}
-    <span title="{{ field.value }}">
-        {{ render_as_html ? field.formattedValue|raw|nl2br : field.formattedValue|nl2br }}
-    </span>
+    <span title="{{ field.value }}">{{ field.formattedValue|raw|nl2br }}</span>
 {% else %}
-    <span title="{{ field.value }}">
-        {{ render_as_html ? field.formattedValue|raw : field.formattedValue|striptags }}
-    </span>
+    <span title="{{ field.value }}">{{ field.formattedValue|raw }}</span>
 {% endif %}


### PR DESCRIPTION
This PR changes the default behavior of how text/textarea field contents are displayed. In previous versions we did an automatic `strip_tags()` call. Now we escape HTML tags by default but we don't stripe tags (although we've added a new option to do that if you want).

### Use case (1): Text contents don't include HTML tags

Nothing changes.

### Use case (2): Text contents include HTML tags

For example, `$title = '<span style="background: yellow">FOO</span>';`

#### BEFORE

There were two behaviors:

* Default: strip tags
* Call `renderAsHtml()` to keep the HTML tags and render them as "raw"

```php
yield TextField::new('title');
// prints: 'FOO'
// user sees: FOO (without a yellow background)
```

```php
yield TextField::new('title')->renderAsHtml();
// prints: '<span style="background: yellow">FOO</span>'
// user sees: FOO (with a yellow background)
```

#### AFTER

There are three behaviors:

* Default: escape HTML tags 
* Call `renderAsHtml()` to keep the HTML tags and render them as "raw"
* Call `stripTags()` to remove all HTML tags (same as the previous default behavior)

```php
yield TextField::new('title');
// prints: '&lt;span style="background: yellow"&gt;FOO&lt;/span&gt;'
// user sees: <span style="background: yellow">FOO</span>
```

```php
yield TextField::new('title')->renderAsHtml();
// prints: '<span style="background: yellow">FOO</span>'
// user sees: FOO (with a yellow background)
```

```php
yield TextField::new('title')->stripTags();
// prints: 'FOO'
// user sees: FOO (without a yellow background)
```
