### PR TITLE
Fix collection delete button

### DIFF
--- a/assets/js/form-type-collection.js
+++ b/assets/js/form-type-collection.js
@@ -13,8 +13,9 @@ const eaCollectionHandler = function (event) {
     document.querySelectorAll('button.field-collection-delete-button').forEach((deleteButton) => {
         deleteButton.addEventListener('click', () => {
             const collection = deleteButton.closest('[data-ea-collection-field]');
+            const item = deleteButton.closest('.field-collection-item');
 
-            deleteButton.closest('.form-group').remove();
+            item.remove();
             document.dispatchEvent(new Event('ea.collection.item-removed'));
 
             EaCollectionProperty.updateCollectionItemCssClasses(collection);


### PR DESCRIPTION
Description:

Collections delete button is broken on 3.5.x.

- Current behavior: when I click on the delete button of a collection item, it removes the entire collection.
- Expected behavior: when I click on the delete button of a collection item, it remove the item in question.

This bug is particularly problematic because an unwary user who saves a form after such an action will experience a data loss.

This fixes #4804
