### PR TITLE
Allow using HTML tags in action labels

### DIFF
--- a/src/Resources/views/crud/action.html.twig
+++ b/src/Resources/views/crud/action.html.twig
@@ -6,13 +6,13 @@
        href="{{ action.linkUrl }}"
        {% for name, value in action.htmlAttributes %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
         {%- if action.icon %}<i class="action-icon {{ action.icon }}"></i> {% endif -%}
-        {%- if action.label is not empty -%}<span class="action-label">{{ action.label|trans }}</span>{%- endif -%}
+        {%- if action.label is not empty -%}<span class="action-label">{{ action.label|trans|raw }}</span>{%- endif -%}
     </a>
 {% elseif 'button' == action.htmlElement %}
     <button class="{{ action.cssClass }}" {% for name, value in action.htmlAttributes %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
         <span class="btn-label">
             {%- if action.icon %}<i class="action-icon {{ action.icon }}"></i> {% endif -%}
-            {%- if action.label is not empty -%}<span class="action-label">{{ action.label|trans }}</span>{%- endif -%}
+            {%- if action.label is not empty -%}<span class="action-label">{{ action.label|trans|raw }}</span>{%- endif -%}
         </span>
     </button>
 {% endif %}


### PR DESCRIPTION
Fixes #3602.

EasyAdmin allows displaying HTML tags everywhere in all labels/contents generated by the developer (not in the contents generated by end users).

An exception are actions, whose labels don't include `|raw` yet. I think it's safe to add that considering what we do in the rest of templates.