### PR TITLE
User menu: display dropdown divider only when there is a secondary menu

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -88,10 +88,10 @@
                         <span class="user-name">{{ ea.user is null ? 'user.anonymous'|trans(domain = 'EasyAdminBundle') : ea.userMenu.name }}</span>
                     </div>
                 </li>
-                <li><hr class="dropdown-divider"></li>
 
                 {% block user_menu %}
                     {% if ea.userMenu.items|length > 0 %}
+                        <li><hr class="dropdown-divider"></li>
                         {% for item in ea.userMenu.items %}
                             <li>
                                 {% if item.isMenuSection and not loop.first %}


### PR DESCRIPTION
If the user menu doesn't have secondary items, there is an orphaned divider being displayed at the bottom. This minor change fixes this, by moving the divider into the "if" block.

Before the patch:
![image](https://user-images.githubusercontent.com/362092/152677921-205291fe-1b65-44ab-a050-6452c0b6bb76.png)

After the patch:
![image](https://user-images.githubusercontent.com/362092/152677944-b0952191-4271-4911-9661-b0d36fec5a7a.png)

When there are menu items, the look stays exactly the same (because the generated HTML is also exactly the same):
![image](https://user-images.githubusercontent.com/362092/152677969-2588052f-fa61-4134-9afb-8ced433608a7.png)

