### PR TITLE
Fix #4199 Allow editing when the file no longer exists

### DIFF
--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -75,11 +75,15 @@ class StringToFileTransformer implements DataTransformerInterface
             return $value;
         }
 
-        if (\is_string($value)) {
+        if (!\is_string($value)) {
+            throw new TransformationFailedException('Expected a string or null.');
+        }
+
+        if (is_file($this->uploadDir.$value)) {
             return new File($this->uploadDir.$value);
         }
 
-        throw new TransformationFailedException('Expected a string or null.');
+        return null;
     }
 
     private function doReverseTransform($value): ?string


### PR DESCRIPTION
Trying to instantiate a `Symfony\Component\HttpFoundation\File\File` object with a file that no longer exists (eg: was removed from storage) will result in an `FileNotFoundException` (500 error without any possibility to edit the entity and maybe upload a new file)

Fixes #4199

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
