### PR TITLE
[FEATURE] : add tabs support for detail page #4887

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Controller;
 
+use ArrayObject;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
@@ -215,7 +216,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             'pageName' => Crud::PAGE_DETAIL,
             'templateName' => 'crud/detail',
             'entity' => $context->getEntity(),
-            'tabs' => $tabs
+            'tabs' => $tabs,
         ]));
 
         $event = new AfterCrudActionEvent($context, $responseParameters);

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -200,7 +200,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
                     ]));
                     $context->getEntity()->getFields()->unset($fieldDto);
                 } else {
-                    if ('default' === $currentTab && !count($tabs)) {
+                    if ('default' === $currentTab && !\count($tabs)) {
                         $tabs[$currentTab] = new ArrayObject($defaultTabMetadata);
                     }
                     $fieldDto->ea_detail_tab = $currentTab;

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -83,7 +83,6 @@ final class FormField implements FieldInterface
         return $field
             ->setFieldFqcn(__CLASS__)
             ->hideOnIndex()
-            ->hideOnDetail()
             ->setProperty('ea_form_tab_'.(new Ulid()))
             ->setLabel($label)
             ->setFormType(EasyAdminTabType::class)

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -46,11 +46,6 @@
                                 <i class="fa fa-fw fa-{{ tab_config.icon }}"></i>
                             {%- endif -%}
                             {{ tab_config['label']|trans(domain = ea.i18n.translationDomain)|trans(domain = 'EasyAdminBundle') }}
-                            {%- if tab_config.errors > 0 -%}
-                                <span class="badge badge-danger" title="{{ 'form.tab.error_badge_title'|trans({'%count%': tab_config.errors}, 'EasyAdminBundle') }}">
-                                        {{- tab_config.errors -}}
-                                    </span>
-                            {%- endif -%}
                         </a>
                     </li>
                 {% endfor %}

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -25,35 +25,79 @@
 {% block content_footer_wrapper '' %}
 
 {% block main %}
-    {% block detail_fields %}
-        {% set form_panel_is_already_open = false %}
-        {% for field in entity.fields %}
-            {% set is_form_field_panel = 'field-form_panel' in field.cssClass %}
-
-            {% if is_form_field_panel or (loop.first and not is_form_field_panel) %}
-                {% if form_panel_is_already_open %}
-                    {{ _self.close_form_field_panel() }}
-                    {% set form_panel_is_already_open = false %}
-                {% endif %}
-
-                {{ _self.open_form_field_panel(is_form_field_panel ? field : null) }}
-                {% set form_panel_is_already_open = true %}
-            {% endif %}
-
-            {% block detail_field %}
-                {% if not is_form_field_panel %}
-                    {{ _self.render_field(entity, field) }}
-                {% endif %}
-            {% endblock %}
-        {% endfor %}
-
-        {{ _self.close_form_field_panel() }}
-    {% endblock %}
-
+    {% if tabs is defined and tabs | length %}
+        {{ _self.render_detail_fields_with_tabs(entity, tabs) }}
+    {% else  %}
+        {{ _self.render_detail_fields(entity, null) }}
+    {% endif %}
     {% block delete_form %}
         {{ include('@EasyAdmin/crud/includes/_delete_form.html.twig', { entity_id: entity.primaryKeyValue }, with_context = false) }}
     {% endblock delete_form %}
 {% endblock %}
+
+{% macro render_detail_fields_with_tabs(entity, tabs) %}
+    <div class="col-12">
+        <div class="nav-tabs-custom form-tabs">
+            <ul class="nav nav-tabs">
+                {% for tab_name, tab_config in tabs %}
+                    <li class="nav-item">
+                        <a class="nav-link {% if tab_config.active %}active{% endif %}" href="#{{ tab_config['id'] }}" id="{{ tab_config['id'] }}-tab" data-bs-toggle="tab">
+                            {%- if tab_config.icon|default(false) -%}
+                                <i class="fa fa-fw fa-{{ tab_config.icon }}"></i>
+                            {%- endif -%}
+                            {{ tab_config['label']|trans(domain = ea.i18n.translationDomain)|trans(domain = 'EasyAdminBundle') }}
+                            {%- if tab_config.errors > 0 -%}
+                                <span class="badge badge-danger" title="{{ 'form.tab.error_badge_title'|trans({'%count%': tab_config.errors}, 'EasyAdminBundle') }}">
+                                        {{- tab_config.errors -}}
+                                    </span>
+                            {%- endif -%}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+            <div class="tab-content">
+                {% for tab_name, tab_config in tabs %}
+                    <div id="{{ tab_config['id'] }}" class="tab-pane {% if tab_config.active %}active{% endif %} {{ tab_config['css_class']|default('') }}">
+                        {% if tab_config['help']|default(false) %}
+                            <div class="content-header-help tab-help">
+                                {{ tab_config['help']|trans(domain = ea.i18n.translationDomain)|raw }}
+                            </div>
+                        {% endif %}
+                        <div class="row">
+                            {% if tab_name is defined and tab_name %}
+                                {{ _self.render_detail_fields(entity, tab_name) }}
+                            {% endif %}
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+{% endmacro %}
+
+{% macro render_detail_fields(entity, tab_name = null) %}
+    {% set form_panel_is_already_open = false %}
+    {% for field in entity.fields|filter(field => (tab_name and field.ea_detail_tab == tab_name or not tab_name) ) %}
+        {% set is_form_field_panel = 'field-form_panel' in field.cssClass %}
+
+        {% if is_form_field_panel or (loop.first and not is_form_field_panel) %}
+            {% if form_panel_is_already_open %}
+                {{ _self.close_form_field_panel() }}
+                {% set form_panel_is_already_open = false %}
+            {% endif %}
+
+            {{ _self.open_form_field_panel(is_form_field_panel ? field : null) }}
+            {% set form_panel_is_already_open = true %}
+        {% endif %}
+
+        {% block detail_field %}
+            {% if not is_form_field_panel %}
+                {{ _self.render_field(entity, field) }}
+            {% endif %}
+        {% endblock %}
+    {% endfor %}
+    {{ _self.close_form_field_panel() }}
+{% endmacro %}
 
 {% macro open_form_field_panel(field = null) %}
     {% set panel_name = field is null ? null : 'content-' ~ field.uniqueId %}

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -25,11 +25,13 @@
 {% block content_footer_wrapper '' %}
 
 {% block main %}
-    {% if tabs is defined and tabs | length %}
-        {{ _self.render_detail_fields_with_tabs(entity, tabs) }}
-    {% else  %}
-        {{ _self.render_detail_fields(entity, null) }}
-    {% endif %}
+    {% block detail_fields %}
+        {% if tabs is defined and tabs | length %}
+            {{ _self.render_detail_fields_with_tabs(entity, tabs) }}
+        {% else  %}
+            {{ _self.render_detail_fields(entity, null) }}
+        {% endif %}
+    {% endblock detail_fields %}
     {% block delete_form %}
         {{ include('@EasyAdmin/crud/includes/_delete_form.html.twig', { entity_id: entity.primaryKeyValue }, with_context = false) }}
     {% endblock delete_form %}


### PR DESCRIPTION
Here is a proposition to support tabs on detail pages. (See issue #4887)
What do you think about it.

<img width="563" alt="Capture d’écran 2022-01-11 à 00 15 05" src="https://user-images.githubusercontent.com/51697251/148854226-7b39bf78-e773-4769-8221-e897c14e6668.png">

<img width="453" alt="Capture d’écran 2022-01-11 à 00 15 00" src="https://user-images.githubusercontent.com/51697251/148854229-729755f3-bbcb-4ae4-b483-917078d457b1.png">
?