### PR TITLE
Supply default placeholder for file chooser

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -619,7 +619,7 @@
 {% block ea_fileupload_widget %}
     <div class="ea-fileupload">
         <div class="input-group">
-            {% set placeholder = '' %}
+            {% set placeholder = t('action.choose_file', {}, 'EasyAdminBundle') %}
             {% set title = '' %}
             {% set filesLabel = 'files'|trans({}, 'EasyAdminBundle') %}
             {% if currentFiles %}


### PR DESCRIPTION
This fixes #5198

The problem was - with default (empty) placeholder `form_label` was falling back to use form type label (or filename when `currentFiles` was not empty). When provided with non-empty default value it is being used and it shows friendly "Choose file" placeholder.

Note: We cannot use default, browser placeholder, as the real file input is being hidden with `display: none`.