### PR TITLE
[3.5] Regression Fix - Remove text align as it overwrites the attribute (breaks some custom fields)

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -4,7 +4,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use function Symfony\Component\String\u;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Contracts\Translation\TranslatableInterface;
@@ -239,7 +238,7 @@ final class FieldDto
         $this->virtual = $isVirtual;
     }
 
-    public function getTextAlign(): string
+    public function getTextAlign(): ?string
     {
         return $this->textAlign;
     }


### PR DESCRIPTION
This change fixes some Custom fields post 3.5 migration, The $textAlign variable overwrote any other attribute which could have been defined in a Custom field and would therefore prevent them from working properly.

I am not sure why this was introduced, but we surely can handle the same via a css class instead. I didn't observe any noticeable changes.

This seems quite critical to me to be able to use the attr to pass on parameters to the fields.