### PR TITLE
Update ajaxEdit visility

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -523,12 +523,12 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $responseParameters;
     }
 
-    private function getContext(): ?AdminContext
+    protected function getContext(): ?AdminContext
     {
         return $this->get(AdminContextProvider::class)->getContext();
     }
 
-    private function ajaxEdit(EntityDto $entityDto, ?string $propertyName, bool $newValue): AfterCrudActionEvent
+    protected function ajaxEdit(EntityDto $entityDto, ?string $propertyName, bool $newValue): AfterCrudActionEvent
     {
         $this->get(EntityUpdater::class)->updateProperty($entityDto, $propertyName, $newValue);
 


### PR DESCRIPTION
Update ajaxEdit visility to ease edit method override
If I want to override the edit method from the AbstractCrudController, I am forced to also override the ajaxEdit method, because its visibilty is set to private.

Setting ajaxEdit visiblity to protected allow to override edit method easily

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
