### PR TITLE
Use getByProperty to inject fieldDto into filter configurators

### DIFF
--- a/src/Factory/FilterFactory.php
+++ b/src/Factory/FilterFactory.php
@@ -73,11 +73,11 @@ final class FilterFactory
 
             $context = $this->adminContextProvider->getContext();
             foreach ($this->filterConfigurators as $configurator) {
-                if (!$configurator->supports($filterDto, $fields->get($property), $entityDto, $context)) {
+                if (!$configurator->supports($filterDto, $fields->getByProperty($property), $entityDto, $context)) {
                     continue;
                 }
 
-                $configurator->configure($filterDto, $fields->get($property), $entityDto, $context);
+                $configurator->configure($filterDto, $fields->getByProperty($property), $entityDto, $context);
             }
 
             $builtFilters[$property] = $filterDto;


### PR DESCRIPTION
@javiereguiluz First of all, thanks for EasyAdmin, great piece of work!

I wasn't sure if this is a bug or if we are doing anything wrong around configuring Field and Filter on a common property.
But because the change to make our solution work was minimal, I've created a PR so it can easily be addressed in case of a real bug 😄 

Looking forward to hearing from you, and feel free to close the PR if the current behaviour is intended.

**Describe the bug**
I've tried to create a FilterConfigurator which depends on options defined on the Field for the same property:

- `AssociationField::new('myProperty')`
- `EntityFilter::new('myProperty')`

Having a look at the `FilterConfiguratorInterface` I thought I could receive the FieldDto instance if my Filter/Field are defined for the same property, however, looking at the FilterFactory code I've realised that it won't work because it is using `$fields->get()` which uses the index of the internal fields array, and the value used to index fields is their `uniqueId` and not their `property`.
Because of the above, the fieldDto is never injected into the filter configurator.

**To Reproduce**
- Create a CrudController
- Configure a Field on a given property
- Configure a Filter on the same given property
- Create a FilterConfigurator which supports the Filter from previous step
- Check if FieldDto is being injected into the FilterConfigurator methods
