### PR TITLE
Info about rel="noreferrer" in docs is not relevant anymore?

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -410,10 +410,6 @@ It links to a relative or absolute URL::
         ];
     }
 
-To avoid leaking internal backend information to external websites, EasyAdmin
-adds the ``rel="noreferrer"`` attribute to all URL menu items, except if the
-menu item defines its own ``rel`` option.
-
 Section Menu Item
 .................
 


### PR DESCRIPTION
I don't see any `rel="noreferrer"` in the code, is it still relevant? Though I see `referrerpolicy="origin-when-cross-origin"`, is it supposed to replace that `rel="noreferrer"` in some way?