### PR TITLE
[field] Automatically set label for custom FormType

### DIFF
--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -42,6 +42,7 @@ trait FieldTrait
     public function setLabel($label): self
     {
         $this->dto->setLabel($label);
+        $this->setFormTypeOption('label', $label);
 
         return $this;
     }


### PR DESCRIPTION
Before when using the `setFormType` function you would manually need to call `setFormTypeOption(s)` to set the `label`.
However since the `new` method supports setting the `label` directly, it would be intuitive to have it directly set for a custom `FormType` too.

Before:
```php
public function configureFields(string $pageName): iterable
{
    // ...
 
    yield Field::new('myField', 'my_label')  // 'my_label' has no value here
        ->setFormType(MyCustomType::class)
        ->setFormTypeOption('label', 'my_label');
}
```

After:
```php
public function configureFields(string $pageName): iterable
{
    // ...
 
    yield Field::new('myField', 'my_label')
        ->setFormType(MyCustomType::class);
}
```

Just a simple addition, if this is not desired, just discard this PR :) 