### PR TITLE
Use CRUD form in CollectionField

### DIFF
--- a/doc/fields/CollectionField.rst
+++ b/doc/fields/CollectionField.rst
@@ -41,6 +41,28 @@ prefer to now allow that::
 
     yield CollectionField::new('...')->allowAdd(false);
 
+useCrudForm
+~~~~~~~~~~~
+
+If you want to reuse the CRUD form of an associated entity you can use this option::
+
+    yield CollectionField::new('...')->useCrudForm();
+
+The CRUD controller can be passed as an argument as well as the page names that are
+used when the CRUD controller's method ``CrudController::configureFields($pageName)``
+is called::
+
+    yield CollectionField::new('...')->useCrudForm(
+        true,
+        CategoryCrudController::class,
+        'new_category_on_article_page',
+        'edit_category_on_article_page'
+    );
+
+.. note::
+
+    To use the CRUD form option Symfony 6.1 or higher is required.
+
 allowDelete
 ~~~~~~~~~~~
 

--- a/src/Field/CollectionField.php
+++ b/src/Field/CollectionField.php
@@ -19,6 +19,10 @@ final class CollectionField implements FieldInterface
     public const OPTION_ENTRY_TYPE = 'entryType';
     public const OPTION_SHOW_ENTRY_LABEL = 'showEntryLabel';
     public const OPTION_RENDER_EXPANDED = 'renderExpanded';
+    public const OPTION_USE_CRUD_FORM = 'useCrudForm';
+    public const OPTION_CRUD_FORM_CONTROLLER_FQCN = 'crudFormControllerFqcn';
+    public const OPTION_CRUD_FORM_NEW_PAGE_NAME = 'crudFormNewPageName';
+    public const OPTION_CRUD_FORM_EDIT_PAGE_NAME = 'crudFormEditPageName';
 
     /**
      * @param string|false|null $label
@@ -38,7 +42,11 @@ final class CollectionField implements FieldInterface
             ->setCustomOption(self::OPTION_ENTRY_IS_COMPLEX, null)
             ->setCustomOption(self::OPTION_ENTRY_TYPE, null)
             ->setCustomOption(self::OPTION_SHOW_ENTRY_LABEL, false)
-            ->setCustomOption(self::OPTION_RENDER_EXPANDED, false);
+            ->setCustomOption(self::OPTION_RENDER_EXPANDED, false)
+            ->setCustomOption(self::OPTION_USE_CRUD_FORM, false)
+            ->setCustomOption(self::OPTION_CRUD_FORM_CONTROLLER_FQCN, null)
+            ->setCustomOption(self::OPTION_CRUD_FORM_NEW_PAGE_NAME, null)
+            ->setCustomOption(self::OPTION_CRUD_FORM_EDIT_PAGE_NAME, null);
     }
 
     public function allowAdd(bool $allow = true): self
@@ -83,6 +91,16 @@ final class CollectionField implements FieldInterface
     public function renderExpanded(bool $renderExpanded = true): self
     {
         $this->setCustomOption(self::OPTION_RENDER_EXPANDED, $renderExpanded);
+
+        return $this;
+    }
+
+    public function useCrudForm(bool $useCrudForm = true, ?string $controllerFqcn = null, ?string $newPageName = null, ?string $editPageName = null): self
+    {
+        $this->setCustomOption(self::OPTION_USE_CRUD_FORM, $useCrudForm);
+        $this->setCustomOption(self::OPTION_CRUD_FORM_CONTROLLER_FQCN, $controllerFqcn);
+        $this->setCustomOption(self::OPTION_CRUD_FORM_NEW_PAGE_NAME, $newPageName);
+        $this->setCustomOption(self::OPTION_CRUD_FORM_EDIT_PAGE_NAME, $editPageName);
 
         return $this;
     }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -346,6 +346,11 @@ return static function (ContainerConfigurator $container) {
         ->set(ChoiceConfigurator::class)
             ->arg(0, service('translator'))
 
+        ->set(CollectionConfigurator::class)
+            ->arg(0, service('request_stack'))
+            ->arg(1, service(EntityFactory::class))
+            ->arg(2, service(ControllerFactory::class))
+
         ->set(SlugConfigurator::class)
             ->arg(0, service('translator'))
 


### PR DESCRIPTION
Implements what @furang wrote here: https://github.com/EasyCorp/EasyAdminBundle/issues/4766.

Needs Symfony 6.1 because it uses `prototype_options` (See https://github.com/symfony/symfony/pull/45605).

I createad a reproducer here: https://github.com/michaelKaefer/ea-reproducer/tree/issue/4766-create-update-relations.

Without this PR you have to create a form type and set it as entry type for associated entities when using `CollectionField`. This doesn't allow using EA fields and could sometimes kind of duplicates the CRUD form of the associated entity. This new option would enable you to use the CRUD form (if you need different form fields and you cannot reuse the CRUD form you still can implement a custom form type).

Related to https://github.com/EasyCorp/EasyAdminBundle/issues/3304.