### PR TITLE
add entity vars for dropdown item action

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -139,7 +139,7 @@
 
                                             <div class="dropdown-menu dropdown-menu-right">
                                                 {% for action in entity.actions %}
-                                                    {{ include(action.templatePath, { action: action, isIncludedInDropdown: ea.crud.showEntityActionsAsDropdown }, with_context = false) }}
+                                                    {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea.crud.showEntityActionsAsDropdown }, with_context = false) }}
                                                 {% endfor %}
                                             </div>
                                         </div>


### PR DESCRIPTION
Just add entity in itemaction when this is an dropdown (`crud.showEntityActionsAsDropdown === true `)

it is useful in template actions and it adds consistency with no dropdown action items (for exemple if you change crud.showEntityActionsAsDropdown option and that one of our item action call entity)