### PR TITLE
 Add includeOnly and remove to Language and Locale field types

### DIFF
--- a/doc/fields/LanguageField.rst
+++ b/doc/fields/LanguageField.rst
@@ -47,5 +47,34 @@ code (e.g. ``ar``, ``my``, ``sl``, etc.)::
 
     yield LanguageField::new('...')->showName(false);
 
+includeOnly
+~~~~~~~~~~~
+
+By default, the locale selector displays all the languages defined by
+the `ICU project`_, the same which is used by Symfony and many other tech projects.
+Use this option to only display the given language codes::
+
+    yield LanguageField::new('...')->includeOnly(['en', 'fr', 'pl']);
+
+remove
+~~~~~~
+
+By default, the locale selector displays all the languages defined by
+the `ICU project`_, the same which is used by Symfony and many other tech projects.
+Use this option to remove the given language codes from that list::
+
+    yield LanguageField::new('...')->remove(['fr', 'pl']);
+
+useAlpha3Codes
+~~~~~~~~~~~~~~
+
+By default, the field expects that the given language code is a 2-letter value
+following the `ISO 639-1 alpha-2`_ format. Use this option if you store the
+language code using the 3-letter value of the `ISO 639-2 alpha-3`_ format::
+
+    yield CountryField::new('...')->useAlpha3Codes();
+
 .. _`LanguageType`: https://symfony.com/doc/current/reference/forms/types/language.html
 .. _`ICU project`: https://icu.unicode.org/
+.. _`ISO 639-1 alpha-2`: https://en.wikipedia.org/wiki/ISO_639-1
+.. _`ISO 639-2 alpha-3`: https://en.wikipedia.org/wiki/ISO_639-2

--- a/doc/fields/LocaleField.rst
+++ b/doc/fields/LocaleField.rst
@@ -49,5 +49,23 @@ code (e.g. ``so_DJ``, ``ug_CN``, ``uk``, etc.)::
 
     yield LocaleField::new('...')->showName(false);
 
+includeOnly
+~~~~~~~~~~~
+
+By default, the locale selector displays all the locales defined by
+the `ICU project`_, the same which is used by Symfony and many other tech projects.
+Use this option to only display the given locale codes::
+
+    yield LocaleField::new('...')->includeOnly(['en', 'fr', 'pl']);
+
+remove
+~~~~~~
+
+By default, the locale selector displays all the locales defined by
+the `ICU project`_, the same which is used by Symfony and many other tech projects.
+Use this option to remove the given locale codes from that list::
+
+    yield LocaleField::new('...')->remove(['fr', 'pl']);
+
 .. _`LocaleType`: https://symfony.com/doc/current/reference/forms/types/locale.html
 .. _`ICU project`: https://icu.unicode.org/

--- a/src/Field/Configurator/LanguageConfigurator.php
+++ b/src/Field/Configurator/LanguageConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -24,11 +25,22 @@ final class LanguageConfigurator implements FieldConfiguratorInterface
     {
         $field->setFormTypeOptionIfNotSet('attr.data-ea-widget', 'ea-autocomplete');
 
+        $alpha3 = $field->getCustomOption(LanguageField::OPTION_LANGUAGE_ALPHA3);
+
+        if (\in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_EDIT, Crud::PAGE_NEW], true)) {
+            $field->setFormTypeOption('choices', $this->generateFormTypeChoices(
+                $alpha3,
+                $field->getCustomOption(LanguageField::OPTION_LANGUAGE_CODES_TO_KEEP),
+                $field->getCustomOption(LanguageField::OPTION_LANGUAGE_CODES_TO_REMOVE))
+            );
+            $field->setFormTypeOption('choice_loader', null);
+        }
+
         if (null === $languageCode = $field->getValue()) {
             return;
         }
 
-        $languageName = $this->getLanguageName($languageCode);
+        $languageName = $this->getLanguageName($languageCode, $alpha3);
         if (null === $languageName) {
             throw new \InvalidArgumentException(sprintf('The "%s" value used as the language code of the "%s" field is not a valid ICU language code.', $languageCode, $field->getProperty()));
         }
@@ -36,12 +48,32 @@ final class LanguageConfigurator implements FieldConfiguratorInterface
         $field->setFormattedValue($languageName);
     }
 
-    private function getLanguageName(string $languageCode): ?string
+    private function getLanguageName(string $languageCode, bool $alpha3): ?string
     {
         try {
-            return Languages::getName($languageCode);
+            return $alpha3 ? Languages::getAlpha3Name($languageCode) : Languages::getName($languageCode);
         } catch (MissingResourceException $e) {
             return null;
         }
+    }
+
+    private function generateFormTypeChoices(bool $alpha3, ?array $languageCodesToKeep, ?array $languageCodesToRemove): array
+    {
+        $choices = [];
+
+        $languages = $alpha3 ? Languages::getAlpha3Names() : Languages::getNames();
+        foreach ($languages as $languageCode => $languageName) {
+            if (null !== $languageCodesToKeep && !\in_array($languageCode, $languageCodesToKeep, true)) {
+                continue;
+            }
+
+            if (null !== $languageCodesToRemove && \in_array($languageCode, $languageCodesToRemove, true)) {
+                continue;
+            }
+
+            $choices[$languageName] = $languageCode;
+        }
+
+        return $choices;
     }
 }

--- a/src/Field/Configurator/LocaleConfigurator.php
+++ b/src/Field/Configurator/LocaleConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -24,6 +25,11 @@ final class LocaleConfigurator implements FieldConfiguratorInterface
     {
         $field->setFormTypeOptionIfNotSet('attr.data-ea-widget', 'ea-autocomplete');
 
+        if (\in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_EDIT, Crud::PAGE_NEW], true)) {
+            $field->setFormTypeOption('choices', $this->generateFormTypeChoices($field->getCustomOption(LocaleField::OPTION_LOCALE_CODES_TO_KEEP), $field->getCustomOption(LocaleField::OPTION_LOCALE_CODES_TO_REMOVE)));
+            $field->setFormTypeOption('choice_loader', null);
+        }
+
         if (null === $localeCode = $field->getValue()) {
             return;
         }
@@ -43,5 +49,25 @@ final class LocaleConfigurator implements FieldConfiguratorInterface
         } catch (MissingResourceException $e) {
             return null;
         }
+    }
+
+    private function generateFormTypeChoices(?array $localeCodesToKeep, ?array $localeCodesToRemove): array
+    {
+        $choices = [];
+
+        $locales = Locales::getNames();
+        foreach ($locales as $localeCode => $localeName) {
+            if (null !== $localeCodesToKeep && !\in_array($localeCode, $localeCodesToKeep, true)) {
+                continue;
+            }
+
+            if (null !== $localeCodesToRemove && \in_array($localeCode, $localeCodesToRemove, true)) {
+                continue;
+            }
+
+            $choices[$localeName] = $localeCode;
+        }
+
+        return $choices;
     }
 }

--- a/src/Field/LanguageField.php
+++ b/src/Field/LanguageField.php
@@ -14,6 +14,9 @@ final class LanguageField implements FieldInterface
 
     public const OPTION_SHOW_CODE = 'showCode';
     public const OPTION_SHOW_NAME = 'showName';
+    public const OPTION_LANGUAGE_ALPHA3 = 'languageAlpha3';
+    public const OPTION_LANGUAGE_CODES_TO_KEEP = 'languageCodesToKeep';
+    public const OPTION_LANGUAGE_CODES_TO_REMOVE = 'languageCodesToRemove';
 
     /**
      * @param string|false|null $label
@@ -28,7 +31,10 @@ final class LanguageField implements FieldInterface
             ->addCssClass('field-language')
             ->setDefaultColumns('col-md-4 col-xxl-3')
             ->setCustomOption(self::OPTION_SHOW_CODE, false)
-            ->setCustomOption(self::OPTION_SHOW_NAME, true);
+            ->setCustomOption(self::OPTION_SHOW_NAME, true)
+            ->setCustomOption(self::OPTION_LANGUAGE_ALPHA3, false)
+            ->setCustomOption(self::OPTION_LANGUAGE_CODES_TO_KEEP, null)
+            ->setCustomOption(self::OPTION_LANGUAGE_CODES_TO_REMOVE, null);
     }
 
     public function showCode(bool $isShown = true): self
@@ -41,6 +47,35 @@ final class LanguageField implements FieldInterface
     public function showName(bool $isShown = true): self
     {
         $this->setCustomOption(self::OPTION_SHOW_NAME, $isShown);
+
+        return $this;
+    }
+
+    public function useAlpha3Codes(bool $useAlpha3 = true): self
+    {
+        $this->setCustomOption(self::OPTION_LANGUAGE_ALPHA3, $useAlpha3);
+
+        return $this;
+    }
+
+    /**
+     * Restricts the list of languages shown by the field to the given list of languages codes.
+     * e.g. ->includeOnly(['de', 'en', 'fr']).
+     */
+    public function includeOnly(array $countryCodesToKeep): self
+    {
+        $this->setCustomOption(self::OPTION_LANGUAGE_CODES_TO_KEEP, $countryCodesToKeep);
+
+        return $this;
+    }
+
+    /**
+     * Removes the given list of languages codes from the languages displayed by the field.
+     * e.g. ->remove(['de', 'fr']).
+     */
+    public function remove(array $countryCodesToRemove): self
+    {
+        $this->setCustomOption(self::OPTION_LANGUAGE_CODES_TO_REMOVE, $countryCodesToRemove);
 
         return $this;
     }

--- a/src/Field/LocaleField.php
+++ b/src/Field/LocaleField.php
@@ -14,6 +14,8 @@ final class LocaleField implements FieldInterface
 
     public const OPTION_SHOW_CODE = 'showCode';
     public const OPTION_SHOW_NAME = 'showName';
+    public const OPTION_LOCALE_CODES_TO_KEEP = 'localeCodesToKeep';
+    public const OPTION_LOCALE_CODES_TO_REMOVE = 'localeCodesToRemove';
 
     /**
      * @param string|false|null $label
@@ -28,7 +30,9 @@ final class LocaleField implements FieldInterface
             ->addCssClass('field-locale')
             ->setDefaultColumns('col-md-5 col-xxl-4')
             ->setCustomOption(self::OPTION_SHOW_CODE, false)
-            ->setCustomOption(self::OPTION_SHOW_NAME, true);
+            ->setCustomOption(self::OPTION_SHOW_NAME, true)
+            ->setCustomOption(self::OPTION_LOCALE_CODES_TO_KEEP, null)
+            ->setCustomOption(self::OPTION_LOCALE_CODES_TO_REMOVE, null);
     }
 
     public function showCode(bool $isShown = true): self
@@ -41,6 +45,28 @@ final class LocaleField implements FieldInterface
     public function showName(bool $isShown = true): self
     {
         $this->setCustomOption(self::OPTION_SHOW_NAME, $isShown);
+
+        return $this;
+    }
+
+    /**
+     * Restricts the list of locales shown by the field to the given list of locale codes.
+     * e.g. ->includeOnly(['de', 'en', 'fr']).
+     */
+    public function includeOnly(array $countryCodesToKeep): self
+    {
+        $this->setCustomOption(self::OPTION_LOCALE_CODES_TO_KEEP, $countryCodesToKeep);
+
+        return $this;
+    }
+
+    /**
+     * Removes the given list of locale codes from the locales displayed by the field.
+     * e.g. ->remove(['de', 'fr']).
+     */
+    public function remove(array $countryCodesToRemove): self
+    {
+        $this->setCustomOption(self::OPTION_LOCALE_CODES_TO_REMOVE, $countryCodesToRemove);
 
         return $this;
     }


### PR DESCRIPTION
This one fixes #5178.

Implementation inspired by `CountryField` (as suggested in the referenced ticket).

As a bonus I've added `alpha3` option to the `LanguageField`.