### PR TITLE
Check that the nullable key exists

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -192,7 +192,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         // If at least one join column of an association field isn't nullable then the field is "required" by default, otherwise the field is optional
         if ($entityDto->isAssociation($field->getProperty())) {
             foreach ($doctrinePropertyMetadata->get('joinColumns', []) as $joinColumn) {
-                if (false === $joinColumn['nullable'] ?? null) {
+                if (\array_key_exists('nullable', $joinColumn) && false === $joinColumn['nullable'] ?? null) {
                     return true;
                 }
             }


### PR DESCRIPTION
Check that the nullable key exists in the $joinColumn array. Fixes #4801.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
