### PR TITLE
Fix search using DQL keywords

### DIFF
--- a/src/Orm/DqlAliasCreator.php
+++ b/src/Orm/DqlAliasCreator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Orm;
+
+use Doctrine\ORM\Query\Lexer;
+
+class DqlAliasCreator
+{
+    public const PREFIX = 'ea_';
+
+    /**
+     * Creates a valid alias for entity names which can be used in DQL queries.
+     *
+     * Defaults to the entity name itself (e.g. "category") but adds a prefix
+     * if the entity name is a reserved keyword in the Doctrine Query Language
+     * (e.g. "order" becomes "ea_order").
+     */
+    public static function create(string $entityName): string
+    {
+        if (self::isReservedKeyword($entityName)) {
+            return self::PREFIX.$entityName;
+        }
+
+        return $entityName;
+    }
+
+    /**
+     * Determines if a string is a reserved keyword in Doctrine Query Language.
+     */
+    private static function isReservedKeyword(string $string): bool
+    {
+        $lexer = new Lexer($string);
+
+        $lexer->moveNext();
+        $token = $lexer->lookahead;
+
+        if (200 <= $token['type']) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -94,11 +94,12 @@ final class EntityRepository implements EntityRepositoryInterface
 
                 for ($i = 0; $i < $numAssociatedProperties - 1; ++$i) {
                     $associatedEntityName = $associatedProperties[$i];
+                    $associatedEntityAlias = DqlAliasCreator::create($associatedEntityName);
                     $associatedPropertyName = $associatedProperties[$i + 1];
 
                     if (!\in_array($associatedEntityName, $entitiesAlreadyJoined, true)) {
                         $parentEntityName = 0 === $i ? 'entity' : $associatedProperties[$i - 1];
-                        $queryBuilder->leftJoin($parentEntityName.'.'.$associatedEntityName, $associatedEntityName);
+                        $queryBuilder->leftJoin($parentEntityName.'.'.$associatedEntityName, $associatedEntityAlias);
                         $entitiesAlreadyJoined[] = $associatedEntityName;
                     }
 
@@ -109,7 +110,7 @@ final class EntityRepository implements EntityRepositoryInterface
                     }
                 }
 
-                $entityName = $associatedEntityName;
+                $entityName = $associatedEntityAlias;
                 $propertyName = $associatedPropertyName;
                 $propertyDataType = $associatedEntityDto->getPropertyDataType($propertyName);
             } else {

--- a/tests/Orm/DqlAliasCreatorTest.php
+++ b/tests/Orm/DqlAliasCreatorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Router;
+
+use EasyCorp\Bundle\EasyAdminBundle\Orm\DqlAliasCreator;
+use PHPUnit\Framework\TestCase;
+
+class DqlAliasCreatorTest extends TestCase
+{
+    /**
+     * @dataProvider createAliasDataProvider
+     */
+    public function testCreateAlias(string $expectedAlias, string $entityName)
+    {
+        $createdAlias = DqlAliasCreator::create($entityName);
+
+        $this->assertSame($expectedAlias, $createdAlias, sprintf('The created DQL alias for "%s" does not match the expected alias "%s".', $createdAlias, $expectedAlias));
+    }
+
+    public static function createAliasDataProvider(): iterable
+    {
+        yield ['category', 'category'];
+        yield ['interval', 'interval']; // "interval" is not a reserved keyword in the Doctrine Query Language but only a reserved keyword in platforms like MySQL
+        yield ['ea_order', 'order']; // "order" is a reserved keyword in the Doctrine Query Language and has to be prefixed to avoid runtime exceptions
+        yield ['ea_orDER', 'orDER']; // cases are ignored
+    }
+}


### PR DESCRIPTION
Would fix https://github.com/EasyCorp/EasyAdminBundle/issues/4306.

The fix is no BC break. If an app is already using the alias it will still work (because an invalid alias which is a keyword would not have worked before anyway). The only change should be that an app now can use property names which are reserved keywords in DQL. For more infos please see the issue.

So in short if we search for `person.category.title` the DQL will be - exactly like it was before this commit - something like:

```
SELECT entity FROM App\Entity\Person entity LEFT JOIN entity.category category WHERE category.title = XXX
```

But if we search `person.order.title` the DQL will be different than it was before this commit because `ea_` is added because `order` is a reserved keyword in DQL:

```
SELECT entity FROM App\Entity\Person entity LEFT JOIN entity.order ea_order WHERE ea_order.title = XXX
```