### PR TITLE
Remove call to the deprecated get method in the AbstractCrudControlle…

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -86,7 +86,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function configureFields(string $pageName): iterable
     {
-        return $this->get(FieldProvider::class)->getDefaultFields($pageName);
+        return $this->container->get(FieldProvider::class)->getDefaultFields($pageName);
     }
 
     public static function getSubscribedServices(): array
@@ -111,7 +111,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
     public function index(AdminContext $context)
     {
         $event = new BeforeCrudActionEvent($context);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -121,21 +121,21 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         }
 
         $fields = FieldCollection::new($this->configureFields(Crud::PAGE_INDEX));
-        $filters = $this->get(FilterFactory::class)->create($context->getCrud()->getFiltersConfig(), $fields, $context->getEntity());
+        $filters = $this->container->get(FilterFactory::class)->create($context->getCrud()->getFiltersConfig(), $fields, $context->getEntity());
         $queryBuilder = $this->createIndexQueryBuilder($context->getSearch(), $context->getEntity(), $fields, $filters);
-        $paginator = $this->get(PaginatorFactory::class)->create($queryBuilder);
+        $paginator = $this->container->get(PaginatorFactory::class)->create($queryBuilder);
 
         // this can happen after deleting some items and trying to return
         // to a 'index' page that no longer exists. Redirect to the last page instead
         if ($paginator->isOutOfRange()) {
-            return $this->redirect($this->get(AdminUrlGenerator::class)
+            return $this->redirect($this->container->get(AdminUrlGenerator::class)
                 ->set(EA::PAGE, $paginator->getLastPage())
                 ->generateUrl());
         }
 
-        $entities = $this->get(EntityFactory::class)->createCollection($context->getEntity(), $paginator->getResults());
-        $this->get(EntityFactory::class)->processFieldsForAll($entities, $fields);
-        $actions = $this->get(EntityFactory::class)->processActionsForAll($entities, $context->getCrud()->getActionsConfig());
+        $entities = $this->container->get(EntityFactory::class)->createCollection($context->getEntity(), $paginator->getResults());
+        $this->container->get(EntityFactory::class)->processFieldsForAll($entities, $fields);
+        $actions = $this->container->get(EntityFactory::class)->processActionsForAll($entities, $context->getCrud()->getActionsConfig());
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
             'pageName' => Crud::PAGE_INDEX,
@@ -148,7 +148,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         ]));
 
         $event = new AfterCrudActionEvent($context, $responseParameters);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -159,7 +159,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
     public function detail(AdminContext $context)
     {
         $event = new BeforeCrudActionEvent($context);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -172,8 +172,8 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             throw new InsufficientEntityPermissionException($context);
         }
 
-        $this->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_DETAIL)));
-        $this->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_DETAIL)));
+        $this->container->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
             'pageName' => Crud::PAGE_DETAIL,
@@ -182,7 +182,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         ]));
 
         $event = new AfterCrudActionEvent($context, $responseParameters);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -193,7 +193,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
     public function edit(AdminContext $context)
     {
         $event = new BeforeCrudActionEvent($context);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -206,8 +206,8 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             throw new InsufficientEntityPermissionException($context);
         }
 
-        $this->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_EDIT)));
-        $this->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_EDIT)));
+        $this->container->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
         $entityInstance = $context->getEntity()->getInstance();
 
         if ($context->getRequest()->isXmlHttpRequest()) {
@@ -229,14 +229,14 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             $this->processUploadedFiles($editForm);
 
             $event = new BeforeEntityUpdatedEvent($entityInstance);
-            $this->get('event_dispatcher')->dispatch($event);
+            $this->container->get('event_dispatcher')->dispatch($event);
             $entityInstance = $event->getEntityInstance();
 
-            $this->updateEntity($this->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
+            $this->updateEntity($this->container->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
 
-            $this->get('event_dispatcher')->dispatch(new AfterEntityUpdatedEvent($entityInstance));
+            $this->container->get('event_dispatcher')->dispatch(new AfterEntityUpdatedEvent($entityInstance));
 
-            return $this->getRedirectResponseAfterSave($context, Action::EDIT);
+            return $this->container->getRedirectResponseAfterSave($context, Action::EDIT);
         }
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
@@ -247,7 +247,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         ]));
 
         $event = new AfterCrudActionEvent($context, $responseParameters);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -258,7 +258,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
     public function new(AdminContext $context)
     {
         $event = new BeforeCrudActionEvent($context);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -272,8 +272,8 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         }
 
         $context->getEntity()->setInstance($this->createEntity($context->getEntity()->getFqcn()));
-        $this->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_NEW)));
-        $this->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_NEW)));
+        $this->container->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
 
         $newForm = $this->createNewForm($context->getEntity(), $context->getCrud()->getNewFormOptions(), $context);
         $newForm->handleRequest($context->getRequest());
@@ -285,15 +285,15 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             $this->processUploadedFiles($newForm);
 
             $event = new BeforeEntityPersistedEvent($entityInstance);
-            $this->get('event_dispatcher')->dispatch($event);
+            $this->container->get('event_dispatcher')->dispatch($event);
             $entityInstance = $event->getEntityInstance();
 
-            $this->persistEntity($this->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
+            $this->persistEntity($this->container->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
 
-            $this->get('event_dispatcher')->dispatch(new AfterEntityPersistedEvent($entityInstance));
+            $this->container->get('event_dispatcher')->dispatch(new AfterEntityPersistedEvent($entityInstance));
             $context->getEntity()->setInstance($entityInstance);
 
-            return $this->getRedirectResponseAfterSave($context, Action::NEW);
+            return $this->container->getRedirectResponseAfterSave($context, Action::NEW);
         }
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
@@ -304,7 +304,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         ]));
 
         $event = new AfterCrudActionEvent($context, $responseParameters);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -315,7 +315,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
     public function delete(AdminContext $context)
     {
         $event = new BeforeCrudActionEvent($context);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -336,26 +336,26 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $entityInstance = $context->getEntity()->getInstance();
 
         $event = new BeforeEntityDeletedEvent($entityInstance);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
         $entityInstance = $event->getEntityInstance();
 
         try {
-            $this->deleteEntity($this->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
+            $this->deleteEntity($this->container->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
         } catch (ForeignKeyConstraintViolationException $e) {
             throw new EntityRemoveException(['entity_name' => $context->getEntity()->getName(), 'message' => $e->getMessage()]);
         }
 
-        $this->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));
+        $this->container->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
             'entity' => $context->getEntity(),
         ]));
 
         $event = new AfterCrudActionEvent($context, $responseParameters);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -364,13 +364,13 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $this->redirect($referrer);
         }
 
-        return $this->redirect($this->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->unset(EA::ENTITY_ID)->generateUrl());
+        return $this->redirect($this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->unset(EA::ENTITY_ID)->generateUrl());
     }
 
     public function batchDelete(AdminContext $context, BatchActionDto $batchActionDto): Response
     {
         $event = new BeforeCrudActionEvent($context);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -379,7 +379,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $this->redirectToRoute($context->getDashboardRouteName());
         }
 
-        $entityManager = $this->getDoctrine()->getManagerForClass($batchActionDto->getEntityFqcn());
+        $entityManager = $this->container->getDoctrine()->getManagerForClass($batchActionDto->getEntityFqcn());
         $repository = $entityManager->getRepository($batchActionDto->getEntityFqcn());
         foreach ($batchActionDto->getEntityIds() as $entityId) {
             $entityInstance = $repository->find($entityId);
@@ -397,7 +397,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             }
 
             $event = new BeforeEntityDeletedEvent($entityInstance);
-            $this->get('event_dispatcher')->dispatch($event);
+            $this->container->get('event_dispatcher')->dispatch($event);
             $entityInstance = $event->getEntityInstance();
 
             try {
@@ -406,7 +406,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
                 throw new EntityRemoveException(['entity_name' => $entityDto->toString(), 'message' => $e->getMessage()]);
             }
 
-            $this->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));
+            $this->container->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));
         }
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
@@ -415,7 +415,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         ]));
 
         $event = new AfterCrudActionEvent($context, $responseParameters);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         if ($event->isPropagationStopped()) {
             return $event->getResponse();
         }
@@ -430,7 +430,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $autocompleteContext = $context->getRequest()->get(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT);
 
         /** @var CrudControllerInterface $controller */
-        $controller = $this->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext[EA::CRUD_CONTROLLER_FQCN], Action::INDEX, $context->getRequest());
+        $controller = $this->container->get(ControllerFactory::class)->getCrudControllerInstance($autocompleteContext[EA::CRUD_CONTROLLER_FQCN], Action::INDEX, $context->getRequest());
         /** @var FieldDto $field */
         $field = FieldCollection::new($controller->configureFields($autocompleteContext['originatingPage']))->getByProperty($autocompleteContext['propertyName']);
         /** @var \Closure|null $queryBuilderCallable */
@@ -440,24 +440,24 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             $queryBuilderCallable($queryBuilder);
         }
 
-        $paginator = $this->get(PaginatorFactory::class)->create($queryBuilder);
+        $paginator = $this->container->get(PaginatorFactory::class)->create($queryBuilder);
 
         return JsonResponse::fromJsonString($paginator->getResultsAsJson());
     }
 
     public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
     {
-        return $this->get(EntityRepository::class)->createQueryBuilder($searchDto, $entityDto, $fields, $filters);
+        return $this->container->get(EntityRepository::class)->createQueryBuilder($searchDto, $entityDto, $fields, $filters);
     }
 
     public function renderFilters(AdminContext $context): KeyValueStore
     {
         $fields = FieldCollection::new($this->configureFields(Crud::PAGE_INDEX));
-        $this->get(EntityFactory::class)->processFields($context->getEntity(), $fields);
-        $filters = $this->get(FilterFactory::class)->create($context->getCrud()->getFiltersConfig(), $context->getEntity()->getFields(), $context->getEntity());
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), $fields);
+        $filters = $this->container->get(FilterFactory::class)->create($context->getCrud()->getFiltersConfig(), $context->getEntity()->getFields(), $context->getEntity());
 
         /** @var FiltersFormType $filtersForm */
-        $filtersForm = $this->get(FormFactory::class)->createFiltersForm($filters, $context->getRequest());
+        $filtersForm = $this->container->get(FormFactory::class)->createFiltersForm($filters, $context->getRequest());
         $formActionParts = parse_url($filtersForm->getConfig()->getAction());
         $queryString = $formActionParts[EA::QUERY] ?? '';
         parse_str($queryString, $queryStringAsArray);
@@ -502,7 +502,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
     {
-        return $this->get(FormFactory::class)->createEditFormBuilder($entityDto, $formOptions, $context);
+        return $this->container->get(FormFactory::class)->createEditFormBuilder($entityDto, $formOptions, $context);
     }
 
     public function createNewForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface
@@ -512,7 +512,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
     {
-        return $this->get(FormFactory::class)->createNewFormBuilder($entityDto, $formOptions, $context);
+        return $this->container->get(FormFactory::class)->createNewFormBuilder($entityDto, $formOptions, $context);
     }
 
     /**
@@ -525,20 +525,20 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     protected function getContext(): ?AdminContext
     {
-        return $this->get(AdminContextProvider::class)->getContext();
+        return $this->container->get(AdminContextProvider::class)->getContext();
     }
 
     protected function ajaxEdit(EntityDto $entityDto, ?string $propertyName, bool $newValue): AfterCrudActionEvent
     {
-        $this->get(EntityUpdater::class)->updateProperty($entityDto, $propertyName, $newValue);
+        $this->container->get(EntityUpdater::class)->updateProperty($entityDto, $propertyName, $newValue);
 
         $event = new BeforeEntityUpdatedEvent($entityDto->getInstance());
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
         $entityInstance = $event->getEntityInstance();
 
-        $this->updateEntity($this->get('doctrine')->getManagerForClass($entityDto->getFqcn()), $entityInstance);
+        $this->updateEntity($this->container->get('doctrine')->getManagerForClass($entityDto->getFqcn()), $entityInstance);
 
-        $this->get('event_dispatcher')->dispatch(new AfterEntityUpdatedEvent($entityInstance));
+        $this->container->get('event_dispatcher')->dispatch(new AfterEntityUpdatedEvent($entityInstance));
 
         $entityDto->setInstance($entityInstance);
 
@@ -548,7 +548,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         ]);
 
         $event = new AfterCrudActionEvent($this->getContext(), $parameters);
-        $this->get('event_dispatcher')->dispatch($event);
+        $this->container->get('event_dispatcher')->dispatch($event);
 
         return $event;
     }
@@ -599,7 +599,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];
 
         if (Action::SAVE_AND_CONTINUE === $submitButtonName) {
-            $url = $this->get(AdminUrlGenerator::class)
+            $url = $this->container->get(AdminUrlGenerator::class)
                 ->setAction(Action::EDIT)
                 ->setEntityId($context->getEntity()->getPrimaryKeyValue())
                 ->generateUrl();
@@ -609,13 +609,13 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
         if (Action::SAVE_AND_RETURN === $submitButtonName) {
             $url = $context->getReferrer()
-                ?? $this->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl();
+                ?? $this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl();
 
             return $this->redirect($url);
         }
 
         if (Action::SAVE_AND_ADD_ANOTHER === $submitButtonName) {
-            $url = $this->get(AdminUrlGenerator::class)->setAction(Action::NEW)->generateUrl();
+            $url = $this->container->get(AdminUrlGenerator::class)->setAction(Action::NEW)->generateUrl();
 
             return $this->redirect($url);
         }


### PR DESCRIPTION
The get method of the symfony framewok has been removed in symfony 6.
The call to $this->get can be replaced by $this->container->get to be compatible with symfony 6 and without broking the backward compatiblity.