### PR TITLE
Fixed some tests and add help to commands

### DIFF
--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -20,6 +20,7 @@ use function Symfony\Component\String\u;
 class MakeAdminDashboardCommand extends Command
 {
     protected static $defaultName = 'make:admin:dashboard';
+    protected static $defaultDescription = 'Creates a new EasyAdmin Dashboard class';
     private $classMaker;
     private $projectDir;
 
@@ -28,6 +29,14 @@ class MakeAdminDashboardCommand extends Command
         parent::__construct($name);
         $this->classMaker = $classMaker;
         $this->projectDir = $projectDir;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription(self::$defaultDescription)
+            ->setHelp($this->getCommandHelp())
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -120,5 +129,18 @@ class MakeAdminDashboardCommand extends Command
         $phpVersion = preg_replace('/[^0-9\.]/', '', $phpVersionRequirement);
 
         return $phpVersion;
+    }
+
+    private function getCommandHelp()
+    {
+        return <<<'HELP'
+The <info>%command.name%</info> command creates a new EasyAdmin Dashboard class
+in your application. Follow the steps shown by the command to configure the
+name and location of the new class.
+
+This command never changes or overwrites an existing class, so you can run it
+safely as many times as needed to create multiple dashboards.
+HELP
+        ;
     }
 }

--- a/src/Command/MakeAdminMigrationCommand.php
+++ b/src/Command/MakeAdminMigrationCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class MakeAdminMigrationCommand extends Command
 {
     protected static $defaultName = 'make:admin:migration';
+    protected static $defaultDescription = 'Migrates EasyAdmin2 YAML config into EasyAdmin 3 PHP config classes';
 
     public const SUCCESS = 0;
     public const FAILURE = 1;
@@ -45,6 +46,8 @@ class MakeAdminMigrationCommand extends Command
     public function configure()
     {
         $this
+            ->setDescription(self::$defaultDescription)
+            ->setHelp($this->getCommandHelp())
             ->addArgument('ea2-backup-file', InputArgument::OPTIONAL, 'The path to the EasyAdmin 2 backup file you want to migrate from.')
         ;
     }
@@ -143,5 +146,21 @@ class MakeAdminMigrationCommand extends Command
         $question = new Question($questionText, $defaultAnswer);
 
         return $helper->ask($this->input, $this->temporarySection, $question);
+    }
+
+    private function getCommandHelp()
+    {
+        return <<<'HELP'
+The <info>%command.name%</info> command migrates the YAML-based configuration of
+an EasyAdmin 2 application into the PHP config classes used by EasyAdmin 3.
+Follow the steps shown by the command to select the YAML configuration file
+and the location and namespace of the newly generated classes.
+
+If you prefer, you can pass the path to the EasyAdmin 2 YAML config backup file
+as an argument:
+
+  <info>php %command.full_name% /path/to/some/easyadmin-config.backup</info>
+HELP
+        ;
     }
 }

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -19,6 +19,7 @@ use function Symfony\Component\String\u;
 class MakeCrudControllerCommand extends Command
 {
     protected static $defaultName = 'make:admin:crud';
+    protected static $defaultDescription = 'Creates a new EasyAdmin CRUD controller class';
     private $projectDir;
     private $classMaker;
     private $doctrine;
@@ -29,6 +30,14 @@ class MakeCrudControllerCommand extends Command
         $this->projectDir = $projectDir;
         $this->classMaker = $classMaker;
         $this->doctrine = $doctrine;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription(self::$defaultDescription)
+            ->setHelp($this->getCommandHelp())
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -95,5 +104,20 @@ class MakeCrudControllerCommand extends Command
         sort($entitiesFqcn);
 
         return $entitiesFqcn;
+    }
+
+    private function getCommandHelp()
+    {
+        return <<<'HELP'
+The <info>%command.name%</info> command creates a new EasyAdmin CRUD controler
+class to manage some Doctrine entity in your application.
+
+Follow the steps shown by the command to select the Doctrine entity and the
+location and namespace of the generated class.
+
+This command never changes or overwrites an existing class, so you can run it
+safely as many times as needed to create multiple CRUD controllers.
+HELP
+        ;
     }
 }

--- a/tests/DependencyInjection/CommandTest.php
+++ b/tests/DependencyInjection/CommandTest.php
@@ -5,7 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\DependencyInjection;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
-class ServicesTest extends KernelTestCase
+class CommandTest extends KernelTestCase
 {
     /**
      * @dataProvider provideCommands
@@ -15,7 +15,12 @@ class ServicesTest extends KernelTestCase
         $application = new Application(self::bootKernel());
 
         $command = $application->find($commandName);
-        $this->assertSame($commandName, $command->getName());
+
+        // It's not enough to test that $this->assertTrue($commandName, $command->getName());
+        // because lazy commands are not instantiated to get their names.
+        // Instead, get the command help to force its instantiation and then
+        // check that help is not empty
+        $this->assertNotEmpty($command->getHelp());
     }
 
     public function provideCommands()


### PR DESCRIPTION
As @chalasr kindly pointed in https://github.com/symfony/symfony/issues/41931#issuecomment-873486763, the current commands test is not really testing that the commands can be instantiated without errors. So, this PR fixes the test and also adds the missing descriptions and help in `make:admin` commands.