### PR TITLE
Direct link to FontAwesome icons

### DIFF
--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -269,6 +269,7 @@ the ``Action`` class constructor::
     $viewInvoice = Action::new('viewInvoice', false);
 
     // the third optional argument is the full CSS class of a FontAwesome icon
+    // see https://fontawesome.com/v5.15/icons?d=gallery&p=2&m=free
     $viewInvoice = Action::new('viewInvoice', 'Invoice', 'fa fa-file-invoice');
 
 Then you can configure the basic HTML/CSS attributes of the button/element

--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -845,7 +845,7 @@ etc. Example:
 .. _`Symfony controllers`: https://symfony.com/doc/current/controller.html
 .. _`Symfony route annotations`: https://symfony.com/doc/current/routing.html#creating-routes-as-annotations
 .. _`context object`: https://wiki.c2.com/?ContextObject
-.. _`FontAwesome`: https://fontawesome.com/
+.. _`FontAwesome`: https://fontawesome.com/v5.15/icons?d=gallery&p=2&m=free
 .. _`allowed values for the "rel" attribute`: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
 .. _`Symfony security permission`: https://symfony.com/doc/current/security.html#roles
 .. _`logout feature`: https://symfony.com/doc/current/security.html#logging-out


### PR DESCRIPTION
Hi,

Just changed the following:

* On the Actions docs, I added a link to FontAwesome icons list
* On the Dashboard docs, I changed the link to the icons list instead of the homepage

Note both links go to the correct FA version & already filter on the free icons.