### PR TITLE
fix(form_theme): regression missing default value.

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -546,7 +546,7 @@
     {{ form_widget(form, { attr: attr|merge({
         style: 'display: none',
         class: 'ea-text-editor-content',
-        'data-number-of-rows': form.vars.ea_crud_form.ea_field.customOptions.get('numOfRows'),
+        'data-number-of-rows': form.vars.ea_crud_form.ea_field.customOptions.get('numOfRows')|default(5),
     }) }) }}
 
     <div class="ea-text-editor-wrapper">


### PR DESCRIPTION
Default value is not preserved in: https://github.com/EasyCorp/EasyAdminBundle/commit/5aeff412a25adb5e488e7b07a485669455b1f814#diff-193b84b4379491300de20548ffdc39f00879b02563ee37144fd79e91fd310ceeL553
This is causing a regression when implementing custom form (collection):

```
TextEditorType : Impossible to access an attribute ("customOptions") on a null variable.
```
