### PR TITLE
Allow deep linking of associations

### DIFF
--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -92,6 +92,18 @@ final class EntityFactory
         return EntityCollection::new($entityDtos);
     }
 
+    public function getEntityMetadata(string $entityFqcn): ClassMetadata
+    {
+        $entityManager = $this->getEntityManager($entityFqcn);
+        $entityMetadata = $entityManager->getClassMetadata($entityFqcn);
+
+        if (1 !== \count($entityMetadata->getIdentifierFieldNames())) {
+            throw new \RuntimeException(sprintf('EasyAdmin does not support Doctrine entities with composite primary keys (such as the ones used in the "%s" entity).', $entityFqcn));
+        }
+
+        return $entityMetadata;
+    }
+
     private function doCreate(?string $entityFqcn = null, $entityId = null, ?string $entityPermission = null, $entityInstance = null): EntityDto
     {
         if (null === $entityInstance && null !== $entityFqcn) {
@@ -125,18 +137,6 @@ final class EntityFactory
         }
 
         return $entityManager;
-    }
-
-    private function getEntityMetadata(string $entityFqcn): ClassMetadata
-    {
-        $entityManager = $this->getEntityManager($entityFqcn);
-        $entityMetadata = $entityManager->getClassMetadata($entityFqcn);
-
-        if (1 !== \count($entityMetadata->getIdentifierFieldNames())) {
-            throw new \RuntimeException(sprintf('EasyAdmin does not support Doctrine entities with composite primary keys (such as the ones used in the "%s" entity).', $entityFqcn));
-        }
-
-        return $entityMetadata;
     }
 
     /**

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -15,6 +15,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -55,12 +56,44 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             $field->setFormTypeOption('attr.data-ea-widget', 'ea-autocomplete');
         }
 
-        if ($entityDto->isToOneAssociation($propertyName)) {
-            $this->configureToOneAssociation($field);
-        }
+        // check for embedded associations
+        $parts = explode('.', $propertyName);
+        if (\count($parts) > 1) {
+            // prepare starting class for association
+            $targetEntityFqcn = $entityDto->getPropertyMetadata($parts[0])->get('targetEntity');
+            array_shift($parts);
+            $metadata = $this->entityFactory->getEntityMetadata($targetEntityFqcn);
 
-        if ($entityDto->isToManyAssociation($propertyName)) {
-            $this->configureToManyAssociation($field);
+            foreach ($parts as $association) {
+                if (!$metadata->hasAssociation($association)) {
+                    throw new \RuntimeException(sprintf('There is no association for the class "%s" with name "%s"', $targetEntityFqcn, $association));
+                }
+
+                // overwrite next class from association
+                $targetEntityFqcn = $metadata->getAssociationTargetClass($association);
+
+                // read next association metadata
+                $metadata = $this->entityFactory->getEntityMetadata($targetEntityFqcn);
+            }
+
+            $accessor = new PropertyAccessor();
+            $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER);
+
+            $relatedEntityId = $accessor->getValue($entityDto->getInstance(), $propertyName.'.'.$metadata->getIdentifierFieldNames()[0]);
+            $relatedEntityDto = $this->entityFactory->create($targetEntityFqcn, $relatedEntityId);
+
+            $field->setFormTypeOptionIfNotSet('class', $relatedEntityDto->getFqcn());
+
+            $field->setCustomOption(AssociationField::OPTION_RELATED_URL, $this->generateLinkToAssociatedEntity($targetCrudControllerFqcn, $relatedEntityDto));
+            $field->setFormattedValue($this->formatAsString($relatedEntityDto->getInstance(), $relatedEntityDto));
+        } else {
+            if ($entityDto->isToOneAssociation($propertyName)) {
+                $this->configureToOneAssociation($field);
+            }
+
+            if ($entityDto->isToManyAssociation($propertyName)) {
+                $this->configureToManyAssociation($field);
+            }
         }
 
         if (true === $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE)) {


### PR DESCRIPTION
Fixes #4512

Adds support for linking to associations within associations as an AssociationField.
While editing seems to work it's not encouraged because of the implications of editing entities further away. It doesn't seem to break though.

Example usage, assuming Foo has a property (OneToOne) bar of instance of Bar, and Bar has a property (OneToOne) car of Car

```php
// assuming Foo is the entity

yield AssociationField('bar.car', 'Car');
```

The related crud controller should be detected automatically, the class for the entity will also be set from the found associations.