### PR TITLE
Custom entity name representation for autocomplete

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -142,7 +142,7 @@ Entity Options
             // By default EasyAdmin normalizes entities by calling __toString()
             // on their object. If you need different normalization for
             // autocompletion, you can pass custom callback
-            ->setAutocompleteInstanceNormalizer(fn (Entity $entity) => $entity->getname())
+            ->setAutocompleteEntityNormalizer(fn (Entity $entity) => $entity->getname())
         ;
     }
 

--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -138,6 +138,11 @@ Entity Options
             // the Symfony Security permission needed to manage the entity
             // (none by default, so you can manage all instances of the entity)
             ->setEntityPermission('ROLE_EDITOR')
+
+            // By default EasyAdmin normalizes entities by calling __toString()
+            // on their object. If you need different normalization for
+            // autocompletion, you can pass custom callback
+            ->setAutocompleteInstanceNormalizer(fn (Entity $entity) => $entity->getname())
         ;
     }
 

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -379,6 +379,13 @@ class Crud
         return $this;
     }
 
+    public function setAutocompleteInstanceNormalizer(?callable $autocompleteInstanceNormalizer): self
+    {
+        $this->dto->setAutocompleteInstanceNormalizer($autocompleteInstanceNormalizer);
+
+        return $this;
+    }
+
     public function getAsDto(): CrudDto
     {
         $this->dto->setPaginator(new PaginatorDto($this->paginatorPageSize, $this->paginatorRangeSize, 1, $this->paginatorFetchJoinCollection, $this->paginatorUseOutputWalkers));

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -379,9 +379,9 @@ class Crud
         return $this;
     }
 
-    public function setAutocompleteInstanceNormalizer(?callable $autocompleteInstanceNormalizer): self
+    public function setAutocompleteEntityNormalizer(?callable $autocompleteEntityNormalizer): self
     {
-        $this->dto->setAutocompleteInstanceNormalizer($autocompleteInstanceNormalizer);
+        $this->dto->setAutocompleteEntityNormalizer($autocompleteEntityNormalizer);
 
         return $this;
     }

--- a/src/Contracts/Orm/EntityPaginatorInterface.php
+++ b/src/Contracts/Orm/EntityPaginatorInterface.php
@@ -34,5 +34,5 @@ interface EntityPaginatorInterface
 
     public function getResults(): ?iterable;
 
-    public function getResultsAsJson(): string;
+    public function getResultsAsJson(?\Closure $entityAsStringNormalizer = null): string;
 }

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -467,7 +467,11 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
         $paginator = $this->container->get(PaginatorFactory::class)->create($queryBuilder);
 
-        return JsonResponse::fromJsonString($paginator->getResultsAsJson());
+        return JsonResponse::fromJsonString(
+            $paginator->getResultsAsJson(
+                $context->getCrud()->getAutocompleteInstanceNormalizer()
+            )
+        );
     }
 
     public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -469,7 +469,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
         return JsonResponse::fromJsonString(
             $paginator->getResultsAsJson(
-                $context->getCrud()->getAutocompleteInstanceNormalizer()
+                $context->getCrud()->getAutocompleteEntityNormalizer()
             )
         );
     }

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
+use Closure;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
@@ -59,6 +60,7 @@ final class CrudDto
     private ?string $entityPermission = null;
     private ?string $contentWidth = null;
     private ?string $sidebarWidth = null;
+    private ?\Closure $autocompleteInstanceNormalizer = null;
 
     public function __construct()
     {
@@ -457,5 +459,15 @@ final class CrudDto
     public function setSidebarWidth(string $sidebarWidth): void
     {
         $this->sidebarWidth = $sidebarWidth;
+    }
+
+    public function getAutocompleteInstanceNormalizer(): ?\Closure
+    {
+        return $this->autocompleteInstanceNormalizer;
+    }
+
+    public function setAutocompleteInstanceNormalizer(?callable $autocompleteInstanceNormalizer): void
+    {
+        $this->autocompleteInstanceNormalizer = $autocompleteInstanceNormalizer ? \Closure::fromCallable($autocompleteInstanceNormalizer) : null;
     }
 }

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -60,7 +60,7 @@ final class CrudDto
     private ?string $entityPermission = null;
     private ?string $contentWidth = null;
     private ?string $sidebarWidth = null;
-    private ?\Closure $autocompleteInstanceNormalizer = null;
+    private ?\Closure $autocompleteEntityNormalizer = null;
 
     public function __construct()
     {
@@ -461,13 +461,13 @@ final class CrudDto
         $this->sidebarWidth = $sidebarWidth;
     }
 
-    public function getAutocompleteInstanceNormalizer(): ?Closure
+    public function getAutocompleteEntityNormalizer(): ?Closure
     {
-        return $this->autocompleteInstanceNormalizer;
+        return $this->autocompleteEntityNormalizer;
     }
 
-    public function setAutocompleteInstanceNormalizer(?callable $autocompleteInstanceNormalizer): void
+    public function setAutocompleteEntityNormalizer(?callable $autocompleteEntityNormalizer): void
     {
-        $this->autocompleteInstanceNormalizer = $autocompleteInstanceNormalizer ? \Closure::fromCallable($autocompleteInstanceNormalizer) : null;
+        $this->autocompleteEntityNormalizer = $autocompleteEntityNormalizer ? \Closure::fromCallable($autocompleteEntityNormalizer) : null;
     }
 }

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -2,7 +2,6 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
-use Closure;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
@@ -468,6 +467,10 @@ final class CrudDto
 
     public function setAutocompleteEntityNormalizer(?callable $autocompleteEntityNormalizer): void
     {
-        $this->autocompleteEntityNormalizer = $autocompleteEntityNormalizer ? \Closure::fromCallable($autocompleteEntityNormalizer) : null;
+        if (null !== $autocompleteEntityNormalizer) {
+            $autocompleteEntityNormalizer = \Closure::fromCallable($autocompleteEntityNormalizer);
+        }
+
+        $this->autocompleteEntityNormalizer = $autocompleteEntityNormalizer;
     }
 }

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -461,7 +461,7 @@ final class CrudDto
         $this->sidebarWidth = $sidebarWidth;
     }
 
-    public function getAutocompleteEntityNormalizer(): ?Closure
+    public function getAutocompleteEntityNormalizer(): ?\Closure
     {
         return $this->autocompleteEntityNormalizer;
     }

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -461,7 +461,7 @@ final class CrudDto
         $this->sidebarWidth = $sidebarWidth;
     }
 
-    public function getAutocompleteInstanceNormalizer(): ?\Closure
+    public function getAutocompleteInstanceNormalizer(): ?Closure
     {
         return $this->autocompleteInstanceNormalizer;
     }

--- a/src/Orm/EntityPaginator.php
+++ b/src/Orm/EntityPaginator.php
@@ -204,9 +204,14 @@ final class EntityPaginator implements EntityPaginatorInterface
         foreach ($this->getResults() ?? [] as $entityInstance) {
             $entityDto = $this->entityFactory->createForEntityInstance($entityInstance);
 
+            $entityAsString = $entityDto->toString();
+            if (null !== $entityAsStringNormalizer) {
+                $entityAsString = $entityAsStringNormalizer($entityInstance);
+            }
+
             $jsonResult['results'][] = [
                 EA::ENTITY_ID => $entityDto->getPrimaryKeyValueAsString(),
-                'entityAsString' => $entityAsStringNormalizer ? $entityAsStringNormalizer($entityInstance) : $entityDto->toString(),
+                'entityAsString' => $entityAsString,
             ];
         }
 

--- a/src/Orm/EntityPaginator.php
+++ b/src/Orm/EntityPaginator.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Orm;
 
+use Closure;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -198,7 +199,7 @@ final class EntityPaginator implements EntityPaginatorInterface
         return $this->rangeLastResultNumber;
     }
 
-    public function getResultsAsJson(): string
+    public function getResultsAsJson(?Closure $entityAsStringNormalizer = null): string
     {
         $jsonResult = [];
         foreach ($this->getResults() ?? [] as $entityInstance) {
@@ -206,7 +207,7 @@ final class EntityPaginator implements EntityPaginatorInterface
 
             $jsonResult['results'][] = [
                 EA::ENTITY_ID => $entityDto->getPrimaryKeyValueAsString(),
-                'entityAsString' => $entityDto->toString(),
+                'entityAsString' => $entityAsStringNormalizer ? $entityAsStringNormalizer($entityInstance) : $entityDto->toString(),
             ];
         }
 

--- a/src/Orm/EntityPaginator.php
+++ b/src/Orm/EntityPaginator.php
@@ -2,7 +2,6 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Orm;
 
-use Closure;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\CountWalker;
 use Doctrine\ORM\Tools\Pagination\Paginator;
@@ -199,7 +198,7 @@ final class EntityPaginator implements EntityPaginatorInterface
         return $this->rangeLastResultNumber;
     }
 
-    public function getResultsAsJson(?Closure $entityAsStringNormalizer = null): string
+    public function getResultsAsJson(?\Closure $entityAsStringNormalizer = null): string
     {
         $jsonResult = [];
         foreach ($this->getResults() ?? [] as $entityInstance) {


### PR DESCRIPTION
Fix #3753 

This implements feature requested in #3753 in a way suggested within.

My one concern in backwards compatibility within `EntityPaginatorInterface`. Not sure what to do here, possibly just write a note in `UPGRADE.md`?