### PR TITLE
Fix docs about form field templates

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -167,7 +167,7 @@ fields in the ``new`` and ``edit`` pages, which use Symfony forms.
 Form Field Templates
 ~~~~~~~~~~~~~~~~~~~~
 
-EasyAdmin provides a ready-to-use `form theme`_ based on Boostrap 4. Dashboards
+EasyAdmin provides a ready-to-use `form theme`_ based on Bootstrap 5. Dashboards
 and CRUD controllers define ``addFormTheme(string $themePath)`` and
 ``setFormThemes(array $themePaths)`` methods so you can
 `customize individual form fields`_ using your own form theme.
@@ -188,7 +188,7 @@ requires to know the `form fragment naming rules`_ defined by Symfony:
 .. code-block:: twig
 
     {# templates/admin/form.html.twig #}
-    {% block _product_custom_title_widget %}
+    {% block _Product_custom_title_widget %}
         {# ... #}
         <a href="...">More information</a>
     {% endblock %}
@@ -215,6 +215,11 @@ Finally, add this custom theme to the list of themes used to render backend form
             ;
         }
     }
+
+.. note::
+
+    You can also override the form widget by using the original field name. In the example above it would look like this:
+    `{% block _Product_title_widget %}`. The full syntax is: `{% block _<Entity name>_<Field name>_widget %}`.
 
 Adding Custom Web Assets
 ------------------------


### PR DESCRIPTION
Hi,

Just a little docs issue that could lead to hours of search :) 

If you check here: https://github.com/EasyCorp/EasyAdminBundle/blob/master/src/Factory/FormFactory.php#L37

The form name is the `$entityDto->getName()` which seems to be the entity name without the namespace, so in the example it should have an uppercase first letter.