### PR TITLE
Allow running script tags included in collection prototypes

### DIFF
--- a/assets/js/field-collection.js
+++ b/assets/js/field-collection.js
@@ -52,12 +52,15 @@ const EaCollectionProperty = {
             const collectionItemsWrapper = collection.querySelector(newItemInsertionSelector);
 
             collectionItemsWrapper.insertAdjacentHTML('beforeend', newItemHtml);
+
+            // Execute JS scripts embedded in prototype
+            const collectionItems = collectionItemsWrapper.querySelectorAll('.field-collection-item');
+            const lastElement = collectionItems[collectionItems.length - 1];
+            lastElement.querySelectorAll('script').forEach(script => eval(script.innerHTML));
+
             // for complex collections of items, show the newly added item as not collapsed
             if (!isArrayCollection) {
                 EaCollectionProperty.updateCollectionItemCssClasses(collection);
-
-                const collectionItems = collectionItemsWrapper.querySelectorAll('.field-collection-item');
-                const lastElement = collectionItems[collectionItems.length - 1];
                 const lastElementCollapseButton = lastElement.querySelector('.accordion-button');
                 lastElementCollapseButton.classList.remove('collapsed');
                 const lastElementBody = lastElement.querySelector('.accordion-collapse');


### PR DESCRIPTION
Hi,

This PR allows to execute JS included in script tags from collection prototype after a collection item has been added.

This was done as CKEditorBundle adds some script tags under the textarea so these scripts need to be executed after the prototype is added to the DOM.