### PR TITLE
[trix-editor] Expose Trix instance to be able to modify config

### DIFF
--- a/assets/js/form-type-text-editor.js
+++ b/assets/js/form-type-text-editor.js
@@ -2,7 +2,7 @@ import DirtyForm from "dirty-form";
 
 require('../css/form-type-text-editor.css');
 
-import 'trix/dist/trix';
+import Trix from 'trix/dist/trix';
 
 // copied from https://github.com/chromium/chromium/search?p=1&q=2507943997699731163
 const requiredFieldMessage = {
@@ -115,3 +115,5 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 });
+
+window.Trix = Trix;


### PR DESCRIPTION
Fixes #4922 

As explained in the issue above now makes it possible to adjust the `Trix` config via for example:

```php

final class DashboardController extends AbstractDashboardController
{
    // ...

    public function configureAssets(): Assets
    {
        return Assets::new()
            ->addHtmlContentToHead("<script>
                if (typeof window.Trix !== 'undefined') {
                    window.Trix.config.blockAttributes.heading1.tagName = 'h2';
                    window.Trix.config.blockAttributes.default.tagName = 'p';
                }
            </script>");
    }
}
```

Very specific for this example when changing the the 'heading.tagName' you should also add some css like:
```css
.trix-content h2 {
    font-size: 1.2em;
    line-height: 1.2;
}
```
Otherwise you wouldn't see any style change between a heading and plain text in your editor.

Ps. I tried running `yarn build` in my fork but that seemed to generate a lot of changes on the 'build' assets (probably due to my dev environment) What should be the proper way to build all the assets again or does this happen on release?