### PR TITLE
feature #4265 Added badge count for menu items

### DIFF
--- a/assets/css/easyadmin-theme/badges.scss
+++ b/assets/css/easyadmin-theme/badges.scss
@@ -19,6 +19,7 @@
   line-height: 16px;
   padding: 1px 5px;
 }
+
 .badge.badge-success {
   background-color: var(--green-100);
   color: var(--text-green-600);

--- a/assets/css/easyadmin-theme/menu.scss
+++ b/assets/css/easyadmin-theme/menu.scss
@@ -30,6 +30,10 @@
             &:first-child { margin-top: 0; }
 
             i { color: inherit; margin-top: 0; }
+
+            .badge {
+                margin-left: 16px;
+            }
         }
 
         .menu-item {
@@ -45,6 +49,10 @@
                     text-decoration-color: var(--sidebar-menu-active-item-border-color);
                     text-decoration-thickness: 2px;
                     text-decoration-skip-ink: auto;
+
+                    &.badge {
+                        text-decoration: none;
+                    }
                 }
             }
 
@@ -84,6 +92,10 @@
             width: 20px;
         }
 
+        .badge {
+            margin-left: 14px;
+        }
+
         .submenu {
             // padding must be 0 for the element that slides up/down;
             // if some padding is needed, create another HTML element inside this one
@@ -98,6 +110,14 @@
 
             .menu-header {
                 padding-left: 26px;
+            }
+
+            .menu-item {
+                margin: 5px 20px 5px 0; // to have the badge count visible
+
+                &:first-child .badge {
+                    margin-top: 2px;
+                }
             }
         }
     }

--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -311,6 +311,8 @@ All menu items define the following methods to configure some options:
 * ``setPermission(string $permission)``, sets the `Symfony security permission`_
   that the user must have to see this menu item. Read the :ref:`menu security reference <security-menu>`
   for more details.
+* ``setBadgeCount(int $count)``, makes it possible to render a notification badge
+  count next to the menu item / section.
 
 The rest of options depend on each menu item type, as explained in the next sections.
 

--- a/src/Config/Menu/MenuItemTrait.php
+++ b/src/Config/Menu/MenuItemTrait.php
@@ -54,6 +54,13 @@ trait MenuItemTrait
         return $this;
     }
 
+    public function setBadgeCount(int $count): self
+    {
+        $this->dto->setBadgeCount($count);
+
+        return $this;
+    }
+
     public function getAsDto(): MenuItemDto
     {
         return $this->dto;

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -29,6 +29,7 @@ final class MenuItemDto
     private $linkRel;
     private $linkTarget;
     private $translationParameters;
+    private $badgeCount;
     /** @var MenuItemDto[] */
     private $subItems;
 
@@ -38,6 +39,7 @@ final class MenuItemDto
         $this->translationParameters = [];
         $this->linkRel = '';
         $this->linkTarget = '_self';
+        $this->badgeCount = 0;
         $this->subItems = [];
     }
 
@@ -174,6 +176,16 @@ final class MenuItemDto
     public function setTranslationParameters(array $translationParameters): void
     {
         $this->translationParameters = $translationParameters;
+    }
+
+    public function getBadgeCount(): int
+    {
+        return $this->badgeCount;
+    }
+
+    public function setBadgeCount(int $badgeCount): void
+    {
+        $this->badgeCount = $badgeCount;
     }
 
     /**

--- a/src/Resources/views/menu.html.twig
+++ b/src/Resources/views/menu.html.twig
@@ -32,12 +32,22 @@
 {% macro render_menu_item(item) %}
     {% if item.isMenuSection %}
         {% if item.icon is not empty %}<i class="menu-icon fa-fw {{ item.icon }}"></i>{% endif %}
-        <span class="{{ item.cssClass }}">{{ item.label|raw }}</span>
+        <span class="position-relative {{ item.cssClass }}">
+            {{ item.label|raw }}
+            {% if (item.badgeCount > 0) %}
+                <span class="position-absolute top-0 start-100 translate-middle badge bg-danger rounded-pill text-white">{{ item.badgeCount }}<span class="visually-hidden"> unread messages</span></span>
+            {% endif %}
+        </span>
     {% else %}
         <a href="{{ item.linkUrl }}" class="{{ item.hasSubItems ? 'submenu-toggle' }} {{ item.cssClass }}" target="{{ item.linkTarget }}" rel="{{ item.linkRel }}" referrerpolicy="origin-when-cross-origin">
             {% if item.icon is not empty %}<i class="menu-icon fa-fw {{ item.icon }}"></i>{% endif %}
-            <span>{{ item.label|raw }}</span>
-            {% if item.hasSubItems %}<i class="fa fa-fw fa-angle-right submenu-toggle-icon"></i>{% endif %}
+            <span class="position-relative">
+                {{ item.label|raw }}
+                {% if (item.badgeCount > 0) %}
+                    <span class="position-absolute top-0 start-100 translate-middle badge bg-danger rounded-pill text-white">{{ item.badgeCount }}<span class="visually-hidden"> unread messages</span></span>
+                {% endif %}
+            </span>
+            {% if item.hasSubItems %}<i class="fa fa-fw fa-angle-right submenu-toggle-icon {{ item.badgeCount > 0 ? 'ps-2' : '' }}"></i>{% endif %}
         </a>
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
First attempt on fixing #4265

![Screenshot 2021-12-31 at 12 30 56](https://user-images.githubusercontent.com/308513/147821450-61ba02e7-f8df-4ad1-a0ce-cbd515fab0b3.jpg)

![Screenshot 2021-12-31 at 12 31 20](https://user-images.githubusercontent.com/308513/147821459-55f14bd2-6d14-4a0d-9681-6e5bf5a57319.jpg)

![Screenshot 2021-12-31 at 12 31 38](https://user-images.githubusercontent.com/308513/147821464-17f0ae65-ad83-4642-8257-1c411895f7d4.jpg)

Things to consider:
1) I've added the 'badgeCount' functionality to the 'MenuItemTrait' which makes it available for sections too, is that desired?
2) ~~The badge text gets underlined when the the menu item, is the current active menu item. I couldn't get styling within the EasyAdminBundle to work (in 'assets/css/easyadmin-theme/badges.scss')? It seemed not to get picked up in my project?~~
3) For now just used bootstrap classes, ~~but could also define a specific custom 'menu-badge' class for styling~~. However via the current implementation bootstrap handles any 'right-to-left' styling. 
~~This would also allow to have the styling a bit more precise. Currently the badge could use a nudge more to the right. And when a menu item has sub items, I add a bootstrap padding class which could also be fixed then. My frontend skills are lacking a bit :)~~
4) Main issue referred to the `4.x / master` branch, but I guess the changes could also be easily merged in `3.x` and glide into `4.x`? If not desired, not a problem to rebase on the `4.x` branch.

Any other feedback is welcome.