### PR TITLE
Improve the pagination when there are hidden results

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -194,7 +194,7 @@
     {% if entities|length > 0 %}
         <div class="content-panel-footer without-padding without-border">
             {% block paginator %}
-                {{ include(ea.templatePath('crud/paginator')) }}
+                {{ include(ea.templatePath('crud/paginator'), { render_detailed_pagination: not some_results_are_hidden }) }}
             {% endblock paginator %}
         </div>
     {% endif %}

--- a/src/Resources/views/crud/paginator.html.twig
+++ b/src/Resources/views/crud/paginator.html.twig
@@ -4,7 +4,9 @@
 
 <div class="list-pagination">
     <div class="list-pagination-counter">
-        {{ 'paginator.results'|trans({'%count%': paginator.numResults|format})|raw }}
+        {% if render_detailed_pagination is defined ? render_detailed_pagination : true %}
+            {{ 'paginator.results'|trans({'%count%': paginator.numResults|format})|raw }}
+        {% endif %}
     </div>
 
     <nav class="pager list-pagination-paginator {{ not paginator.hasPreviousPage ? 'first-page' }} {{ not paginator.hasNextPage ? 'last-page' }}">
@@ -15,15 +17,21 @@
                 </a>
             </li>
 
-            {% for page in paginator.pageRange %}
-                <li class="page-item {{ page == paginator.currentPage ? 'active' }} {{ page is null ? 'disabled' }}">
-                    {% if page is null %}
-                        <span class="page-link">&hellip;</span>
-                    {% else %}
-                        <a class="page-link" href="{{ paginator.generateUrlForPage(page) }}">{{ page }}</a>
-                    {% endif %}
+            {% if render_detailed_pagination is defined ? render_detailed_pagination : true %}
+                {% for page in paginator.pageRange %}
+                    <li class="page-item {{ page == paginator.currentPage ? 'active' }} {{ page is null ? 'disabled' }}">
+                        {% if page is null %}
+                            <span class="page-link">&hellip;</span>
+                        {% else %}
+                            <a class="page-link" href="{{ paginator.generateUrlForPage(page) }}">{{ page }}</a>
+                        {% endif %}
+                    </li>
+                {% endfor %}
+            {% else %}
+                <li class="page-item active {{ paginator.currentPage is null ? 'disabled' }}">
+                    <a class="page-link" href="{{ paginator.generateUrlForPage(paginator.currentPage) }}">{{ paginator.currentPage }}</a>
                 </li>
-            {% endfor %}
+            {% endif %}
 
             <li class="page-item {{ not paginator.hasNextPage ? 'disabled' }}">
                 <a class="page-link" href="{{ not paginator.hasNextPage ? '#' : paginator.generateUrlForPage(paginator.nextPage) }}">


### PR DESCRIPTION
Fixes #4361.

It looks like this:

![](https://user-images.githubusercontent.com/73419/134767975-a3793db8-8be2-4a06-bc3d-1eaab70a312d.png)

and when you go to another page:

![](https://user-images.githubusercontent.com/73419/134767980-04a42cbb-2ea5-46d8-91dc-fe491f73394b.png)
