### PR TITLE
Removing "HTML tags"

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -170,7 +170,7 @@ You can override the default page titles with the following methods::
             ->setPageTitle('detail', fn (Product $product) => (string) $product)
             ->setPageTitle('edit', fn (Category $category) => sprintf('Editing <b>%s</b>', $category->getName()))
 
-            // the help message displayed to end users (it can contain HTML tags)
+            // the help message displayed to end users
             ->setHelp('edit', '...')
         ;
     }


### PR DESCRIPTION
Help is rendered as a tooltip over a question mark icon, see screenshot at https://github.com/EasyCorp/EasyAdminBundle/issues/3760#issue-700761162 - so HTML isn't possible, or is it?
I'd like to add a link to my help message, is there an easier way than overriding the template?
