### PR TITLE
Fix issue #5039 - Security issue on delete action

### DIFF
--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -50,7 +50,8 @@ final class AdminContextFactory
     public function create(Request $request, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController): AdminContext
     {
         $crudAction = $request->query->get(EA::CRUD_ACTION);
-        $validPageNames = [Crud::PAGE_INDEX, Crud::PAGE_DETAIL, Crud::PAGE_EDIT, Crud::PAGE_NEW];
+        // We must add the "delete" page to have a valid context action config during the action validation (issue #5039)
+        $validPageNames = [Crud::PAGE_INDEX, Crud::PAGE_DETAIL, Crud::PAGE_EDIT, Crud::PAGE_NEW, 'delete'];
         $pageName = \in_array($crudAction, $validPageNames, true) ? $crudAction : null;
 
         $dashboardDto = $this->getDashboardDto($request, $dashboardController);


### PR DESCRIPTION
Fix #5039

**Reason:** On delete action, the action config DTO is empty.

**Explanation:**
The page "delete" is not defined as a "valid" page during admin context initialization. Then, the page name is null and a default action config DTO is created:
https://github.com/EasyCorp/EasyAdminBundle/blob/3904ee3ea2966aaeed9cdaa1f9a56f57e72757ab/src/Factory/AdminContextFactory.php#L53-L54

https://github.com/EasyCorp/EasyAdminBundle/blob/3904ee3ea2966aaeed9cdaa1f9a56f57e72757ab/src/Factory/AdminContextFactory.php#L131-L133

Without a valid action config DTO, it's not possible for the EA security voter to get the configured permission in the CRUD controller (because not defined!). That's why no custom voter could be called on delete action, because the passed attribute is `null` (no permission)... And the access is always **granted**.