### PR TITLE
Allow customizing redirect response after saving entity

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -286,6 +286,28 @@ Templates and Form Options
         ;
     }
 
+Redirection configuration after saving
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to change or improve redirection after saving an entity, you can override the
+``getRedirectResponseAfterSave()`` method. Eg. if you want to add a "save and view detail" action::
+
+    protected function getRedirectResponseAfterSave(AdminContext $context, string $action): RedirectResponse
+    {
+        $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];
+
+        if ('saveAndViewDetail' === $submitButtonName) {
+            $url = $this->get(AdminUrlGenerator::class)
+                ->setAction(Action::DETAIL)
+                ->setEntityId($context->getEntity()->getPrimaryKeyValue())
+                ->generateUrl();
+
+            return $this->redirect($url);
+        }
+
+        return parent::getRedirectResponseAfterSave($context, $action);
+    }
+
 Same Configuration in Different CRUD Controllers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -53,6 +53,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use function Symfony\Component\String\u;
 
@@ -235,25 +236,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
             $this->get('event_dispatcher')->dispatch(new AfterEntityUpdatedEvent($entityInstance));
 
-            $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];
-            if (Action::SAVE_AND_CONTINUE === $submitButtonName) {
-                $url = $this->get(AdminUrlGenerator::class)
-                    ->setAction(Action::EDIT)
-                    ->setEntityId($context->getEntity()->getPrimaryKeyValue())
-                    ->generateUrl();
-
-                return $this->redirect($url);
-            }
-
-            if (Action::SAVE_AND_RETURN === $submitButtonName) {
-                $url = empty($context->getReferrer())
-                    ? $this->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl()
-                    : $context->getReferrer();
-
-                return $this->redirect($url);
-            }
-
-            return $this->redirectToRoute($context->getDashboardRouteName());
+            return $this->getRedirectResponseAfterSave($context, Action::EDIT);
         }
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
@@ -310,30 +293,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             $this->get('event_dispatcher')->dispatch(new AfterEntityPersistedEvent($entityInstance));
             $context->getEntity()->setInstance($entityInstance);
 
-            $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];
-            if (Action::SAVE_AND_CONTINUE === $submitButtonName) {
-                $url = $this->get(AdminUrlGenerator::class)
-                    ->setAction(Action::EDIT)
-                    ->setEntityId($context->getEntity()->getPrimaryKeyValue())
-                    ->generateUrl();
-
-                return $this->redirect($url);
-            }
-
-            if (Action::SAVE_AND_RETURN === $submitButtonName) {
-                $url = $context->getReferrer()
-                    ?? $this->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl();
-
-                return $this->redirect($url);
-            }
-
-            if (Action::SAVE_AND_ADD_ANOTHER === $submitButtonName) {
-                $url = $this->get(AdminUrlGenerator::class)->setAction(Action::NEW)->generateUrl();
-
-                return $this->redirect($url);
-            }
-
-            return $this->redirectToRoute($context->getDashboardRouteName());
+            return $this->getRedirectResponseAfterSave($context, Action::NEW);
         }
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
@@ -632,5 +592,34 @@ abstract class AbstractCrudController extends AbstractController implements Crud
                 $uploadNew($file, $uploadDir, $fileName);
             }
         }
+    }
+
+    protected function getRedirectResponseAfterSave(AdminContext $context, string $action): RedirectResponse
+    {
+        $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];
+
+        if (Action::SAVE_AND_CONTINUE === $submitButtonName) {
+            $url = $this->get(AdminUrlGenerator::class)
+                ->setAction(Action::EDIT)
+                ->setEntityId($context->getEntity()->getPrimaryKeyValue())
+                ->generateUrl();
+
+            return $this->redirect($url);
+        }
+
+        if (Action::SAVE_AND_RETURN === $submitButtonName) {
+            $url = $context->getReferrer()
+                ?? $this->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl();
+
+            return $this->redirect($url);
+        }
+
+        if (Action::SAVE_AND_ADD_ANOTHER === $submitButtonName) {
+            $url = $this->get(AdminUrlGenerator::class)->setAction(Action::NEW)->generateUrl();
+
+            return $this->redirect($url);
+        }
+
+        return $this->redirectToRoute($context->getDashboardRouteName());
     }
 }


### PR DESCRIPTION
Hi,

This PR allows customizing easily (= without overriding the entire edit/new methods) the redirect response after saving an entity.