### PR TITLE
Fix custom action permissions

### DIFF
--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -130,7 +130,7 @@ final class Actions
         return $this;
     }
 
-    public function getAsDto(string $pageName): ActionConfigDto
+    public function getAsDto(?string $pageName): ActionConfigDto
     {
         $this->dto->setPageName($pageName);
 

--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -36,7 +36,7 @@ final class ActionConfigDto
         }
     }
 
-    public function setPageName(string $pageName): void
+    public function setPageName(?string $pageName): void
     {
         $this->pageName = $pageName;
     }

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -128,7 +128,7 @@ final class AdminContextFactory
 
     private function getActionConfig(DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ?string $pageName): ActionConfigDto
     {
-        if (null === $crudController || null === $pageName) {
+        if (null === $crudController) {
             return new ActionConfigDto();
         }
 

--- a/tests/Controller/CategoryCrudControllerTest.php
+++ b/tests/Controller/CategoryCrudControllerTest.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config\Action as AppAction;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CategoryCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\SecureDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
@@ -332,6 +333,28 @@ class CategoryCrudControllerTest extends WebTestCase
         ];
     }
 
+    /**
+     * @dataProvider customPage
+     */
+    public function testCustomPage(string $username, int $expectedStatusCode)
+    {
+        $this->client->request('GET', $this->generateCustomActionUrl(), [], [], ['PHP_AUTH_USER' => $username, 'PHP_AUTH_PW' => '1234']);
+
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    public function customPage(): \Generator
+    {
+        yield [
+            $this->generateUsername('ROLE_USER'),
+            403, // Expected status code of the response
+        ];
+        yield [
+            $this->generateUsername('ROLE_ADMIN'),
+            200,
+        ];
+    }
+
     private function assertResultCount(int $expectedResultCount): void
     {
         if (0 > $expectedResultCount) {
@@ -399,5 +422,26 @@ class CategoryCrudControllerTest extends WebTestCase
             ->setAction('renderFilters')
             ->set('referrer', $referrer)
             ->generateUrl();
+    }
+
+    private function generateCustomActionUrl(): string
+    {
+        return $this->adminUrlGenerator
+            ->setDashboard(SecureDashboardController::class)
+            ->setController(CategoryCrudController::class)
+            ->setAction(AppAction::CUSTOM_ACTION)
+            ->generateUrl();
+    }
+
+    private function generateUsername(string $role): string
+    {
+        switch ($role) {
+            case 'ROLE_USER':
+                return 'user';
+            case 'ROLE_ADMIN':
+                return 'admin';
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unknown role, use one of: %s', implode(', ', ['ROLE_USER', 'ROLE_ADMIN'])));
     }
 }

--- a/tests/TestApplication/config/packages/security.php
+++ b/tests/TestApplication/config/packages/security.php
@@ -13,6 +13,10 @@ $configuration = [
         'test_users' => [
             'memory' => [
                 'users' => [
+                    'user' => [
+                        'password' => '1234',
+                        'roles' => ['ROLE_USER'],
+                    ],
                     'admin' => [
                         'password' => '1234',
                         'roles' => ['ROLE_ADMIN'],
@@ -31,8 +35,12 @@ $configuration = [
         ],
     ],
 
+    'role_hierarchy' => [
+        'ROLE_ADMIN' => ['ROLE_USER'],
+    ],
+
     'access_control' => [
-        ['path' => '^/secure_admin', 'roles' => ['ROLE_ADMIN']],
+        ['path' => '^/secure_admin', 'roles' => ['ROLE_USER']],
     ],
 ];
 

--- a/tests/TestApplication/src/Config/Action.php
+++ b/tests/TestApplication/src/Config/Action.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config;
+
+class Action
+{
+    public const CUSTOM_ACTION = 'customAction';
+}

--- a/tests/TestApplication/src/Controller/CategoryCrudController.php
+++ b/tests/TestApplication/src/Controller/CategoryCrudController.php
@@ -2,12 +2,20 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config\Action as AppAction;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use Symfony\Component\HttpFoundation\Response;
 
 class CategoryCrudController extends AbstractCrudController
 {
@@ -26,10 +34,29 @@ class CategoryCrudController extends AbstractCrudController
         ];
     }
 
+    public function configureActions(Actions $actions): Actions
+    {
+        $customPageAction = Action::new(AppAction::CUSTOM_ACTION)
+            ->createAsGlobalAction()
+            ->linkToCrudAction('customPage');
+
+        return $actions->add(Crud::PAGE_INDEX, $customPageAction)
+            ->setPermission(AppAction::CUSTOM_ACTION, 'ROLE_ADMIN');
+    }
+
     public function configureFilters(Filters $filters): Filters
     {
         return $filters
             ->add('name')
             ->add('active');
+    }
+
+    public function customAction(AdminContext $context): Response
+    {
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => AppAction::CUSTOM_ACTION, 'entity' => $context->getEntity()])) {
+            throw new ForbiddenActionException($context);
+        }
+
+        return new Response();
     }
 }


### PR DESCRIPTION
Would fix https://github.com/EasyCorp/EasyAdminBundle/issues/3845.

I'm not sure if allowing the `$pageName` to be `NULL` produces any errors somewhere else - but I didn't find any error and the tests still run successfully, so i hope it doesn't break anything.
