### PR TITLE
Provide a better default favicon

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -241,7 +241,10 @@ explained later)::
                 // you can include HTML contents too (e.g. to link to an image)
                 ->setTitle('<img src="..."> ACME <span class="text-small">Corp.</span>')
 
-                // the path defined in this method is passed to the Twig asset() function
+                // by default EasyAdmin displays a black square as its default favicon;
+                // use this method to display a custom favicon: the given path is passed
+                // "as is" to the Twig asset() function:
+                // <link rel="shortcut icon" href="{{ asset('...') }}">
                 ->setFaviconPath('favicon.svg')
 
                 // the domain used by default is 'messages'
@@ -853,9 +856,10 @@ applications can rely on its default values:
                 // the same domain as the rest of the Dashboard)
                 'translation_domain' => 'admin',
 
-                // the full path of the favicon to use in the login page;
-                // the given value is passed "as is" to the "href" attribute of
-                // the "<link rel="shortcut icon">" tag used to render the icon
+                // by default EasyAdmin displays a black square as its default favicon;
+                // use this method to display a custom favicon: the given path is passed
+                // "as is" to the Twig asset() function:
+                // <link rel="shortcut icon" href="{{ asset('...') }}">
                 'favicon_path' => '/favicon-admin.svg',
 
                 // the title visible above the login form (define this option only if you are

--- a/src/Dto/DashboardDto.php
+++ b/src/Dto/DashboardDto.php
@@ -10,7 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 final class DashboardDto
 {
     private $routeName;
-    private string $faviconPath = 'favicon.ico';
+    private string $faviconPath = 'data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⬛</text></svg>';
     private string $title = 'EasyAdmin';
     private string $translationDomain = 'messages';
     private $textDirection;

--- a/src/Resources/views/page/login_minimal.html.twig
+++ b/src/Resources/views/page/login_minimal.html.twig
@@ -10,7 +10,9 @@
         <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
         <meta name="generator" content="EasyAdmin" />
 
-        {% block head_favicon %}{% endblock %}
+        {% block head_favicon %}
+            <link rel="shortcut icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⬛</text></svg>">
+        {% endblock %}
 
         <title>{{ block('page_title')|striptags|raw }}</title>
 


### PR DESCRIPTION
Providing a default favicon is very important to avoid unnecessary 404 errors.

We used `favicon.ico` as the default value ... but that it's no longer as popular as it was a few years ago. Most sites today use PNG, SVG, etc. to define their favicons.

So, let's use something similar to Symfony apps. By default (via this recipe: https://github.com/symfony/recipes/pull/1023/files) Symfony uses an inlined favicon (which avoids extra files and extra HTTP requests) which displays a black circle (⚫️). This favicon is simple/agnostic and it resembles the Symfony logo.

Let's do the same, but using a black square (⬛). This makes it easier to differentiate between a ⚫️ public page of the website and a ⬛ private page of the backend.

Please remember that this is just a default favicon. Most backends will customize their favicon just by calling to the related Dashboard method.