### PR TITLE
Fix issue #5240 - entity placeholders ignored for Crud::PAGE_NEW titles

### DIFF
--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -43,7 +43,7 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle('new', ea.i18n.translationParameters) %}
+        {% set custom_page_title = ea.crud.customPageTitle('new', null, ea.i18n.translationParameters) %}
         {{ custom_page_title is null
             ? ea.crud.defaultPageTitle('new', null, ea.i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}


### PR DESCRIPTION
missed $entityInstance parameter / misplaced $translationParameters parameter
