### PR TITLE
Show form error messages for collection entry

### DIFF
--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -216,8 +216,7 @@
 
     <div class="field-collection-item {{ is_complex ? 'field-collection-item-complex' }} {{ not form.vars.valid ? 'is-invalid' }}">
         {% if is_array_field|default(false) %}
-            {{ form_label(form) }}
-            {{ form_widget(form) }}
+            {{ form_row(form) }}
             {% if allows_deleting_items and not disabled %}
                 {{ delete_item_button }}
             {% endif %}
@@ -236,7 +235,7 @@
                 <div id="{{ id }}-contents" class="accordion-collapse collapse {{ render_expanded ? 'show' }}">
                     <div class="accordion-body">
                         <div class="row">
-                            {{ form_widget(form) }}
+                            {{ form_row(form) }}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
After #5075 error messages are not rendered anymore.
This patch will show them, restoring the previous "design".

We could manually render the form errors and maybe even show some info in the accordion tab, but this is out of scope for now.

