### PR TITLE
Mentioning CSRF protection as requirement

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,7 +30,7 @@ Technical Requirements
 EasyAdmin requires the following:
 
 * PHP 7.2 or higher;
-* Symfony 4.4 or higher;
+* Symfony 4.4 or higher; with [CSRF protection](https://symfony.com/doc/current/security/csrf.html) enabled
 * Doctrine ORM entities (Doctrine ODM is not supported).
 
 Installation


### PR DESCRIPTION
Second attempt after https://github.com/EasyCorp/EasyAdminBundle/pull/3405 :-)

The error message when disabling CSRF now is:
> The service "EasyCorp\Bundle\EasyAdminBundle\Factory\ActionFactory" has a dependency on a non-existent service "security.csrf.token_manager".

... which still doesn't tell people how to fix it...
