### PR TITLE
Add EntityLifecycleEventInterface to the Before/AfterEntity Events

### DIFF
--- a/src/Contracts/Event/EntityLifecycleEventInterface.php
+++ b/src/Contracts/Event/EntityLifecycleEventInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Event;
+
+/**
+ * @author: Benjamin Leibinger <mail@leibinger.io>
+ */
+interface EntityLifecycleEventInterface
+{
+    public function getEntityInstance();
+}

--- a/src/Event/AbstractLifecycleEvent.php
+++ b/src/Event/AbstractLifecycleEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Event;
+
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Event\EntityLifecycleEventInterface;
+
+/**
+ * @author: Benjamin Leibinger <mail@leibinger.io>
+ */
+abstract class AbstractLifecycleEvent implements EntityLifecycleEventInterface
+{
+    protected $entityInstance;
+
+    public function __construct($entityInstance)
+    {
+        $this->entityInstance = $entityInstance;
+    }
+
+    public function getEntityInstance()
+    {
+        return $this->entityInstance;
+    }
+}

--- a/src/Event/AfterEntityDeletedEvent.php
+++ b/src/Event/AfterEntityDeletedEvent.php
@@ -5,17 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AfterEntityDeletedEvent
+final class AfterEntityDeletedEvent extends AbstractLifecycleEvent
 {
-    private $entityInstance;
-
-    public function __construct($entityInstance)
-    {
-        $this->entityInstance = $entityInstance;
-    }
-
-    public function getEntityInstance()
-    {
-        return $this->entityInstance;
-    }
 }

--- a/src/Event/AfterEntityPersistedEvent.php
+++ b/src/Event/AfterEntityPersistedEvent.php
@@ -5,17 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AfterEntityPersistedEvent
+final class AfterEntityPersistedEvent extends AbstractLifecycleEvent
 {
-    private $entityInstance;
-
-    public function __construct($entityInstance)
-    {
-        $this->entityInstance = $entityInstance;
-    }
-
-    public function getEntityInstance()
-    {
-        return $this->entityInstance;
-    }
 }

--- a/src/Event/AfterEntityUpdatedEvent.php
+++ b/src/Event/AfterEntityUpdatedEvent.php
@@ -11,17 +11,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AfterEntityUpdatedEvent
+final class AfterEntityUpdatedEvent extends AbstractLifecycleEvent
 {
-    private $entityInstance;
-
-    public function __construct($entityInstance)
-    {
-        $this->entityInstance = $entityInstance;
-    }
-
-    public function getEntityInstance()
-    {
-        return $this->entityInstance;
-    }
 }

--- a/src/Event/BeforeEntityDeletedEvent.php
+++ b/src/Event/BeforeEntityDeletedEvent.php
@@ -5,19 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class BeforeEntityDeletedEvent
+final class BeforeEntityDeletedEvent extends AbstractLifecycleEvent
 {
     use StoppableEventTrait;
-
-    private $entityInstance;
-
-    public function __construct($entityInstance)
-    {
-        $this->entityInstance = $entityInstance;
-    }
-
-    public function getEntityInstance()
-    {
-        return $this->entityInstance;
-    }
 }

--- a/src/Event/BeforeEntityPersistedEvent.php
+++ b/src/Event/BeforeEntityPersistedEvent.php
@@ -5,17 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class BeforeEntityPersistedEvent
+final class BeforeEntityPersistedEvent extends AbstractLifecycleEvent
 {
-    private $entityInstance;
-
-    public function __construct($entityInstance)
-    {
-        $this->entityInstance = $entityInstance;
-    }
-
-    public function getEntityInstance()
-    {
-        return $this->entityInstance;
-    }
 }

--- a/src/Event/BeforeEntityUpdatedEvent.php
+++ b/src/Event/BeforeEntityUpdatedEvent.php
@@ -5,17 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class BeforeEntityUpdatedEvent
+final class BeforeEntityUpdatedEvent extends AbstractLifecycleEvent
 {
-    private $entityInstance;
-
-    public function __construct($entityInstance)
-    {
-        $this->entityInstance = $entityInstance;
-    }
-
-    public function getEntityInstance()
-    {
-        return $this->entityInstance;
-    }
 }


### PR DESCRIPTION
With this Interface you can easily reuse functions for the BeforeEntity/AfterEntity{Deleted,Persisted,Updated} Events in an EventSubscriber. 

Example usage: 
If you want to create or update a user via a crudcontroller then you need to hash the password from the user before you persist or update the entity. Of Course you can also create two Methods which do basically the same with just a different event as parameter but then sonarqube will tell you this is a code smell. With this Interface you can easily reuse the function which does the password hashing.

```php
namespace App\EventSubscriber;

use App\Entity\User;
use EasyCorp\Bundle\EasyAdminBundle\Contracts\Event\EntityLifecycleEvent;
use EasyCorp\Bundle\EasyAdminBundle\Event\BeforeEntityPersistedEvent;
use EasyCorp\Bundle\EasyAdminBundle\Event\BeforeEntityUpdatedEvent;
use Symfony\Component\EventDispatcher\EventSubscriberInterface;
use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;

class UserPasswordSubscriber implements EventSubscriberInterface
{
    private UserPasswordHasherInterface $passwordHasher;

    public function __construct(UserPasswordHasherInterface $passwordHasher)
    {
        $this->passwordHasher = $passwordHasher;
    }

    public static function getSubscribedEvents(): array
    {
        return [
            BeforeEntityUpdatedEvent::class => ['updatePasswordHash'],
            BeforeEntityPersistedEvent::class => ['updatePasswordHash'],
        ];
    }

    public function updatePasswordHash(EntityLifecycleEventInterface $event): void
    {
        $entity = $event->getEntityInstance();

        if ($entity instanceof User && !empty($entity->getPlainPassword())) {
            $entity->setPassword($this->passwordHasher->hashPassword($entity, $entity->getPlainPassword()));
        }
    }
}
```