### PR TITLE
Fix wrong double translation of placeholder text

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -56,7 +56,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
 
         if ($entityDto->isToOneAssociation($propertyName)) {
-            $this->configureToOneAssociation($field);
+            $this->configureToOneAssociation($field), $context->getI18n()->getTranslationDomain();
         }
 
         if ($entityDto->isToManyAssociation($propertyName)) {
@@ -97,12 +97,15 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
     }
 
-    private function configureToOneAssociation(FieldDto $field): void
+    private function configureToOneAssociation(FieldDto $field, string $translationDomain): void
     {
         $field->setCustomOption(AssociationField::OPTION_DOCTRINE_ASSOCIATION_TYPE, 'toOne');
 
         if (false === $field->getFormTypeOption('required')) {
-            $field->setFormTypeOptionIfNotSet('attr.placeholder', $this->translator->trans('label.form.empty_value', [], 'EasyAdminBundle'));
+            $placeholderText = ($translationDomain === 'messages')
+                ? $this->translator->trans('label.form.empty_value', [], 'EasyAdminBundle')
+                : 'label.form.empty_value';
+            $field->setFormTypeOptionIfNotSet('attr.placeholder', $placeholderText);
         }
 
         $targetEntityFqcn = $field->getDoctrineMetadata()->get('targetEntity');

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -56,7 +56,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
 
         if ($entityDto->isToOneAssociation($propertyName)) {
-            $this->configureToOneAssociation($field), $context->getI18n()->getTranslationDomain();
+            $this->configureToOneAssociation($field, $context->getI18n()->getTranslationDomain());
         }
 
         if ($entityDto->isToManyAssociation($propertyName)) {


### PR DESCRIPTION
Fix #3453.

The real fix, as discussed in other issues, is to no longer translate things in PHP and use e.g. `Translatable` class to pass things to templates and translate them there. But, meanwhile, let's temporarily fix this.