### PR TITLE
Add Makefile for development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: *
+
+## —— Help ————————————————————————————————————
+help: ## Show help
+	@grep -E '(^[a-zA-Z0-9_-]+:.*?##.*$$)|(^##)' Makefile | awk 'BEGIN {FS = ":.*?## "}{printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}' | sed -e 's/\[32m##/[33m/'
+
+## —— Tests ———————————————————————————————————
+tests: ## Run tests
+	rm -rf $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/test/cache/*
+	php vendor/bin/simple-phpunit -v
+
+## —— Linters —————————————————————————————————
+linter-code-syntax: ## Lint PHP code (in dry-run mode, does not edit files)
+	docker run --rm -it -w=/app -v $(shell pwd):/app oskarstark/php-cs-fixer-ga:latest --diff -vvv --dry-run --using-cache=no
+linter-docs: ## Lint docs
+	docker run --rm -it -e DOCS_DIR='/docs' -v $(shell pwd)/doc:/docs oskarstark/doctor-rst:latest --short


### PR DESCRIPTION
Usefull for development:
- people who are new can see at one glance how to run tests and linters
- no need to remember how to run linters and tests (and how to clean the test cache)
- `make` can be used with autocompletion, so tests and linters can be run really quickly

Usage:
```console
user@machine:~/projects/EasyAdminBundle$ make help
 —— Help ———————————————————————————————————— 
help                           Show help
 —— Tests ——————————————————————————————————— 
tests                          Run tests
 —— Linters ————————————————————————————————— 
linter-code-syntax             Lint PHP code (in dry-run mode, does not edit files)
linter-docs                    Lint docs
```