### PR TITLE
Add a disabled helper method for fields

### DIFF
--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -74,6 +74,13 @@ trait FieldTrait
         return $this;
     }
 
+    public function setDisabled(bool $disabled = true): self
+    {
+        $this->dto->setFormTypeOption('disabled', $disabled);
+
+        return $this;
+    }
+
     public function setRequired(bool $isRequired): self
     {
         $this->dto->setFormTypeOption('required', $isRequired);


### PR DESCRIPTION
Just adds a shortcut to fields since I'm tired of writing the same thing all the time
```php
new MoneyField::new('something')
        ->setFormTypeOption('disabled', true);
````
Becomes
```php
new MoneyField::new('something')
        ->setDisabled();
```