### PR TITLE
[Bug] Fixing tomselect over-filtering Ajax autocomplete results

### DIFF
--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -111,6 +111,13 @@ export default class Autocomplete
                     .then(json => { this.setNextUrl(query, json.next_page); callback(json.results) })
                     .catch(() => callback());
             },
+            // on remote calls, we don't want tomselect to further filter the results by "entityAsString"
+            // this override causes all results to be returned with the sorting from the server
+            score: function(search) {
+                return function(item) {
+                    return 1;
+                };
+            },
             render: {
                 option: function(item, escape) {
                     return `<div>${item.entityAsString}</div>`;


### PR DESCRIPTION
Hi!

While playing with tomselect in another project (and also experimenting with its behavior in our Symfonycasts admin area), I noticed that it sometimes "over-filters" the results.

Example: suppose:

A) there is an autocomplete for a `User` entity, and `User.email` is the stringified version of that object.
B) My email is `ryan@symfonycasts.com` but I have a `User.lastName` set to `weaver`.

When I search for "weaver", the Ajax endpoint DOES return my user record. But then, TomSelect filters it out because the `entityAsString` (which is `ryan@symfonycasts.com`) does not contain `weaver`. 

This PR fixes that by overriding the `score` function. Normally, this function returns `0` for the result above, which then apparently causes TomSelect to hide it completely.

Cheers!