### PR TITLE
Remove filtering for head/body contents

### DIFF
--- a/src/Dto/AssetsDto.php
+++ b/src/Dto/AssetsDto.php
@@ -125,14 +125,10 @@ final class AssetsDto
             }
         }
         foreach ($this->headContents as $headContent) {
-            if ($headContent->getLoadedOn()->has($pageName)) {
-                $filteredAssets->addHtmlContentToHead($headContent);
-            }
+            $filteredAssets->addHtmlContentToHead($headContent);
         }
         foreach ($this->bodyContents as $bodyContent) {
-            if ($bodyContent->getLoadedOn()->has($pageName)) {
-                $filteredAssets->addHtmlContentToBody($bodyContent);
-            }
+            $filteredAssets->addHtmlContentToBody($bodyContent);
         }
 
         return $filteredAssets;


### PR DESCRIPTION
See #5020 

`$headContent` and `$bodyContent` are arrays of strings so cause a failure when treated like an AssetDto.

From the string type-hint and the new docs it looks like the idea was for them to stay as strings rather than be converted to DTOs so I removed the filter check.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
