### PR TITLE
Fixed the URL generation when using multiple dashboards

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -75,7 +75,7 @@ final class AdminUrlGenerator
 
     public function setRoute(string $routeName, array $routeParameters = []): self
     {
-        $this->unsetAllExcept(EA::MENU_INDEX, EA::SUBMENU_INDEX);
+        $this->unsetAllExcept(EA::MENU_INDEX, EA::SUBMENU_INDEX, EA::DASHBOARD_CONTROLLER_FQCN);
         $this->setRouteParameter(EA::ROUTE_NAME, $routeName);
         $this->setRouteParameter(EA::ROUTE_PARAMS, $routeParameters);
 


### PR DESCRIPTION
When you generate a URL with a custom route in an application with multiple dashboards, you see an error. This PR fixes it.