### PR TITLE
Improve the tests output

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,13 +2,15 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.0/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/bin/.phpunit/phpunit/phpunit.xsd"
          colors="true"
          bootstrap="tests/bootstrap.php">
 
     <php>
+        <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
+        <server name="APP_DEBUG" value="false" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="KERNEL_CLASS" value="EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Kernel" />
     </php>
@@ -26,9 +28,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
-            <directory>src/</directory>
-        </whitelist>
-    </filter>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
Without these changes, I'm seeing some "Uncaught PHP exception" messages in the PHPUnit output. For example:

```
PHPUnit 9.5.16 by Sebastian Bergmann and contributors.

Testing
...............................[error] Uncaught PHP Exception EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException: "You don't have enough permissions to run the "customAction" action on the "EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CategoryCrudController" or the "customAction" action has been disabled." at tests/TestApplication/src/Controller/CategoryCrudController.php line 57

................................  63 / 205 ( 30%)
....................................................S.....S.... 126 / 205 ( 61%)
.....................S.S.....S................................. 189 / 205 ( 92%)
................                                                205 / 205 (100%)
```