### PR TITLE
removing Static defaultdescription & defaultname for sf6.1 depreciations using Annotations instead

### DIFF
--- a/src/Command/MakeAdminDashboardCommand.php
+++ b/src/Command/MakeAdminDashboardCommand.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Command;
 
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,10 +17,12 @@ use function Symfony\Component\String\u;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
+#[AsCommand(
+    name: 'make:admin:dashboard',
+    description: 'Creates a new EasyAdmin Dashboard class',
+)]
 class MakeAdminDashboardCommand extends Command
 {
-    protected static $defaultName = 'make:admin:dashboard';
-    protected static $defaultDescription = 'Creates a new EasyAdmin Dashboard class';
     private ClassMaker $classMaker;
     private string $projectDir;
 
@@ -33,7 +36,6 @@ class MakeAdminDashboardCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription(self::$defaultDescription)
             ->setHelp($this->getCommandHelp())
         ;
     }
@@ -115,6 +117,6 @@ name and location of the new class.
 This command never changes or overwrites an existing class, so you can run it
 safely as many times as needed to create multiple dashboards.
 HELP
-        ;
+            ;
     }
 }

--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Command;
 
 use Doctrine\Persistence\ManagerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,10 +17,12 @@ use function Symfony\Component\String\u;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
+#[AsCommand(
+    name: 'make:admin:crud',
+    description: 'Creates a new EasyAdmin CRUD controller class',
+)]
 class MakeCrudControllerCommand extends Command
 {
-    protected static $defaultName = 'make:admin:crud';
-    protected static $defaultDescription = 'Creates a new EasyAdmin CRUD controller class';
     private string $projectDir;
     private ClassMaker $classMaker;
     private ManagerRegistry $doctrine;
@@ -35,7 +38,6 @@ class MakeCrudControllerCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription(self::$defaultDescription)
             ->setHelp($this->getCommandHelp())
         ;
     }
@@ -120,6 +122,6 @@ location and namespace of the generated class.
 This command never changes or overwrites an existing class, so you can run it
 safely as many times as needed to create multiple CRUD controllers.
 HELP
-        ;
+            ;
     }
 }


### PR DESCRIPTION
Just removing the old call to $defaultDescription and $defaultName to use the new annotations system instead. 


check this pr for dev log : https://github.com/EasyCorp/EasyAdminBundle/pull/5148