### PR TITLE
Fixing Symfony 6 support in DynamicChoiceLoader - for ArrayFilter 

### DIFF
--- a/src/Form/ChoiceList/Loader/DynamicChoiceLoader.php
+++ b/src/Form/ChoiceList/Loader/DynamicChoiceLoader.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\ChoiceList\Loader;
 
 use Symfony\Component\Form\ChoiceList\ArrayChoiceList;
+use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface;
 
 /**
@@ -18,7 +19,7 @@ class DynamicChoiceLoader implements ChoiceLoaderInterface
     private $cached = false;
     private $choiceList;
 
-    public function loadChoiceList($value = null)
+    public function loadChoiceList(?callable $value = null): ChoiceListInterface
     {
         if (null === $this->choiceList || !$this->cached) {
             $this->choiceList = new ArrayChoiceList(array_combine($this->choices, $this->choices));


### PR DESCRIPTION
Hi!

On Symfony 6 with an `ArrayFilter`:

```php
    public function configureFilters(Filters $filters): Filters
    {
        return parent::configureFilters($filters)
            ->add(ArrayFilter::new('roles'));
    }
```

When opening the "Filters" menu, the Ajax request fails with:

> Fatal error: Declaration of EasyCorp\Bundle\EasyAdminBundle\Form\ChoiceList\Loader\DynamicChoiceLoader::loadChoiceList($value = null) must be compatible with Symfony\Component\Form\ChoiceList\Loader\ChoiceLoaderInterface::loadChoiceList(?callable $value = null): Symfony\Component\Form\ChoiceList\ChoiceListInterface in /path/to/app//vendor/easycorp/easyadmin-bundle/src/Form/ChoiceList/Loader/DynamicChoiceLoader.php on line 21

I believe adding this in 3.x is safe. However, I could also re-make this for the 4.x branch only if you prefer.

Thanks!