### PR TITLE
Add new "rawHtmlOutput" option to TextEditorField

### DIFF
--- a/src/Field/TextEditorField.php
+++ b/src/Field/TextEditorField.php
@@ -14,6 +14,7 @@ final class TextEditorField implements FieldInterface
     use FieldTrait;
 
     public const OPTION_NUM_OF_ROWS = 'numOfRows';
+    public const OPTION_RAW_HTML_OUTPUT = 'rawHtmlOutput';
 
     /**
      * @param string|false|null $label
@@ -30,6 +31,13 @@ final class TextEditorField implements FieldInterface
             ->addJsFiles(Asset::new('bundles/easyadmin/field-text-editor.js')->onlyOnForms())
             ->setDefaultColumns('col-md-9 col-xxl-7')
             ->setCustomOption(self::OPTION_NUM_OF_ROWS, null);
+    }
+
+    public function rawHtmlOutput($enable = true): self
+    {
+        $this->setCustomOption(self::OPTION_RAW_HTML_OUTPUT, $enable);
+
+        return $this;
     }
 
     public function setNumOfRows(int $rows): self

--- a/src/Resources/views/crud/field/text_editor.html.twig
+++ b/src/Resources/views/crud/field/text_editor.html.twig
@@ -2,7 +2,11 @@
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% if ea.crud.currentAction == 'detail' %}
-    {{ field.formattedValue|nl2br }}
+    {% if field.customOptions.get('rawHtmlOutput') %}
+        {{ field.formattedValue|raw }}
+    {% else %}
+        {{ field.formattedValue|nl2br }}
+    {% endif %}
 {% else %}
     {% set html_id = 'ea-text-editor-' ~ field.uniqueId %}
     <a href="#" data-bs-toggle="modal" data-bs-target="#{{ html_id }}">
@@ -18,7 +22,11 @@
                     </button>
                 </div>
                 <div class="modal-body">
-                    {{ field.formattedValue|nl2br }}
+                    {% if field.customOptions.get('rawHtmlOutput') %}
+                        {{ field.formattedValue|raw }}
+                    {% else %}
+                        {{ field.formattedValue|nl2br }}
+                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
To optionally enable raw HTML output in detail action
and inside modal content (on index action).

Relates: #5155