### PR TITLE
Change the way the class parameter is loaded through embedded associations

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -80,11 +80,11 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             $accessor = new PropertyAccessor();
             $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER);
 
+            $field->setFormTypeOptionIfNotSet('class', $targetEntityFqcn);
+
             try {
                 $relatedEntityId = $accessor->getValue($entityDto->getInstance(), $propertyName.'.'.$metadata->getIdentifierFieldNames()[0]);
                 $relatedEntityDto = $this->entityFactory->create($targetEntityFqcn, $relatedEntityId);
-
-                $field->setFormTypeOptionIfNotSet('class', $relatedEntityDto->getFqcn());
 
                 $field->setCustomOption(AssociationField::OPTION_RELATED_URL, $this->generateLinkToAssociatedEntity($targetCrudControllerFqcn, $relatedEntityDto));
                 $field->setFormattedValue($this->formatAsString($relatedEntityDto->getInstance(), $relatedEntityDto));


### PR DESCRIPTION
This fixes a potential issue I realized while looking over the code again.

As the class for the association is already known at this point, it's fine to just set it earlier, before a possible crash from the property accessor.
There's another side issue, but that one cannot be solved through the embedded association feature set, as it's related to form creation and is more of a user-side issue.

Consider the following
```
Entity First:
  OneToOne Second second;

Entity Second:
  OneToOne First first;
  OneToOne ?Third third;

Entity Third: 
  OneToOne Second second;
```

If user then attempts to fetch the entity for `first.second.third` it's possible that the link will be broken in the second entity, and the **forms won't render correctly**.
Granted, this is simply because of a reliance on an entity that is not set. The form should then recognize it cannot load the entity and remove the field. It is fine to leave it in the detail and index views, as the exception is handled by this code.