### PR TITLE
add url inActionDto::getAsConfigObject

### DIFF
--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -233,6 +233,10 @@ final class ActionDto
         $action->setHtmlAttributes($this->htmlAttributes);
         $action->setTranslationParameters($this->translationParameters);
 
+        if (null !== $this->url) {
+            $action->linkToUrl($this->url);
+        }
+
         if (null !== $this->templatePath) {
             $action->setTemplatePath($this->templatePath);
         }


### PR DESCRIPTION
If I have an crud controller A with
```
public function configureActions(Actions $actions): Actions
    {
        return $actions
            ->update(Crud::PAGE_INDEX, Action::NEW, function (Action $action) {
                return $action->linkToUrl(function () use ($action) {
                    return $this->generateAdminUrl(Crud::PAGE_NEW); //generate url and add params
                });
            })
    }
```

And I have an crud controller B who extend A with

```
public function configureActions(Actions $actions): Actions
{
        $actions = parent::configureActions($actions);
         return $actions
            ->update(Crud::PAGE_INDEX, Action::NEW, function (Action $action) {
                return $action->addCssClass('action-new btn btn-secondary');
            })
}

```

The parameters are lost because the url is in ActionDto while the update function transforms ActionDto into ActionConfig and then transforms ActionConfig into ActionDto.

The url is not passed into the ActionConfig on the first transformation and so the ActionConfig is overwritten on the last transformation.

This makes this behaviour strange with a loss of parameters due to the use of update to add css
