### PR TITLE
Fix for InvalidArgumentException when field property contains square brackets

### DIFF
--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -48,7 +48,7 @@ class CrudFormType extends AbstractType
             // 'property_path' option to keep the original field name
             if (false !== strpos($fieldDto->getProperty(), '.')) {
                 $formFieldOptions['property_path'] = $fieldDto->getProperty();
-                $name = str_replace('.', '_', $fieldDto->getProperty());
+                $name = str_replace(['.', '[', ']'], '_', $fieldDto->getProperty());
             } else {
                 $name = $fieldDto->getProperty();
             }


### PR DESCRIPTION
### Issue
When a property uses square brackets like in the following example:
```
public function configureFields(string $pageName): iterable
{
    $galleryTranslationEnTitle = TextareaField::new('galleryTranslation[en].title');
    ...
```
then an InvalidArgumentException is triggered:
```
The name "galleryTranslation[en]_title" contains illegal characters. Names should start with a letter, digit or underscore and only contain letters, digits, numbers, underscores ("_"), hyphens ("-") and colons (":").
```

### The fix
A one liner fix in CrudFormType class that defines the name variable when the field property contains a dot.