### PR TITLE
Fix deprecation

### DIFF
--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -42,7 +42,7 @@ final class BatchActionDtoResolver implements ArgumentValueResolverInterface
 
         yield new BatchActionDto(
             $context->getRequest()->request->get(EA::BATCH_ACTION_NAME),
-            $context->getRequest()->request->get(EA::BATCH_ACTION_ENTITY_IDS) ?: [],
+            $context->getRequest()->request->all(EA::BATCH_ACTION_ENTITY_IDS) ?: [],
             $context->getRequest()->request->get(EA::ENTITY_FQCN),
             $referrerUrl,
             $context->getRequest()->request->get(EA::BATCH_ACTION_CSRF_TOKEN)


### PR DESCRIPTION
Returning an array with \Symfony\Component\HttpFoundation\InputBag::get is deprecated.

>         if (null !== $value && $this !== $value && !is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) >{
>            trigger_deprecation('symfony/http-foundation', '5.1', 'Retrieving a non-string value from "%s()" is deprecated, and will throw >a "%s" exception in Symfony 6.0, use "%s::all($key)" instead.', __METHOD__, BadRequestException::class, __CLASS__);
>        }
