### PR TITLE
Prevent a crash if the TextEditorType is used from a user's form

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -451,7 +451,7 @@
 
 {# EasyAdmin's TextEditor form type #}
 {% block ea_text_editor_widget %}
-    {% set numOfRows = form.vars.ea_crud_form.ea_field.customOptions.get('numOfRows') %}
+    {% set numOfRows = form.vars.ea_crud_form.ea_field.customOptions.get('numOfRows')|default(5) %}
 
     {{ form_widget(form, { attr: attr|merge({ style: 'display: none', class: 'ea-text-editor-content' }) }) }}
 


### PR DESCRIPTION
This will simply stop a null-ish get, assuming the user creates a form and uses said form in CollectionField.
In that case, this line caused a crash, because customOptions was not defined by default.
As this is a simple number get, I find it permissible to simply allow a default value and prevent this behavior.

This will __not__ fix the fact that the element will not display, as the css and js files are missing by default, but can be worked around by hand-adding them to the Dashboard controller (essentially the workaround we used)