### PR TITLE
Fix PHP 8.1 deprecation about nullable argument

### DIFF
--- a/src/Config/MenuItem.php
+++ b/src/Config/MenuItem.php
@@ -40,7 +40,7 @@ final class MenuItem
         return new LogoutMenuItem($label, $icon);
     }
 
-    public static function linkToRoute(string $label, ?string $icon = null, string $routeName, array $routeParameters = []): RouteMenuItem
+    public static function linkToRoute(string $label, ?string $icon, string $routeName, array $routeParameters = []): RouteMenuItem
     {
         return new RouteMenuItem($label, $icon, $routeName, $routeParameters);
     }


### PR DESCRIPTION
Fixes #4821.

This argument was never really nullable (except when using named PHP arguments), because you must provide the route name after it, so you must pass at least `null` to that argument. Let's do this change, required to fix a PHP 8.1 deprecation, and let's move on 😄 