### PR TITLE
Fix panel help translation

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -495,7 +495,7 @@
                             </a>
 
                             {% if panel_config.help|default(false) %}
-                                <div class="form-panel-help">{{ panel_config.help|raw }}</div>
+                                <div class="form-panel-help">{{ panel_config.help|trans|raw }}</div>
                             {% endif %}
                         </div>
                     </div>


### PR DESCRIPTION
I guess this small bug was introduced in https://github.com/EasyCorp/EasyAdminBundle/pull/5066. Panel help translation are currently not working for me, neither strings nor TranslatableMessages are working. This PR fixes it for me. Maybe @Lustmored can you take a quick look at this, is this PR correct?