### PR TITLE
Update Symfony compatibility for 3.x & 4.x in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Versions
 --------
 
 | Repository Branch | EasyAdmin Version | Symfony Compatibility  | PHP Compatibility | Status               | Docs
-| ----------------- | ----------------- | ---------------------- | ----------------- | -------------------- | ---
-| `4.x`             | `4.x`             | `5.x`, and `6.x`       | `8.0.2` or higher | New features and bug fixes | [Read Docs](https://symfony.com/bundles/EasyAdminBundle/master/index.html)
-| `3.x`             | `3.x`             | `4.x`, and `5.x`       | `7.2.5` or higher | Bug fixes only; no new features | [Read Docs](https://symfony.com/bundles/EasyAdminBundle/3.x/index.html)
+| ----------------- | ----------------- |------------------------| ----------------- | -------------------- | ---
+| `4.x`             | `4.x`             | `5.4`, and `6.x`       | `8.0.2` or higher | New features and bug fixes | [Read Docs](https://symfony.com/bundles/EasyAdminBundle/master/index.html)
+| `3.x`             | `3.x`             | `4.4`, and `5.x`       | `7.2.5` or higher | Bug fixes only; no new features | [Read Docs](https://symfony.com/bundles/EasyAdminBundle/3.x/index.html)
 | `2.x`             | `2.x`             | `4.x`, and `5.x`       | `7.1.3` or higher | No longer maintained | [Read Docs](https://symfony.com/bundles/EasyAdminBundle/2.x/index.html)
 | `1.x`             | `1.x`             | `2.x`, `3.x` and `4.x` | `5.3.0` or higher | No longer maintained | -
 


### PR DESCRIPTION
Symfony compatibility in README for 3.x & 4.x are wrong so I updated it a little bit