### PR TITLE
Test lowest dependencies; downgrade SecurityVoter::supports(); Symfony 4.4 fixes

### DIFF
--- a/.github/workflows/tests-lowest-dependencies.yaml
+++ b/.github/workflows/tests-lowest-dependencies.yaml
@@ -1,0 +1,39 @@
+# OS: Linux; Symfony: lowest supported by this bundle; PHP: lowest supported by this bundle
+name: "Tests - Lowest supported dependencies"
+
+on:
+    pull_request:
+    push:
+        branches:
+            - 'master'
+
+env:
+    fail-fast: true
+
+jobs:
+    tests:
+        runs-on: 'ubuntu-latest'
+        continue-on-error: false
+        steps:
+            - name: 'Checkout code'
+              uses: actions/checkout@v2.3.3
+
+            - name: 'Install PHP with extensions'
+              uses: shivammathur/setup-php@2.7.0
+              with:
+                  coverage: none
+                  php-version: '7.2.5'
+                  tools: composer:v2
+                  extensions: mbstring, intl, pdo, pdo_sqlite, sqlite3
+                  ini-values: date.timezone=UTC
+
+            - name: 'Install project dependencies'
+              run: |
+                  composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                  composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --prefer-lowest
+                  vendor/bin/simple-phpunit install
+
+            - name: 'Run tests'
+              env:
+                  SYMFONY_DEPRECATIONS_HELPER: 'max[indirect]=10&max[total]=27'
+              run: vendor/bin/simple-phpunit -v

--- a/composer.json
+++ b/composer.json
@@ -44,10 +44,10 @@
         "symfony/browser-kit": "^4.4|^5.0|^6.0",
         "symfony/css-selector": "^4.4|^5.0|^6.0",
         "symfony/dom-crawler": "^4.4|^5.0|^6.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0|^6.0"
+        "symfony/phpunit-bridge": "^5.2|^6.0"
     },
     "conflict": {
-        "doctrine/dbal": ">=3.0.0"
+        "doctrine/dbal": "<2.10 || >=3.0.0"
     },
     "config": {
         "sort-packages": true

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -27,7 +27,10 @@ final class SecurityVoter extends Voter
         $this->adminContextProvider = $adminContextProvider;
     }
 
-    protected function supports(string $permissionName, $subject): bool
+    /**
+     * @return bool
+     */
+    protected function supports($permissionName, $subject)
     {
         return Permission::exists($permissionName);
     }

--- a/tests/Dto/CrudDtoTest.php
+++ b/tests/Dto/CrudDtoTest.php
@@ -39,11 +39,11 @@ class CrudDtoTest extends TestCase
         yield ['Foo Bar', 'Foo Bar'];
         // see https://github.com/EasyCorp/EasyAdminBundle/issues/4176
         yield ['link', 'link'];
-        yield [fn () => null, null];
-        yield [fn () => '', ''];
-        yield [fn () => 'foo', 'foo'];
-        yield [fn () => 'Foo Bar', 'Foo Bar'];
-        yield [fn () => 'link', 'link'];
-        yield [fn ($entityInstance) => 'Entity #'.$entityInstance->getPrimaryKeyValue(), 'Entity #42'];
+        yield [function () { return null; }, null];
+        yield [function () { return ''; }, ''];
+        yield [function () { return 'foo'; }, 'foo'];
+        yield [function () { return 'Foo Bar'; }, 'Foo Bar'];
+        yield [function () { return 'link'; }, 'link'];
+        yield [function ($entityInstance) { return 'Entity #'.$entityInstance->getPrimaryKeyValue(); }, 'Entity #42'];
     }
 }


### PR DESCRIPTION
Would close https://github.com/EasyCorp/EasyAdminBundle/issues/4382.

Important Notes:
- I had to downgrade `SecurityVoter::supports()` signature again which was just upgraded these days because otherwise `symfony/security-core` would be required in 5.0 or higher (which makes it impossible to install EA in symfony 4). I hope this is not a problem.. At least all tests still suceed, so I hope it is OK..

Notes:
- `symfony/phpunit-bridge` v5.2 or higher is now required because we use `PolyfillAssertTrait::assertMatchesRegularExpression()` in our tests (was added in 5.2, in https://github.com/symfony/phpunit-bridge/commit/f00fa7b6d3b1ce14e002b15cdfc94d4527c8c032)
- `doctrine/dbal` now conflicts with versions <2.10 because we use `Doctrine\DBAL\Types\Types` in lots of places (was introducd in 2.10 in https://github.com/doctrine/dbal/commit/4d40444b5c9d2dedb9b029fe62d25d9b375b368d, see also https://github.com/doctrine/dbal/blob/3.2.x/UPGRADE.md#deprecated-type-constants)
- PHP's `fn()` was introduced in PHP7.4 but we use PHP7.2, so I removed all occurences