### PR TITLE
Add BeforeFieldsProcessedEvent

### DIFF
--- a/src/Event/BeforeFieldsProcessedEvent.php
+++ b/src/Event/BeforeFieldsProcessedEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Event;
+
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+
+final class BeforeFieldsProcessedEvent
+{
+    private $entityDto;
+    private $fieldCollection;
+    private $pageName;
+
+    public function __construct(EntityDto $entityDto, FieldCollection $fieldCollection, string $pageName)
+    {
+        $this->entityDto = $entityDto;
+        $this->fieldCollection = $fieldCollection;
+        $this->pageName = $pageName;
+    }
+
+    public function getEntityDto(): EntityDto
+    {
+        return $this->entityDto;
+    }
+
+    public function getFieldCollection(): FieldCollection
+    {
+        return $this->fieldCollection;
+    }
+
+    public function getPageName(): string
+    {
+        return $this->pageName;
+    }
+}


### PR DESCRIPTION
Let's say you have entities that implement some interfaces, like `TranslatableInterface` or `LoggableInterface`. So those entities always have some specific fields or mechanics in the background.

It's a bit repetitive to always state those fields to be used inside the edit view or detail view or index view. So I was missing some kind of event triggered before the fields are processed or some other way of adjusting the fields shown in the view. You could subscribe to that event and still adjust the fields last minute. So in the end you wouldn't need to always deal with the fields provided by those interfaces, you could just add a subscriber that manages those cases.

The idea is to add `BeforeFieldsProcessedEvent` that gets the:
* `EntityDto`
* `FieldCollection` and
* page name (edit, index, detail etc.)

`FieldCollection` already provides methods like `prepend`, `get`, `set`, `unset` etc. So you can subscribe to this event and adjust the FieldCollection to your needs, maybe re-arrange the fields or add/remove a field etc.