### PR TITLE
Fixed modals close button

### DIFF
--- a/src/Resources/views/crud/field/code_editor.html.twig
+++ b/src/Resources/views/crud/field/code_editor.html.twig
@@ -18,8 +18,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">{{ field.label }}</h5>
-                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="{{ 'action.close'|trans([], domain = 'EasyAdminBundle') }}">
-                        <span aria-hidden="true">&times;</span>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'action.close'|trans([], domain = 'EasyAdminBundle') }}">
                     </button>
                 </div>
                 <div class="modal-body">

--- a/src/Resources/views/crud/field/text_editor.html.twig
+++ b/src/Resources/views/crud/field/text_editor.html.twig
@@ -14,8 +14,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <h5 class="modal-title">{{ field.label }}</h5>
-                    <button type="button" class="close" data-bs-dismiss="modal" aria-label="{{ 'action.close'|trans([], domain = 'EasyAdminBundle') }}">
-                        <span aria-hidden="true">&times;</span>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'action.close'|trans([], domain = 'EasyAdminBundle') }}">
                     </button>
                 </div>
                 <div class="modal-body">


### PR DESCRIPTION
Close buttons in modals, since Bootstrap 5 uses a different class.

Before:
![image](https://user-images.githubusercontent.com/3246162/127785875-6851f183-9799-4cd6-859e-340e24be796c.png)
After:
![image](https://user-images.githubusercontent.com/3246162/127785887-c114f496-5791-49a6-9e7b-c960e75d48ca.png)
