### PR TITLE
Allow to generate relative URLs in the backend

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -245,6 +245,10 @@ explained later)::
                 // triggers an error. If this causes any issue in your backend, call this method
                 // to disable this feature and remove all URL signature checks
                 ->disableUrlSignatures()
+
+                // by default, all backend URLs are generated as absolute URLs. If you
+                // need to generate relative URLs instead, call this method
+                ->generateRelativeUrls()
             ;
         }
     }

--- a/src/Config/Dashboard.php
+++ b/src/Config/Dashboard.php
@@ -78,6 +78,13 @@ final class Dashboard
         return $this;
     }
 
+    public function generateRelativeUrls(bool $relativeUrls = true): self
+    {
+        $this->dto->setAbsoluteUrls(!$relativeUrls);
+
+        return $this;
+    }
+
     public function getAsDto(): DashboardDto
     {
         return $this->dto;

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -97,6 +97,11 @@ final class AdminContext
         return $this->dashboardDto->getSignedUrls();
     }
 
+    public function getAbsoluteUrls(): bool
+    {
+        return $this->dashboardDto->getAbsoluteUrls();
+    }
+
     public function getDashboardTitle(): string
     {
         return $this->dashboardDto->getTitle();

--- a/src/Dto/DashboardDto.php
+++ b/src/Dto/DashboardDto.php
@@ -17,6 +17,7 @@ final class DashboardDto
     private $contentWidth;
     private $sidebarWidth;
     private $signedUrls;
+    private $absoluteUrls;
 
     public function __construct()
     {
@@ -26,6 +27,7 @@ final class DashboardDto
         $this->contentWidth = Crud::LAYOUT_CONTENT_DEFAULT;
         $this->sidebarWidth = Crud::LAYOUT_SIDEBAR_DEFAULT;
         $this->signedUrls = true;
+        $this->absoluteUrls = true;
     }
 
     public function getRouteName(): string
@@ -106,6 +108,18 @@ final class DashboardDto
     public function setSignedUrls(bool $signedUrls): self
     {
         $this->signedUrls = $signedUrls;
+
+        return $this;
+    }
+
+    public function getAbsoluteUrls(): bool
+    {
+        return $this->absoluteUrls;
+    }
+
+    public function setAbsoluteUrls(bool $absoluteUrls): self
+    {
+        $this->absoluteUrls = $absoluteUrls;
 
         return $this;
     }

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -245,7 +245,8 @@ final class AdminUrlGenerator
         });
         ksort($routeParameters, \SORT_STRING);
 
-        $url = $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, UrlGeneratorInterface::ABSOLUTE_URL);
+        $urlType = $this->adminContextProvider->getContext()->getAbsoluteUrls() ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::RELATIVE_PATH;
+        $url = $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType);
 
         if ($this->signUrls()) {
             $url = $this->urlSigner->sign($url);

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Router;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
@@ -13,33 +14,284 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\UrlSigner;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class AdminUrlGeneratorTest extends WebTestCase
 {
     use ExpectDeprecationTrait;
 
-    private $adminUrlGenerator;
-    private $adminUrlGeneratorWithSignedUrls;
+    public function testGenerateEmptyUrl()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
 
-    protected function setUp(): void
+        // the foo=bar query params come from the current request (defined in the mock of the setUp() method)
+        $this->assertSame('http://localhost/admin?foo=bar', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testGetRouteParameters()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $this->assertSame('bar', $adminUrlGenerator->get('foo'));
+        $this->assertNull($adminUrlGenerator->get('this_query_param_does_not_exist'));
+    }
+
+    public function testSetRouteParameters()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->set('foo', 'not_bar');
+        $this->assertSame('http://localhost/admin?foo=not_bar', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testNullParameters()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->set('param1', null);
+        $adminUrlGenerator->set('param2', 'null');
+        $this->assertSame('http://localhost/admin?foo=bar&param2=null', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testSetAll()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setAll(['foo1' => 'bar1', 'foo2' => 'bar2']);
+        $this->assertSame('http://localhost/admin?foo=bar&foo1=bar1&foo2=bar2', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testUnsetAll()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->set('foo1', 'bar1');
+        $adminUrlGenerator->unsetAll();
+        $this->assertSame('http://localhost/admin', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testUnsetAllExcept()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setAll(['foo1' => 'bar1', 'foo2' => 'bar2', 'foo3' => 'bar3', 'foo4' => 'bar4']);
+        $adminUrlGenerator->unsetAllExcept('foo3', 'foo2');
+        $this->assertSame('http://localhost/admin?foo2=bar2&foo3=bar3', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testParametersAreSorted()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setAll(['1_foo' => 'bar', 'a_foo' => 'bar', '2_foo' => 'bar']);
+        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $adminUrlGenerator->generateUrl());
+
+        $adminUrlGenerator->setAll(['2_foo' => 'bar', 'a_foo' => 'bar', '1_foo' => 'bar']);
+        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $adminUrlGenerator->generateUrl());
+
+        $adminUrlGenerator->setAll(['a_foo' => 'bar', '2_foo' => 'bar', '1_foo' => 'bar']);
+        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testUrlParametersDontAffectOtherUrls()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->set('page', '1');
+        $adminUrlGenerator->set('sort', ['id' => 'ASC']);
+        $this->assertSame('http://localhost/admin?foo=bar&page=1&sort%5Bid%5D=ASC', $adminUrlGenerator->generateUrl());
+
+        $this->assertSame('http://localhost/admin?foo=bar', $adminUrlGenerator->generateUrl());
+
+        $adminUrlGenerator->set('page', '2');
+        $this->assertSame('http://localhost/admin?foo=bar&page=2', $adminUrlGenerator->generateUrl());
+        $this->assertNull($adminUrlGenerator->get('sort'));
+    }
+
+    public function testExplicitDashboardController()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setDashboard('App\Controller\Admin\SomeDashboardController');
+        $this->assertSame('http://localhost/another_admin?foo=bar', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testUnknownExplicitDashboardController()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given "ThisDashboardControllerDoesNotExist" class is not a valid Dashboard controller. Make sure it extends from "EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController" or implements "EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface".');
+
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setDashboard('ThisDashboardControllerDoesNotExist');
+        $adminUrlGenerator->generateUrl();
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testCrudIdMethodIsTransformedIntoCrudFqcn()
+    {
+        // The following assert should work, but it fails for some unknown reason ("Failed asserting that string matches format description.")
+        // $this->expectDeprecation("Since easycorp/easyadmin-bundle 3.2.0: The \"setCrudId()\" method of the \"EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator\" service and the related \"crudId\" query parameter are deprecated. Instead, use the CRUD Controller FQCN and the \"setController()\" method like this: ->setController('App\Controller\Admin\SomeCrudController').");
+
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setCrudId('a1b2c3');
+        $this->assertNull($adminUrlGenerator->get(EA::CRUD_ID));
+        $this->assertSame('App\Controller\Admin\SomeCrudController', $adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
+    }
+
+    public function testCrudIdParameterIsTransformedIntoCrudFqcn()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        // don't use setCrudId() because it transforms the crudId into crudFqcn automatically
+        $adminUrlGenerator->set(EA::CRUD_ID, 'a1b2c3');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testUnknowCrudId()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The given "this_id_does_not_exist" value is not a valid CRUD ID. Instead of dealing with CRUD controller IDs when generating admin URLs, use the "setController()" method to set the CRUD controller FQCN.');
+
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        // don't use setCrudId() because it transforms the crudId into crudFqcn automatically
+        $adminUrlGenerator->set(EA::CRUD_ID, 'this_id_does_not_exist');
+        $adminUrlGenerator->generateUrl();
+    }
+
+    public function testDefaultCrudAction()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setController('FooController');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=FooController&foo=bar', $adminUrlGenerator->generateUrl());
+
+        $adminUrlGenerator->setController('FooController');
+        $adminUrlGenerator->setAction(Action::NEW);
+        $this->assertSame('http://localhost/admin?crudAction=new&crudControllerFqcn=FooController&foo=bar', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testControllerParameterRemovesRouteParameters()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_NAME));
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_PARAMS));
+
+        $adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+        $adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_NAME));
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_PARAMS));
+    }
+
+    public function testActionParameterRemovesRouteParameters()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setAction(Action::INDEX);
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_NAME));
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_PARAMS));
+
+        $adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+        $adminUrlGenerator->setAction(Action::INDEX);
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_NAME));
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_PARAMS));
+    }
+
+    public function testRouteParametersRemoveOtherParameters()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+        $this->assertNull($adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
+
+        $adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $adminUrlGenerator->set(EA::MENU_INDEX, 3);
+        $adminUrlGenerator->set('foo', 'bar');
+        $adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+
+        $this->assertNull($adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
+        $this->assertNull($adminUrlGenerator->get('foo'));
+        $this->assertSame(3, $adminUrlGenerator->get(EA::MENU_INDEX));
+    }
+
+    public function testIncludeReferrer()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->includeReferrer();
+        $this->assertSame('http://localhost/admin?foo=bar&referrer=/?foo%3Dbar', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testRemoveReferrer()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->removeReferrer();
+        $this->assertSame('http://localhost/admin?foo=bar', $adminUrlGenerator->generateUrl());
+
+        $adminUrlGenerator->set(EA::REFERRER, 'https://example.com/foo');
+        $adminUrlGenerator->removeReferrer();
+        $this->assertSame('http://localhost/admin?foo=bar', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testSignedUrls()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator(true);
+
+        $adminUrlGenerator->set('foo1', 'bar1');
+        $adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1&signature=yGwN-pwX_xBtCMu87wfD0wyXQm-v4QO_IjCiB6cMvRw', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testUrlsWithoutSignatures()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator(true);
+
+        $adminUrlGenerator->set('foo1', 'bar1');
+        $adminUrlGenerator->addSignature(false);
+        $adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1', $adminUrlGenerator->generateUrl());
+    }
+
+    public function testRelativeUrls()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator(false, true);
+
+        $adminUrlGenerator->set('foo1', 'bar1');
+        $adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1', $adminUrlGenerator->generateUrl());
+
+        $adminUrlGenerator = $this->getAdminUrlGenerator(true, true);
+
+        $adminUrlGenerator->set('foo1', 'bar1');
+        $adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
+        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1&signature=yGwN-pwX_xBtCMu87wfD0wyXQm-v4QO_IjCiB6cMvRw', $adminUrlGenerator->generateUrl());
+    }
+
+    private function getAdminUrlGenerator(bool $signedUrls = false, bool $absoluteUrls = true): AdminUrlGenerator
     {
         self::bootKernel();
 
         $adminContext = $this->getMockBuilder(AdminContext::class)->disableOriginalConstructor()->getMock();
         $adminContext->method('getDashboardRouteName')->willReturn('admin');
-        $adminContext->method('getSignedUrls')->willReturn(false);
+        $adminContext->method('getSignedUrls')->willReturn($signedUrls);
+        $adminContext->method('getAbsoluteUrls')->willReturn($absoluteUrls);
         $adminContext->method('getRequest')->willReturn(new Request(['foo' => 'bar']));
 
-        $adminContextProvider = $this->getMockBuilder(AdminContextProvider::class)->disableOriginalConstructor()->getMock();
-        $adminContextProvider->method('getContext')->willReturn($adminContext);
+        $request = new Request();
+        $request->query->set('foo', 'bar');
+        $request->attributes->set(EasyAdminBundle::CONTEXT_ATTRIBUTE_NAME, $adminContext);
 
-        $adminContextWithSignedUrls = $this->getMockBuilder(AdminContext::class)->disableOriginalConstructor()->getMock();
-        $adminContextWithSignedUrls->method('getDashboardRouteName')->willReturn('admin');
-        $adminContextWithSignedUrls->method('getSignedUrls')->willReturn(true);
-        $adminContextWithSignedUrls->method('getRequest')->willReturn(new Request(['foo' => 'bar']));
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
 
-        $adminContextProviderWithSignedUrls = $this->getMockBuilder(AdminContextProvider::class)->disableOriginalConstructor()->getMock();
-        $adminContextProviderWithSignedUrls->method('getContext')->willReturn($adminContextWithSignedUrls);
+        $adminContextProvider = new AdminContextProvider($requestStack);
 
         $dashboardControllerRegistry = $this->getMockBuilder(DashboardControllerRegistry::class)->disableOriginalConstructor()->getMock();
         $dashboardControllerRegistry->method('getRouteByControllerFqcn')->willReturnMap([
@@ -53,224 +305,9 @@ class AdminUrlGeneratorTest extends WebTestCase
             ['a1b2c3', 'App\Controller\Admin\SomeCrudController'],
         ]);
 
-        $this->adminUrlGenerator = new AdminUrlGenerator(
-            $adminContextProvider,
-            self::$container->get('router'),
-            $dashboardControllerRegistry,
-            $crudControllerRegistry,
-            new UrlSigner('abc123')
-        );
+        $router = self::$container->get('router');
+        $uriSigner = new UrlSigner('abc123');
 
-        $this->adminUrlGeneratorWithSignedUrls = new AdminUrlGenerator(
-            $adminContextProviderWithSignedUrls,
-            self::$container->get('router'),
-            $dashboardControllerRegistry,
-            $crudControllerRegistry,
-            new UrlSigner('abc123')
-        );
-    }
-
-    public function testGenerateEmptyUrl()
-    {
-        // the foo=bar query params come from the current request (defined in the mock of the setUp() method)
-        $this->assertSame('http://localhost/admin?foo=bar', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testGetRouteParameters()
-    {
-        $this->assertSame('bar', $this->adminUrlGenerator->get('foo'));
-        $this->assertNull($this->adminUrlGenerator->get('this_query_param_does_not_exist'));
-    }
-
-    public function testSetRouteParameters()
-    {
-        $this->adminUrlGenerator->set('foo', 'not_bar');
-        $this->assertSame('http://localhost/admin?foo=not_bar', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testNullParameters()
-    {
-        $this->adminUrlGenerator->set('param1', null);
-        $this->adminUrlGenerator->set('param2', 'null');
-        $this->assertSame('http://localhost/admin?foo=bar&param2=null', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testSetAll()
-    {
-        $this->adminUrlGenerator->setAll(['foo1' => 'bar1', 'foo2' => 'bar2']);
-        $this->assertSame('http://localhost/admin?foo=bar&foo1=bar1&foo2=bar2', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testUnsetAll()
-    {
-        $this->adminUrlGenerator->set('foo1', 'bar1');
-        $this->adminUrlGenerator->unsetAll();
-        $this->assertSame('http://localhost/admin', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testUnsetAllExcept()
-    {
-        $this->adminUrlGenerator->setAll(['foo1' => 'bar1', 'foo2' => 'bar2', 'foo3' => 'bar3', 'foo4' => 'bar4']);
-        $this->adminUrlGenerator->unsetAllExcept('foo3', 'foo2');
-        $this->assertSame('http://localhost/admin?foo2=bar2&foo3=bar3', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testParametersAreSorted()
-    {
-        $this->adminUrlGenerator->setAll(['1_foo' => 'bar', 'a_foo' => 'bar', '2_foo' => 'bar']);
-        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $this->adminUrlGenerator->generateUrl());
-
-        $this->adminUrlGenerator->setAll(['2_foo' => 'bar', 'a_foo' => 'bar', '1_foo' => 'bar']);
-        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $this->adminUrlGenerator->generateUrl());
-
-        $this->adminUrlGenerator->setAll(['a_foo' => 'bar', '2_foo' => 'bar', '1_foo' => 'bar']);
-        $this->assertSame('http://localhost/admin?1_foo=bar&2_foo=bar&a_foo=bar&foo=bar', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testUrlParametersDontAffectOtherUrls()
-    {
-        $this->adminUrlGenerator->set('page', '1');
-        $this->adminUrlGenerator->set('sort', ['id' => 'ASC']);
-        $this->assertSame('http://localhost/admin?foo=bar&page=1&sort%5Bid%5D=ASC', $this->adminUrlGenerator->generateUrl());
-
-        $this->assertSame('http://localhost/admin?foo=bar', $this->adminUrlGenerator->generateUrl());
-
-        $this->adminUrlGenerator->set('page', '2');
-        $this->assertSame('http://localhost/admin?foo=bar&page=2', $this->adminUrlGenerator->generateUrl());
-        $this->assertNull($this->adminUrlGenerator->get('sort'));
-    }
-
-    public function testExplicitDashboardController()
-    {
-        $this->adminUrlGenerator->setDashboard('App\Controller\Admin\SomeDashboardController');
-        $this->assertSame('http://localhost/another_admin?foo=bar', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testUnknownExplicitDashboardController()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given "ThisDashboardControllerDoesNotExist" class is not a valid Dashboard controller. Make sure it extends from "EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController" or implements "EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface".');
-
-        $this->adminUrlGenerator->setDashboard('ThisDashboardControllerDoesNotExist');
-        $this->adminUrlGenerator->generateUrl();
-    }
-
-    /**
-     * @group legacy
-     */
-    public function testCrudIdMethodIsTransformedIntoCrudFqcn()
-    {
-        $this->adminUrlGenerator->setCrudId('a1b2c3');
-        // The following assert should work, but it fails for some unknown reason ("Failed asserting that string matches format description.")
-        // $this->expectDeprecation("Since easycorp/easyadmin-bundle 3.2.0: The \"setCrudId()\" method of the \"EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator\" service and the related \"crudId\" query parameter are deprecated. Instead, use the CRUD Controller FQCN and the \"setController()\" method like this: ->setController('App\Controller\Admin\SomeCrudController').");
-
-        $this->assertNull($this->adminUrlGenerator->get(EA::CRUD_ID));
-        $this->assertSame('App\Controller\Admin\SomeCrudController', $this->adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
-    }
-
-    public function testCrudIdParameterIsTransformedIntoCrudFqcn()
-    {
-        // don't use setCrudId() because it transforms the crudId into crudFqcn automatically
-        $this->adminUrlGenerator->set(EA::CRUD_ID, 'a1b2c3');
-        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testUnknowCrudId()
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The given "this_id_does_not_exist" value is not a valid CRUD ID. Instead of dealing with CRUD controller IDs when generating admin URLs, use the "setController()" method to set the CRUD controller FQCN.');
-
-        // don't use setCrudId() because it transforms the crudId into crudFqcn automatically
-        $this->adminUrlGenerator->set(EA::CRUD_ID, 'this_id_does_not_exist');
-        $this->adminUrlGenerator->generateUrl();
-    }
-
-    public function testDefaultCrudAction()
-    {
-        $this->adminUrlGenerator->setController('FooController');
-        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=FooController&foo=bar', $this->adminUrlGenerator->generateUrl());
-
-        $this->adminUrlGenerator->setController('FooController');
-        $this->adminUrlGenerator->setAction(Action::NEW);
-        $this->assertSame('http://localhost/admin?crudAction=new&crudControllerFqcn=FooController&foo=bar', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testControllerParameterRemovesRouteParameters()
-    {
-        $this->adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
-        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_NAME));
-        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_PARAMS));
-
-        $this->adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
-        $this->adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
-        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_NAME));
-        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_PARAMS));
-    }
-
-    public function testActionParameterRemovesRouteParameters()
-    {
-        $this->adminUrlGenerator->setAction(Action::INDEX);
-        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_NAME));
-        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_PARAMS));
-
-        $this->adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
-        $this->adminUrlGenerator->setAction(Action::INDEX);
-        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_NAME));
-        $this->assertNull($this->adminUrlGenerator->get(EA::ROUTE_PARAMS));
-    }
-
-    public function testRouteParametersRemoveOtherParameters()
-    {
-        $this->adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
-        $this->assertNull($this->adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
-
-        $this->adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
-        $this->adminUrlGenerator->set(EA::MENU_INDEX, 3);
-        $this->adminUrlGenerator->set('foo', 'bar');
-        $this->adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
-
-        $this->assertNull($this->adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
-        $this->assertNull($this->adminUrlGenerator->get('foo'));
-        $this->assertSame(3, $this->adminUrlGenerator->get(EA::MENU_INDEX));
-    }
-
-    public function testIncludeReferrer()
-    {
-        $this->adminUrlGenerator->includeReferrer();
-        $this->assertSame('http://localhost/admin?foo=bar&referrer=/?foo%3Dbar', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testRemoveReferrer()
-    {
-        $this->adminUrlGenerator->removeReferrer();
-        $this->assertSame('http://localhost/admin?foo=bar', $this->adminUrlGenerator->generateUrl());
-
-        $this->adminUrlGenerator->set(EA::REFERRER, 'https://example.com/foo');
-        $this->adminUrlGenerator->removeReferrer();
-        $this->assertSame('http://localhost/admin?foo=bar', $this->adminUrlGenerator->generateUrl());
-    }
-
-    public function testUrlsWithSignatures()
-    {
-        $this->adminUrlGenerator->set('foo1', 'bar1');
-        $this->adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
-        $this->adminUrlGenerator->addSignature();
-        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1&signature=yGwN-pwX_xBtCMu87wfD0wyXQm-v4QO_IjCiB6cMvRw', $this->adminUrlGenerator->generateUrl());
-
-        $this->adminUrlGeneratorWithSignedUrls->set('foo1', 'bar1');
-        $this->adminUrlGeneratorWithSignedUrls->setController('App\Controller\Admin\SomeCrudController');
-        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1&signature=yGwN-pwX_xBtCMu87wfD0wyXQm-v4QO_IjCiB6cMvRw', $this->adminUrlGeneratorWithSignedUrls->generateUrl());
-    }
-
-    public function testUrlsWithoutSignatures()
-    {
-        $this->adminUrlGenerator->set('foo1', 'bar1');
-        $this->adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
-        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1', $this->adminUrlGenerator->generateUrl());
-
-        $this->adminUrlGeneratorWithSignedUrls->set('foo1', 'bar1');
-        $this->adminUrlGeneratorWithSignedUrls->setController('App\Controller\Admin\SomeCrudController');
-        $this->adminUrlGeneratorWithSignedUrls->addSignature(false);
-        $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1', $this->adminUrlGeneratorWithSignedUrls->generateUrl());
+        return new AdminUrlGenerator($adminContextProvider, $router, $dashboardControllerRegistry, $crudControllerRegistry, $uriSigner);
     }
 }


### PR DESCRIPTION
I still think that always generating absolute URLs is the best thing to do ... but many people have asked us in the past to also generate relative URLs for different reasons (see #4431, #3542, etc.). So, this PR finally adds that option. Tests are pending to be fixed.