### PR TITLE
Use filters on nested properties

### DIFF
--- a/doc/filters.rst
+++ b/doc/filters.rst
@@ -35,6 +35,8 @@ explicitly::
     use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
     use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
     use EasyCorp\Bundle\EasyAdminBundle\Filter\BooleanFilter;
+    use EasyCorp\Bundle\EasyAdminBundle\Filter\NestedFilter;
+    use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
 
     class ProductCrudController extends AbstractCrudController
     {
@@ -48,6 +50,11 @@ explicitly::
                 // most of the times there is no need to define the
                 // filter type because EasyAdmin can guess it automatically
                 ->add(BooleanFilter::new('published'))
+
+                // Use filter on nested property
+                ->add(NestedFilter::wrap(
+                    TextFilter::new('options.name')
+                ))
             ;
         }
     }
@@ -79,6 +86,9 @@ These are the built-in filters provided by EasyAdmin:
 * ``TextFilter``: applied by default to string/text fields. It's rendered as a
   ``<select>`` list with the condition (contains/not contains/etc.) and an ``<input>`` or
   ``<textarea>`` to define the comparison value.
+* ``NestedFilter``: A wrapper allowing to use any filters on nested properties.
+This filter is able to apply left joins until the last property in the given path
+and let the wrapped filter applies its conditions to query.
 
 Custom Filters
 --------------

--- a/src/Dto/FilterDataDto.php
+++ b/src/Dto/FilterDataDto.php
@@ -32,6 +32,11 @@ final class FilterDataDto
         return $filterData;
     }
 
+    public function getIndex(): int
+    {
+        return $this->index;
+    }
+
     public function getEntityAlias(): string
     {
         return $this->entityAlias;

--- a/src/Filter/Configurator/NestedConfigurator.php
+++ b/src/Filter/Configurator/NestedConfigurator.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\NestedFilter;
+
+/**
+ * @author Brandon Marcachi <brandon.marcachi@gmail.com>
+ */
+final class NestedConfigurator implements FilterConfiguratorInterface
+{
+    private $doctrine;
+    private $filterConfigurators;
+
+    public function __construct(ManagerRegistry $doctrine, iterable $filterConfigurators = [])
+    {
+        $this->doctrine = $doctrine;
+        $this->filterConfigurators = $filterConfigurators;
+    }
+
+    public function supports(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): bool
+    {
+        return NestedFilter::class === $filterDto->getFqcn();
+    }
+
+    public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
+    {
+        $entityFqcn = $entityDto->getFqcn();
+
+        [$targetClassMetadata, $targetProperty] = NestedFilter::extractTargets(
+            $this->getObjectManager($entityFqcn),
+            $entityFqcn,
+            $filterDto->getProperty()
+        );
+
+        $wrappedEntityDto = new EntityDto($targetClassMetadata->getName(), $targetClassMetadata);
+        $wrappedFilter = $this->extractWrappedFilter($filterDto);
+        $wrappedFilterDto = $wrappedFilter->getAsDto();
+        $wrappedFilterDto->setProperty($targetProperty);
+
+        $this->configureFilter($wrappedFilterDto, $wrappedEntityDto, $context);
+
+        $filterDto->setFormType($wrappedFilterDto->getFormType());
+        $filterDto->setFormTypeOptions($wrappedFilterDto->getFormTypeOptions());
+
+        $this->removeWrappedFilterOption($filterDto);
+    }
+
+    private function extractWrappedFilter(FilterDto $filterDto): FilterInterface
+    {
+        return $filterDto->getFormTypeOption(NestedFilter::FORM_OPTION_WRAPPED_FILTER);
+    }
+
+    private function removeWrappedFilterOption(FilterDto $filterDto): void
+    {
+        [$root, $filterKey] = explode('.', NestedFilter::FORM_OPTION_WRAPPED_FILTER);
+
+        $data = $filterDto->getFormTypeOption($root);
+        unset($data[$filterKey]);
+        $filterDto->setFormTypeOption($root, $data);
+    }
+
+    private function configureFilter(FilterDto $filterDto, EntityDto $entityDto, AdminContext $context): void
+    {
+        foreach ($this->filterConfigurators as $configurator) {
+            if ($configurator->supports($filterDto, null, $entityDto, $context)) {
+                $configurator->configure($filterDto, null, $entityDto, $context);
+            }
+        }
+    }
+
+    private function getObjectManager(string $entityFqcn): ObjectManager
+    {
+        if (null === $objectManager = $this->doctrine->getManagerForClass($entityFqcn)) {
+            throw new \RuntimeException(sprintf('There is no Doctrine Object Manager defined for the "%s" class.', $entityFqcn));
+        }
+
+        return $objectManager;
+    }
+}

--- a/src/Filter/NestedFilter.php
+++ b/src/Filter/NestedFilter.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Filter;
+
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ObjectManager;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
+
+/**
+ * @author Brandon Marcachi <brandon.marcachi@gmail.com>
+ */
+final class NestedFilter implements FilterInterface
+{
+    use FilterTrait;
+
+    public const FORM_OPTION_WRAPPED_FILTER = 'attr.wrapped_filter';
+
+    public const PATH_SEPARATOR_EXPECTED = '.';
+    public const PATH_SEPARATOR = '_';
+
+    /** @var FilterInterface */
+    private $wrappedFilter;
+
+    public static function new(string $propertyName, string $label = null): self
+    {
+        throw new \RuntimeException('Instead of this method, use the "wrap()" method.');
+    }
+
+    public static function wrap(FilterInterface $filter): FilterInterface
+    {
+        $filterDto = $filter->getAsDto();
+        $property = $filterDto->getProperty();
+
+        if (false === strpos($property, self::PATH_SEPARATOR_EXPECTED)) {
+            return $filter;
+        }
+
+        return (new self())
+            ->setFilterFqcn(__CLASS__)
+            ->setProperty($property)
+            ->setFormType($filterDto->getFormType())
+            ->setFormTypeOptions($filterDto->getFormTypeOptions())
+            ->setWrappedFilter($filter)
+        ;
+    }
+
+    public function apply(QueryBuilder $queryBuilder, FilterDataDto $filterDataDto, ?FieldDto $fieldDto, EntityDto $entityDto): void
+    {
+        $propertyPath = $filterDataDto->getProperty();
+
+        [$targetClassMetadata, $targetProperty] = self::extractTargets(
+            $queryBuilder->getEntityManager(),
+            $entityDto->getFqcn(),
+            $propertyPath
+        );
+
+        $wrappedEntityDto = new EntityDto($targetClassMetadata->getName(), $targetClassMetadata);
+        $wrappedFilter = $this->getWrappedFilter();
+        $wrappedFilterDto = $wrappedFilter->getAsDto();
+        $wrappedFilterDto->setProperty($targetProperty);
+
+        // Apply required left joins and get the alias we have to work with
+        $alias = $this->applyLeftJoins($queryBuilder, $filterDataDto->getEntityAlias(), $propertyPath);
+
+        // Recreate FilterDataDto adapted for the wrapped filter
+        $wrappedFilterDataDto = FilterDataDto::new($filterDataDto->getIndex(), $wrappedFilterDto, $alias, [
+            'value' => $filterDataDto->getValue(),
+            'value2' => $filterDataDto->getValue2(),
+            'comparison' => $filterDataDto->getComparison(),
+        ]);
+
+        $wrappedFilterDto->apply($queryBuilder, $wrappedFilterDataDto, null, $wrappedEntityDto);
+    }
+
+    public static function extractTargets(ObjectManager $objectManager, string $class, string $propertyPath): array
+    {
+        $segments = explode(self::PATH_SEPARATOR, $propertyPath);
+        $metadata = $objectManager->getClassMetadata($class);
+        $lastIndex = \count($segments) - 1;
+        $property = null;
+
+        foreach ($segments as $i => $prop) {
+            if (!$metadata->hasField($prop) && !$metadata->hasAssociation($prop)) {
+                self::throwInvalidPropertyPathException($propertyPath, $class);
+            }
+
+            // The target property must be at the end of path
+            if ($i === $lastIndex) {
+                $property = $prop;
+                break;
+            }
+
+            if (!$metadata->hasAssociation($prop)) {
+                self::throwInvalidPropertyPathException($propertyPath, $class);
+            }
+
+            // Move to next nested class
+            $metadata = $objectManager->getClassMetadata($metadata->getAssociationTargetClass($prop));
+        }
+
+        return [$metadata, $property];
+    }
+
+    public function setWrappedFilter(FilterInterface $filter): self
+    {
+        $this->wrappedFilter = $filter;
+
+        return $this->setFormTypeOption(self::FORM_OPTION_WRAPPED_FILTER, $filter);
+    }
+
+    public function getWrappedFilter(): FilterInterface
+    {
+        return $this->wrappedFilter;
+    }
+
+    public function setProperty(string $propertyName): self
+    {
+        // Replace dots with underscore to avoid errors
+        $this->dto->setProperty(
+            str_replace(self::PATH_SEPARATOR_EXPECTED, self::PATH_SEPARATOR, $propertyName)
+        );
+
+        return $this;
+    }
+
+    private function applyLeftJoins(QueryBuilder $qb, string $alias, string $propertyPath): string
+    {
+        $path = explode(self::PATH_SEPARATOR, $propertyPath);
+        $lastIndex = \count($path) - 1;
+        $currentAlias = $alias;
+
+        foreach ($path as $i => $prop) {
+            if ($i === $lastIndex) {
+                break;
+            }
+
+            $nextAlias = sprintf('%s_%s', $currentAlias, $prop);
+            if (!\in_array($nextAlias, $qb->getAllAliases(), true)) {
+                $qb->leftJoin(sprintf('%s.%s', $currentAlias, $prop), $nextAlias);
+            }
+
+            $currentAlias = $nextAlias;
+        }
+
+        return $currentAlias;
+    }
+
+    private static function throwInvalidPropertyPathException(string $propertyPath, string $class): void
+    {
+        throw new \InvalidArgumentException(sprintf(
+            'The property path "%s" for class "%s" is invalid.',
+            str_replace(self::PATH_SEPARATOR, self::PATH_SEPARATOR_EXPECTED, $propertyPath),
+            $class
+        ));
+    }
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -55,6 +55,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\CommonConfigurator as Co
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\ComparisonConfigurator as ComparisonFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\DateTimeConfigurator as DateTimeFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\EntityConfigurator as EntityFilterConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\NestedConfigurator as NestedFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\NullConfigurator as NullFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\NumericConfigurator as NumericFilterConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\TextConfigurator as TextFilterConfigurator;
@@ -285,6 +286,12 @@ return static function (ContainerConfigurator $container) {
         ->set(NumericFilterConfigurator::class)
 
         ->set(TextFilterConfigurator::class)
+
+        ->set(NestedFilterConfigurator::class)
+            ->arg(0, new Reference('doctrine'))
+            ->arg(1, \function_exists('tagged')
+                ? tagged(EasyAdminExtension::TAG_FILTER_CONFIGURATOR)
+                : tagged_iterator(EasyAdminExtension::TAG_FILTER_CONFIGURATOR))
 
         ->set(ActionFactory::class)
             ->arg(0, new Reference(AdminContextProvider::class))

--- a/tests/Filter/Configurator/NestedConfiguratorTest.php
+++ b/tests/Filter/Configurator/NestedConfiguratorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Filter;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\NestedConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\NestedFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class NestedConfiguratorTest extends KernelTestCase
+{
+    /** @var Registry */
+    private $doctrine;
+
+    /** @var NestedConfigurator */
+    private $nestedConfigurator;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        $this->doctrine = $container->get('doctrine');
+        $this->nestedConfigurator = $container->get(NestedConfigurator::class);
+    }
+
+    public function testConfigure()
+    {
+        $class = User::class;
+        $attr = ['class' => 'foo'];
+
+        $textFilter = TextFilter::new('blogPosts.categories.name');
+        $textFilter->setFormTypeOption('attr', $attr);
+
+        $nestedFilter = NestedFilter::wrap($textFilter);
+
+        $objectManager = $this->doctrine->getManagerForClass($class);
+        $entityDto = new EntityDto($class, $objectManager->getClassMetadata($class));
+        $adminContext = $this->getMockBuilder(AdminContext::class)->disableOriginalConstructor()->getMock();
+
+        $wrappedFilter = $nestedFilter->getWrappedFilter();
+        $wrappedFilterDto = $wrappedFilter->getAsDto();
+        $nestedFilterDto = $nestedFilter->getAsDto();
+
+        self::assertEquals('blogPosts.categories.name', $wrappedFilterDto->getProperty());
+
+        $this->nestedConfigurator->configure($nestedFilter->getAsDto(), null, $entityDto, $adminContext);
+
+        self::assertEquals('name', $wrappedFilterDto->getProperty());
+        self::assertEquals('blogPosts_categories_name', $nestedFilterDto->getProperty());
+
+        self::assertEquals($wrappedFilterDto->getFormType(), $nestedFilterDto->getFormType());
+        self::assertEquals($wrappedFilterDto->getFormTypeOptions(), $nestedFilterDto->getFormTypeOptions());
+    }
+}

--- a/tests/Filter/NestedFilterTest.php
+++ b/tests/Filter/NestedFilterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Filter;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\NestedConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\NestedFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\User;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class NestedFilterTest extends KernelTestCase
+{
+    /** @var Registry */
+    private $doctrine;
+
+    /** @var NestedConfigurator */
+    private $nestedConfigurator;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $container = self::getContainer();
+
+        $this->doctrine = $container->get('doctrine');
+        $this->nestedConfigurator = $container->get(NestedConfigurator::class);
+    }
+
+    public function testWrap()
+    {
+        $wrappedFilter = TextFilter::new('blogPosts.categories');
+        $nestedFilter = NestedFilter::wrap($wrappedFilter);
+
+        self::assertEquals($wrappedFilter, $nestedFilter->getWrappedFilter());
+        // Does not wrap filter if no dot found in path
+        self::assertInstanceOf(TextFilter::class, NestedFilter::wrap(TextFilter::new('blogPosts')));
+    }
+
+    /**
+     * @dataProvider getTestApplyDataProvider
+     */
+    public function testApply(string $class, FilterInterface $wrapperFilter, array $values, string $result, string $exceptionMessage = '')
+    {
+        $alias = 'o';
+        $objectManager = $this->doctrine->getManagerForClass($class);
+        $queryBuilder = $objectManager->getRepository($class)->createQueryBuilder($alias);
+
+        $filter = NestedFilter::wrap($wrapperFilter);
+        $filterDataDto = FilterDataDto::new(0, $filter->getAsDto(), $alias, $values);
+        $entityDto = new EntityDto($class, $objectManager->getClassMetadata($class));
+        $adminContext = $this->getMockBuilder(AdminContext::class)->disableOriginalConstructor()->getMock();
+
+        try {
+            $this->nestedConfigurator->configure($filter->getAsDto(), null, $entityDto, $adminContext);
+            $filter->apply($queryBuilder, $filterDataDto, null, $entityDto);
+
+            self::assertEquals($result, $queryBuilder->getQuery()->getDQL());
+            self::assertEquals($values['value'], $queryBuilder->getParameters()[0]->getValue());
+        } catch (\Exception $e) {
+            // Expect exception
+            if (\Exception::class === $result) {
+                self::assertEquals($e->getMessage(), $exceptionMessage);
+
+                return;
+            }
+
+            throw $e;
+        }
+
+        try {
+            $queryBuilder->getQuery()->getResult();
+            $executionSuccedeed = true;
+        } catch (\Exception $e) {
+            $executionSuccedeed = false;
+        }
+
+        self::assertTrue($executionSuccedeed);
+    }
+
+    public function getTestApplyDataProvider(): iterable
+    {
+        yield [
+            Category::class,
+            TextFilter::new('blogPosts.author.name'),
+            ['value' => 'foo', 'value2' => null, 'comparison' => '='],
+            'SELECT o FROM '.Category::class.' o LEFT JOIN o.blogPosts o_blogPosts LEFT JOIN o_blogPosts.author o_blogPosts_author WHERE o_blogPosts_author.name = :name_0',
+        ];
+
+        yield [
+            BlogPost::class,
+            TextFilter::new('author.name'),
+            ['value' => 'foo', 'value2' => null, 'comparison' => '='],
+            'SELECT o FROM '.BlogPost::class.' o LEFT JOIN o.author o_author WHERE o_author.name = :name_0',
+        ];
+
+        yield [
+            User::class,
+            EntityFilter::new('blogPosts.categories'),
+            ['value' => [1, 2], 'value2' => null, 'comparison' => 'IN'],
+            'SELECT o FROM '.User::class.' o LEFT JOIN o.blogPosts o_blogPosts LEFT JOIN o_blogPosts.categories ea_categories_0 WHERE ea_categories_0 IN (:categories_0)',
+        ];
+
+        yield [
+            User::class,
+            TextFilter::new('blogPosts.author.blogPosts.categories.name'),
+            ['value' => 'foo', 'value2' => null, 'comparison' => '='],
+            'SELECT o FROM '.User::class.' o LEFT JOIN o.blogPosts o_blogPosts LEFT JOIN o_blogPosts.author o_blogPosts_author LEFT JOIN o_blogPosts_author.blogPosts o_blogPosts_author_blogPosts LEFT JOIN o_blogPosts_author_blogPosts.categories o_blogPosts_author_blogPosts_categories WHERE o_blogPosts_author_blogPosts_categories.name = :name_0',
+        ];
+
+        yield [
+            User::class,
+            TextFilter::new('blogPosts.invalid.name'),
+            ['value' => 'foo', 'value2' => null, 'comparison' => '='],
+            \Exception::class,
+            'The property path "blogPosts.invalid.name" for class "'.User::class.'" is invalid.',
+        ];
+
+        yield [
+            User::class,
+            TextFilter::new('blogPosts.author.name.test'),
+            ['value' => 'foo', 'value2' => null, 'comparison' => '='],
+            \Exception::class,
+            'The property path "blogPosts.author.name.test" for class "'.User::class.'" is invalid.',
+        ];
+    }
+}


### PR DESCRIPTION
This PR makes filters support properties with dot notation by using a new filter as wrapper.

 - The NestedConfigurator is able to configure the wrapped filter by (re)invoking the configurators collection and copy configured FormType and options to display the correct wrapped filter view.
 
 - The NestedFilter is able to apply required left joins for a given path and delegate query customization to wrapped filter by recreating adapted arguments (like FilterDataDto and EntityDto)
 
 There is no tests for now, but i can add it if you are interested by the purpose.