### PR TITLE
Add a custom Twig function to handle CSRF token generation in templates

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -126,6 +126,7 @@ return static function (ContainerConfigurator $container) {
             // service whenever we generate a new URL, Maybe it's enough with the route parameter
             // initialization done after generating each URL
             ->arg(0, new Reference('service_locator_'.AdminUrlGenerator::class))
+            ->arg(1, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
             ->tag('twig.extension')
 
         ->set(EaCrudFormTypeExtension::class)

--- a/src/Resources/views/crud/includes/_delete_form.html.twig
+++ b/src/Resources/views/crud/includes/_delete_form.html.twig
@@ -1,6 +1,6 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 <form method="post" id="delete-form" style="display: none">
-    <input type="hidden" name="token" value="{{  csrf_token_intention|default(false) ? csrf_token('ea-delete') : '' }}" />
+    <input type="hidden" name="token" value="{{ ea_csrf_token('ea-delete') }}" />
 </form>
 
 <div id="modal-delete" class="modal fade" tabindex="-1">


### PR DESCRIPTION
This is an alternative to #5071 to fix #5059.