### PR TITLE
Fix some types in FlattenException class methods

### DIFF
--- a/src/Exception/FlattenException.php
+++ b/src/Exception/FlattenException.php
@@ -13,14 +13,7 @@ final class FlattenException extends BaseFlattenException
     /** @var ExceptionContext */
     private $context;
 
-    /**
-     * @param int $statusCode
-     *
-     * @return FlattenException
-     *
-     * @throws \RuntimeException
-     */
-    public static function create(\Exception $exception, $statusCode = null, array $headers = []): BaseFlattenException
+    public static function create(\Exception $exception, ?int $statusCode = null, array $headers = []): static
     {
         if (!$exception instanceof BaseException) {
             throw new \RuntimeException(sprintf('You should only try to create an instance of "%s" with a "EasyCorp\Bundle\EasyAdminBundle\Exception\BaseException" instance, or subclass. "%s" given.', __CLASS__, \get_class($exception)));


### PR DESCRIPTION
Tries to fix this error, which was reported via Symfony Slack:

```
PHP Fatal error:  Declaration of EasyCorp\Bundle\EasyAdminBundle\Exception\FlattenException::create(Exception $exception, $statusCode = null, array $headers = []): Symfony\Component\ErrorHandler\Exception\FlattenException must be compatible with Symfony\Component\ErrorHandler\Exception\FlattenException::create(Exception $exception, ?int $statusCode = null, array $headers = []): static in /app/vendor/easycorp/easyadmin-bundle/src/Exception/FlattenException.php on line 23
```