### PR TITLE
fix #3968 and #4443 related to AdminUrlGenerator referrer generation when app is in a subdirectory

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -294,7 +294,7 @@ final class AdminUrlGenerator
             $this->dashboardRoute = $adminContext->getDashboardRouteName();
             $currentRouteParameters = $routeParametersForReferrer = $adminContext->getRequest()->query->all();
             unset($routeParametersForReferrer[EA::REFERRER]);
-            $this->currentPageReferrer = sprintf('%s?%s', $adminContext->getRequest()->getPathInfo(), http_build_query($routeParametersForReferrer));
+            $this->currentPageReferrer = sprintf('%s%s?%s', $adminContext->getRequest()->getBaseUrl(), $adminContext->getRequest()->getPathInfo(), http_build_query($routeParametersForReferrer));
         }
 
         $this->includeReferrer = null;


### PR DESCRIPTION
Fixes #3968
Fixes #4443 

This add the baseUrl() concatenation to the referrer in AdminUrlGenerator that cause filters to use a wrongly generated action url when app is running in a domain.tld/subdirectory 

I did some test In my wodby docker stack using traefik + apache2 + php-fpm)

When app is at root ( http://www.domain.tld/ ) $adminContext->getRequest()->getBaseUrl() is entirely empty (no trailing slash)
When app is in a subdirectory (tested with both a single and a triple subdirectory) $adminContext->getRequest()->getBaseUrl() just hold the right prefix.

