### PR TITLE
Query for symfony/uid Doctrine type "uuid" if needed

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -135,7 +135,7 @@ final class EntityRepository implements EntityRepositoryInterface
                     ->setParameter('query_for_numbers', $dqlParameters['numeric_query']);
             } elseif ($isGuidProperty && $isUuidQuery) {
                 $queryBuilder->orWhere(sprintf('%s.%s = :query_for_uuids', $entityName, $propertyName))
-                    ->setParameter('query_for_uuids', $dqlParameters['uuid_query']);
+                    ->setParameter('query_for_uuids', $dqlParameters['uuid_query'], 'uuid' === $propertyDataType ? 'uuid' : null);
             } elseif ($isUlidProperty && $isUlidQuery) {
                 $queryBuilder->orWhere(sprintf('%s.%s = :query_for_uuids', $entityName, $propertyName))
                     ->setParameter('query_for_uuids', $dqlParameters['uuid_query'], 'ulid');


### PR DESCRIPTION
Would fix https://github.com/EasyCorp/EasyAdminBundle/issues/4158

See docs for `symfony/uid` here: https://symfony.com/doc/current/components/uid.html#storing-uuids-in-databases :

*When using built-in Doctrine repository methods (e.g. findOneBy()), Doctrine knows how to convert these UUID types to build the SQL query (e.g. ->findOneBy(['user' => $user->getUuid()])). However, when using DQL queries or building the query yourself, you'll need to set uuid as the type of the UUID parameters: .....*