### PR TITLE
Add error message if no CRUD controller is found

### DIFF
--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -92,6 +92,10 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             $targetCrudControllerFqcn = $field->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_CONTROLLER_FQCN)
                 ?? $context->getCrudControllers()->findCrudFqcnByEntityFqcn($targetEntityFqcn);
 
+            if (null === $targetCrudControllerFqcn) {
+                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" cannot find a CRUD controller to render its entries. You can either create a CRUD controller for the entity "%s" or explicitly pass an existing CRUD controller to "useEntryCrudForm()".', $field->getProperty(), $context->getCrud()?->getControllerFqcn(), $targetEntityFqcn));
+            }
+
             $crudEditPageName = $field->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_EDIT_PAGE_NAME) ?? Crud::PAGE_EDIT;
             $editEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::EDIT, $crudEditPageName);
             $field->setFormTypeOption('entry_options.entityDto', $editEntityDto);


### PR DESCRIPTION
Sorry, I overlooked this until now. Without this message - if we forget to create a CRUD controller - we get an error message which does not help:
    
```
EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CollectionConfigurator::createEntityDto(): Argument #2 ($targetCrudControllerFqcn) must be of type string, null given, called in /app/vendor/easycorp/easyadmin-bundle/src/Field/Configurator/CollectionConfigurator.php on line 100
```
