### PR TITLE
Allow `Translatable` objects in addition to `string` in translated context

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,48 @@
 Upgrade between EasyAdmin 4.x versions
 ======================================
 
+EasyAdmin 4.X.0
+---------------
+
+### Signature changes
+
+Many classes have been changed to allow using `Translatable` objects
+in places where previously only `string`, `false` or `null` were allowed.
+
+Return types were also loosened to allow returning `Translatable` where applicable.
+
+Full list of changes in final classes:
+
+    Config\Action (new, setLabel); only docblocks and deprecation logic
+    Config\Menu*MenuItem (constructors)
+    Config\MenuItem (linkTo*, section, subMenu)
+    Dto\ActionDto (getLabel, setLabel and private field)
+    Dto\CrudDto (getEntityLabelInSingular, setEntityLabelInSingular,getEntityLabelInPlural, setEntityLabelInPlural, setCustomPageTitle, getHelpMessage, setHelpMessage)
+    Dto\FieldDto (getLabel, setLabel, getHelp, setHelp)
+    Dto\FilterDto (getLabel, setLabel); only docblocks
+    Dto\MenuItemDto (getLabel, setLabel)
+    Field*Field (new); only docblocks
+    Field\FormField (addPanel, addTab)
+
+List of signature changes in non-final classes and traits:
+
+    Config\Crud (setHelp)
+    Field\FieldTrait (setLabel, setHelp); setLabel only in docblock
+
+### New setChoicesTranslatable() option in `ChoiceField`
+
+Setting it allows usage of `Translatable` objects within choices,
+but requires flipped array to be passed as choices. For example:
+
+    yield ChoiceField::new('...')->setChoicesTranslatable()->setChoices([
+        'paid' => t('Paid Invoice'),
+        'pending' => t('Invoice Sent but Unpaid'),
+        'refunded' => 'Refunded Invoice', // You can mix strings with Translatable objects
+    ]);
+
+Upgrade between EasyAdmin 4.x versions
+======================================
+
 EasyAdmin 4.1.0
 ---------------
 

--- a/doc/fields/ChoiceField.rst
+++ b/doc/fields/ChoiceField.rst
@@ -146,3 +146,17 @@ Symfony Forms: ``['Label visible to users' => 'submitted_value', ...]``::
 
 .. _`TomSelect`: https://tom-select.js.org/
 .. _`ChoiceType`: https://symfony.com/doc/current/reference/forms/types/entity.html
+
+setChoicesTranslatable
+~~~~~~~~~~~~~~~~~~~~~~
+
+Setting this option allows usage of `Translatable` objects within choices.
+When set choices should be provided in a "flipped" way, where submitted values
+are the keys and labels are values that can be strings or translatable objects::
+
+    yield ChoiceField::new('...')->setChoicesTranslatable()->setChoices([
+        'paid' => t('Paid Invoice'),
+        'pending' => t('Invoice Sent but Unpaid'),
+        'refunded' => 'Refunded Invoice', // You can mix strings with Translatable objects
+    ]);
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,6 +27,7 @@ Table of Contents
     actions
     security
     events
+    translation
     upgrade
 
 Technical Requirements

--- a/doc/translation.rst
+++ b/doc/translation.rst
@@ -1,0 +1,21 @@
+Extracting translation strings from dashboard
+=============================================
+
+Since version 4.X EasyAdmin allows using `Translatable` objects
+as labels, titles, help messages etc. If you want to automatically
+extract translation from dashboard it is recommended to pass
+`Translatable` objects everywhere and let Symfony default extractor
+find them.
+
+For example:::
+
+    TextField::new('firstName', t('Name'))
+
+    $crud
+        ->setEntityLabelInSingular(t('Product'))
+        ->setEntityLabelInPlural(t('Products'))
+    ;
+
+.. note::
+
+    If you need to use EasyAdmin placeholders (`%entity_name%` etc.) in title or actions with translatable objects you should either use default Symfony `TranslatableMessage` class or provide them by yourself as parameters. Due to the nature of `TranslatableInterface` it is not possible to append additional parameters to other classes.

--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto;
 use function Symfony\Component\String\u;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -41,12 +42,13 @@ final class Action
     }
 
     /**
-     * @param string|false|null $label Use FALSE to hide the label; use NULL to autogenerate it
-     * @param string|null       $icon  The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
+     * @param TranslatableInterface|string|false|null $label Use FALSE to hide the label; use NULL to autogenerate it
+     * @param string|null                             $icon  The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function new(string $name, /* string|false|null */ $label = null, ?string $icon = null): self
+    public static function new(string $name, /* TranslatableInterface|string|false|null */ $label = null, ?string $icon = null): self
     {
         if (!\is_string($label)
+            && !$label instanceof TranslatableInterface
             && false !== $label
             && null !== $label) {
             trigger_deprecation(
@@ -87,11 +89,12 @@ final class Action
     }
 
     /**
-     * @param string|false|null $label Use FALSE to hide the label; use NULL to autogenerate it
+     * @param TranslatableInterface|string|false|null $label Use FALSE to hide the label; use NULL to autogenerate it
      */
-    public function setLabel(/* string|false|null */ $label): self
+    public function setLabel(/* TranslatableInterface|string|false|null */ $label): self
     {
         if (!\is_string($label)
+            && !$label instanceof TranslatableInterface
             && false !== $label
             && null !== $label) {
             trigger_deprecation(

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionConfigDto;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -144,14 +145,14 @@ final class Actions
     private function createBuiltInAction(string $pageName, string $actionName): Action
     {
         if (Action::BATCH_DELETE === $actionName) {
-            return Action::new(Action::BATCH_DELETE, '__ea__action.delete', null)
+            return Action::new(Action::BATCH_DELETE, t('action.delete', domain: 'EasyAdminBundle'), null)
                 ->linkToCrudAction(Action::BATCH_DELETE)
                 ->setCssClass('action-'.Action::BATCH_DELETE)
                 ->addCssClass('btn btn-danger pr-0');
         }
 
         if (Action::NEW === $actionName) {
-            return Action::new(Action::NEW, '__ea__action.new', null)
+            return Action::new(Action::NEW, t('action.new', domain: 'EasyAdminBundle'), null)
                 ->createAsGlobalAction()
                 ->linkToCrudAction(Action::NEW)
                 ->setCssClass('action-'.Action::NEW)
@@ -159,21 +160,21 @@ final class Actions
         }
 
         if (Action::EDIT === $actionName) {
-            return Action::new(Action::EDIT, '__ea__action.edit', null)
+            return Action::new(Action::EDIT, t('action.edit', domain: 'EasyAdminBundle'), null)
                 ->linkToCrudAction(Action::EDIT)
                 ->setCssClass('action-'.Action::EDIT)
                 ->addCssClass(Crud::PAGE_DETAIL === $pageName ? 'btn btn-primary' : '');
         }
 
         if (Action::DETAIL === $actionName) {
-            return Action::new(Action::DETAIL, '__ea__action.detail')
+            return Action::new(Action::DETAIL, t('action.detail', domain: 'EasyAdminBundle'))
                 ->linkToCrudAction(Action::DETAIL)
                 ->setCssClass('action-'.Action::DETAIL)
                 ->addCssClass(Crud::PAGE_EDIT === $pageName ? 'btn btn-secondary' : '');
         }
 
         if (Action::INDEX === $actionName) {
-            return Action::new(Action::INDEX, '__ea__action.index')
+            return Action::new(Action::INDEX, t('action.index', domain: 'EasyAdminBundle'))
                 ->linkToCrudAction(Action::INDEX)
                 ->setCssClass('action-'.Action::INDEX)
                 ->addCssClass(\in_array($pageName, [Crud::PAGE_DETAIL, Crud::PAGE_EDIT, Crud::PAGE_NEW], true) ? 'btn btn-secondary' : '');
@@ -182,14 +183,14 @@ final class Actions
         if (Action::DELETE === $actionName) {
             $cssClass = \in_array($pageName, [Crud::PAGE_DETAIL, Crud::PAGE_EDIT], true) ? 'btn btn-secondary pr-0 text-danger' : 'text-danger';
 
-            return Action::new(Action::DELETE, '__ea__action.delete', Crud::PAGE_INDEX === $pageName ? null : 'fa fa-fw fa-trash-o')
+            return Action::new(Action::DELETE, t('action.delete', domain: 'EasyAdminBundle'), Crud::PAGE_INDEX === $pageName ? null : 'fa fa-fw fa-trash-o')
                 ->linkToCrudAction(Action::DELETE)
                 ->setCssClass('action-'.Action::DELETE)
                 ->addCssClass($cssClass);
         }
 
         if (Action::SAVE_AND_RETURN === $actionName) {
-            return Action::new(Action::SAVE_AND_RETURN, Crud::PAGE_EDIT === $pageName ? '__ea__action.save' : '__ea__action.create')
+            return Action::new(Action::SAVE_AND_RETURN, t(Crud::PAGE_EDIT === $pageName ? 'action.save' : 'action.create', domain: 'EasyAdminBundle'))
                 ->setCssClass('action-'.Action::SAVE_AND_RETURN)
                 ->addCssClass('btn btn-primary action-save')
                 ->displayAsButton()
@@ -198,7 +199,7 @@ final class Actions
         }
 
         if (Action::SAVE_AND_CONTINUE === $actionName) {
-            return Action::new(Action::SAVE_AND_CONTINUE, Crud::PAGE_EDIT === $pageName ? '__ea__action.save_and_continue' : '__ea__action.create_and_continue', 'far fa-edit')
+            return Action::new(Action::SAVE_AND_CONTINUE, t(Crud::PAGE_EDIT === $pageName ? 'action.save_and_continue' : 'action.create_and_continue', domain: 'EasyAdminBundle'), 'far fa-edit')
                 ->setCssClass('action-'.Action::SAVE_AND_CONTINUE)
                 ->addCssClass('btn btn-secondary action-save')
                 ->displayAsButton()
@@ -207,7 +208,7 @@ final class Actions
         }
 
         if (Action::SAVE_AND_ADD_ANOTHER === $actionName) {
-            return Action::new(Action::SAVE_AND_ADD_ANOTHER, '__ea__action.create_and_add_another')
+            return Action::new(Action::SAVE_AND_ADD_ANOTHER, t('action.create_and_add_another', domain: 'EasyAdminBundle'))
                 ->setCssClass('action-'.Action::SAVE_AND_ADD_ANOTHER)
                 ->addCssClass('btn btn-secondary action-save')
                 ->displayAsButton()

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -6,6 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\PaginatorDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -113,7 +114,7 @@ class Crud
         return $this;
     }
 
-    public function setHelp(string $pageName, string $helpMessage): self
+    public function setHelp(string $pageName, TranslatableInterface|string $helpMessage): self
     {
         if (!\in_array($pageName, $this->getValidPageNames(), true)) {
             throw new \InvalidArgumentException(sprintf('The first argument of the "%s()" method must be one of these valid page names: %s ("%s" given).', __METHOD__, implode(', ', $this->getValidPageNames()), $pageName));

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -7,6 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use Symfony\Component\Uid\AbstractUid;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToCrud()
@@ -17,7 +18,7 @@ final class CrudMenuItem implements MenuItemInterface
 {
     use MenuItemTrait;
 
-    public function __construct(string $label, ?string $icon, string $entityFqcn)
+    public function __construct(TranslatableInterface|string $label, ?string $icon, string $entityFqcn)
     {
         $this->dto = new MenuItemDto();
 

--- a/src/Config/Menu/DashboardMenuItem.php
+++ b/src/Config/Menu/DashboardMenuItem.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToDashboard()
@@ -14,7 +15,7 @@ final class DashboardMenuItem implements MenuItemInterface
 {
     use MenuItemTrait;
 
-    public function __construct(string $label, ?string $icon)
+    public function __construct(TranslatableInterface|string $label, ?string $icon)
     {
         $this->dto = new MenuItemDto();
 

--- a/src/Config/Menu/ExitImpersonationMenuItem.php
+++ b/src/Config/Menu/ExitImpersonationMenuItem.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToExitImpersonation()
@@ -14,7 +15,7 @@ final class ExitImpersonationMenuItem implements MenuItemInterface
 {
     use MenuItemTrait;
 
-    public function __construct(string $label, ?string $icon)
+    public function __construct(TranslatableInterface|string $label, ?string $icon)
     {
         $this->dto = new MenuItemDto();
 

--- a/src/Config/Menu/LogoutMenuItem.php
+++ b/src/Config/Menu/LogoutMenuItem.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToLogout()
@@ -14,7 +15,7 @@ final class LogoutMenuItem implements MenuItemInterface
 {
     use MenuItemTrait;
 
-    public function __construct(string $label, ?string $icon)
+    public function __construct(TranslatableInterface|string $label, ?string $icon)
     {
         $this->dto = new MenuItemDto();
 

--- a/src/Config/Menu/RouteMenuItem.php
+++ b/src/Config/Menu/RouteMenuItem.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToRoute()
@@ -14,7 +15,7 @@ final class RouteMenuItem implements MenuItemInterface
 {
     use MenuItemTrait;
 
-    public function __construct(string $label, ?string $icon, string $routeName, array $routeParameters)
+    public function __construct(TranslatableInterface|string $label, ?string $icon, string $routeName, array $routeParameters)
     {
         $this->dto = new MenuItemDto();
 

--- a/src/Config/Menu/SectionMenuItem.php
+++ b/src/Config/Menu/SectionMenuItem.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::section()
@@ -17,7 +18,7 @@ final class SectionMenuItem implements MenuItemInterface
         setLinkTarget as private;
     }
 
-    public function __construct(?string $label, ?string $icon)
+    public function __construct(TranslatableInterface|string|null $label, ?string $icon)
     {
         $this->dto = new MenuItemDto();
 

--- a/src/Config/Menu/SubMenuItem.php
+++ b/src/Config/Menu/SubMenuItem.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::submenu()
@@ -20,7 +21,7 @@ final class SubMenuItem implements MenuItemInterface
     /** @var MenuItemInterface[] */
     private array $subMenuItems = [];
 
-    public function __construct(string $label, ?string $icon = null)
+    public function __construct(TranslatableInterface|string $label, ?string $icon = null)
     {
         $this->dto = new MenuItemDto();
 

--- a/src/Config/Menu/UrlMenuItem.php
+++ b/src/Config/Menu/UrlMenuItem.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToUrl()
@@ -14,7 +15,7 @@ final class UrlMenuItem implements MenuItemInterface
 {
     use MenuItemTrait;
 
-    public function __construct(string $label, ?string $icon, string $url)
+    public function __construct(TranslatableInterface|string $label, ?string $icon, string $url)
     {
         $this->dto = new MenuItemDto();
 

--- a/src/Config/MenuItem.php
+++ b/src/Config/MenuItem.php
@@ -10,6 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\RouteMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\SectionMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\SubMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\UrlMenuItem;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -23,7 +24,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function linkToCrud(string $label, ?string $icon, string $entityFqcn): CrudMenuItem
+    public static function linkToCrud(TranslatableInterface|string $label, ?string $icon, string $entityFqcn): CrudMenuItem
     {
         return new CrudMenuItem($label, $icon, $entityFqcn);
     }
@@ -31,7 +32,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function linkToDashboard(string $label, ?string $icon = null): DashboardMenuItem
+    public static function linkToDashboard(TranslatableInterface|string $label, ?string $icon = null): DashboardMenuItem
     {
         return new DashboardMenuItem($label, $icon);
     }
@@ -39,7 +40,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function linkToExitImpersonation(string $label, ?string $icon = null): ExitImpersonationMenuItem
+    public static function linkToExitImpersonation(TranslatableInterface|string $label, ?string $icon = null): ExitImpersonationMenuItem
     {
         return new ExitImpersonationMenuItem($label, $icon);
     }
@@ -47,7 +48,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function linkToLogout(string $label, ?string $icon = null): LogoutMenuItem
+    public static function linkToLogout(TranslatableInterface|string $label, ?string $icon = null): LogoutMenuItem
     {
         return new LogoutMenuItem($label, $icon);
     }
@@ -55,7 +56,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function linkToRoute(string $label, ?string $icon, string $routeName, array $routeParameters = []): RouteMenuItem
+    public static function linkToRoute(TranslatableInterface|string $label, ?string $icon, string $routeName, array $routeParameters = []): RouteMenuItem
     {
         return new RouteMenuItem($label, $icon, $routeName, $routeParameters);
     }
@@ -63,7 +64,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function linkToUrl(string $label, ?string $icon, string $url): UrlMenuItem
+    public static function linkToUrl(TranslatableInterface|string $label, ?string $icon, string $url): UrlMenuItem
     {
         return new UrlMenuItem($label, $icon, $url);
     }
@@ -71,7 +72,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function section(?string $label = null, ?string $icon = null): SectionMenuItem
+    public static function section(TranslatableInterface|string|null $label = null, ?string $icon = null): SectionMenuItem
     {
         return new SectionMenuItem($label, $icon);
     }
@@ -79,7 +80,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function subMenu(string $label, ?string $icon = null): SubMenuItem
+    public static function subMenu(TranslatableInterface|string $label, ?string $icon = null): SubMenuItem
     {
         return new SubMenuItem($label, $icon);
     }

--- a/src/Controller/AbstractDashboardController.php
+++ b/src/Controller/AbstractDashboardController.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
+use function Symfony\Component\Translation\t;
 
 /**
  * This class is useful to extend your dashboard from it instead of implementing
@@ -54,7 +55,7 @@ abstract class AbstractDashboardController extends AbstractController implements
 
     public function configureMenuItems(): iterable
     {
-        yield MenuItem::linkToDashboard('__ea__page_title.dashboard', 'fa fa-home');
+        yield MenuItem::linkToDashboard(t('page_title.dashboard', domain: 'EasyAdminBundle'), 'fa fa-home');
     }
 
     public function configureUserMenu(UserInterface $user): UserMenu
@@ -63,11 +64,10 @@ abstract class AbstractDashboardController extends AbstractController implements
 
         if (class_exists(LogoutUrlGenerator::class)) {
             $userMenuItems[] = MenuItem::section();
-            $userMenuItems[] = MenuItem::linkToLogout('__ea__user.sign_out', 'fa-sign-out');
+            $userMenuItems[] = MenuItem::linkToLogout(t('user.sign_out', domain: 'EasyAdminBundle'), 'fa-sign-out');
         }
-
         if ($this->isGranted(Permission::EA_EXIT_IMPERSONATION)) {
-            $userMenuItems[] = MenuItem::linkToExitImpersonation('__ea__user.exit_impersonation', 'fa-user-lock');
+            $userMenuItems[] = MenuItem::linkToExitImpersonation(t('user.exit_impersonation', domain: 'EasyAdminBundle'), 'fa-user-lock');
         }
 
         $userName = '';

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -11,7 +12,7 @@ final class ActionDto
 {
     private ?string $type = null;
     private ?string $name = null;
-    private ?string $label = null;
+    private TranslatableInterface|string|null $label = null;
     private ?string $icon = null;
     private string $cssClass = '';
     private ?string $htmlElement = null;
@@ -60,12 +61,12 @@ final class ActionDto
         $this->name = $name;
     }
 
-    public function getLabel(): ?string
+    public function getLabel(): TranslatableInterface|string|null
     {
         return $this->label;
     }
 
-    public function setLabel(?string $label): void
+    public function setLabel(TranslatableInterface|string|null $label): void
     {
         $this->label = $label;
     }

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -7,6 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use function Symfony\Component\String\u;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -144,19 +145,20 @@ final class FieldDto
     }
 
     /**
-     * @return string|false|null
+     * @return TranslatableInterface|string|false|null
      */
-    public function getLabel()/* : string|false|null */
+    public function getLabel()/* : TranslatableInterface|string|false|null */
     {
         return $this->label;
     }
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
-    public function setLabel(/* string|false|null */ $label): void
+    public function setLabel(/* TranslatableInterface|string|false|null */ $label): void
     {
         if (!\is_string($label)
+            && !$label instanceof TranslatableInterface
             && false !== $label
             && null !== $label) {
             trigger_deprecation(
@@ -165,7 +167,7 @@ final class FieldDto
                 'Argument "%s" for "%s" must be one of these types: %s. Passing type "%s" will cause an error in 5.0.0.',
                 '$label',
                 __METHOD__,
-                '"string", "false" or "null"',
+                '"TranslatableInterface", "string", "false" or "null"',
                 \gettype($label)
             );
         }
@@ -256,12 +258,12 @@ final class FieldDto
         $this->permission = $permission;
     }
 
-    public function getHelp(): ?string
+    public function getHelp(): TranslatableInterface|string|null
     {
         return $this->help;
     }
 
-    public function setHelp(string $help): void
+    public function setHelp(TranslatableInterface|string $help): void
     {
         $this->help = $help;
     }

--- a/src/Dto/FilterDto.php
+++ b/src/Dto/FilterDto.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
 use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -78,19 +79,20 @@ final class FilterDto
     }
 
     /**
-     * @return string|false|null
+     * @return TranslatableInterface|string|false|null
      */
-    public function getLabel()/* : string|false|null */
+    public function getLabel()/* : TranslatableInterface|string|false|null */
     {
         return $this->label;
     }
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
-    public function setLabel(/* string|false|null */ $label): void
+    public function setLabel(/* TranslatableInterface|string|false|null */ $label): void
     {
         if (!\is_string($label)
+            && !$label instanceof TranslatableInterface
             && false !== $label
             && null !== $label) {
             trigger_deprecation(

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -2,6 +2,8 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
+use Symfony\Contracts\Translation\TranslatableInterface;
+
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
@@ -19,7 +21,7 @@ final class MenuItemDto
     private ?string $type = null;
     private ?int $index = null;
     private ?int $subIndex = null;
-    private ?string $label = null;
+    private TranslatableInterface|string|null $label = null;
     private ?string $icon = null;
     private string $cssClass = '';
     private ?string $permission = null;
@@ -63,12 +65,12 @@ final class MenuItemDto
         $this->subIndex = $subIndex;
     }
 
-    public function getLabel(): string
+    public function getLabel(): TranslatableInterface|string
     {
         return $this->label;
     }
 
-    public function setLabel(string $label): void
+    public function setLabel(TranslatableInterface|string $label): void
     {
         $this->label = $label;
     }

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -12,11 +12,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
+use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
-use function Symfony\Component\String\u;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use function Symfony\Component\Translation\t;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -25,15 +26,13 @@ final class ActionFactory
 {
     private AdminContextProvider $adminContextProvider;
     private AuthorizationCheckerInterface $authChecker;
-    private TranslatorInterface $translator;
     private AdminUrlGenerator $adminUrlGenerator;
     private ?CsrfTokenManagerInterface $csrfTokenManager;
 
-    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authChecker, TranslatorInterface $translator, AdminUrlGenerator $adminUrlGenerator, ?CsrfTokenManagerInterface $csrfTokenManager = null)
+    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authChecker, AdminUrlGenerator $adminUrlGenerator, ?CsrfTokenManagerInterface $csrfTokenManager = null)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->authChecker = $authChecker;
-        $this->translator = $translator;
         $this->adminUrlGenerator = $adminUrlGenerator;
         $this->csrfTokenManager = $csrfTokenManager;
     }
@@ -112,19 +111,21 @@ final class ActionFactory
 
         if (false === $actionDto->getLabel()) {
             $actionDto->setHtmlAttribute('title', $actionDto->getName());
+        } elseif (!$actionDto->getLabel() instanceof TranslatableInterface) {
+            $translationParameters = array_merge(
+                $defaultTranslationParameters,
+                $actionDto->getTranslationParameters()
+            );
+            $label = $actionDto->getLabel();
+            $translatableActionLabel = empty($label) ? $label : t($label, $translationParameters, $translationDomain);
+            $actionDto->setLabel($translatableActionLabel);
         } else {
-            $uLabel = u($actionDto->getLabel());
-            // labels with this prefix are considered internal and must be translated
-            // with 'EasyAdminBundle' translation domain, regardless of the backend domain
-            if ($uLabel->startsWith('__ea__')) {
-                $uLabel = $uLabel->after('__ea__');
-                $translationDomain = 'EasyAdminBundle';
-            }
-
-            $translationParameters = array_merge($defaultTranslationParameters, $actionDto->getTranslationParameters());
-            $label = $uLabel->toString();
-            $translatedActionLabel = empty($label) ? $label : $this->translator->trans($label, $translationParameters, $translationDomain);
-            $actionDto->setLabel($translatedActionLabel);
+            $actionDto->setLabel(
+                TranslatableUtils::withParameters(
+                    $actionDto->getLabel(),
+                    $defaultTranslationParameters
+                )
+            );
         }
 
         $defaultTemplatePath = $adminContext->getTemplatePath('crud/action');

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -15,8 +15,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
-use function Symfony\Component\String\u;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use function Symfony\Component\Translation\t;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -25,15 +25,13 @@ final class MenuFactory
 {
     private AdminContextProvider $adminContextProvider;
     private AuthorizationCheckerInterface $authChecker;
-    private TranslatorInterface $translator;
     private LogoutUrlGenerator $logoutUrlGenerator;
     private AdminUrlGenerator $adminUrlGenerator;
 
-    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authChecker, TranslatorInterface $translator, LogoutUrlGenerator $logoutUrlGenerator, AdminUrlGenerator $adminUrlGenerator)
+    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authChecker, LogoutUrlGenerator $logoutUrlGenerator, AdminUrlGenerator $adminUrlGenerator)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->authChecker = $authChecker;
-        $this->translator = $translator;
         $this->logoutUrlGenerator = $logoutUrlGenerator;
         $this->adminUrlGenerator = $adminUrlGenerator;
     }
@@ -90,21 +88,17 @@ final class MenuFactory
 
     private function buildMenuItem(MenuItemDto $menuItemDto, array $subItems, int $index, int $subIndex, string $translationDomain): MenuItemDto
     {
-        $uLabel = u($menuItemDto->getLabel());
-        // labels with this prefix are considered internal and must be translated
-        // with 'EasyAdminBundle' translation domain, regardlesss of the backend domain
-        if ($uLabel->startsWith('__ea__')) {
-            $uLabel = $uLabel->after('__ea__');
-            $translationDomain = 'EasyAdminBundle';
+        if (!$menuItemDto->getLabel() instanceof TranslatableInterface) {
+            $label = $menuItemDto->getLabel();
+            $menuItemDto->setLabel(
+                empty($label) ? $label : t($label, $menuItemDto->getTranslationParameters(), $translationDomain)
+            );
         }
-        $label = $uLabel->toString();
-        $translatedLabel = empty($label) ? $label : $this->translator->trans($label, $menuItemDto->getTranslationParameters(), $translationDomain);
 
         $url = $this->generateMenuItemUrl($menuItemDto, $index, $subIndex);
 
         $menuItemDto->setIndex($index);
         $menuItemDto->setSubIndex($subIndex);
-        $menuItemDto->setLabel($translatedLabel);
         $menuItemDto->setLinkUrl($url);
         $menuItemDto->setSubItems($subItems);
 

--- a/src/Field/ArrayField.php
+++ b/src/Field/ArrayField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -14,7 +15,7 @@ final class ArrayField implements FieldInterface
     use FieldTrait;
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -28,7 +29,7 @@ final class AssociationField implements FieldInterface
     public const PARAM_AUTOCOMPLETE_CONTEXT = 'autocompleteContext';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/AvatarField.php
+++ b/src/Field/AvatarField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\Size;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -17,7 +18,7 @@ final class AvatarField implements FieldInterface
     public const OPTION_HEIGHT = 'height';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/BooleanField.php
+++ b/src/Field/BooleanField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -20,7 +21,7 @@ final class BooleanField implements FieldInterface
     public const CSRF_TOKEN_NAME = 'ea-toggle';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/ChoiceField.php
+++ b/src/Field/ChoiceField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -15,6 +16,7 @@ final class ChoiceField implements FieldInterface
     public const OPTION_ALLOW_MULTIPLE_CHOICES = 'allowMultipleChoices';
     public const OPTION_AUTOCOMPLETE = 'autocomplete';
     public const OPTION_CHOICES = 'choices';
+    public const OPTION_CHOICES_TRANSLATABLE = 'choicesTranslatable';
     public const OPTION_RENDER_AS_BADGES = 'renderAsBadges';
     public const OPTION_RENDER_EXPANDED = 'renderExpanded';
     public const OPTION_WIDGET = 'widget';
@@ -26,7 +28,7 @@ final class ChoiceField implements FieldInterface
     public const WIDGET_NATIVE = 'native';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {
@@ -38,6 +40,7 @@ final class ChoiceField implements FieldInterface
             ->addCssClass('field-select')
             ->setDefaultColumns('') // this is set dynamically in the field configurator
             ->setCustomOption(self::OPTION_CHOICES, null)
+            ->setCustomOption(self::OPTION_CHOICES_TRANSLATABLE, false)
             ->setCustomOption(self::OPTION_ALLOW_MULTIPLE_CHOICES, false)
             ->setCustomOption(self::OPTION_RENDER_AS_BADGES, null)
             ->setCustomOption(self::OPTION_RENDER_EXPANDED, false)
@@ -76,6 +79,19 @@ final class ChoiceField implements FieldInterface
         }
 
         $this->setCustomOption(self::OPTION_CHOICES, $choiceGenerator);
+
+        return $this;
+    }
+
+    /**
+     * When set choices must follow flipped format where values can be translatable objects:
+     * ['submitted_value' => t('field.label'), 'other_value' => 'Field Label', ...].
+     *
+     * You still can use callback, but it is assumed to return flipped values too.
+     */
+    public function setChoicesTranslatable(bool $choicesTranslatable = true): self
+    {
+        $this->setCustomOption(self::OPTION_CHOICES_TRANSLATABLE, $choicesTranslatable);
 
         return $this;
     }

--- a/src/Field/CodeEditorField.php
+++ b/src/Field/CodeEditorField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CodeEditorType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -22,7 +23,7 @@ final class CodeEditorField implements FieldInterface
     private const ALLOWED_LANGUAGES = ['css', 'dockerfile', 'js', 'markdown', 'nginx', 'php', 'shell', 'sql', 'twig', 'xml', 'yaml-frontmatter', 'yaml'];
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/CollectionField.php
+++ b/src/Field/CollectionField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -21,7 +22,7 @@ final class CollectionField implements FieldInterface
     public const OPTION_RENDER_EXPANDED = 'renderExpanded';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/ColorField.php
+++ b/src/Field/ColorField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -16,7 +17,7 @@ final class ColorField implements FieldInterface
     public const OPTION_SHOW_VALUE = 'showValue';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -17,7 +17,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -26,13 +26,11 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 {
     private EntityFactory $entityFactory;
     private AdminUrlGenerator $adminUrlGenerator;
-    private TranslatorInterface $translator;
 
-    public function __construct(EntityFactory $entityFactory, AdminUrlGenerator $adminUrlGenerator, TranslatorInterface $translator)
+    public function __construct(EntityFactory $entityFactory, AdminUrlGenerator $adminUrlGenerator)
     {
         $this->entityFactory = $entityFactory;
         $this->adminUrlGenerator = $adminUrlGenerator;
-        $this->translator = $translator;
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
@@ -140,7 +138,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         $field->setCustomOption(AssociationField::OPTION_DOCTRINE_ASSOCIATION_TYPE, 'toOne');
 
         if (false === $field->getFormTypeOption('required')) {
-            $field->setFormTypeOptionIfNotSet('attr.placeholder', $this->translator->trans('label.form.empty_value', [], 'EasyAdminBundle'));
+            $field->setFormTypeOptionIfNotSet('attr.placeholder', t('label.form.empty_value', [], 'EasyAdminBundle'));
         }
 
         $targetEntityFqcn = $field->getDoctrineMetadata()->get('targetEntity');

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -8,21 +8,17 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Translation\ChoiceMessage;
+use EasyCorp\Bundle\EasyAdminBundle\Translation\ChoicesMessage;
 use function Symfony\Component\String\u;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use function Symfony\Component\Translation\t;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class ChoiceConfigurator implements FieldConfiguratorInterface
 {
-    private TranslatorInterface $translator;
-
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
-
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {
         return ChoiceField::class === $field->getFieldFqcn();
@@ -30,6 +26,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
+        $areChoicesTranslatable = $field->getCustomOption(ChoiceField::OPTION_CHOICES_TRANSLATABLE);
         $isExpanded = $field->getCustomOption(ChoiceField::OPTION_RENDER_EXPANDED);
         $isMultipleChoice = $field->getCustomOption(ChoiceField::OPTION_ALLOW_MULTIPLE_CHOICES);
 
@@ -38,7 +35,12 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
             throw new \InvalidArgumentException(sprintf('The "%s" choice field must define its possible choices using the setChoices() method.', $field->getProperty()));
         }
 
-        $field->setFormTypeOptionIfNotSet('choices', $choices);
+        if ($areChoicesTranslatable) {
+            $field->setFormTypeOptionIfNotSet('choices', array_keys($choices));
+            $field->setFormTypeOptionIfNotSet('choice_label', fn ($value) => $choices[$value]);
+        } else {
+            $field->setFormTypeOptionIfNotSet('choices', $choices);
+        }
         $field->setFormTypeOptionIfNotSet('multiple', $isMultipleChoice);
         $field->setFormTypeOptionIfNotSet('expanded', $isExpanded);
 
@@ -72,17 +74,26 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         $translationParameters = $context->getI18n()->getTranslationParameters();
         $translationDomain = $context->getI18n()->getTranslationDomain();
         $selectedChoices = [];
-        $flippedChoices = array_flip($choices);
+        $flippedChoices = $areChoicesTranslatable ? $choices : array_flip($choices);
         // $value is a scalar for single selections and an array for multiple selections
         foreach ((array) $fieldValue as $selectedValue) {
             if (null !== $selectedChoice = $flippedChoices[$selectedValue] ?? null) {
-                $choiceValue = $this->translator->trans($selectedChoice, $translationParameters, $translationDomain);
-                $selectedChoices[] = $isRenderedAsBadge
-                    ? sprintf('<span class="%s">%s</span>', $this->getBadgeCssClass($badgeSelector, $selectedValue, $field), $choiceValue)
-                    : $choiceValue;
+                if ($selectedValue instanceof TranslatableInterface) {
+                    $choiceValue = $selectedValue;
+                } else {
+                    $choiceValue = t(
+                        $selectedChoice,
+                        $translationParameters,
+                        $translationDomain
+                    );
+                }
+                $selectedChoices[] = new ChoiceMessage(
+                    $choiceValue,
+                    $isRenderedAsBadge ? $this->getBadgeCssClass($badgeSelector, $selectedValue, $field) : null
+                );
             }
         }
-        $field->setFormattedValue(implode($isRenderedAsBadge ? '' : ', ', $selectedChoices));
+        $field->setFormattedValue(new ChoicesMessage($selectedChoices, $isRenderedAsBadge));
     }
 
     private function getChoices($choiceGenerator, EntityDto $entity, FieldDto $field): array

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -12,19 +12,18 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AvatarField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use function Symfony\Component\String\u;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use function Symfony\Component\Translation\t;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class CommonPreConfigurator implements FieldConfiguratorInterface
 {
-    private TranslatorInterface $translator;
     private PropertyAccessorInterface $propertyAccessor;
 
-    public function __construct(TranslatorInterface $translator, PropertyAccessorInterface $propertyAccessor)
+    public function __construct(PropertyAccessorInterface $propertyAccessor)
     {
-        $this->translator = $translator;
         $this->propertyAccessor = $propertyAccessor;
     }
 
@@ -70,7 +69,6 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
 
             $field->setFormTypeOptionIfNotSet('help', $helpMessage);
             $field->setFormTypeOptionIfNotSet('help_html', true);
-            $field->setFormTypeOptionIfNotSet('help_translation_parameters', $field->getTranslationParameters());
         }
 
         if (!empty($field->getCssClass())) {
@@ -82,7 +80,6 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         }
 
         $field->setFormTypeOptionIfNotSet('label', $field->getLabel());
-        $field->setFormTypeOptionIfNotSet('label_translation_parameters', $field->getTranslationParameters());
     }
 
     private function buildValueOption(FieldDto $field, EntityDto $entityDto)
@@ -97,17 +94,21 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         return $this->propertyAccessor->getValue($entityInstance, $propertyName);
     }
 
-    private function buildHelpOption(FieldDto $field, string $translationDomain): ?string
+    private function buildHelpOption(FieldDto $field, string $translationDomain): ?TranslatableInterface
     {
         if ((null === $help = $field->getHelp()) || empty($help)) {
             return $help;
         }
 
-        return $this->translator->trans($help, $field->getTranslationParameters(), $translationDomain);
+        if ($help instanceof TranslatableInterface) {
+            return $help;
+        }
+
+        return t($help, $field->getTranslationParameters(), $translationDomain);
     }
 
     /**
-     * @return string|false|null
+     * @return TranslatableInterface|string|false|null
      */
     private function buildLabelOption(FieldDto $field, string $translationDomain, ?string $currentPage)
     {
@@ -115,7 +116,11 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         if (FormField::class === $field->getFieldFqcn()) {
             $label = $field->getLabel();
 
-            return empty($label) ? $label : $this->translator->trans($label, $field->getTranslationParameters(), $translationDomain);
+            if ($label instanceof TranslatableInterface) {
+                return $label;
+            }
+
+            return empty($label) ? $label : t($label, $field->getTranslationParameters(), $translationDomain);
         }
 
         // if an Avatar field doesn't define its label, don't autogenerate it for the 'index' page
@@ -140,7 +145,11 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
             return $label;
         }
 
-        return $this->translator->trans($label, $field->getTranslationParameters(), $translationDomain);
+        if ($label instanceof TranslatableInterface) {
+            return $label;
+        }
+
+        return t($label, $field->getTranslationParameters(), $translationDomain);
     }
 
     private function buildSortableOption(FieldDto $field, EntityDto $entityDto): bool

--- a/src/Field/Configurator/SlugConfigurator.php
+++ b/src/Field/Configurator/SlugConfigurator.php
@@ -7,20 +7,14 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\SlugField;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use function Symfony\Component\Translation\t;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class SlugConfigurator implements FieldConfiguratorInterface
 {
-    private TranslatorInterface $translator;
-
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
-    }
-
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {
         return SlugField::class === $field->getFieldFqcn();
@@ -35,7 +29,11 @@ final class SlugConfigurator implements FieldConfiguratorInterface
         $field->setFormTypeOption('target', $targetFieldName);
 
         if (null !== $unlockConfirmationMessage = $field->getCustomOption(SlugField::OPTION_UNLOCK_CONFIRMATION_MESSAGE)) {
-            $field->setFormTypeOption('attr.data-confirm-text', $this->translator->trans($unlockConfirmationMessage, [], $context->getI18n()->getTranslationDomain()));
+            if (!$unlockConfirmationMessage instanceof TranslatableInterface) {
+                $unlockConfirmationMessage = t($unlockConfirmationMessage, [], $context->getI18n()->getTranslationDomain());
+            }
+
+            $field->setFormTypeOption('attr.data-confirm-text', $unlockConfirmationMessage);
         }
     }
 }

--- a/src/Field/CountryField.php
+++ b/src/Field/CountryField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -24,7 +25,7 @@ final class CountryField implements FieldInterface
     public const OPTION_FLAG_CODE = 'flagCode';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/CurrencyField.php
+++ b/src/Field/CurrencyField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -17,7 +18,7 @@ final class CurrencyField implements FieldInterface
     public const OPTION_SHOW_SYMBOL = 'showSymbol';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/DateField.php
+++ b/src/Field/DateField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -16,7 +17,7 @@ final class DateField implements FieldInterface
     public const OPTION_WIDGET = 'widget';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/DateTimeField.php
+++ b/src/Field/DateTimeField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -46,7 +47,7 @@ final class DateTimeField implements FieldInterface
     public const OPTION_WIDGET = 'widget';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/EmailField.php
+++ b/src/Field/EmailField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -13,7 +14,7 @@ final class EmailField implements FieldInterface
     use FieldTrait;
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -12,7 +13,7 @@ final class Field implements FieldInterface
     use FieldTrait;
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -36,7 +37,7 @@ trait FieldTrait
     }
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public function setLabel($label): self
     {
@@ -150,7 +151,7 @@ trait FieldTrait
         return $this;
     }
 
-    public function setHelp(string $help): self
+    public function setHelp(TranslatableInterface|string $help): self
     {
         $this->dto->setHelp($help);
 

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -7,6 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EaFormPanelType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EaFormRowType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EasyAdminTabType;
 use Symfony\Component\Uid\Ulid;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -31,8 +32,8 @@ final class FormField implements FieldInterface
     }
 
     /**
-     * @param string|false|null $label
-     * @param string|null       $icon  The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
+     * @param TranslatableInterface|string|false|null $label
+     * @param string|null                             $icon  The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
     public static function addPanel($label = false, ?string $icon = null): self
     {
@@ -77,7 +78,7 @@ final class FormField implements FieldInterface
     /**
      * @return static
      */
-    public static function addTab(string $label, ?string $icon = null): self
+    public static function addTab(TranslatableInterface|string $label, ?string $icon = null): self
     {
         $field = new self();
 

--- a/src/Field/HiddenField.php
+++ b/src/Field/HiddenField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -13,7 +14,7 @@ final class HiddenField implements FieldInterface
     use FieldTrait;
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/IdField.php
+++ b/src/Field/IdField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -15,7 +16,7 @@ final class IdField implements FieldInterface
     public const OPTION_MAX_LENGTH = 'maxLength';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -18,7 +19,7 @@ final class ImageField implements FieldInterface
     public const OPTION_UPLOADED_FILE_NAME_PATTERN = 'uploadedFileNamePattern';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/IntegerField.php
+++ b/src/Field/IntegerField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -15,7 +16,7 @@ final class IntegerField implements FieldInterface
     public const OPTION_NUMBER_FORMAT = 'numberFormat';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/LanguageField.php
+++ b/src/Field/LanguageField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\LanguageType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -22,7 +23,7 @@ final class LanguageField implements FieldInterface
     public const OPTION_LANGUAGE_CODES_TO_REMOVE = 'languageCodesToRemove';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/LocaleField.php
+++ b/src/Field/LocaleField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -18,7 +19,7 @@ final class LocaleField implements FieldInterface
     public const OPTION_LOCALE_CODES_TO_REMOVE = 'localeCodesToRemove';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/MoneyField.php
+++ b/src/Field/MoneyField.php
@@ -6,6 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Intl\Currencies;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -20,7 +21,7 @@ final class MoneyField implements FieldInterface
     public const OPTION_STORED_AS_CENTS = 'storedAsCents';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/NumberField.php
+++ b/src/Field/NumberField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -18,7 +19,7 @@ final class NumberField implements FieldInterface
     public const OPTION_NUMBER_FORMAT = 'numberFormat';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/PercentField.php
+++ b/src/Field/PercentField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -19,7 +20,7 @@ final class PercentField implements FieldInterface
     public const OPTION_ROUNDING_MODE = 'roundingMode';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/SlugField.php
+++ b/src/Field/SlugField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\SlugType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Jonathan Scheiber <contact@jmsche.fr>
@@ -17,7 +18,7 @@ final class SlugField implements FieldInterface
     public const OPTION_UNLOCK_CONFIRMATION_MESSAGE = 'unlockConfirmationMessage';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {
@@ -41,7 +42,7 @@ final class SlugField implements FieldInterface
         return $this;
     }
 
-    public function setUnlockConfirmationMessage(string $message): self
+    public function setUnlockConfirmationMessage(string|TranslatableInterface $message): self
     {
         $this->setCustomOption(self::OPTION_UNLOCK_CONFIRMATION_MESSAGE, $message);
 

--- a/src/Field/TelephoneField.php
+++ b/src/Field/TelephoneField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -13,7 +14,7 @@ final class TelephoneField implements FieldInterface
     use FieldTrait;
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/TextEditorField.php
+++ b/src/Field/TextEditorField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\TextEditorType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -17,7 +18,7 @@ final class TextEditorField implements FieldInterface
     public const OPTION_TRIX_EDITOR_CONFIG = 'trixEditorConfig';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/TextField.php
+++ b/src/Field/TextField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -17,7 +18,7 @@ final class TextField implements FieldInterface
     public const OPTION_STRIP_TAGS = 'stripTags';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/TextareaField.php
+++ b/src/Field/TextareaField.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -19,7 +20,7 @@ final class TextareaField implements FieldInterface
     public const OPTION_STRIP_TAGS = TextField::OPTION_STRIP_TAGS;
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/TimeField.php
+++ b/src/Field/TimeField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -16,7 +17,7 @@ final class TimeField implements FieldInterface
     public const OPTION_WIDGET = 'widget';
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/TimezoneField.php
+++ b/src/Field/TimezoneField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -13,7 +14,7 @@ final class TimezoneField implements FieldInterface
     use FieldTrait;
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Field/UrlField.php
+++ b/src/Field/UrlField.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -13,7 +14,7 @@ final class UrlField implements FieldInterface
     use FieldTrait;
 
     /**
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null): self
     {

--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -85,7 +85,7 @@ class CrudFormType extends AbstractType
                 $metadata['label'] = $fieldDto->getLabel();
                 $metadata['help'] = $fieldDto->getHelp();
                 $metadata[FormField::OPTION_ICON] = $fieldDto->getCustomOption(FormField::OPTION_ICON);
-                $currentFormTab = $fieldDto->getLabel();
+                $currentFormTab = (string) $fieldDto->getLabel();
 
                 // plain arrays are not enough for tabs because they are modified in the
                 // lifecycle of a form (e.g. add info about form errors). Use an ArrayObject instead.

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -83,7 +83,6 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 return static function (ContainerConfigurator $container) {
     $services = $container->services()
@@ -173,11 +172,10 @@ return static function (ContainerConfigurator $container) {
 
         ->set(AdminContextFactory::class)
             ->arg(0, '%kernel.cache_dir%')
-            ->arg(1, service('translator'))
-            ->arg(2, new Reference('security.token_storage', ContainerInterface::NULL_ON_INVALID_REFERENCE))
-            ->arg(3, service(MenuFactory::class))
-            ->arg(4, service(CrudControllerRegistry::class))
-            ->arg(5, service(EntityFactory::class))
+            ->arg(1, new Reference('security.token_storage', ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->arg(2, new Reference(MenuFactory::class))
+            ->arg(3, new Reference(CrudControllerRegistry::class))
+            ->arg(4, new Reference(EntityFactory::class))
 
         ->set(AdminUrlGenerator::class)
             // I don't know if we truly need the share() method to get a new instance of the
@@ -197,11 +195,10 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, '%kernel.secret%')
 
         ->set(MenuFactory::class)
-            ->arg(0, service(AdminContextProvider::class))
-            ->arg(1, service(AuthorizationChecker::class))
-            ->arg(2, service('translator'))
-            ->arg(3, service('security.logout_url_generator'))
-            ->arg(4, service(AdminUrlGenerator::class))
+            ->arg(0, new Reference(AdminContextProvider::class))
+            ->arg(1, new Reference(AuthorizationChecker::class))
+            ->arg(2, new Reference('security.logout_url_generator'))
+            ->arg(3, new Reference(AdminUrlGenerator::class))
 
         ->set(EntityRepository::class)
             ->arg(0, service(AdminContextProvider::class))
@@ -269,11 +266,10 @@ return static function (ContainerConfigurator $container) {
         ->set(TextFilterConfigurator::class)
 
         ->set(ActionFactory::class)
-            ->arg(0, service(AdminContextProvider::class))
-            ->arg(1, service(AuthorizationChecker::class))
-            ->arg(2, service('translator'))
-            ->arg(3, service(AdminUrlGenerator::class))
-            ->arg(4, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->arg(0, new Reference(AdminContextProvider::class))
+            ->arg(1, new Reference(AuthorizationChecker::class))
+            ->arg(2, new Reference(AdminUrlGenerator::class))
+            ->arg(3, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
 
         ->set(SecurityVoter::class)
             ->arg(0, service(AuthorizationChecker::class))
@@ -287,9 +283,8 @@ return static function (ContainerConfigurator $container) {
         ->set(ArrayConfigurator::class)
 
         ->set(AssociationConfigurator::class)
-            ->arg(0, service(EntityFactory::class))
-            ->arg(1, service(AdminUrlGenerator::class))
-            ->arg(2, service(TranslatorInterface::class))
+            ->arg(0, new Reference(EntityFactory::class))
+            ->arg(1, new Reference(AdminUrlGenerator::class))
 
         ->set(AvatarConfigurator::class)
 
@@ -307,8 +302,7 @@ return static function (ContainerConfigurator $container) {
             ->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR, ['priority' => -9999])
 
         ->set(CommonPreConfigurator::class)
-            ->arg(0, service('translator'))
-            ->arg(1, service('property_accessor'))
+            ->arg(0, new Reference('property_accessor'))
             ->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR, ['priority' => 9999])
 
         ->set(CountryConfigurator::class)
@@ -344,10 +338,8 @@ return static function (ContainerConfigurator $container) {
         ->set(PercentConfigurator::class)
 
         ->set(ChoiceConfigurator::class)
-            ->arg(0, service('translator'))
 
         ->set(SlugConfigurator::class)
-            ->arg(0, service('translator'))
 
         ->set(TelephoneConfigurator::class)
 

--- a/src/Resources/views/crud/action.html.twig
+++ b/src/Resources/views/crud/action.html.twig
@@ -6,13 +6,13 @@
        href="{{ action.linkUrl }}"
        {% for name, value in action.htmlAttributes %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
         {%- if action.icon %}<i class="action-icon {{ action.icon }}"></i> {% endif -%}
-        {%- if action.label is not empty -%}<span class="action-label">{{ action.label }}</span>{%- endif -%}
+        {%- if action.label is not empty -%}<span class="action-label">{{ action.label|trans }}</span>{%- endif -%}
     </a>
 {% elseif 'button' == action.htmlElement %}
     <button class="{{ action.cssClass }}" {% for name, value in action.htmlAttributes %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
         <span class="btn-label">
             {%- if action.icon %}<i class="action-icon {{ action.icon }}"></i> {% endif -%}
-            {%- if action.label is not empty -%}<span class="action-label">{{ action.label }}</span>{%- endif -%}
+            {%- if action.label is not empty -%}<span class="action-label">{{ action.label|trans }}</span>{%- endif -%}
         </span>
     </button>
 {% endif %}

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -2,8 +2,6 @@
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% extends ea.templatePath('layout') %}
 
-{% trans_default_domain ea.i18n.translationDomain %}
-
 {% block body_id 'ea-detail-' ~ entity.name ~ '-' ~ entity.primaryKeyValue %}
 {% block body_class 'ea-detail ea-detail-' ~ entity.name %}
 
@@ -37,10 +35,10 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null) %}
+        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle')
-            : (custom_page_title|trans(ea.i18n.translationParameters))|raw }}
+            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
+            : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}
 
@@ -112,7 +110,7 @@
                             {% if panel_icon %}
                                 <i class="form-panel-icon {{ panel_icon }}"></i>
                             {% endif %}
-                            {{ panel_label|raw }}
+                            {{ panel_label|trans|raw }}
                         </a>
 
                         {% if panel_help %}
@@ -136,7 +134,7 @@
 {% macro render_field(entity, field) %}
     <div class="data-row {{ field.cssClass }}">
         <dt>
-            {{ field.label|raw }}
+            {{ field.label|trans|raw }}
 
             {% if field.help is not empty %}
                 <a tabindex="0" class="data-help" data-bs-toggle="popover" data-bs-custom-class="ea-content-help-popover" data-bs-animation="true" data-bs-html="true" data-bs-placement="right" data-bs-trigger="focus" data-bs-content="{{ field.help|e('html_attr') }}">

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -43,10 +43,10 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null) %}
+        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle|trans(ea.i18n.translationParameters, 'EasyAdminBundle')
-            : (custom_page_title|trans(ea.i18n.translationParameters))|raw }}
+            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
+            : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/crud/field/choice.html.twig
+++ b/src/Resources/views/crud/field/choice.html.twig
@@ -1,4 +1,4 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{{ field.formattedValue|raw }}
+{{ field.formattedValue|trans|raw }}

--- a/src/Resources/views/crud/field/code_editor.html.twig
+++ b/src/Resources/views/crud/field/code_editor.html.twig
@@ -17,7 +17,7 @@
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">{{ field.label }}</h5>
+                    <h5 class="modal-title">{{ field.label|trans }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'action.close'|trans([], domain = 'EasyAdminBundle') }}">
                     </button>
                 </div>

--- a/src/Resources/views/crud/field/text_editor.html.twig
+++ b/src/Resources/views/crud/field/text_editor.html.twig
@@ -13,7 +13,7 @@
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">{{ field.label }}</h5>
+                    <h5 class="modal-title">{{ field.label|trans }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'action.close'|trans([], domain = 'EasyAdminBundle') }}">
                     </button>
                 </div>

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -427,7 +427,7 @@
                                 {%- if tab_config.icon|default(false) -%}
                                     <i class="fa fa-fw fa-{{ tab_config.icon }}"></i>
                                 {%- endif -%}
-                                {{ tab_config['label'] }}
+                                {{ tab_config['label']|trans(domain = ea.i18n.translationDomain) }}
                                 {%- if tab_config.errors > 0 -%}
                                     <span class="badge badge-danger" title="{{ 'form.tab.error_badge_title'|trans({'%count%': tab_config.errors}, 'EasyAdminBundle') }}">
                                         {{- tab_config.errors -}}
@@ -491,7 +491,7 @@
                                 {% if panel_config.icon|default(false) %}
                                     <i class="form-panel-icon {{ panel_config.icon }}"></i>
                                 {% endif %}
-                                {{ panel_config.label|raw }}
+                                {{ panel_config.label|trans|raw }}
                             </a>
 
                             {% if panel_config.help|default(false) %}
@@ -752,6 +752,11 @@
         'data-ea-slug-field': '',
         'data-target': form.parent.children[target].vars.id
     }) %}
+    {% if attr['data-confirm-text'] is defined %}
+        {% set attr = attr|merge({
+            'data-confirm-text': attr['data-confirm-text']|trans
+        }) %}
+    {% endif %}
 
     <div class="input-group">
         {{ block('form_widget') }}

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -37,10 +37,10 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle('index') %}
+        {% set custom_page_title = ea.crud.customPageTitle('index', null, ea.i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle('index')|trans(ea.i18n.translationParameters, 'EasyAdminBundle')
-            : (custom_page_title|trans(ea.i18n.translationParameters))|raw }}
+            ? ea.crud.defaultPageTitle('index', null, ea.i18n.translationParameters)|trans|raw
+            : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}
 
@@ -52,7 +52,7 @@
                 {% set applied_filters = ea.request.query.all['filters']|default([])|keys %}
                 <div class="btn-group action-filters">
                     <a href="#" data-href="{{ ea_url().setAction('renderFilters').includeReferrer() }}" class="btn btn-secondary btn-labeled btn-labeled-right action-filters-button disabled {{ applied_filters ? 'action-filters-applied' }}" data-bs-toggle="modal" data-bs-target="#modal-filters">
-                        <i class="fa fa-filter fa-fw"></i> {{ 'filter.title'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}{% if applied_filters %} <span class="action-filters-button-count">({{ applied_filters|length }})</span>{% endif %}
+                        <i class="fa fa-filter fa-fw"></i> {{ t('filter.title', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}{% if applied_filters %} <span class="action-filters-button-count">({{ applied_filters|length }})</span>{% endif %}
                     </a>
                     {% if applied_filters %}
                         <a href="{{ ea_url().unset('filters') }}" class="btn btn-secondary action-filters-reset">
@@ -115,16 +115,16 @@
                         <th class="{{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} header-for-{{ field.cssClass|split(' ')|filter(class => class starts with 'field-')|join('') }} text-{{ field.textAlign }}" dir="{{ ea.i18n.textDirection }}">
                             {% if field.isSortable %}
                                 <a href="{{ ea_url({ page: 1, sort: { (field.property): next_sort_direction } }).includeReferrer() }}">
-                                    {{ field.label|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
+                                    {{ field.label|trans|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
                                 </a>
                             {% else %}
-                                <span>{{ field.label|raw }}</span>
+                                <span>{{ field.label|trans|raw }}</span>
                             {% endif %}
                         </th>
                     {% endfor %}
 
                     <th {% if ea.crud.showEntityActionsAsDropdown %}style="width: 10px"{% endif %} dir="{{ ea.i18n.textDirection }}">
-                        <span class="sr-only">{{ 'action.entity_actions'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}</span>
+                        <span class="sr-only">{{ t('action.entity_actions', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}</span>
                     </th>
                 </tr>
             {% endblock table_head %}
@@ -145,7 +145,7 @@
                         {% endif %}
 
                         {% for field in entity.fields %}
-                            <td data-label="{{ field.label|e('html_attr') }}" class="{{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea.i18n.textDirection }}">
+                            <td data-label="{{ field.label|trans|e('html_attr') }}" class="{{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea.i18n.textDirection }}">
                                 {{ include(field.templatePath, { field: field, entity: entity }, with_context = false) }}
                             </td>
                         {% endfor %}
@@ -195,7 +195,7 @@
                         {% if 3 == loop.index %}
                             <tr class="no-results">
                                 <td colspan="100">
-                                    {{ 'datagrid.no_results'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}
+                                    {{ t('datagrid.no_results', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}
                                 </td>
                             </tr>
                         {% endif %}

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -43,10 +43,10 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle('new') %}
+        {% set custom_page_title = ea.crud.customPageTitle('new', ea.i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle('new')|trans(ea.i18n.translationParameters, 'EasyAdminBundle')
-            : (custom_page_title|trans(ea.i18n.translationParameters))|raw }}
+            ? ea.crud.defaultPageTitle('new', null, ea.i18n.translationParameters)|trans|raw
+            : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}
 

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -105,7 +105,7 @@
                                        target="{{ item.linkTarget }}" rel="{{ item.linkRel }}"
                                        referrerpolicy="origin-when-cross-origin">
                                         {% if item.icon is not empty %}<i class="fa fa-fw {{ item.icon }}"></i>{% endif %}
-                                        <span>{{ item.label }}</span>
+                                        <span>{{ item.label|trans }}</span>
                                     </a>
                                 {% endif %}
                             </li>
@@ -219,7 +219,7 @@
                                                         <i class="fas fa-search content-search-icon"></i>
 
                                                         <label class="content-search-label" data-value="{{ app.request.get('query') }}">
-                                                            <input class="form-control {{ app.request.get('query') is null ? 'is-blank' }}" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ 'action.search'|trans(ea.i18n.translationParameters, 'EasyAdminBundle') }}" spellcheck="false" autocorrect="off" onInput="this.parentNode.dataset.value=this.value"{% if ea.crud.currentAction == 'index' and ea.crud.autofocusSearch == true %} autofocus="autofocus"{% endif %}>
+                                                            <input class="form-control {{ app.request.get('query') is null ? 'is-blank' }}" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ t('action.search', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}" spellcheck="false" autocorrect="off" onInput="this.parentNode.dataset.value=this.value"{% if ea.crud.currentAction == 'index' and ea.crud.autofocusSearch == true %} autofocus="autofocus"{% endif %}>
                                                         </label>
 
                                                         {% if app.request.get('query') %}

--- a/src/Resources/views/menu.html.twig
+++ b/src/Resources/views/menu.html.twig
@@ -34,7 +34,7 @@
         <span class="menu-header-contents">
             {% if item.icon is not empty %}<i class="menu-icon fa-fw {{ item.icon }}"></i>{% endif %}
             <span class="menu-item-label position-relative {{ item.cssClass }}">
-                {{ item.label|raw }}
+                {{ item.label|trans|raw }}
             </span>
             {% if item.badge %}
                 <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" style="{{ item.badge.htmlStyle }}">{{ item.badge.content }}</span>
@@ -44,7 +44,7 @@
         <a href="{{ item.linkUrl }}" class="menu-item-contents {{ item.hasSubItems ? 'submenu-toggle' }} {{ item.cssClass }}" target="{{ item.linkTarget }}" rel="{{ item.linkRel }}" referrerpolicy="origin-when-cross-origin">
             {% if item.icon is not empty %}<i class="menu-icon fa-fw {{ item.icon }}"></i>{% endif %}
             <span class="menu-item-label position-relative">
-                {{ item.label|raw }}
+                {{ item.label|trans|raw }}
             </span>
             {% if item.hasSubItems %}<i class="fa fa-fw fa-angle-right submenu-toggle-icon"></i>{% endif %}
             {% if item.badge %}

--- a/src/Translation/ChoiceMessage.php
+++ b/src/Translation/ChoiceMessage.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Translation;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ *
+ * @internal
+ */
+final class ChoiceMessage implements TranslatableInterface
+{
+    public function __construct(
+        private TranslatableInterface $message,
+        private ?string $cssClass
+    ) {
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        $message = $this->message->trans($translator, $locale);
+
+        if ($this->cssClass) {
+            return sprintf(
+                '<span class="%s">%s</span>',
+                $this->cssClass,
+                $message
+            );
+        }
+
+        return $message;
+    }
+
+    public function __toString(): string
+    {
+        if ($this->cssClass) {
+            return sprintf(
+                '<span class="%s">%s</span>',
+                $this->cssClass,
+                $this->message
+            );
+        }
+
+        return (string) $this->message;
+    }
+}

--- a/src/Translation/ChoicesMessage.php
+++ b/src/Translation/ChoicesMessage.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Translation;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ *
+ * @internal
+ */
+final class ChoicesMessage implements TranslatableInterface
+{
+    public function __construct(
+        /** @var ChoiceMessage[] */
+        private array $choices,
+        private bool $isRenderedAsBadge
+    ) {
+    }
+
+    public function trans(TranslatorInterface $translator, string $locale = null): string
+    {
+        return implode(
+            $this->isRenderedAsBadge ? '' : ', ',
+            array_map(
+                static fn (ChoiceMessage $message) => $message->trans($translator, $locale),
+                $this->choices
+            )
+        );
+    }
+
+    public function __toString(): string
+    {
+        return implode(
+            $this->isRenderedAsBadge ? '' : ', ',
+            $this->choices
+        );
+    }
+}

--- a/src/Translation/TranslatableUtils.php
+++ b/src/Translation/TranslatableUtils.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Translation;
+
+use function Symfony\Component\Translation\t;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+/**
+ * @author Jakub Caban <kuba.iluvatar@gmail.com>
+ */
+class TranslatableUtils
+{
+    /**
+     * This method will append provided parameters to translatable object if it is of TranslatableMessage class.
+     *
+     * Due to the limited nature of TranslatableInterface we cannot guarantee correct behavior
+     * of any other TranslatableInterface implementation, therefore they will be returned as provided.
+     */
+    public static function withParameters(TranslatableInterface $translatable, array $parameters): TranslatableInterface
+    {
+        if (TranslatableMessage::class !== \get_class($translatable)) {
+            return $translatable;
+        }
+
+        return t(
+            $translatable->getMessage(),
+            array_merge(
+                $parameters,
+                $translatable->getParameters()
+            ),
+            $translatable->getDomain()
+        );
+    }
+}

--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -4,7 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ChoiceConfigurator;
-use Symfony\Component\HttpKernel\Kernel;
+use function Symfony\Component\Translation\t;
 
 class ChoiceFieldTest extends AbstractFieldTest
 {
@@ -16,8 +16,7 @@ class ChoiceFieldTest extends AbstractFieldTest
 
         $this->choices = ['a' => 1, 'b' => 2, 'c' => 3];
 
-        $container = Kernel::MAJOR_VERSION >= 6 ? static::getContainer() : self::$container;
-        $this->configurator = new ChoiceConfigurator($container->get('translator'));
+        $this->configurator = new ChoiceConfigurator();
     }
 
     public function testFieldWithoutChoices()
@@ -35,7 +34,18 @@ class ChoiceFieldTest extends AbstractFieldTest
         self::assertSame(['foo' => 1, 'bar' => 2], $this->configure($field)->getFormTypeOption(ChoiceField::OPTION_CHOICES));
 
         $field->setValue(1);
-        self::assertSame('foo', $this->configure($field)->getFormattedValue());
+        self::assertSame('foo', (string) $this->configure($field)->getFormattedValue());
+    }
+
+    public function testFieldWithTranslatableChoices()
+    {
+        $field = ChoiceField::new('foo')->setChoices([1 => t('foo'), 2 => 'bar'])->setChoicesTranslatable();
+
+        $field->setValue(1);
+        self::assertSame('foo', (string) $this->configure($field)->getFormattedValue());
+
+        $field->setValue(2);
+        self::assertSame('bar', (string) $this->configure($field)->getFormattedValue());
     }
 
     public function testFieldWithWrongVisualOptions()
@@ -86,27 +96,27 @@ class ChoiceFieldTest extends AbstractFieldTest
         $field = ChoiceField::new('foo')->setChoices($this->choices);
 
         $field->setValue(1);
-        self::assertSame('a', $this->configure($field)->getFormattedValue());
+        self::assertSame('a', (string) $this->configure($field)->getFormattedValue());
 
         $field->setValue([1, 3]);
-        self::assertSame('a, c', $this->configure($field)->getFormattedValue());
+        self::assertSame('a, c', (string) $this->configure($field)->getFormattedValue());
 
         $field->setValue(1)->renderAsBadges();
-        self::assertSame('<span class="badge badge-secondary">a</span>', $this->configure($field)->getFormattedValue());
+        self::assertSame('<span class="badge badge-secondary">a</span>', (string) $this->configure($field)->getFormattedValue());
 
         $field->setValue([1, 3])->renderAsBadges();
-        self::assertSame('<span class="badge badge-secondary">a</span><span class="badge badge-secondary">c</span>', $this->configure($field)->getFormattedValue());
+        self::assertSame('<span class="badge badge-secondary">a</span><span class="badge badge-secondary">c</span>', (string) $this->configure($field)->getFormattedValue());
 
         $field->setValue(1)->renderAsBadges([1 => 'warning', '3' => 'danger']);
-        self::assertSame('<span class="badge badge-warning">a</span>', $this->configure($field)->getFormattedValue());
+        self::assertSame('<span class="badge badge-warning">a</span>', (string) $this->configure($field)->getFormattedValue());
 
         $field->setValue([1, 3])->renderAsBadges([1 => 'warning', '3' => 'danger']);
-        self::assertSame('<span class="badge badge-warning">a</span><span class="badge badge-danger">c</span>', $this->configure($field)->getFormattedValue());
+        self::assertSame('<span class="badge badge-warning">a</span><span class="badge badge-danger">c</span>', (string) $this->configure($field)->getFormattedValue());
 
         $field->setValue(1)->renderAsBadges(function ($value) { return $value > 1 ? 'success' : 'primary'; });
-        self::assertSame('<span class="badge badge-primary">a</span>', $this->configure($field)->getFormattedValue());
+        self::assertSame('<span class="badge badge-primary">a</span>', (string) $this->configure($field)->getFormattedValue());
 
         $field->setValue([1, 3])->renderAsBadges(function ($value) { return $value > 1 ? 'success' : 'primary'; });
-        self::assertSame('<span class="badge badge-primary">a</span><span class="badge badge-success">c</span>', $this->configure($field)->getFormattedValue());
+        self::assertSame('<span class="badge badge-primary">a</span><span class="badge badge-success">c</span>', (string) $this->configure($field)->getFormattedValue());
     }
 }


### PR DESCRIPTION
This PR is pretty massive, yet almost all of it's code changes are just enablers for features that are already in Symfony Forms (5.4+) and Symfony Translation (also 5.4+). It allows passing `Translatable` objects as labels and other parts.

### Background

Currently my main problem with EasyAdmin is translation extraction. I maintain pretty large project where translation extraction is build into workflow very tightly and using manual extraction is unmaintainable. Fortunately most translations in admin context have no parameters, so I can workaround that by doing:
```
yield TextField::new('name', (string) t('Client name'));
```
But that's just a dirty hack and works only when label needs no parameters to translate properly. This is why I would benefit greatly if EasyAdmin would simply allow those objects internally and I think other users would welcome it too :smiley: 

I have tested those changes on real life projects and they worked like a charm :smile: 

### Complexity (?)

As stated before most of the changes are just enablers. By just changing some signatures and adding very simple logic whenever EasyAdmin translates content I was able to pass `Translatable` objects to templates and Symfony Forms, where they handle it without any additional work.

### Backwards compatibility

Functional backwards compatibility is kept. By that I mean - if project uses strings in those contexts (or leaves them empty for Easy Admin to fill with default values), no incompatibility arises. Setters accept strings as before and getters will return those strings. Also - everything will be translated, as before.

Unfortunately the same cannot be said about class signatures. Summary of signature changes are as follows:

Final classes with signature changes:

- Config\Action (new, setLabel); only docblocks and deprecation logic
- Config\Menu\*MenuItem (constructors)
- Config\MenuItem (linkTo*, section, subMenu)
- Dto\ActionDto (getLabel, setLabel and private field)
- Dto\CrudDto (getEntityLabelInSingular, setEntityLabelInSingular,getEntityLabelInPlural, setEntityLabelInPlural, setCustomPageTitle, getHelpMessage, setHelpMessage)
- Dto\FieldDto (getLabel, setLabel, getHelp, setHelp)
- Dto\FilterDto (getLabel, setLabel); only docblocks
- Dto\MenuItemDto (getLabel, setLabel)
- Field\*Field (new); only docblocks
- Field\FormField (addPanel, addTab)

Non-final classes with signature changes:

- Config\Crud (setHelp)
- Field\FieldTrait (setLabel, setHelp); setLabel only in docblock

I wouldn't consider signature changes in setters in final classes as BI, but getters are - end user code might expect getter to return `?string`, while this PR changes it to `TranslatableInterface|string|null`. Again - in simple use case, where user is not using `Translatable` objects this assumption will still hold. But libraries, bundles and other code does not have such guarantee.

Also one non-final class and commonly used trait have signature changes in parameter types that will raise errors when inherited.

I don't see any way we can achieve the same without breaking BC, therefore I think this change can only target `5.0`. But I'd love to hear from the others :)

### TODO

- [x] get feedback
- [x] write tests for functional changes (probably just translating part, there is no point in testing getters and setters IMO)
- [x] Add UPGRADE/CHANGELOG entry documenting changes
