### PR TITLE
Do not access primary key on new form

### DIFF
--- a/src/Field/Configurator/BooleanConfigurator.php
+++ b/src/Field/Configurator/BooleanConfigurator.php
@@ -32,8 +32,13 @@ final class BooleanConfigurator implements FieldConfiguratorInterface
         $isRenderedAsSwitch = true === $field->getCustomOption(BooleanField::OPTION_RENDER_AS_SWITCH);
 
         if ($isRenderedAsSwitch) {
-            $toggleUrl = $this->adminUrlGenerator->setAction(Action::EDIT)->setEntityId($entityDto->getPrimaryKeyValue())->set('fieldName', $field->getProperty())->generateUrl();
-            $field->setCustomOption(BooleanField::OPTION_TOGGLE_URL, $toggleUrl);
+            $crudDto = $context->getCrud();
+
+            if (null !== $crudDto && Action::NEW !== $crudDto->getCurrentAction()) {
+                $toggleUrl = $this->adminUrlGenerator->setAction(Action::EDIT)->setEntityId($entityDto->getPrimaryKeyValue())->set('fieldName', $field->getProperty())->generateUrl();
+                $field->setCustomOption(BooleanField::OPTION_TOGGLE_URL, $toggleUrl);
+            }
+
             $field->setFormTypeOptionIfNotSet('label_attr.class', 'checkbox-switch');
             $field->setCssClass($field->getCssClass().' has-switch');
         }


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

When creating a new entity using the `new` action, there should be no call to the primary key.