### PR TITLE
Add parameters to display a "remember me" checkbox on login page

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -767,6 +767,18 @@ applications can rely on its default values:
 
                 // the 'name' HTML attribute of the <input> used for the password field (default: '_password')
                 'password_parameter' => 'my_custom_password_field',
+
+                // whether to enable or not the "remember me" checkbox (default: false)
+                'remember_me_enabled' => true,
+
+                // remember me name form field (default: '_remember_me')
+                'remember_me_parameter' => 'custom_remember_me_param',
+
+                // whether to check by default the "remember me" checkbox (default: false)
+                'remember_me_checked' => true,
+
+                // the label displayed for the remember me checkbox (the |trans filter is applied to it)
+                'remember_me_label' => 'Remember me',
             ]);
         }
     }

--- a/src/Resources/translations/EasyAdminBundle.ar.php
+++ b/src/Resources/translations/EasyAdminBundle.ar.php
@@ -115,6 +115,7 @@ return [
         'username' => 'إسم المستخدم',
         'password' => 'كلمة السّر',
         'sign_in' => 'تسجيل الدخول',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.bg.php
+++ b/src/Resources/translations/EasyAdminBundle.bg.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Потребителско има',
         'password' => 'Парола',
         'sign_in' => 'Вход',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.ca.php
+++ b/src/Resources/translations/EasyAdminBundle.ca.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Nom d\'usuari',
         'password' => 'Contrasenya',
         'sign_in' => 'Iniciar sessió',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.cs.php
+++ b/src/Resources/translations/EasyAdminBundle.cs.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Login',
         'password' => 'Heslo',
         'sign_in' => 'Přihlásit',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.da.php
+++ b/src/Resources/translations/EasyAdminBundle.da.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Username',
         'password' => 'Password',
         'sign_in' => 'Sign in',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.de.php
+++ b/src/Resources/translations/EasyAdminBundle.de.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Benutzername',
         'password' => 'Passwort',
         'sign_in' => 'Login',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.el.php
+++ b/src/Resources/translations/EasyAdminBundle.el.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Username',
         'password' => 'Password',
         'sign_in' => 'Sign in',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.en.php
+++ b/src/Resources/translations/EasyAdminBundle.en.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Username',
         'password' => 'Password',
         'sign_in' => 'Sign in',
+        'remember_me' => 'Remember me',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.es.php
+++ b/src/Resources/translations/EasyAdminBundle.es.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Nombre de usuario',
         'password' => 'Contraseña',
         'sign_in' => 'Iniciar sesión',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.eu.php
+++ b/src/Resources/translations/EasyAdminBundle.eu.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Erabiltzailea',
         'password' => 'Pasahitza',
         'sign_in' => 'Hasi saioa',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.fa.php
+++ b/src/Resources/translations/EasyAdminBundle.fa.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Username',
         'password' => 'Password',
         'sign_in' => 'Sign in',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.fi.php
+++ b/src/Resources/translations/EasyAdminBundle.fi.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Username',
         'password' => 'Password',
         'sign_in' => 'Sign in',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.fr.php
+++ b/src/Resources/translations/EasyAdminBundle.fr.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Identifiant',
         'password' => 'Mot de passe',
         'sign_in' => 'Connectez-vous',
+        'remember_me' => 'Rester connecté',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.gl.php
+++ b/src/Resources/translations/EasyAdminBundle.gl.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Nome de usuario',
         'password' => 'Contrasinal',
         'sign_in' => 'Iniciar sesión',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.hr.php
+++ b/src/Resources/translations/EasyAdminBundle.hr.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Korisničko ime',
         'password' => 'Lozinka',
         'sign_in' => 'Prijavi se',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.hu.php
+++ b/src/Resources/translations/EasyAdminBundle.hu.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Felhasználónév',
         'password' => 'Jelszó',
         'sign_in' => 'Belépés',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.it.php
+++ b/src/Resources/translations/EasyAdminBundle.it.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Nome utente',
         'password' => 'Password',
         'sign_in' => 'Accedi',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.lt.php
+++ b/src/Resources/translations/EasyAdminBundle.lt.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Vartotojo vardas',
         'password' => 'Slaptažodis',
         'sign_in' => 'Prisijungti',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.nl.php
+++ b/src/Resources/translations/EasyAdminBundle.nl.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Gebruikersnaam',
         'password' => 'Wachtwoord',
         'sign_in' => 'Inloggen',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.no.php
+++ b/src/Resources/translations/EasyAdminBundle.no.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Brukernavn',
         'password' => 'Passord',
         'sign_in' => 'Logg inn',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.pl.php
+++ b/src/Resources/translations/EasyAdminBundle.pl.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Użytkownik',
         'password' => 'Hasło',
         'sign_in' => 'Zaloguj się',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.pt.php
+++ b/src/Resources/translations/EasyAdminBundle.pt.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Usuário',
         'password' => 'Senha',
         'sign_in' => 'Entrar',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.pt_BR.php
+++ b/src/Resources/translations/EasyAdminBundle.pt_BR.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Usuário',
         'password' => 'Senha',
         'sign_in' => 'Entrar',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.ro.php
+++ b/src/Resources/translations/EasyAdminBundle.ro.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Utilizator',
         'password' => 'Parolă',
         'sign_in' => 'Autentifică-te',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.ru.php
+++ b/src/Resources/translations/EasyAdminBundle.ru.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Логин',
         'password' => 'Пароль',
         'sign_in' => 'Войти',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.sl.php
+++ b/src/Resources/translations/EasyAdminBundle.sl.php
@@ -115,6 +115,7 @@ return [
         'username' => 'uporabniško ime',
         'password' => 'Geslo',
         'sign_in' => 'Prijava',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.sr_RS.php
+++ b/src/Resources/translations/EasyAdminBundle.sr_RS.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Username',
         'password' => 'Password',
         'sign_in' => 'Sign in',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.sv.php
+++ b/src/Resources/translations/EasyAdminBundle.sv.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Username',
         'password' => 'Password',
         'sign_in' => 'Sign in',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.tr.php
+++ b/src/Resources/translations/EasyAdminBundle.tr.php
@@ -115,6 +115,7 @@ return [
         'username' => 'Kullanıcı adı',
         'password' => 'Şifre',
         'sign_in' => 'Giriş yap',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.uk.php
+++ b/src/Resources/translations/EasyAdminBundle.uk.php
@@ -116,6 +116,7 @@ return [
         'username' => 'Логін',
         'password' => 'Пароль',
         'sign_in' => 'Увійти',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/translations/EasyAdminBundle.zh_CN.php
+++ b/src/Resources/translations/EasyAdminBundle.zh_CN.php
@@ -116,6 +116,7 @@ return [
         'username' => '用户名',
         'password' => '密码',
         'sign_in' => '登录',
+        // 'remember_me' => '',
     ],
 
     'exception' => [

--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -12,6 +12,7 @@
     {% set page_title = block('page_title') %}
     {% set _username_label = username_label is defined ? username_label|trans : 'login_page.username'|trans({}, 'EasyAdminBundle') %}
     {% set _password_label = password_label is defined ? password_label|trans : 'login_page.password'|trans({}, 'EasyAdminBundle') %}
+    {% set _remember_me_label = remember_me_label is defined ? remember_me_label|trans : 'login_page.remember_me'|trans({}, 'EasyAdminBundle') %}
     {% set _sign_in_label = sign_in_label is defined ? sign_in_label|trans : 'login_page.sign_in'|trans({}, 'EasyAdminBundle') %}
 
     <div class="login-wrapper">
@@ -62,6 +63,15 @@
                         <input type="password" id="password" name="{{ password_parameter|default('_password') }}" class="form-control" required autocomplete="current-password">
                     </div>
                 </div>
+
+                {% if remember_me_enabled|default(false) %}
+                    <div class="form-group">
+                        <input class="form-check-input" type="checkbox" id="remember_me" name="{{ remember_me_parameter|default('_remember_me') }}" {{ remember_me_checked|default(false) ? 'checked' }}>
+                        <label class="form-check-label" for="remember_me">
+                            {{ _remember_me_label }}
+                        </label>
+                    </div>
+                {% endif %}
 
                 <div class="form-group">
                     <button type="submit" class="btn btn-primary btn-lg w-100">{{ _sign_in_label }}</button>


### PR DESCRIPTION
Hi,

This PR allows to display a "remember me" checkbox on the login page (without having to override the entire login template).

I think the four parameters should be enough to customize it.

Here is a screenshot of the "feature":

![image](https://user-images.githubusercontent.com/3929498/131323841-aab99185-2a49-4689-ae53-56cc82705806.png)
