### PR TITLE
Fix regression to make the batch actions work with sf4.4 and sf5

### DIFF
--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -42,7 +42,7 @@ final class BatchActionDtoResolver implements ArgumentValueResolverInterface
 
         yield new BatchActionDto(
             $context->getRequest()->request->get(EA::BATCH_ACTION_NAME),
-            $context->getRequest()->request->all(EA::BATCH_ACTION_ENTITY_IDS) ?: [],
+            $context->getRequest()->request->all()[EA::BATCH_ACTION_ENTITY_IDS] ?: [],
             $context->getRequest()->request->get(EA::ENTITY_FQCN),
             $referrerUrl,
             $context->getRequest()->request->get(EA::BATCH_ACTION_CSRF_TOKEN)


### PR DESCRIPTION
https://github.com/EasyCorp/EasyAdminBundle/pull/4672 introduces a regression because all() does not accept a parameter on Symfony 4.

So we have to use it the same way Symfony uses it (\Symfony\Component\Security\Http\ParameterBagUtils::getParameterBagValue for instance).
