### PR TITLE
Allow to filter the list of countries displayed in Country field

### DIFF
--- a/src/Field/Configurator/CountryConfigurator.php
+++ b/src/Field/Configurator/CountryConfigurator.php
@@ -64,7 +64,7 @@ final class CountryConfigurator implements FieldConfiguratorInterface
         }
 
         if (\in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_EDIT, Crud::PAGE_NEW], true)) {
-            $field->setFormTypeOption('choices', $this->generateFormTypeChoices($countryCodeFormat));
+            $field->setFormTypeOption('choices', $this->generateFormTypeChoices($countryCodeFormat, $field->getCustomOption(CountryField::OPTION_COUNTRY_CODES_TO_KEEP), $field->getCustomOption(CountryField::OPTION_COUNTRY_CODES_TO_REMOVE)));
 
             // the value of this form option must be a string to properly propagate it as an HTML attribute value
             $field->setFormTypeOption('attr.data-ea-autocomplete-render-items-as-html', 'true');
@@ -111,13 +111,21 @@ final class CountryConfigurator implements FieldConfiguratorInterface
         }
     }
 
-    private function generateFormTypeChoices(string $countryCodeFormat): array
+    private function generateFormTypeChoices(string $countryCodeFormat, ?array $countryCodesToKeep, ?array $countryCodesToRemove): array
     {
         $usesAlpha3Codes = CountryField::FORMAT_ISO_3166_ALPHA3 === $countryCodeFormat;
         $choices = [];
 
         $countries = $usesAlpha3Codes ? Countries::getAlpha3Names() : Countries::getNames();
         foreach ($countries as $countryCode => $countryName) {
+            if (null !== $countryCodesToKeep && !\in_array($countryCode, $countryCodesToKeep, true)) {
+                continue;
+            }
+
+            if (null !== $countryCodesToRemove && \in_array($countryCode, $countryCodesToRemove, true)) {
+                continue;
+            }
+
             $countryCodeAlpha2 = $usesAlpha3Codes ? Countries::getAlpha2Code($countryCode) : $countryCode;
             $flagImageName = \in_array($countryCodeAlpha2, self::FLAGS_WITH_IMAGE_FILE, true) ? $countryCodeAlpha2 : 'UNKNOWN';
             $flagImagePath = $this->assetPackages->getUrl(sprintf('bundles/easyadmin/images/flags/%s.png', $flagImageName));

--- a/src/Field/CountryField.php
+++ b/src/Field/CountryField.php
@@ -18,6 +18,8 @@ final class CountryField implements FieldInterface
     public const OPTION_SHOW_FLAG = 'showFlag';
     public const OPTION_SHOW_NAME = 'showName';
     public const OPTION_COUNTRY_CODE_FORMAT = 'countryCodeFormat';
+    public const OPTION_COUNTRY_CODES_TO_KEEP = 'countryCodesToKeep';
+    public const OPTION_COUNTRY_CODES_TO_REMOVE = 'countryCodesToRemove';
     /** @internal used to store the code of the flag to use independently from the country code format used */
     public const OPTION_FLAG_CODE = 'flagCode';
 
@@ -35,7 +37,9 @@ final class CountryField implements FieldInterface
             ->setDefaultColumns('col-md-4 col-xxl-3')
             ->setCustomOption(self::OPTION_SHOW_FLAG, true)
             ->setCustomOption(self::OPTION_SHOW_NAME, true)
-            ->setCustomOption(self::OPTION_COUNTRY_CODE_FORMAT, self::FORMAT_ISO_3166_ALPHA2);
+            ->setCustomOption(self::OPTION_COUNTRY_CODE_FORMAT, self::FORMAT_ISO_3166_ALPHA2)
+            ->setCustomOption(self::OPTION_COUNTRY_CODES_TO_KEEP, null)
+            ->setCustomOption(self::OPTION_COUNTRY_CODES_TO_REMOVE, null);
     }
 
     public function showFlag(bool $isShown = true): self
@@ -55,6 +59,28 @@ final class CountryField implements FieldInterface
     public function useAlpha3Codes(bool $useAlpha3 = true): self
     {
         $this->setCustomOption(self::OPTION_COUNTRY_CODE_FORMAT, $useAlpha3 ? self::FORMAT_ISO_3166_ALPHA3 : self::FORMAT_ISO_3166_ALPHA2);
+
+        return $this;
+    }
+
+    /**
+     * Restricts the list of countries shown by the field to the given list of country codes.
+     * e.g. ->includeOnly(['AR', 'BR', 'ES', 'PT']).
+     */
+    public function includeOnly(array $countryCodesToKeep): self
+    {
+        $this->setCustomOption(self::OPTION_COUNTRY_CODES_TO_KEEP, $countryCodesToKeep);
+
+        return $this;
+    }
+
+    /**
+     * Removes the given list of country codes from the countries displayed by the field.
+     * e.g. ->remove(['AF', 'KP']).
+     */
+    public function remove(array $countryCodesToRemove): self
+    {
+        $this->setCustomOption(self::OPTION_COUNTRY_CODES_TO_REMOVE, $countryCodesToRemove);
 
         return $this;
     }


### PR DESCRIPTION
Fixes #4962.

Now `CountryField` includes two methods to "filter in" and "filter out" countries:

```php
CountryField::new('...')->includeOnly(['AR', 'BR', 'ES', 'PT']);

CountryField::new('...')->remove(['AF', 'KP']);
```