### PR TITLE
Added missing `--form-bg` variable

### DIFF
--- a/assets/css/easyadmin-theme/variables-theme.scss
+++ b/assets/css/easyadmin-theme/variables-theme.scss
@@ -106,6 +106,7 @@
     --datalist-label-color: var(--gray-500);
     --datalist-value-color: var(--gray-600);
     --pagination-color: var(--gray-600);
+    --form-bg: var(--white);
     --form-label-color: var(--gray-800);
     --form-input-border-color: var(--gray-300);
     --form-input-hover-border-color: var(--gray-400);


### PR DESCRIPTION
After redesign update, modal header has transparent background because `--form-bg` variable is missing. Note: This variable is used in few places, so we may expect some side effects. I'll try to verify it tommorow.

Before:
![image](https://user-images.githubusercontent.com/3246162/127921197-531b1d83-2ddc-4082-a9c8-cc891bdf5053.png)
After:
![image](https://user-images.githubusercontent.com/3246162/127921265-a9ec5c70-da05-4d1b-b685-65b5bf0fa5f0.png)
