### PR TITLE
Transform some objects to string when needed

### DIFF
--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -210,6 +210,7 @@ final class Action
             ->replaceMatches('/[_\s]+/', ' ')
             ->trim()
             ->lower()
-            ->title(true);
+            ->title(true)
+            ->toString();
     }
 }

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -177,7 +177,7 @@ final class AdminContextFactory
         if (null !== $crudDto) {
             $translationParameters['%entity_name%'] = $entityName = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
             $translationParameters['%entity_id%'] = $entityId = $request->query->get(EA::ENTITY_ID);
-            $translationParameters['%entity_short_id%'] = null === $entityId ? null : u((string) $entityId)->truncate(7);
+            $translationParameters['%entity_short_id%'] = null === $entityId ? null : u((string) $entityId)->truncate(7)->toString();
 
             $entityInstance = null === $entityDto ? null : $entityDto->getInstance();
             $translatedSingularLabel = $this->translator->trans($crudDto->getEntityLabelInSingular($entityInstance) ?? $entityName, $translationParameters, $translationDomain);

--- a/src/Field/Configurator/ArrayConfigurator.php
+++ b/src/Field/Configurator/ArrayConfigurator.php
@@ -45,7 +45,7 @@ final class ArrayConfigurator implements FieldConfiguratorInterface
                 }, $values->getValues());
             }
 
-            $field->setFormattedValue(u(', ')->join($values));
+            $field->setFormattedValue(u(', ')->join($values)->toString());
         }
     }
 }

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -111,7 +111,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
             }
         }
 
-        $badgeTypeCssClass = empty($badgeType) ? '' : u($badgeType)->ensureStart('badge-');
+        $badgeTypeCssClass = empty($badgeType) ? '' : u($badgeType)->ensureStart('badge-')->toString();
 
         return $commonBadgeCssClass.' '.$badgeTypeCssClass;
     }

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -78,7 +78,7 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
 
         $isDetailAction = Action::DETAIL === $context->getCrud()->getCurrentAction();
 
-        return u(', ')->join($collectionItemsAsText)->truncate($isDetailAction ? 512 : 32, '…');
+        return u(', ')->join($collectionItemsAsText)->truncate($isDetailAction ? 512 : 32, '…')->toString();
     }
 
     private function countNumElements($collection): int

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -219,6 +219,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
             ->replaceMatches('/[_\s]+/', ' ')
             ->trim()
             ->lower()
-            ->title(true);
+            ->title(true)
+            ->toString();
     }
 }

--- a/src/Field/Configurator/IdConfigurator.php
+++ b/src/Field/Configurator/IdConfigurator.php
@@ -28,7 +28,7 @@ final class IdConfigurator implements FieldConfiguratorInterface
         }
 
         if (-1 !== $maxLength && null !== $field->getValue()) {
-            $field->setFormattedValue(u($field->getValue())->truncate($maxLength, '…'));
+            $field->setFormattedValue(u($field->getValue())->truncate($maxLength, '…')->toString());
         }
     }
 }

--- a/src/Field/Configurator/UrlConfigurator.php
+++ b/src/Field/Configurator/UrlConfigurator.php
@@ -28,7 +28,7 @@ final class UrlConfigurator implements FieldConfiguratorInterface
         $prettyUrl = rtrim($prettyUrl, '/');
 
         if (Action::INDEX === $context->getCrud()->getCurrentAction()) {
-            $prettyUrl = u($prettyUrl)->truncate(32, '…');
+            $prettyUrl = u($prettyUrl)->truncate(32, '…')->toString();
         }
 
         $field->setFormattedValue($prettyUrl);

--- a/src/Maker/ClassMaker.php
+++ b/src/Maker/ClassMaker.php
@@ -26,7 +26,7 @@ final class ClassMaker
     public function make(string $generatedFilePathPattern, string $skeletonName, array $skeletonParameters): string
     {
         $skeletonPath = sprintf('%s/%s', $this->kernel->locateResource('@EasyAdminBundle/Resources/skeleton'), $skeletonName);
-        $generatedFileRelativeDir = u($generatedFilePathPattern)->beforeLast('/')->trimEnd('/');
+        $generatedFileRelativeDir = u($generatedFilePathPattern)->beforeLast('/')->trimEnd('/')->toString();
         $generatedFileNamePattern = u($generatedFilePathPattern)->afterLast('/')->trimStart('/');
 
         $generatedFileDir = sprintf('%s/%s', $this->projectDir, $generatedFileRelativeDir);


### PR DESCRIPTION
I know that Symfony String objects transform to `__toString()` automatically ... but in some edge-cases I've seen some type errors ... so let's update the code to use plain PHP strings where those are expected.