### PR TITLE
Fixed case-typo in method name "MenuItem::linkToDashboard"

### DIFF
--- a/src/Controller/AbstractDashboardController.php
+++ b/src/Controller/AbstractDashboardController.php
@@ -58,7 +58,7 @@ abstract class AbstractDashboardController extends AbstractController implements
 
     public function configureMenuItems(): iterable
     {
-        yield MenuItem::linktoDashboard('__ea__page_title.dashboard', 'fa fa-home');
+        yield MenuItem::linkToDashboard('__ea__page_title.dashboard', 'fa fa-home');
     }
 
     public function configureUserMenu(UserInterface $user): UserMenu

--- a/src/Resources/skeleton/dashboard.tpl
+++ b/src/Resources/skeleton/dashboard.tpl
@@ -30,7 +30,7 @@ class <?= $class_name; ?> extends AbstractDashboardController
 
     public function configureMenuItems(): iterable
     {
-        yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
+        yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
         // yield MenuItem::linkToCrud('The Label', 'fas fa-list', EntityClass::class);
     }
 }


### PR DESCRIPTION
AbstractDashboardController and dashboard.tpl use "linktoDashboard" instead of "linkToDashboard"

![grafik](https://user-images.githubusercontent.com/1715912/143848090-d2a29423-9eff-4fcb-8ea4-826b604d9cf8.png)
