### PR TITLE
disable the Validation on Filters form

### DIFF
--- a/src/Form/Type/FiltersFormType.php
+++ b/src/Form/Type/FiltersFormType.php
@@ -30,6 +30,7 @@ class FiltersFormType extends AbstractType
             'allow_extra_fields' => true,
             'csrf_protection' => false,
             'ea_filters' => FilterCollection::new(),
+            'validation_groups' => false,
         ]);
     }
 


### PR DESCRIPTION
We can't filter the list on index action page, if we select invalid entity in filters form.  We need to disable validation in filters form.
