### PR TITLE
set only background-color in form-select and form-widget

### DIFF
--- a/assets/css/easyadmin-theme/forms.scss
+++ b/assets/css/easyadmin-theme/forms.scss
@@ -78,7 +78,7 @@ label.form-check-label {
 .form-widget input.form-control,
 .form-widget textarea.form-control,
 .form-widget .form-select {
-    background: var(--form-control-bg);
+    background-color: var(--form-control-bg);
     border: 1px solid var(--form-input-border-color);
     box-shadow: var(--form-input-shadow);
     color: var(--form-input-text-color);


### PR DESCRIPTION
when setting `background` to `var(--form-control-bg);` it will also override the `background-repeat` from `form-select` from bootstrap where it is set to `no-repeat`. as only color is set via the variable we should change `background` to `background-color`. Other possible workaround is to explicit add `background-repeat: no-repeat` here instead of changing `background`

fixes #5197

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
