### PR TITLE
Removed strange padding-right

### DIFF
--- a/assets/css/easyadmin-theme/datagrids.scss
+++ b/assets/css/easyadmin-theme/datagrids.scss
@@ -53,7 +53,6 @@ table.datagrid {
       td.field-boolean {
         padding-left: 8px;
         text-align: left;
-        padding-right: calc(100% - 35%);
 
         &::before {
           color: var(--table-cell-color);


### PR DESCRIPTION
You are applying a 65% right padding to a td that already has a 35% left padding. That leaves 0 width for the contents.
In practice, the contents end up overflowing the width and since they are visible, they look fine anyway.
I'm not sure if that was the intention, but it seems a very hacky way to accomplish whatever you're trying to accomplish.

This seems completely unnecessary and it makes it impossible to add extra content to the cell.
I'll try to post a screenshot later, but I like to occasionally add things right next to field values in the tables.
For example, imagine a crud page for managing users. Next to the email or ID field, I like to add an "Emulate" link/button to impersonate the user (and to make it extra-nice looking I style it with float:right). And that works out of the box.
Next to the "Is Verified" field, I like to add a link/button to re-send the email verification link to the user. And that breaks because of this padding-right rule. It goes to a newline unnecessarily, and if I add float:right to it, it breaks the layout completely.

I tried removing your rule (actually, what I tried is overriding it with one that matches the "previous" one) and I don't see any side effects. Even if there are (and I would like to know what those are), I think a better solution should be devised. I don't think a 100% padding with content systematically overflowing can be the right solution to whatever the problem is.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
