### PR TITLE
Fix using closure function for custom page titles #4377

### DIFF
--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -9,9 +9,11 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {{ ea.crud.customPageTitle is null
-            ? (ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle'))|raw
-            : ea.crud.customPageTitle|trans(ea.i18n.translationParameters)|raw }}
+        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null) %}
+        {% set default_page_title = ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
+        {{ custom_page_title is null
+            ? default_page_title|raw
+            : custom_page_title|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -36,9 +36,11 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {{ ea.crud.customPageTitle is null
-            ? (ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle'))|raw
-            : ea.crud.customPageTitle|trans(ea.i18n.translationParameters)|raw }}
+        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null) %}
+        {% set default_page_title = ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
+        {{ custom_page_title is null
+            ? default_page_title|raw
+            : custom_page_title|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -9,8 +9,11 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set default_title = ea.crud.defaultPageTitle('index')|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
-        {{ ea.crud.customPageTitle is null ? default_title|raw : ea.crud.customPageTitle('index')|trans(ea.i18n.translationParameters)|raw }}
+        {% set custom_page_title = ea.crud.customPageTitle('index') %}
+        {% set default_page_title = ea.crud.defaultPageTitle('index')|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
+        {{ custom_page_title is null
+            ? default_page_title|raw
+            : custom_page_title|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -29,8 +29,11 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set default_title = ea.crud.defaultPageTitle('new')|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
-        {{ ea.crud.customPageTitle is null ? default_title|raw : ea.crud.customPageTitle('new')|trans(ea.i18n.translationParameters)|raw }}
+        {% set custom_page_title = ea.crud.customPageTitle('new') %}
+        {% set default_page_title = ea.crud.defaultPageTitle('new')|trans(ea.i18n.translationParameters, 'EasyAdminBundle') %}
+        {{ custom_page_title is null
+            ? default_page_title|raw
+            : custom_page_title|trans(ea.i18n.translationParameters)|raw }}
     {%- endapply -%}
 {% endblock %}
 


### PR DESCRIPTION
* fixed usage of closure function for custom page title of CRUD edit/detail page giving the current entity instance as closure parameter
* unified template code of content title block for CRUD new/index templates to be similar to edit/detail templates

fixes #4377 
