### PR TITLE
Prevent jQuery upgrade to 3.6 to avoid focus issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "codemirror": "^5.47.0",
     "dirty-form": "^0.4.0",
     "file-loader": "^6.0.0",
-    "jquery": "^3.5.1",
+    "jquery": "~3.5.1",
     "mark.js": "^8.11.1",
     "node-sass": "^4.9.4",
     "popper.js": "^1.14.5",


### PR DESCRIPTION
Prevent jQuery migration to 3.6

The latest updates include jQuery 3.6, which introduced a focus issue in the select2 library as described here: https://github.com/select2/select2/issues/5993.

I don't think there is a need for this upgrade, especially considering we are looking at getting rid of jQuery in the future. 

Please note I haven't been able to test this change as I could not setup the yarn environment for some reason linked to compiling line breaks on windows, whereas it used to work in the past (but this is not my expertise at all...). 

This change should be straightforward though. 
