### PR TITLE
Fix virtual/manual field values being overwritten

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -38,9 +38,14 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
     {
         $translationDomain = $context->getI18n()->getTranslationDomain();
 
-        $value = $this->buildValueOption($field, $entityDto);
-        $field->setValue($value);
-        $field->setFormattedValue($value);
+        // do not attempt to read a field if it already has a set value
+        // this basically means that someone written something to it
+        // either as a virtual field or overwrite
+        if (null === $field->getValue()) {
+            $value = $this->buildValueOption($field, $entityDto);
+            $field->setValue($value);
+            $field->setFormattedValue($value);
+        }
 
         $label = $this->buildLabelOption($field, $translationDomain, $context->getCrud()->getCurrentPage());
         $field->setLabel($label);


### PR DESCRIPTION
Assuming the following configuration in a detail or edit view
```php
yield NumberField::new('nonExistingWhatever')->setValue(15);
```
nothing will happen currently, as in, the value will be shown as null.
That is because the PreConfigurator will overwrite the value no matter if it's been explicitly set or not from the configureFields method in the crud controller.

A quick solution to this problem is checking the field to see if it's different than null before overwriting it, if it's overwritten it shouldn't be modified and should just be passed to the proper configurator down the line.