### PR TITLE
Added flash support on login page

### DIFF
--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -18,6 +18,7 @@
 
     <div class="login-wrapper">
         <header class="main-header">
+        {% include '@EasyAdmin/flash_messages.html.twig' %}
             <div id="header-logo">
                 {% block header_logo %}
                     {% if page_title %}


### PR DESCRIPTION
Just an addition of support for flash messages on the login page.

We imagine that this feature could be interesting in some cases such as the following:

- A user reset his password, is redirected to the login page, and sees a flash message appear, telling him that his password has been reset and that he can connect