### PR TITLE
Provide Bootstrap variable to custom backend pages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
-var Encore = require('@symfony/webpack-encore');
+const Encore = require('@symfony/webpack-encore');
 const WebpackRTLPlugin = require('webpack-rtl-plugin');
+const bootstrap = require('bootstrap/dist/js/bootstrap.min');
 
 Encore
     .setOutputPath('./src/Resources/public/')
@@ -34,6 +35,10 @@ Encore
     .addEntry('form-type-collection', './assets/js/form-type-collection.js')
     .addEntry('form-type-slug', './assets/js/form-type-slug.js')
     .addEntry('form-type-textarea', './assets/js/form-type-textarea.js')
+
+    .autoProvideVariables({
+        bootstrap: 'bootstrap',
+    });
 ;
 
 module.exports = Encore.getWebpackConfig();


### PR DESCRIPTION
This tries to fix #4952.

@weaverryan I thought this was going to be a simple change, but sadly it doesn't work. I just ping you in case you can remember any related issue and a way to fix it. What we want to achieve is: make Bootstrap available as a variable called `bootstrap` in all pages that include EasyAdmin JS file. Thanks!

```
$ yarn encore production

yarn run v1.22.17
warning ../../package.json: No license field
$ projects/EasyAdminBundle/node_modules/.bin/encore production
Running webpack ...

[webpack-cli] Failed to load 'projects/EasyAdminBundle/webpack.config.js' config
[webpack-cli] ReferenceError: document is not defined
    at F (projects/EasyAdminBundle/node_modules/bootstrap/dist/js/bootstrap.min.js:6:7393)
    at projects/EasyAdminBundle/node_modules/bootstrap/dist/js/bootstrap.min.js:6:8202
    at projects/EasyAdminBundle/node_modules/bootstrap/dist/js/bootstrap.min.js:6:84
    at Object.<anonymous> (projects/EasyAdminBundle/node_modules/bootstrap/dist/js/bootstrap.min.js:6:256)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```