### PR TITLE
imagine_filter fail when lazy mode is enabled

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -6,6 +6,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
+use Twig\Extension\ExtensionInterface;
+use Twig\Extension\RuntimeExtensionInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
@@ -73,11 +75,21 @@ class EasyAdminTwigExtension extends AbstractExtension
     // Code adapted from https://stackoverflow.com/a/48606773/2804294 (License: CC BY-SA 3.0)
     public function applyFilterIfExists(Environment $environment, $value, string $filterName, ...$filterArguments)
     {
-        if (false === $filter = $environment->getFilter($filterName)) {
+        if (false == $filter = $environment->getFilter($filterName)) {
             return $value;
         }
 
-        return $filter->getCallable()($value, ...$filterArguments);
+        list($class, $method) = $filter->getCallable();
+        if ($class instanceof ExtensionInterface) {
+            return $filter->getCallable()($value, ...$filterArguments);
+        }
+
+        $object = $environment->getRuntime($class);
+        if ($object instanceof RuntimeExtensionInterface && method_exists($object, $method)) {
+            return $object->$method($value, ...$filterArguments);
+        }
+
+        return null;
     }
 
     public function representAsString($value): string


### PR DESCRIPTION
Hi everybody ! 

The problem occurs when I use the VichImageType and its form widget associated. 
This line `ea_apply_filter_if_exists('imagine_filter', formTypeOptions.imagine_pattern)` fail.

I got the error `Non-static method Liip\ImagineBundle\Templating\LazyFilterRuntime::filter() cannot be called statically` when liip_imagine is configurered in lazy mode 

```yaml
# liip_imagine.yaml
liip_imagine:
    twig:
        mode: 'lazy'
```

Everything works very well if this mode is disabled. 

You can reproduce that problem with the current version of Symfony ( 5.3 ) with php 8.

Just a more complex problem, getFilter is marked as internal by Twig https://github.com/twigphp/Twig/pull/1889 
So, we shouldn't use it... but I don't see how to avoid it :-/ 

I also changed the strict comparison, because on version 2 getFilter can return false but on version 3 it can return null.

Thanks a lot for your review :) 
