### PR TITLE
Check for ea variable when rendering flash messages

### DIFF
--- a/src/Resources/views/flash_messages.html.twig
+++ b/src/Resources/views/flash_messages.html.twig
@@ -1,4 +1,8 @@
-{% trans_default_domain ea.i18n.translationDomain %}
+{# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
+{# This template checks for 'ea' variable existence because it can
+   be used in a EasyAdmin Dashboard controller, where 'ea' is defined
+   or from any other Symfony controller, where 'ea' is not defined #}
+{% trans_default_domain ea is defined ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 {% if app.session is not null and app.session.started %}
     {% set flash_messages = app.session.flashbag.all %}
 


### PR DESCRIPTION
Same check as performed in `login.html.twig`. Template might be used in non EA context aware controllers