### PR TITLE
Fix deprecation 

### DIFF
--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -42,7 +42,7 @@ final class BatchActionDtoResolver implements ArgumentValueResolverInterface
 
         yield new BatchActionDto(
             $context->getRequest()->request->get(EA::BATCH_ACTION_NAME),
-            $context->getRequest()->request->get(EA::BATCH_ACTION_ENTITY_IDS, []),
+            $context->getRequest()->request->get(EA::BATCH_ACTION_ENTITY_IDS) ?: [],
             $context->getRequest()->request->get(EA::ENTITY_FQCN),
             $referrerUrl,
             $context->getRequest()->request->get(EA::BATCH_ACTION_CSRF_TOKEN)


### PR DESCRIPTION
To reproduce : any use of a batch action will trigger the deprecation.

The default value of the \Symfony\Component\HttpFoundation\InputBag::get method cannot be an array.

`@param string|int|float|bool|null $default The default value if the input key does not exist`

It triggers a deprecation:

`[2021-09-10T15:34:36.350168+00:00] php.INFO: User Deprecated: Since symfony/http-foundation 5.1: Passing a non-scalar value as 2nd argument to "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, pass a scalar or null instead. {"exception":"[object] (ErrorException(code: 0): User Deprecated: Since symfony/http-foundation 5.1: Passing a non-scalar value as 2nd argument to \"Symfony\\Component\\HttpFoundation\\InputBag::get()\" is deprecated, pass a scalar or null instead. at /var/www/html/vendor/symfony/http-foundation/InputBag.php:33)"} []`

The usage of the null coalescing operator avoids it.