### PR TITLE
Prevent inaccessible template being displayed with virtual/manual fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .php_cs.cache
 composer.lock
 .phpunit.result.cache

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -163,8 +163,11 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
             return $templatePath;
         }
 
+        // if field has a value it must not be displayed as inaccessible
+        // this only happens if the field used still has a template name
+        // instead of a direct path to one
         $isPropertyReadable = $this->propertyAccessor->isReadable($entityDto->getInstance(), $field->getProperty());
-        if (!$isPropertyReadable) {
+        if (!$isPropertyReadable && null === $field->getValue()) {
             return $adminContext->getTemplatePath('label/inaccessible');
         }
 


### PR DESCRIPTION
Hi, again with something related to #4444, I didn't have time to check for this before and we had some issues upgrading to 3.4, so I only noticed it today.

Basically whenever a field doesn't exist, even if a value was set to it it'll still be ignored and not get displayed (even though it'll properly pass through a configurator), because the property on the entity is not accessible.

This can be likely safely ignored assuming the value assigned to the field from the controller is not a null.