### PR TITLE
Add step attribute to time widgets to fix Safari bug

### DIFF
--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -84,7 +84,7 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
             $field->setFormTypeOption('widget', 'single_text');
             $field->setFormTypeOption('html5', true);
 
-            if (('' !== trim($icuDateTimePattern) && str_contains($icuDateTimePattern, 's')) || DateTimeField::FORMAT_SHORT !== $timeFormat) {
+            if (('' !== trim($icuDateTimePattern) && str_contains($icuDateTimePattern, 's')) || (DateTimeField::FORMAT_SHORT !== $timeFormat && DateTimeField::FORMAT_NONE !== $timeFormat)) {
                 $attr = $field->getFormTypeOption('attr') ?? [];
                 $attr['step'] = '1';
                 $field->setFormTypeOption('attr', $attr);

--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -85,9 +85,7 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
             $field->setFormTypeOption('html5', true);
 
             if (('' !== trim($icuDateTimePattern) && str_contains($icuDateTimePattern, 's')) || (DateTimeField::FORMAT_SHORT !== $timeFormat && DateTimeField::FORMAT_NONE !== $timeFormat)) {
-                $attr = $field->getFormTypeOption('attr') ?? [];
-                $attr['step'] = '1';
-                $field->setFormTypeOption('attr', $attr);
+                $field->setFormTypeOption('with_seconds', true);
             }
         } elseif (DateTimeField::WIDGET_CHOICE === $widgetOption) {
             $field->setFormTypeOption('widget', 'choice');

--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -83,6 +83,12 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
         if (DateTimeField::WIDGET_NATIVE === $widgetOption) {
             $field->setFormTypeOption('widget', 'single_text');
             $field->setFormTypeOption('html5', true);
+
+            if (('' !== trim($icuDateTimePattern) && str_contains($icuDateTimePattern, 's')) || DateTimeField::FORMAT_SHORT !== $timeFormat) {
+                $attr = $field->getFormTypeOption('attr') ?? [];
+                $attr['step'] = '1';
+                $field->setFormTypeOption('attr', $attr);
+            }
         } elseif (DateTimeField::WIDGET_CHOICE === $widgetOption) {
             $field->setFormTypeOption('widget', 'choice');
             $field->setFormTypeOption('html5', true);


### PR DESCRIPTION
My attempt at fixing #5309 

This PR adds a `step` attribute with a value of 1 (seconds) to HTML5 datetime/datetime-local/time widgets whose formatted value contains seconds.

This resolves a bug in Safari where a form cannot be submitted as described in the linked issue.