### PR TITLE
allow to add custom query params for autocompleteEnpointUrl

### DIFF
--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -28,6 +28,8 @@ final class AssociationField implements FieldInterface
     /** @internal this option is intended for internal use only */
     public const PARAM_AUTOCOMPLETE_CONTEXT = 'autocompleteContext';
 
+	public const OPTION_AUTOCOMPLETE_CUSTOM_QUERY = 'autocompleteCustomQuery';
+
     /**
      * @param TranslatableInterface|string|false|null $label
      */
@@ -45,12 +47,14 @@ final class AssociationField implements FieldInterface
             ->setCustomOption(self::OPTION_WIDGET, self::WIDGET_AUTOCOMPLETE)
             ->setCustomOption(self::OPTION_QUERY_BUILDER_CALLABLE, null)
             ->setCustomOption(self::OPTION_RELATED_URL, null)
-            ->setCustomOption(self::OPTION_DOCTRINE_ASSOCIATION_TYPE, null);
+            ->setCustomOption(self::OPTION_DOCTRINE_ASSOCIATION_TYPE, null)
+	        ->setCustomOption(self::OPTION_AUTOCOMPLETE_CUSTOM_QUERY, null);
     }
 
-    public function autocomplete(): self
+    public function autocomplete(?array $customQueryParams = null): self
     {
         $this->setCustomOption(self::OPTION_AUTOCOMPLETE, true);
+	    $this->setCustomOption(self::OPTION_AUTOCOMPLETE_CUSTOM_QUERY, $customQueryParams);
 
         return $this;
     }

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -28,7 +28,7 @@ final class AssociationField implements FieldInterface
     /** @internal this option is intended for internal use only */
     public const PARAM_AUTOCOMPLETE_CONTEXT = 'autocompleteContext';
 
-	public const OPTION_AUTOCOMPLETE_CUSTOM_QUERY = 'autocompleteCustomQuery';
+    public const OPTION_AUTOCOMPLETE_CUSTOM_QUERY = 'autocompleteCustomQuery';
 
     /**
      * @param TranslatableInterface|string|false|null $label
@@ -48,13 +48,13 @@ final class AssociationField implements FieldInterface
             ->setCustomOption(self::OPTION_QUERY_BUILDER_CALLABLE, null)
             ->setCustomOption(self::OPTION_RELATED_URL, null)
             ->setCustomOption(self::OPTION_DOCTRINE_ASSOCIATION_TYPE, null)
-	        ->setCustomOption(self::OPTION_AUTOCOMPLETE_CUSTOM_QUERY, null);
+            ->setCustomOption(self::OPTION_AUTOCOMPLETE_CUSTOM_QUERY, null);
     }
 
     public function autocomplete(?array $customQueryParams = null): self
     {
         $this->setCustomOption(self::OPTION_AUTOCOMPLETE, true);
-	    $this->setCustomOption(self::OPTION_AUTOCOMPLETE_CUSTOM_QUERY, $customQueryParams);
+        $this->setCustomOption(self::OPTION_AUTOCOMPLETE_CUSTOM_QUERY, $customQueryParams);
 
         return $this;
     }

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -117,12 +117,12 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                     'originatingPage' => $context->getCrud()->getCurrentPage(),
                 ]);
 
-	        $customQueryParams = $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_CUSTOM_QUERY);
-	        if (is_array($customQueryParams)) {
-		        foreach ($customQueryParams as $key => $value) {
-			        $autocompleteEndpointUrl->set($key, $value);
-		        }
-	        }
+            $customQueryParams = $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_CUSTOM_QUERY);
+            if (is_array($customQueryParams)) {
+                foreach ($customQueryParams as $key => $value) {
+                    $autocompleteEndpointUrl->set($key, $value);
+                }
+            }
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl->generateUrl());
         } else {

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -115,10 +115,16 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                     EA::CRUD_CONTROLLER_FQCN => $context->getRequest()->query->get(EA::CRUD_CONTROLLER_FQCN),
                     'propertyName' => $propertyName,
                     'originatingPage' => $context->getCrud()->getCurrentPage(),
-                ])
-                ->generateUrl();
+                ]);
 
-            $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);
+	        $customQueryParams = $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_CUSTOM_QUERY);
+	        if (is_array($customQueryParams)) {
+		        foreach ($customQueryParams as $key => $value) {
+			        $autocompleteEndpointUrl->set($key, $value);
+		        }
+	        }
+
+            $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl->generateUrl());
         } else {
             $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($field) {
                 // TODO: should this use `createIndexQueryBuilder` instead, so we get the default ordering etc.?

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -118,7 +118,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 ]);
 
             $customQueryParams = $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_CUSTOM_QUERY);
-            if (is_array($customQueryParams)) {
+            if (\is_array($customQueryParams)) {
                 foreach ($customQueryParams as $key => $value) {
                     $autocompleteEndpointUrl->set($key, $value);
                 }


### PR DESCRIPTION
Allow to add custom query params for autocomplete in AssociationField.

`yield AssociationField::new('something')->autocomplete(['key' => 'value']);`
