### PR TITLE
Simplify some Doctrine requirements in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,8 @@
     "require": {
         "php": ">=7.2.5",
         "ext-json": "*",
-        "doctrine/common": "^2.13 || ^3.0",
-        "doctrine/dbal": "^2.10 || ^3.0",
         "doctrine/doctrine-bundle": "^1.12|^2.0",
         "doctrine/orm": "^2.6,>=2.6.3",
-        "doctrine/persistence": "^1.3.3 || ^2.0",
         "nikic/php-parser": "^4.3",
         "symfony/asset": "^4.4|^5.0",
         "symfony/cache": "^4.4|^5.0",


### PR DESCRIPTION
If I'm right, we don't need to define these dependencies explicitly because they are installed and resolved indirectly via Doctrine bundle and Doctrine ORM.