### PR TITLE
Fix a leftover method usage

### DIFF
--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -147,7 +147,7 @@ final class FieldFactory
         $newField->setValue($fieldDto->getValue());
         $newField->setFormattedValue($fieldDto->getFormattedValue());
         $newField->setCssClass(trim($newField->getCssClass().' '.$fieldDto->getCssClass()));
-        $newField->setRowCssClass(trim($newField->getRowCssClass().' '.$fieldDto->getRowCssClass()));
+        $newField->setColumns($fieldDto->getColumns());
         $newField->setTranslationParameters($fieldDto->getTranslationParameters());
         $newField->setAssets($newField->getAssets()->mergeWith($fieldDto->getAssets()));
 


### PR DESCRIPTION
Fixes #4507.

Before using "columns" I thought about allowing to define the entire row CSS ... but it was more complicated for the same result, so I reverted that.