### PR TITLE
removing Static defaultdescription & defaultname for sf6.1 depreciations

### DIFF
--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -21,9 +21,7 @@ use function Symfony\Component\String\u;
 
 #[AsCommand(
     name: 'app:make:admin:dashboard',
-    description: 'Creates a new EasyAdmin  Dashboard class',
-    hidden: false,
-    aliases: ['app:make:admin:dashboard']
+    description: 'Creates a new EasyAdmin Dashboard class',
 )]
 class MakeAdminDashboardCommand extends Command
 {
@@ -40,7 +38,6 @@ class MakeAdminDashboardCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription($this->description)
             ->setHelp($this->getCommandHelp())
         ;
     }

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -28,9 +28,8 @@ class MakeAdminDashboardCommand extends Command
     private ClassMaker $classMaker;
     private string $projectDir;
 
-    public function __construct(ClassMaker $classMaker, string $projectDir, string $name = null)
+    public function __construct(ClassMaker $classMaker, string $projectDir)
     {
-        parent::__construct($name);
         $this->classMaker = $classMaker;
         $this->projectDir = $projectDir;
     }

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -18,8 +18,6 @@ use function Symfony\Component\String\u;
  */
 class MakeAdminDashboardCommand extends Command
 {
-    protected static $defaultName = 'make:admin:dashboard';
-    protected static $defaultDescription = 'Creates a new EasyAdmin Dashboard class';
     private ClassMaker $classMaker;
     private string $projectDir;
 
@@ -33,7 +31,7 @@ class MakeAdminDashboardCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription(self::$defaultDescription)
+            ->setDescription(Command::$defaultDescription)
             ->setHelp($this->getCommandHelp())
         ;
     }

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -3,9 +3,8 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Command;
 
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
-use Symfony\Component\Console\Command\Command;
-
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -18,7 +17,6 @@ use function Symfony\Component\String\u;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-
 #[AsCommand(
     name: 'app:make:admin:dashboard',
     description: 'Creates a new EasyAdmin Dashboard class',
@@ -28,8 +26,9 @@ class MakeAdminDashboardCommand extends Command
     private ClassMaker $classMaker;
     private string $projectDir;
 
-    public function __construct(ClassMaker $classMaker, string $projectDir)
+    public function __construct(ClassMaker $classMaker, string $projectDir, string $name = null)
     {
+        parent::__construct($name);
         $this->classMaker = $classMaker;
         $this->projectDir = $projectDir;
     }

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -29,9 +29,8 @@ class MakeAdminDashboardCommand extends Command
 {
     private ClassMaker $classMaker;
     private string $projectDir;
-    private $description;
 
-    public function __construct(ClassMaker $classMaker, string $projectDir, string $name = null, string $description)
+    public function __construct(ClassMaker $classMaker, string $projectDir, string $name = null)
     {
         parent::__construct($name);
         $this->classMaker = $classMaker;

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -18,7 +18,6 @@ use function Symfony\Component\String\u;
  */
 class MakeAdminDashboardCommand extends Command
 {
-    static string $defaultName = 'make:admin:dashboard';
     private ClassMaker $classMaker;
     private string $projectDir;
 

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Command;
 
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
 use Symfony\Component\Console\Command\Command;
+
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -35,7 +36,6 @@ class MakeAdminDashboardCommand extends Command
         parent::__construct($name);
         $this->classMaker = $classMaker;
         $this->projectDir = $projectDir;
-        $this->description = Command::getDefaultDescription;
     }
 
     protected function configure()

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -16,22 +16,31 @@ use function Symfony\Component\String\u;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
+
+#[AsCommand(
+    name: 'app:make:admin:dashboard',
+    description: 'Creates a new EasyAdmin  Dashboard class',
+    hidden: false,
+    aliases: ['app:make:admin:dashboard']
+)]
 class MakeAdminDashboardCommand extends Command
 {
     private ClassMaker $classMaker;
     private string $projectDir;
+    private $description;
 
-    public function __construct(ClassMaker $classMaker, string $projectDir, string $name = null)
+    public function __construct(ClassMaker $classMaker, string $projectDir, string $name = null, string $description)
     {
         parent::__construct($name);
         $this->classMaker = $classMaker;
         $this->projectDir = $projectDir;
+        $this->description = parent::getDefaultDescription;
     }
 
     protected function configure()
     {
         $this
-            ->setDescription('Creates a new EasyAdmin Dashboard class')
+            ->setDescription($this->description)
             ->setHelp($this->getCommandHelp())
         ;
     }

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Command;
 
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -34,7 +35,7 @@ class MakeAdminDashboardCommand extends Command
         parent::__construct($name);
         $this->classMaker = $classMaker;
         $this->projectDir = $projectDir;
-        $this->description = parent::getDefaultDescription;
+        $this->description = Command::getDefaultDescription;
     }
 
     protected function configure()

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -18,7 +18,7 @@ use function Symfony\Component\String\u;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 #[AsCommand(
-    name: 'app:make:admin:dashboard',
+    name: 'make:admin:dashboard',
     description: 'Creates a new EasyAdmin Dashboard class',
 )]
 class MakeAdminDashboardCommand extends Command

--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -18,6 +18,7 @@ use function Symfony\Component\String\u;
  */
 class MakeAdminDashboardCommand extends Command
 {
+    static string $defaultName = 'make:admin:dashboard';
     private ClassMaker $classMaker;
     private string $projectDir;
 
@@ -31,7 +32,7 @@ class MakeAdminDashboardCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription(Command::$defaultDescription)
+            ->setDescription('Creates a new EasyAdmin Dashboard class')
             ->setHelp($this->getCommandHelp())
         ;
     }

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -18,7 +18,6 @@ use function Symfony\Component\String\u;
  */
 class MakeCrudControllerCommand extends Command
 {
-    static string $defaultName = 'make:admin:crud';
     private string $projectDir;
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -23,7 +23,6 @@ use function Symfony\Component\String\u;
 )]
 class MakeCrudControllerCommand extends Command
 {
-
     private string $projectDir;
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -38,7 +38,7 @@ class MakeCrudControllerCommand extends Command
         $this->projectDir = $projectDir;
         $this->classMaker = $classMaker;
         $this->doctrine = $doctrine;
-        $this->description = parent::getDefaultDescription;
+        $this->description = Command::getDefaultDescription;
     }
 
     protected function configure()

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -18,7 +18,7 @@ use function Symfony\Component\String\u;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 #[AsCommand(
-    name: 'app:make:admin:crud',
+    name: 'make:admin:crud',
     description: 'Creates a new EasyAdmin CRUD controller class',
 )]
 class MakeCrudControllerCommand extends Command

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -4,8 +4,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Command;
 
 use Doctrine\Persistence\ManagerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -17,7 +17,6 @@ use function Symfony\Component\String\u;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-
 #[AsCommand(
     name: 'app:make:admin:crud',
     description: 'Creates a new EasyAdmin CRUD controller class',
@@ -29,8 +28,9 @@ class MakeCrudControllerCommand extends Command
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;
 
-    public function __construct(string $projectDir, ClassMaker $classMaker, ManagerRegistry $doctrine)
+    public function __construct(string $projectDir, ClassMaker $classMaker, ManagerRegistry $doctrine, string $name = null)
     {
+        parent::__construct($name);
         $this->projectDir = $projectDir;
         $this->classMaker = $classMaker;
         $this->doctrine = $doctrine;

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -29,9 +29,8 @@ class MakeCrudControllerCommand extends Command
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;
 
-    public function __construct(string $projectDir, ClassMaker $classMaker, ManagerRegistry $doctrine, string $name = null)
+    public function __construct(string $projectDir, ClassMaker $classMaker, ManagerRegistry $doctrine)
     {
-        parent::__construct($name);
         $this->projectDir = $projectDir;
         $this->classMaker = $classMaker;
         $this->doctrine = $doctrine;

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Command;
 use Doctrine\Persistence\ManagerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -16,24 +17,34 @@ use function Symfony\Component\String\u;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
+
+#[AsCommand(
+    name: 'app:make:admin:crud',
+    description: 'Creates a new EasyAdmin CRUD controller class',
+    hidden: false,
+    aliases: ['app:make:admin:crud']
+)]
 class MakeCrudControllerCommand extends Command
 {
+
     private string $projectDir;
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;
+    private $description;
 
-    public function __construct(string $projectDir, ClassMaker $classMaker, ManagerRegistry $doctrine, string $name = null)
+    public function __construct(string $projectDir, ClassMaker $classMaker, ManagerRegistry $doctrine, string $name = null, string $description)
     {
         parent::__construct($name);
         $this->projectDir = $projectDir;
         $this->classMaker = $classMaker;
         $this->doctrine = $doctrine;
+        $this->description = parent::getDefaultDescription;
     }
 
     protected function configure()
     {
         $this
-            ->setDescription('Creates a new EasyAdmin CRUD controller class')
+            ->setDescription($this->description)
             ->setHelp($this->getCommandHelp())
         ;
     }

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -18,6 +18,7 @@ use function Symfony\Component\String\u;
  */
 class MakeCrudControllerCommand extends Command
 {
+    static string $defaultName = 'make:admin:crud';
     private string $projectDir;
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;
@@ -33,7 +34,7 @@ class MakeCrudControllerCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription(Command::$defaultDescription)
+            ->setDescription('Creates a new EasyAdmin CRUD controller class')
             ->setHelp($this->getCommandHelp())
         ;
     }

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -30,15 +30,13 @@ class MakeCrudControllerCommand extends Command
     private string $projectDir;
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;
-    private $description;
 
-    public function __construct(string $projectDir, ClassMaker $classMaker, ManagerRegistry $doctrine, string $name = null, string $description)
+    public function __construct(string $projectDir, ClassMaker $classMaker, ManagerRegistry $doctrine, string $name = null)
     {
         parent::__construct($name);
         $this->projectDir = $projectDir;
         $this->classMaker = $classMaker;
         $this->doctrine = $doctrine;
-        $this->description = Command::getDefaultDescription;
     }
 
     protected function configure()

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -21,8 +21,6 @@ use function Symfony\Component\String\u;
 #[AsCommand(
     name: 'app:make:admin:crud',
     description: 'Creates a new EasyAdmin CRUD controller class',
-    hidden: false,
-    aliases: ['app:make:admin:crud']
 )]
 class MakeCrudControllerCommand extends Command
 {
@@ -42,7 +40,6 @@ class MakeCrudControllerCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription($this->description)
             ->setHelp($this->getCommandHelp())
         ;
     }

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -18,8 +18,6 @@ use function Symfony\Component\String\u;
  */
 class MakeCrudControllerCommand extends Command
 {
-    protected static $defaultName = 'make:admin:crud';
-    protected static $defaultDescription = 'Creates a new EasyAdmin CRUD controller class';
     private string $projectDir;
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;
@@ -35,7 +33,7 @@ class MakeCrudControllerCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription(self::$defaultDescription)
+            ->setDescription(Command::$defaultDescription)
             ->setHelp($this->getCommandHelp())
         ;
     }


### PR DESCRIPTION
<!--
Deleting Old overiding in MakeAdminDashboardCommand and MakeCrudControllerCommand for $defaultName & $defaultDescription,
Use the Symfony\Component\Console\Command\Command::$defaultName & Symfony\Component\Console\Command\Command::$defaultDescription instead.
-->
