### PR TITLE
Introduce an AdminUrlGeneratorInterface

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -14,7 +14,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AdminUrlGenerator
+final class AdminUrlGenerator implements AdminUrlGeneratorInterface
 {
     private bool $isInitialized = false;
     private AdminContextProvider $adminContextProvider;

--- a/src/Router/AdminUrlGeneratorInterface.php
+++ b/src/Router/AdminUrlGeneratorInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Router;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+interface AdminUrlGeneratorInterface
+{
+    public function setDashboard(string $dashboardControllerFqcn): self;
+
+    public function setCrudId(string $crudId): self;
+
+    public function setController(string $crudControllerFqcn): self;
+
+    public function setAction(string $action): self;
+
+    public function setRoute(string $routeName, array $routeParameters = []): self;
+
+    public function setEntityId($entityId): self;
+
+    public function get(string $paramName);
+
+    public function set(string $paramName, $paramValue): self;
+
+    public function setAll(array $routeParameters): self;
+
+    public function unset(string $paramName): self;
+
+    public function unsetAll(): self;
+
+    public function unsetAllExcept(string ...$namesOfParamsToKeep): self;
+
+    public function includeReferrer(): self;
+
+    public function removeReferrer(): self;
+
+    public function setReferrer(string $referrer): self;
+
+    public function addSignature(bool $addSignature = true): self;
+
+    public function getSignature(): string;
+
+    public function generateUrl(): string;
+}


### PR DESCRIPTION
The `AdminUrlGenerator` class is currently declared `final`.

As it's `final` class, it can't be mocked which can be a problem.
In my case, I use the generator in a custom class and I can't simply create a unit test for this one, because I cant' mock it, I need to create a real instance, which depends on another `final` class (eg. `AdminContextProvider`).

So I suggest to add a `AdminUrlGneratorInterface` to solve this issue.