### PR TITLE
fix: issue #5038 datetimefilter array to string conversion error

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -188,7 +188,14 @@
                                                             {# This code re-applies your filters on searches, an iterable check is needed in cases we have more than one object for a filter #}
                                                             {% if value is iterable %}
                                                                 {% for index, iterValue in value %}
-                                                                    <input type="hidden" name="filters[{{ field }}][{{ key }}][{{ index }}]" value="{{ iterValue }}">
+                                                                    {# This sub-level iterable check is needed in cases we have more complex filters like the DateTimeFilter cf. issue #5038 #}
+                                                                    {% if iterValue is iterable %}
+                                                                        {% for subIndex, subIterValue in iterValue %}
+                                                                            <input type="hidden" name="filters[{{ field }}][{{ key }}][{{ index }}][{{ subIndex }}]" value="{{ subIterValue }}">
+                                                                        {% endfor %}
+                                                                    {% else %}
+                                                                        <input type="hidden" name="filters[{{ field }}][{{ key }}][{{ index }}]" value="{{ iterValue }}">
+                                                                    {% endif %}
                                                                 {% endfor %}
                                                             {% else %}
                                                                 <input type="hidden" name="filters[{{ field }}][{{ key }}]" value="{{ value }}">


### PR DESCRIPTION
Fix the issue #5038 as the structure of the DateTimeFilter needs another sub-level to be described properly else an Array to string conversion error happens in dev env or the values are lost (converted to the string `Array`) elsewhere when using the global search field.
