### PR TITLE
Allow DBAL 3

### DIFF
--- a/.github/workflows/tests-maintained-symfony.yaml
+++ b/.github/workflows/tests-maintained-symfony.yaml
@@ -17,7 +17,7 @@ jobs:
         continue-on-error: false
         strategy:
             matrix:
-                php-version: ['8.0']
+                php-version: ['8.1']
                 symfony-version: ['5.2']
         steps:
             - name: 'Checkout code'

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.2.5",
         "ext-json": "*",
-        "doctrine/doctrine-bundle": "^1.12|^2.0",
+        "doctrine/doctrine-bundle": "^2.5",
         "doctrine/orm": "^2.6,>=2.6.3",
         "nikic/php-parser": "^4.3",
         "symfony/asset": "^4.4|^5.0|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/uid": "^5.1"
     },
     "require-dev": {
-        "dama/doctrine-test-bundle": "^6.4",
+        "dama/doctrine-test-bundle": "^6.7",
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "psr/log": "~1.0",
         "symfony/browser-kit": "^4.4|^5.0|^6.0",


### PR DESCRIPTION
In #4834 I had to remove DBAL 3 support because I can't make tests pass.

This PR tries to re-add DBAL 3 support. **I need help** trying to find a solution for these test failures:

https://github.com/EasyCorp/EasyAdminBundle/runs/4340827054?check_suite_focus=true

Thanks!