### PR TITLE
Set timezone for tests to UTC

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,9 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 // needed to avoid encoding issues when running tests on different platforms
 setlocale(\LC_ALL, 'en_US.UTF-8');
 
+// needed to avoid failed tests when other timezones than UTC are configured for PHP
+date_default_timezone_set('UTC');
+
 // we want final classes in code but we need non-final classes in tests
 // after trying many solutions (see https://tomasvotruba.com/blog/2019/03/28/how-to-mock-final-classes-in-phpunit/)
 // none ws reliable enough, so this custom solution removes the 'final' keyword


### PR DESCRIPTION
If there is another timezone configured for PHP (e.g. `Europe/Vienna`) there are currently 22 tests failing. With this commit there are currently 0 tests failing.

The currently failing tests all are similar to this example:
```php
1) EasyCorp\Bundle\EasyAdminBundle\Tests\Intl\IntlFormatterTest::testFormatTime with data set #7 ('3:04:05 PM Coordinated Universal Time', DateTime Object (...), 'full', '', null, 'gregorian', 'en')
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'3:04:05 PM Coordinated Universal Time'
+'3:04:05 PM Central European Standard Time'
```