### PR TITLE
Make EntityFilter work with uids

### DIFF
--- a/src/Filter/EntityFilter.php
+++ b/src/Filter/EntityFilter.php
@@ -2,6 +2,9 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Filter;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\Mapping\MappingException;
 use Doctrine\ORM\Query\Expr\Orx;
 use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterInterface;
@@ -10,6 +13,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\EntityFilterType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
+use Symfony\Component\Uid\Ulid;
+use Symfony\Component\Uid\Uuid;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -53,7 +58,7 @@ final class EntityFilter implements FilterInterface
                     $orX->add(sprintf('%s IS NULL', $assocAlias));
                 }
                 $queryBuilder->andWhere($orX)
-                    ->setParameter($parameterName, $value);
+                    ->setParameter($parameterName, $this->processParameterValue($queryBuilder, $value));
             }
         } elseif (null === $value || ($isMultiple && 0 === \count($value))) {
             $queryBuilder->andWhere(sprintf('%s.%s %s', $alias, $property, $comparison));
@@ -64,7 +69,81 @@ final class EntityFilter implements FilterInterface
                 $orX->add(sprintf('%s.%s IS NULL', $alias, $property));
             }
             $queryBuilder->andWhere($orX)
-                ->setParameter($parameterName, $value);
+                ->setParameter($parameterName, $this->processParameterValue($queryBuilder, $value));
         }
+    }
+
+    /**
+     * @param mixed $parameterValue
+     *
+     * @return mixed
+     */
+    private function processParameterValue(QueryBuilder $queryBuilder, $parameterValue)
+    {
+        if (!$parameterValue instanceof ArrayCollection) {
+            return $this->processSingleParameterValue($queryBuilder, $parameterValue);
+        }
+
+        return $parameterValue->map(function ($element) use ($queryBuilder) {
+            return $this->processSingleParameterValue($queryBuilder, $element);
+        });
+    }
+
+    /**
+     * If the parameter value is a bound entity or a collection of bound entities
+     * and its primary key is either of type "uuid" or "ulid" defined in
+     * symfony/doctrine-bridge then the parameter value is converted from the
+     * entity to the database value of its primary key.
+     *
+     * Otherwise, the parameter value is not processed.
+     *
+     * For example, if the used platform is MySQL:
+     *
+     *      App\Entity\Category {#1040 ▼
+     *          -id: Symfony\Component\Uid\UuidV6 {#1046 ▼
+     *              #uid: "1ec4d51f-c746-6f60-b698-634384c1b64c"
+     *          }
+     *          -title: "cat 2"
+     *      }
+     *
+     *  gets processed to a binary value:
+     *
+     *      b"\x1EÄÕ\x1FÇFo`¶˜cC„Á¶L"
+     *
+     * @param mixed $parameterValue
+     *
+     * @return mixed
+     */
+    private function processSingleParameterValue(QueryBuilder $queryBuilder, $parameterValue)
+    {
+        $entityManager = $queryBuilder->getEntityManager();
+
+        try {
+            $classMetadata = $entityManager->getClassMetadata(\get_class($parameterValue));
+        } catch (\Throwable $exception) {
+            // only reached if $parameterValue does not contain an object of a managed
+            // entity, return as we only need to process bound entities
+            return $parameterValue;
+        }
+
+        try {
+            $identifierType = $classMetadata->getTypeOfField($classMetadata->getSingleIdentifierFieldName());
+        } catch (MappingException $exception) {
+            throw new \RuntimeException(sprintf('The EntityFilter does not support entities with a composite primary key or entities without an identifier. Please check your entity "%s".', \get_class($parameterValue)));
+        }
+
+        $identifierValue = $entityManager->getUnitOfWork()->getSingleIdentifierValue($parameterValue);
+
+        if (('uuid' === $identifierType && $identifierValue instanceof Uuid)
+            || ('ulid' === $identifierType && $identifierValue instanceof Ulid)) {
+            try {
+                return Type::getType($identifierType)->convertToDatabaseValue($identifierValue, $entityManager->getConnection()->getDatabasePlatform());
+            } catch (\Throwable $exception) {
+                // if the conversion fails we cannot process the uid parameter value
+                return $parameterValue;
+            }
+        }
+
+        return $parameterValue;
     }
 }


### PR DESCRIPTION
Would fix https://github.com/EasyCorp/EasyAdminBundle/issues/4125.

The implementation is a little complicated but I found no other way to iplement this.

Note: we cannot set the parameter type like `->setParameter($name, $value, 'uuid')` if the `$value` is an `ArrayCollection` (= on `to-many` associations) so we have to convert the entity to the database value of its identifier.
