### PR TITLE
Fix 8.1 regression

### DIFF
--- a/src/Intl/IntlFormatter.php
+++ b/src/Intl/IntlFormatter.php
@@ -179,8 +179,8 @@ final class IntlFormatter
 
         $calendar = 'gregorian' === $calendar ? \IntlDateFormatter::GREGORIAN : \IntlDateFormatter::TRADITIONAL;
 
-        $dateFormatValue = self::DATE_FORMATS[$dateFormat] ?? null;
-        $timeFormatValue = self::DATE_FORMATS[$timeFormat] ?? null;
+        $dateFormatValue = self::DATE_FORMATS[$dateFormat] ?? self::DATE_FORMATS['full'];
+        $timeFormatValue = self::DATE_FORMATS[$timeFormat] ?? self::DATE_FORMATS['full'];
 
         $hash = $locale.'|'.$dateFormatValue.'|'.$timeFormatValue.'|'.$timezone->getName().'|'.$calendar.'|'.$pattern;
 


### PR DESCRIPTION
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/4835

Symfony defaults to \IntlDateFormatter::FULL (cf https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/Intl/DateFormatter/IntlDateFormatter.php#L147)

So the fix simply pre-default those two variables.