### PR TITLE
Allow to display all collection items expanded by default

### DIFF
--- a/src/Field/CollectionField.php
+++ b/src/Field/CollectionField.php
@@ -17,6 +17,7 @@ final class CollectionField implements FieldInterface
     public const OPTION_ENTRY_IS_COMPLEX = 'entryIsComplex';
     public const OPTION_ENTRY_TYPE = 'entryType';
     public const OPTION_SHOW_ENTRY_LABEL = 'showEntryLabel';
+    public const OPTION_RENDER_EXPANDED = 'renderExpanded';
 
     /**
      * @param string|false|null $label
@@ -35,7 +36,8 @@ final class CollectionField implements FieldInterface
             ->setCustomOption(self::OPTION_ALLOW_DELETE, true)
             ->setCustomOption(self::OPTION_ENTRY_IS_COMPLEX, null)
             ->setCustomOption(self::OPTION_ENTRY_TYPE, null)
-            ->setCustomOption(self::OPTION_SHOW_ENTRY_LABEL, false);
+            ->setCustomOption(self::OPTION_SHOW_ENTRY_LABEL, false)
+            ->setCustomOption(self::OPTION_RENDER_EXPANDED, false);
     }
 
     public function allowAdd(bool $allow = true): self
@@ -73,6 +75,13 @@ final class CollectionField implements FieldInterface
     public function showEntryLabel(bool $showLabel = true): self
     {
         $this->setCustomOption(self::OPTION_SHOW_ENTRY_LABEL, $showLabel);
+
+        return $this;
+    }
+
+    public function renderExpanded(bool $renderExpanded = true): self
+    {
+        $this->setCustomOption(self::OPTION_RENDER_EXPANDED, $renderExpanded);
 
         return $this;
     }

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -178,6 +178,7 @@
     {% set is_array_field = 'EasyCorp\\Bundle\\EasyAdminBundle\\Field\\ArrayField' == form_parent(form).vars.ea_crud_form.ea_field.fieldFqcn %}
     {% set is_complex = form_parent(form).vars.ea_crud_form.ea_field.customOptions.get('entryIsComplex') ?? false %}
     {% set allows_deleting_items = form_parent(form).vars.allow_delete|default(false) %}
+    {% set render_expanded = form_parent(form).vars.ea_crud_form.ea_field.customOptions.get('renderExpanded') ?? false %}
     {% set delete_item_button %}
         <button type="button" class="btn btn-link btn-link-danger field-collection-delete-button"
                 title="{{ 'action.remove_item'|trans({}, 'EasyAdminBundle') }}"
@@ -195,7 +196,7 @@
         {% else %}
             <div class="accordion-item">
                 <h2 class="accordion-header">
-                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#{{ id }}-contents">
+                    <button class="accordion-button {{ render_expanded ? '' : 'collapsed' }}" type="button" data-bs-toggle="collapse" data-bs-target="#{{ id }}-contents">
                         <i class="fas fw fa-chevron-right form-collection-item-collapse-marker"></i>
                         {{ value|ea_as_string }}
                     </button>
@@ -204,7 +205,7 @@
                         {{ delete_item_button }}
                     {% endif %}
                 </h2>
-                <div id="{{ id }}-contents" class="accordion-collapse collapse">
+                <div id="{{ id }}-contents" class="accordion-collapse collapse {{ render_expanded ? 'show' }}">
                     <div class="accordion-body">
                         {{ form_widget(form) }}
                     </div>


### PR DESCRIPTION
Fixes problems like #4532.

Thanks to this option you can have the old behavior (all collection items fully visible on page load) while keeping the nice new features (item collapsing and better design in general).