### PR TITLE
Allow to configure the favicon of the login page

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -853,6 +853,11 @@ applications can rely on its default values:
                 // the same domain as the rest of the Dashboard)
                 'translation_domain' => 'admin',
 
+                // the full path of the favicon to use in the login page;
+                // the given value is passed "as is" to the "href" attribute of
+                // the "<link rel="shortcut icon">" tag used to render the icon
+                'favicon_path' => '/favicon-admin.svg',
+
                 // the title visible above the login form (define this option only if you are
                 // rendering the login template in a regular Symfony controller; when rendering
                 // it from an EasyAdmin Dashboard this is automatically set as the Dashboard title)

--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -8,6 +8,14 @@
 {% block body_class 'page-login' %}
 {% block page_title %}{{ page_title is defined ? page_title|raw : (ea is defined ? ea.dashboardTitle|raw : '') }}{% endblock %}
 
+{% block head_favicon %}
+    {% if favicon_path|default(false) %}
+        <link rel="shortcut icon" href="{{ favicon_path }}">
+    {% else %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
 {% block wrapper_wrapper %}
     {% set page_title = block('page_title') %}
     {% set _username_label = username_label is defined ? username_label|trans : 'login_page.username'|trans({}, 'EasyAdminBundle') %}

--- a/src/Resources/views/page/login_minimal.html.twig
+++ b/src/Resources/views/page/login_minimal.html.twig
@@ -10,6 +10,8 @@
         <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
         <meta name="generator" content="EasyAdmin" />
 
+        {% block head_favicon %}{% endblock %}
+
         <title>{{ block('page_title')|striptags|raw }}</title>
 
         {% block head_stylesheets %}


### PR DESCRIPTION
Fixes #5233.

When the login page is served by EasyAdmin, you see the same favicon as the rest of the backend. In other cases, you can use the new `favicon_path` option.