### PR TITLE
Do not translate field help in form_row block

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -65,10 +65,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         $field->setDoctrineMetadata($doctrineMetadata);
 
         if (null !== $field->getHelp()) {
-            $helpMessage = $this->buildHelpOption($field, $translationDomain);
-            $field->setHelp($helpMessage);
-
-            $field->setFormTypeOptionIfNotSet('help', $helpMessage);
+            $field->setFormTypeOptionIfNotSet('help', $field->getHelp());
             $field->setFormTypeOptionIfNotSet('help_html', true);
             $field->setFormTypeOptionIfNotSet('help_translation_parameters', $field->getTranslationParameters());
         }
@@ -95,15 +92,6 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         }
 
         return $this->propertyAccessor->getValue($entityInstance, $propertyName);
-    }
-
-    private function buildHelpOption(FieldDto $field, string $translationDomain): ?string
-    {
-        if ((null === $help = $field->getHelp()) || empty($help)) {
-            return $help;
-        }
-
-        return $this->translator->trans($help, $field->getTranslationParameters(), $translationDomain);
     }
 
     /**

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -110,10 +110,8 @@
                     </div>
                 {% endif %}
 
-                {% if ea.field.help ?? false %}
-                    <small class="form-help">{{ ea.field.help|raw }}</small>
-                {% elseif form.vars.help ?? false %}
-                    <small class="form-help">{{ form.vars.help|trans(form.vars.help_translation_parameters, form.vars.translation_domain)|raw }}</small>
+                {% if form.vars.help ?? false %}
+                    <small class="form-help">{{ form.vars.help|raw }}</small>
                 {% endif %}
 
                 {{- form_errors(form) -}}

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -111,7 +111,7 @@
                 {% endif %}
 
                 {% if form.vars.help ?? false %}
-                    <small class="form-help">{{ form.vars.help|raw }}</small>
+                    <small class="form-help">{{ form.vars.help|trans(form.vars.help_translation_parameters, form.vars.translation_domain)|raw }}</small>
                 {% endif %}
 
                 {{- form_errors(form) -}}


### PR DESCRIPTION
Form help message is already translated with `EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CommonPreConfigurator::buildHelpOption` method.
