### PR TITLE
Fix search using DQL keywords

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -94,11 +94,21 @@ final class EntityRepository implements EntityRepositoryInterface
 
                 for ($i = 0; $i < $numAssociatedProperties - 1; ++$i) {
                     $associatedEntityName = $associatedProperties[$i];
+                    // the DQL alias defaults to $associatedEntityName and is only prefixed with "ea_"
+                    // if $associatedEntityName is a reserved keyword or if there is no way to detect
+                    // reserved keywords
+                    try {
+                        $associatedEntityAlias = $queryBuilder->getEntityManager()->getConnection()->getDatabasePlatform()->getReservedKeywordsList()->isKeyword($associatedEntityName)
+                            ? 'ea_'.$associatedEntityName
+                            : $associatedEntityName;
+                    } catch (\Throwable $exception) {
+                        $associatedEntityAlias = $associatedEntityName;
+                    }
                     $associatedPropertyName = $associatedProperties[$i + 1];
 
                     if (!\in_array($associatedEntityName, $entitiesAlreadyJoined, true)) {
                         $parentEntityName = 0 === $i ? 'entity' : $associatedProperties[$i - 1];
-                        $queryBuilder->leftJoin($parentEntityName.'.'.$associatedEntityName, $associatedEntityName);
+                        $queryBuilder->leftJoin($parentEntityName.'.'.$associatedEntityName, $associatedEntityAlias);
                         $entitiesAlreadyJoined[] = $associatedEntityName;
                     }
 
@@ -109,7 +119,7 @@ final class EntityRepository implements EntityRepositoryInterface
                     }
                 }
 
-                $entityName = $associatedEntityName;
+                $entityName = $associatedEntityAlias;
                 $propertyName = $associatedPropertyName;
                 $propertyDataType = $associatedEntityDto->getPropertyDataType($propertyName);
             } else {


### PR DESCRIPTION
Would fix https://github.com/EasyCorp/EasyAdminBundle/issues/4306.

The fix is no BC break. If an app is already using the alias it will still work (because an invalid alias which is a keyword would not have worked before anyway). The only change should be that an app now can use property names which are reserved keywords in DQL. For more infos please see the issue.
