### PR TITLE
[FIX] Action detail - French translation

### DIFF
--- a/src/Resources/translations/EasyAdminBundle.fr.php
+++ b/src/Resources/translations/EasyAdminBundle.fr.php
@@ -45,7 +45,7 @@ return [
         'entity_actions' => 'Actions',
         'new' => 'Créer %entity_label_singular%',
         'search' => 'Rechercher',
-        'detail' => 'Voir',
+        'detail' => 'Consulter',
         'edit' => 'Éditer',
         'delete' => 'Supprimer',
         'cancel' => 'Annuler',


### PR DESCRIPTION
A little PR for built-in action french translation.
In french, we say "Consulter" instead of "Voir" (weird in this case, "Voir" is "see" with eyes but not including the reading context).

Previsous canceled pull request: [https://github.com/EasyCorp/EasyAdminBundle/pull/4654](https://github.com/EasyCorp/EasyAdminBundle/pull/4654)