### PR TITLE
Wrapped the action label (NOT icon) in a span

### DIFF
--- a/src/Resources/views/crud/action.html.twig
+++ b/src/Resources/views/crud/action.html.twig
@@ -6,13 +6,13 @@
        href="{{ action.linkUrl }}"
        {% for name, value in action.htmlAttributes %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
         {%- if action.icon %}<i class="action-icon {{ action.icon }}"></i> {% endif -%}
-        {%- if action.label is not empty -%}{{ action.label }}{%- endif -%}
+        {%- if action.label is not empty -%}<span class="action-label">{{ action.label }}</span>{%- endif -%}
     </a>
 {% elseif 'button' == action.htmlElement %}
     <button class="{{ action.cssClass }}" {% for name, value in action.htmlAttributes %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
         <span class="btn-label">
             {%- if action.icon %}<i class="action-icon {{ action.icon }}"></i> {% endif -%}
-            {%- if action.label is not empty -%}{{ action.label }}{%- endif -%}
+            {%- if action.label is not empty -%}<span class="action-label">{{ action.label }}</span>{%- endif -%}
         </span>
     </button>
 {% endif %}


### PR DESCRIPTION
This allows for easier and/or more powerful styling of the action text and icon separately.

For example, here's my use case. In the index page, I want the icon to be visible always, but, when the screen width is below Bootstrap's 
"small" breakpoint (that is, when each entity gets its own "table" and the actions get their own row) I want the labels to become visible.

Without this, I'm unable to do that (or at least it becomes very cumbersome), because I can't target the label text not including the icon.

With this improvement, I can.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
