### PR TITLE
Improve nullable control

### DIFF
--- a/doc/fields/DateField.rst
+++ b/doc/fields/DateField.rst
@@ -110,3 +110,12 @@ the valid `PHP timezone IDs`_)::
 .. _`DateType`: https://symfony.com/doc/current/reference/forms/types/date.html
 .. _`ICU Datetime Pattern`: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
 .. _`PHP timezone IDs`: https://www.php.net/manual/en/timezones.php
+
+nullable
+~~~~~~~~
+
+By default, in form pages (``edit`` and ``new``) the field with a null value is rendered hidden with a check box for leave empty.
+This option renders the field visible on null values and removes the leave empty checkbox::
+
+    yield DateField::new('...')->nullable(true);
+

--- a/doc/fields/DateTimeField.rst
+++ b/doc/fields/DateTimeField.rst
@@ -111,3 +111,12 @@ the valid `PHP timezone IDs`_)::
 .. _`DateTimeType`: https://symfony.com/doc/current/reference/forms/types/datetime.html
 .. _`ICU Datetime Pattern`: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
 .. _`PHP timezone IDs`: https://www.php.net/manual/en/timezones.php
+
+nullable
+~~~~~~~~
+
+By default, in form pages (``edit`` and ``new``) the field with a null value is rendered hidden with a check box for leave empty.
+This option renders the field visible on null values and removes the leave empty checkbox::
+
+    yield DateTimeField::new('...')->nullable(true);
+

--- a/doc/fields/TimeField.rst
+++ b/doc/fields/TimeField.rst
@@ -110,3 +110,12 @@ the valid `PHP timezone IDs`_)::
 .. _`TimeType`: https://symfony.com/doc/current/reference/forms/types/time.html
 .. _`ICU Datetime Pattern`: https://unicode-org.github.io/icu/userguide/format_parse/datetime/
 .. _`PHP timezone IDs`: https://www.php.net/manual/en/timezones.php
+
+nullable
+~~~~~~~~
+
+By default, in form pages (``edit`` and ``new``) the field with a null value is rendered hidden with a check box for leave empty.
+This option renders the field visible on null values and removes the leave empty checkbox::
+
+    yield TimeField::new('...')->nullable(true);
+

--- a/src/Field/DateField.php
+++ b/src/Field/DateField.php
@@ -14,6 +14,7 @@ final class DateField implements FieldInterface
 
     public const OPTION_DATE_PATTERN = 'datePattern';
     public const OPTION_WIDGET = 'widget';
+    public const OPTION_NULLABLE = 'nullable';
 
     /**
      * @param string|false|null $label
@@ -30,7 +31,8 @@ final class DateField implements FieldInterface
             // the proper default values of these options are set on the Crud class
             ->setCustomOption(self::OPTION_DATE_PATTERN, null)
             ->setCustomOption(DateTimeField::OPTION_TIMEZONE, null)
-            ->setCustomOption(self::OPTION_WIDGET, DateTimeField::WIDGET_NATIVE);
+            ->setCustomOption(self::OPTION_WIDGET, DateTimeField::WIDGET_NATIVE)
+            ->setCustomOption(self::OPTION_NULLABLE, null);
     }
 
     /**
@@ -104,6 +106,16 @@ final class DateField implements FieldInterface
         } else {
             $this->setCustomOption(self::OPTION_WIDGET, DateTimeField::WIDGET_TEXT);
         }
+
+        return $this;
+    }
+
+    /**
+     * Sets if leave empty checkbox is present
+     */
+    public function nullable(bool $nullable = true): self
+    {
+        $this->setCustomOption(self::OPTION_NULLABLE, $nullable);
 
         return $this;
     }

--- a/src/Field/DateTimeField.php
+++ b/src/Field/DateTimeField.php
@@ -45,6 +45,8 @@ final class DateTimeField implements FieldInterface
     public const OPTION_TIMEZONE = 'timezone';
     public const OPTION_WIDGET = 'widget';
 
+    public const OPTION_NULLABLE = 'nullable';
+
     /**
      * @param string|false|null $label
      */
@@ -61,7 +63,8 @@ final class DateTimeField implements FieldInterface
             ->setCustomOption(self::OPTION_DATE_PATTERN, null)
             ->setCustomOption(self::OPTION_TIME_PATTERN, null)
             ->setCustomOption(self::OPTION_TIMEZONE, null)
-            ->setCustomOption(self::OPTION_WIDGET, self::WIDGET_NATIVE);
+            ->setCustomOption(self::OPTION_WIDGET, self::WIDGET_NATIVE)
+            ->setCustomOption(self::OPTION_NULLABLE, null);
     }
 
     /**
@@ -155,6 +158,16 @@ final class DateTimeField implements FieldInterface
         } else {
             $this->setCustomOption(self::OPTION_WIDGET, self::WIDGET_TEXT);
         }
+
+        return $this;
+    }
+
+    /**
+     * Sets if leave empty checkbox is present
+     */
+    public function nullable(bool $nullable = true): self
+    {
+        $this->setCustomOption(self::OPTION_NULLABLE, $nullable);
 
         return $this;
     }

--- a/src/Field/TimeField.php
+++ b/src/Field/TimeField.php
@@ -14,6 +14,7 @@ final class TimeField implements FieldInterface
 
     public const OPTION_TIME_PATTERN = 'timePattern';
     public const OPTION_WIDGET = 'widget';
+    public const OPTION_NULLABLE = 'nullable';
 
     /**
      * @param string|false|null $label
@@ -102,6 +103,16 @@ final class TimeField implements FieldInterface
         } else {
             $this->setCustomOption(self::OPTION_WIDGET, DateTimeField::WIDGET_TEXT);
         }
+
+        return $this;
+    }
+
+    /**
+     * Sets if leave empty checkbox is present
+     */
+    public function nullable(bool $nullable = true): self
+    {
+        $this->setCustomOption(self::OPTION_NULLABLE, $nullable);
 
         return $this;
     }

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -107,7 +107,7 @@
                     <div class="nullable-control">
                         <label>
                             <input type="checkbox" {% if ea.crud.currentAction == 'edit' and data is null and valid %}checked="checked"{% endif %}>
-                            {{ 'label.nullable_field'|trans({}, 'EasyAdminBundle')}}
+                            <span class="nullable-control-text">{{ 'label.nullable_field'|trans({}, 'EasyAdminBundle')}}</span>
                         </label>
                     </div>
                 {% endif %}

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -103,12 +103,13 @@
                     'EasyCorp\\Bundle\\EasyAdminBundle\\Field\\DateField',
                     'EasyCorp\\Bundle\\EasyAdminBundle\\Field\\TimeField',
                 ] %}
-                {% if form.vars.ea_crud_form.ea_field.fieldFqcn|default(false) in nullable_fields_fqcn and not form.vars.ea_crud_form.ea_field.formTypeOptions.required %}
+                {% if form.vars.ea_crud_form.ea_field.fieldFqcn|default(false) in nullable_fields_fqcn and not form.vars.ea_crud_form.ea_field.formTypeOptions.required and not form.vars.ea_crud_form.ea_field.customOptions.get('nullable') %}
                     <div class="nullable-control">
                         <label>
                             <input type="checkbox" {% if ea.crud.currentAction == 'edit' and data is null and valid %}checked="checked"{% endif %}>
                             <span class="nullable-control-text">{{ 'label.nullable_field'|trans({}, 'EasyAdminBundle')}}</span>
                         </label>
+                        {{ dump(form.vars.ea_crud_form.ea_field) }}
                     </div>
                 {% endif %}
 

--- a/tests/Field/DateFieldTest.php
+++ b/tests/Field/DateFieldTest.php
@@ -165,4 +165,19 @@ class DateFieldTest extends AbstractFieldTest
 
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(DateField::OPTION_WIDGET));
     }
+
+    public function testFieldNullable()
+    {
+        $field = DateField::new('foo');
+        $field->setFieldFqcn(DateField::class);
+        $field->nullable();
+        $fieldDto = $this->configure($field);
+
+        $this->assertSame(true, $fieldDto->getCustomOption(DateField::OPTION_NULLABLE));
+
+        $field->nullable(false);
+        $fieldDto = $this->configure($field);
+
+        $this->assertSame(false, $fieldDto->getCustomOption(DateField::OPTION_NULLABLE));
+    }
 }

--- a/tests/Field/DateTimeFieldTest.php
+++ b/tests/Field/DateTimeFieldTest.php
@@ -182,4 +182,19 @@ class DateTimeFieldTest extends AbstractFieldTest
 
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(DateTimeField::OPTION_WIDGET));
     }
+
+    public function testFieldNullable()
+    {
+        $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
+        $field->setFieldFqcn(DateTimeField::class);
+        $field->nullable();
+        $fieldDto = $this->configure($field);
+
+        $this->assertSame(true, $fieldDto->getCustomOption(DateTimeField::OPTION_NULLABLE));
+
+        $field->nullable(false);
+        $fieldDto = $this->configure($field);
+
+        $this->assertSame(false, $fieldDto->getCustomOption(DateTimeField::OPTION_NULLABLE));
+    }
 }

--- a/tests/Field/TimeFieldTest.php
+++ b/tests/Field/TimeFieldTest.php
@@ -168,4 +168,19 @@ class TimeFieldTest extends AbstractFieldTest
 
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(TimeField::OPTION_WIDGET));
     }
+
+    public function testFieldNullable()
+    {
+        $field = TimeField::new('foo');
+        $field->setFieldFqcn(TimeField::class);
+        $field->nullable();
+        $fieldDto = $this->configure($field);
+
+        $this->assertSame(true, $fieldDto->getCustomOption(TimeField::OPTION_NULLABLE));
+
+        $field->nullable(false);
+        $fieldDto = $this->configure($field);
+
+        $this->assertSame(false, $fieldDto->getCustomOption(TimeField::OPTION_NULLABLE));
+    }
 }


### PR DESCRIPTION
This is a proposal for an improvement to the nullable-control checkbox that was added. This adds an option to DateField, DateTimeField, and TimeField to disable the checkbox. 
It also adds a span around the label text 'Leave blank' with a class nullable-control-text so the text can be changed by the user.

see #5065 and #3392 

I believe I have followed the coding standard for EA and the contrib guide line, however I apologize if i have missed something.
