### PR TITLE
Fix modal zIndex for be on top of the top bar

### DIFF
--- a/assets/css/easyadmin-theme/variables-bootstrap.scss
+++ b/assets/css/easyadmin-theme/variables-bootstrap.scss
@@ -132,7 +132,8 @@ $modal-footer-border-color: $modal-header-border-color;
 $modal-lg: 900px;
 $modal-md: 500px;
 $modal-sm: 300px;
-$zindex-modal-backdrop: 1040;
+$zindex-modal-backdrop: 2020;
+$zindex-modal: 2040;
 
 $offcanvas-padding-y: 15px;
 $offcanvas-padding-x: 20px;


### PR DESCRIPTION
Hi,

I submit you this small fix about the zIndex of the modal. Because currently the topbar pass on top of the modal.
This fix is related to my issue there : EasyCorp#4547.

Thanks.
