### PR TITLE
Clarifying nested associations

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -220,7 +220,7 @@ Search, Order, and Pagination Options
             // (user can later change this sorting by clicking on the table columns)
             ->setDefaultSort(['id' => 'DESC'])
             ->setDefaultSort(['id' => 'DESC', 'title' => 'ASC', 'startsAt' => 'DESC'])
-            // you can sort by Doctrine associations up to two levels
+            // you can sort by Doctrine associations (but not nested associations)
             ->setDefaultSort(['seller.name' => 'ASC'])
 
             // the max number of entities to display per page


### PR DESCRIPTION
By "two levels" you mean `foo.bar`? Cause with `foo.bar.baz` I'm getting:
> Class App\Entity\Foo has no field or association named bar.baz

=> I would call this *one* level: You can hop from the current entity to `Foo`, but then it's over. You can't do a *second* hop to `Bar`.
So I'm trying to avoid a number here ;-)