### PR TITLE
Fixed an issue with absolute/relative URL generation

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -245,7 +245,8 @@ final class AdminUrlGenerator
         });
         ksort($routeParameters, \SORT_STRING);
 
-        $urlType = $this->adminContextProvider->getContext()->getAbsoluteUrls() ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::RELATIVE_PATH;
+        $context = $this->adminContextProvider->getContext();
+        $urlType = null !== $context && false === $context->getAbsoluteUrls() ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_URL;
         $url = $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType);
 
         if ($this->signUrls()) {


### PR DESCRIPTION
In some scenarios there is no context because there's no request (e.g. console commands, email templates, etc.) so we need to protect agains the "context is null" case.