### PR TITLE
[FEATURE] [3.X] Allow multiple permissions for menu items

### DIFF
--- a/src/Config/Menu/MenuItemTrait.php
+++ b/src/Config/Menu/MenuItemTrait.php
@@ -33,6 +33,13 @@ trait MenuItemTrait
         return $this;
     }
 
+    public function setPermissions(array $permissions): self
+    {
+        $this->dto->setPermissions($permissions);
+
+        return $this;
+    }
+
     public function setTranslationParameters(array $parameters): self
     {
         $this->dto->setTranslationParameters($parameters);

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -22,7 +22,7 @@ final class MenuItemDto
     private $label;
     private $icon;
     private $cssClass;
-    private $permission;
+    private $permissions;
     private $routeName;
     private $routeParameters;
     private $linkUrl;
@@ -39,6 +39,7 @@ final class MenuItemDto
         $this->linkRel = '';
         $this->linkTarget = '_self';
         $this->subItems = [];
+        $this->permissions = [];
     }
 
     public function getType(): string
@@ -126,14 +127,19 @@ final class MenuItemDto
         $this->routeParameters = $routeParameters;
     }
 
-    public function getPermission(): ?string
+    public function getPermissions(): ?array
     {
-        return $this->permission;
+        return $this->permissions;
     }
 
     public function setPermission(?string $permission): void
     {
-        $this->permission = $permission;
+        $this->permissions = [$permission];
+    }
+	
+    public function setPermissions(?array $permissions): void
+    {
+        $this->permissions = $permissions;
     }
 
     public function getCssClass(): string

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -127,7 +127,7 @@ final class MenuItemDto
         $this->routeParameters = $routeParameters;
     }
 
-    public function getPermissions(): ?array
+    public function getPermissions(): array
     {
         return $this->permissions;
     }
@@ -136,8 +136,8 @@ final class MenuItemDto
     {
         $this->permissions = [$permission];
     }
-	
-    public function setPermissions(?array $permissions): void
+
+    public function setPermissions(array $permissions): void
     {
         $this->permissions = $permissions;
     }

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -64,9 +64,9 @@ final class SecurityVoter extends Voter
     {
         // users can see the menu item if they have the permission required by the menu item
         $isGranted = empty($menuItemDto->getPermissions());
-        foreach($menuItemDto->getPermissions() as $permission){
+        foreach ($menuItemDto->getPermissions() as $permission) {
             $isGranted = $this->authorizationChecker->isGranted($permission);
-            if($isGranted){
+            if ($isGranted) {
                 break;
             }
         }

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -63,7 +63,15 @@ final class SecurityVoter extends Voter
     private function voteOnViewMenuItemPermission(MenuItemDto $menuItemDto): bool
     {
         // users can see the menu item if they have the permission required by the menu item
-        return $this->authorizationChecker->isGranted($menuItemDto->getPermission(), $menuItemDto);
+        $isGranted = empty($menuItemDto->getPermissions());
+        foreach($menuItemDto->getPermissions() as $permission){
+            $isGranted = $this->authorizationChecker->isGranted($permission);
+            if($isGranted){
+                break;
+            }
+        }
+
+        return $isGranted;
     }
 
     /**


### PR DESCRIPTION
**Explanation**

Currently, you can only set one permission per menu item in your dashboard configuration. However, it may be useful to be able to set multiple permissions especially for subMenu.


**Example**:

If you want to only show a submenu if one of its `MenuItem` is allowed, you cannot set multiple permissions on your submenu item.

This PR add a new `setPermissions(array $permissions)` to solve this issue.

```
yield MenuItem::subMenu('Administration', 'fa fa-users-cog')->setPermissions(['ROLE_USER_CRUD','ROLE_ANNOUNCEMENT_CRUD'])->setSubItems(
  [
     MenuItem::linkToCrud('User', 'fa fa-user', User::class)->setPermission('ROLE_USER_CRUD'),
     MenuItem::linkToCrud('Announcement', 'fa fa-book', Announcement::class)->setPermission('ROLE_ANNOUNCEMENT_CRUD'),
  ]
);
```

**Backward compatibility**

The method `setPermission` is still there but will store the value in an array instead of a `?string`.