### PR TITLE
Update Crud::setPageTitle() signature to include TranslatableInterface

### DIFF
--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -90,11 +90,12 @@ class Crud
     }
 
     /**
-     * @param string|callable $title The callable signature is: fn ($entityInstance): string
+     * @param TranslatableInterface|string|callable $title The callable signature is: fn ($entityInstance): string
      */
-    public function setPageTitle(string $pageName, /* string|callable */ $title): self
+    public function setPageTitle(string $pageName, /* TranslatableInterface|string|callable */ $title): self
     {
         if (!\is_string($title)
+            && !$title instanceof TranslatableInterface
             && !\is_callable($title)) {
             trigger_deprecation(
                 'easycorp/easyadmin-bundle',


### PR DESCRIPTION
The DTO supports `TranslatableInterface`. I belive this was just missed when support was introduced