### PR TITLE
Fix collection entry form

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -188,7 +188,7 @@
     {% endif %}
 {% endblock collection_widget %}
 
-{% block collection_entry_widget %}
+{% block collection_entry_row %}
     {% set is_array_field = 'EasyCorp\\Bundle\\EasyAdminBundle\\Field\\ArrayField' == form_parent(form).vars.ea_crud_form.ea_field.fieldFqcn ?? false %}
     {% set is_complex = form_parent(form).vars.ea_crud_form.ea_field.customOptions.get('entryIsComplex') ?? false %}
     {% set allows_deleting_items = form_parent(form).vars.allow_delete|default(false) %}
@@ -226,7 +226,7 @@
             </div>
         {% endif %}
     </div>
-{% endblock collection_entry_widget %}
+{% endblock collection_entry_row %}
 
 {% block form_widget_compound %}
     <div class="form-widget-compound">


### PR DESCRIPTION
Tries to fix https://github.com/EasyCorp/EasyAdminBundle/issues/4605

I can't really explain this PR.. I really hope someone understands better than me and can review it. I'm not sure about this PR but it seems to fix the mentioned issue. I think it introduces a BC break, so it would be for `v5.0.0`.

I guess it is working because `collection_entry_row` is always rendered and `collection_entry_wiget` is only rendered when we do not define an entry type in EA, like for example: `CollectionField::new('orders')->setEntryType(OrderType::class)`.