### PR TITLE
Add docs and improve error message for custom mapping types

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -467,6 +467,14 @@ In addition to these, EasyAdmin includes other field types for specific values:
   that correspond to Symfony's ``EntityType``, ``CollectionType`` and ``ChoiceType``
   respectively.
 
+.. tip::
+
+    If you want to use one of Doctrine's `Custom Mapping Types`_ you should
+    create one of Symfony's `Custom Form Field Types`_ and one of
+    EasyAdmin's :ref:`Custom Fields <custom-fields>`. Note that for some
+    custom mapping types you will also need to customize EasyAdmin's
+    search and filter functionality if you need them.
+
 Field Configuration
 -------------------
 
@@ -751,3 +759,5 @@ attribute of the tag to run your configurator before or after the built-in ones.
 .. _`Bootstrap grid system`: https://getbootstrap.com/docs/5.0/layout/grid/
 .. _`Bootstrap breakpoints`: https://getbootstrap.com/docs/5.0/layout/breakpoints/
 .. _`Doctrine DBAL Type`: https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html
+.. _`Custom Mapping Types`: https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#custom-mapping-types
+.. _`Custom Form Field Types`: https://symfony.com/doc/current/form/create_custom_field_type.html

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -137,7 +137,7 @@ final class FieldFactory
                 $guessedFieldFqcn = self::$doctrineTypeToFieldFqcn[$doctrinePropertyType] ?? null;
 
                 if (null === $guessedFieldFqcn) {
-                    throw new \RuntimeException(sprintf('The Doctrine type of the "%s" field is "%s", which is not supported by EasyAdmin yet.', $fieldDto->getProperty(), $doctrinePropertyType));
+                    throw new \RuntimeException(sprintf('The Doctrine type of the "%s" field is "%s", which is not supported by EasyAdmin. For Doctrine\'s Custom Mapping Types have a look at EasyAdmin\'s field docs.', $fieldDto->getProperty(), $doctrinePropertyType));
                 }
             }
 


### PR DESCRIPTION
Intends to replace https://github.com/EasyCorp/EasyAdminBundle/pull/3354 and fix https://github.com/EasyCorp/EasyAdminBundle/issues/3278.

The replaced PR didn't get merged and this PR adds a tip in the docs that it is easy to implement custom fields for Doctrine's custom mapping types in our apps (which I find clearer, not too hard to do and most of all the replaced PR cannot handle all custom mapping types like for example phone numbers that include multiple form fields: phone number and country code).

It also makes clear that EasyAdminBundle does not intend to deal with custom mapping types in the future (I'm not sure if that is true, but I suppose..)