### PR TITLE
Fixed bug  when canSelectMultiple to a filter configuration is true.

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -185,7 +185,13 @@
                                                 {% block search_form_filters %}
                                                     {% for field, array in ea.search.appliedFilters %}
                                                         {% for key, value in array %}
-                                                            <input type="hidden" name="filters[{{ field }}][{{ key }}]" value="{{ value }}">
+                                                            {% if value is iterable %}
+                                                                {% for num, listValue in value %}
+                                                                    <input type="hidden" name="filters[{{ field }}][{{ key }}][{{ num }}]" value="{{ listValue }}">
+                                                                {% endfor %}
+                                                            {% else %}
+                                                                <input type="hidden" name="filters[{{ field }}][{{ key }}]" value="{{ value }}">
+                                                            {% endif %}
                                                         {% endfor %}
                                                     {% endfor %}
                                                 {% endblock %}


### PR DESCRIPTION
Fixed bug "Warning: Array to string conversion" when canSelectMultiple to a filter configuration is true.

#4879 