### PR TITLE
Add Form Tabs support #4725

### DIFF
--- a/assets/css/easyadmin-theme/forms.scss
+++ b/assets/css/easyadmin-theme/forms.scss
@@ -238,7 +238,7 @@ fieldset .form-group .nullable-control label {
 // Form tabs
 .form-tabs .nav-tabs {
     background: var(--white);
-    margin: -20px -20px 20px;
+    margin: 20px -20px 20px;
     padding-left: 20px;
 }
 

--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -340,6 +340,39 @@ the "panels" created with the special ``FormField`` object::
         ];
     }
 
+Form Tabs
+~~~~~~~~~~~
+
+In pages where you display lots of fields, you can divide them in tabs using
+the "tabs" created with the special ``FormField`` object::
+
+    use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            IdField::new('id')->hideOnForm(),
+
+            // Add a tab
+            FormField::addTab('First Tab'),
+
+            // You can use a Form Panel inside a Form Tab
+            FormField::addPanel('User Details'),
+
+            // Your fields
+            TextField::new('firstName'),
+            TextField::new('lastName'),
+
+            // Add a second Form Tab
+            FormField::addPanel('Second Tab'),
+
+            // Other fields
+            EmailField::new('email'),
+
+        ];
+    }
+
+
 Field Types
 -----------
 

--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -354,7 +354,7 @@ the "tabs" created with the special ``FormField`` object::
             IdField::new('id')->hideOnForm(),
 
             // Add a tab
-            FormField::addTab('First Tab'),
+            FormField::addTab('First Tab', 'user'),
 
             // You can use a Form Panel inside a Form Tab
             FormField::addPanel('User Details'),
@@ -364,10 +364,13 @@ the "tabs" created with the special ``FormField`` object::
             TextField::new('lastName'),
 
             // Add a second Form Tab
+            // Tabs can also define their icon, CSS class and help message
+            FormField::addPanel('Contact information')
+                ->setIcon('phone')->addCssClass('optional')
+                ->setHelp('Phone number is preferred'),
             FormField::addPanel('Second Tab'),
 
-            // Other fields
-            EmailField::new('email'),
+            TextField::new('phone'),
 
         ];
     }

--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -354,7 +354,7 @@ the "tabs" created with the special ``FormField`` object::
             IdField::new('id')->hideOnForm(),
 
             // Add a tab
-            FormField::addTab('First Tab', 'user'),
+            FormField::addTab('First Tab'),
 
             // You can use a Form Panel inside a Form Tab
             FormField::addPanel('User Details'),

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -76,10 +76,9 @@ final class FormField implements FieldInterface
     }
 
     /**
-     * @param string  $label
-     * @param ?string $icon
-     *
-     * @return FormField
+     * @param string $label
+     * @param string|null $icon
+     * @return static
      */
     public static function addTab(string $label, ?string $icon = null): self
     {

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -77,9 +77,10 @@ final class FormField implements FieldInterface
 
     /**
      * @param string $label
+     * @param ?string $icon
      * @return FormField
      */
-    public static function addTab($label): self
+    public static function addTab($label, ?string $icon = null): self
     {
         $field = new self();
 
@@ -91,7 +92,8 @@ final class FormField implements FieldInterface
             ->setTemplateName('crud/field/form_tab')
             ->setLabel($label)
             ->setFormType(EasyAdminTabType::class)
-            ->setFormTypeOptions(['mapped' => false, 'required' => false]);
+            ->setFormTypeOptions(['mapped' => false, 'required' => false])
+            ->setCustomOption(self::OPTION_ICON, $icon);
     }
 
     public function setIcon(string $iconCssClass): self

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -76,11 +76,12 @@ final class FormField implements FieldInterface
     }
 
     /**
-     * @param string $label
+     * @param string  $label
      * @param ?string $icon
      * @return FormField
+     *
      */
-    public static function addTab($label, ?string $icon = null): self
+    public static function addTab(string $label, ?string $icon = null): self
     {
         $field = new self();
 

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -78,8 +78,8 @@ final class FormField implements FieldInterface
     /**
      * @param string  $label
      * @param ?string $icon
-     * @return FormField
      *
+     * @return FormField
      */
     public static function addTab(string $label, ?string $icon = null): self
     {

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -76,8 +76,6 @@ final class FormField implements FieldInterface
     }
 
     /**
-     * @param string $label
-     * @param string|null $icon
      * @return static
      */
     public static function addTab(string $label, ?string $icon = null): self

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EaFormPanelType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EaFormRowType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminTabType;
 use Symfony\Component\Uid\Ulid;
 
 /**
@@ -72,6 +73,25 @@ final class FormField implements FieldInterface
             ->addCssClass('field-form_row')
             ->setFormTypeOptions(['mapped' => false, 'required' => false])
             ->setCustomOption(self::OPTION_ROW_BREAKPOINT, $breakpointName);
+    }
+
+    /**
+     * @param string $label
+     * @return FormField
+     */
+    public static function addTab($label): self
+    {
+        $field = new self();
+
+        return $field
+            ->setFieldFqcn(__CLASS__)
+            ->hideOnIndex()
+            ->hideOnDetail()
+            ->setProperty('ea_form_tab_'.(new Ulid()))
+            ->setTemplateName('crud/field/form_tab')
+            ->setLabel($label)
+            ->setFormType(EasyAdminTabType::class)
+            ->setFormTypeOptions(['mapped' => false, 'required' => false]);
     }
 
     public function setIcon(string $iconCssClass): self

--- a/src/Form/EventListener/EasyAdminTabSubscriber.php
+++ b/src/Form/EventListener/EasyAdminTabSubscriber.php
@@ -26,14 +26,14 @@ class EasyAdminTabSubscriber implements EventSubscriberInterface
      */
     public function handleViolations(FormEvent $event)
     {
-        $formTabs = $event->getForm()->getConfig()->getAttribute('easyadmin_form_tabs');
+        $formTabs = $event->getForm()->getConfig()->getAttribute('ea_form_tabs');
 
         $firstTabWithErrors = null;
         foreach ($event->getForm() as $child) {
             $errors = $child->getErrors(true);
 
             if (\count($errors) > 0) {
-                $formTab = $child->getConfig()->getAttribute('easyadmin_form_tab');
+                $formTab = $child->getConfig()->getAttribute('ea_form_tab');
                 $formTabs[$formTab]['errors'] += \count($errors);
 
                 if (null === $firstTabWithErrors) {

--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -86,7 +86,7 @@ class CrudFormType extends AbstractType
                 $metadata['label'] = $fieldDto->getLabel();
                 $metadata['help'] = $fieldDto->getHelp();
                 $metadata[FormField::OPTION_ICON] = $fieldDto->getCustomOption(FormField::OPTION_ICON);
-                $currentFormTab =  $fieldDto->getLabel();
+                $currentFormTab = $fieldDto->getLabel();
 
                 // plain arrays are not enough for tabs because they are modified in the
                 // lifecycle of a form (e.g. add info about form errors). Use an ArrayObject instead.

--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -84,6 +84,8 @@ class CrudFormType extends AbstractType
                 $metadata['errors'] = 0;
                 $metadata['id'] = $fieldDto->getProperty();
                 $metadata['label'] = $fieldDto->getLabel();
+                $metadata['help'] = $fieldDto->getHelp();
+                $metadata[FormField::OPTION_ICON] = $fieldDto->getCustomOption(FormField::OPTION_ICON);
                 $currentFormTab =  $fieldDto->getLabel();
 
                 // plain arrays are not enough for tabs because they are modified in the

--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -82,7 +82,9 @@ class CrudFormType extends AbstractType
                 // The first tab should be marked as active by default
                 $metadata['active'] = 0 === \count($formTabs);
                 $metadata['errors'] = 0;
-                $currentFormTab = $metadata['fieldName'];
+                $metadata['id'] = $fieldDto->getProperty();
+                $metadata['label'] = $fieldDto->getLabel();
+                $currentFormTab =  $fieldDto->getLabel();
 
                 // plain arrays are not enough for tabs because they are modified in the
                 // lifecycle of a form (e.g. add info about form errors). Use an ArrayObject instead.

--- a/src/Form/Type/EasyAdminTabType.php
+++ b/src/Form/Type/EasyAdminTabType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+
+/**
+ * The 'tab' form type is a special form type used to display a design
+ * element needed to create complex form layouts. This "fake" type just displays
+ * some HTML tags and it must be added to a form as "unmapped" and "non required".
+ */
+class EasyAdminTabType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'ea_form_tabs';
+    }
+}

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -416,7 +416,7 @@
         <div class="col-12">
             <div class="nav-tabs-custom form-tabs">
                 <ul class="nav nav-tabs">
-                    {% for tab_name, tab_config in ea_form_tabs %}
+                    {% for tab_name, tab_config in ea_crud_form.form_tabs %}
                         <li class="nav-item">
                             <a class="nav-link {% if tab_config.active %}active{% endif %}" href="#{{ tab_config['id'] }}" id="{{ tab_config['id'] }}-tab" data-bs-toggle="tab">
                                 {%- if tab_config.icon|default(false) -%}
@@ -433,7 +433,7 @@
                     {% endfor %}
                 </ul>
                 <div class="tab-content">
-                    {% for tab_name, tab_config in ea_form_tabs %}
+                    {% for tab_name, tab_config in ea_crud_form.form_tabs %}
                         <div id="{{ tab_config['id'] }}" class="tab-pane {% if tab_config.active %}active{% endif %} {{ tab_config['css_class']|default('') }}">
                             {% if tab_config['help']|default(false) %}
                                 <div class="content-header-help tab-help">
@@ -441,7 +441,9 @@
                                 </div>
                             {% endif %}
 
-                            {{ block('ea_crud_widget_panels') }}
+                            <div class="row">
+                                {{ block('ea_crud_widget_panels') }}
+                            </div>
                         </div>
                     {% endfor %}
                 </div>


### PR DESCRIPTION

[3.X] Add Form Tabs support #4725

### Add feature to support form tabs on cruds

I've found a rapid way to make it works.
What do you think about it ?

Example of how to use this feature

_

In pages where you display lots of fields, you can divide them in tabs using
the "tabs" created with the special FormField object::

use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;

public function configureFields(string $pageName): iterable
{
    return [
        IdField::new('id')->hideOnForm(),

        // Add a tab
        FormField::addTab('First Tab'),

        // You can use a Form Panel inside a Form Tab
        FormField::addPanel('User Details'),

        // Your fields
        TextField::new('firstName'),
        TextField::new('lastName'),

        // Add a second Form Tab
        // Tabs can also define their icon, CSS class and help message
        FormField::addPanel('Contact information')
            ->setIcon('phone')->addCssClass('optional')
            ->setHelp('Phone number is preferred'),
        FormField::addPanel('Second Tab'),

        TextField::new('phone'),

    ];
}
_