### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/linter-code-syntax.yaml
+++ b/.github/workflows/linter-code-syntax.yaml
@@ -6,6 +6,9 @@ on: [push, pull_request]
 env:
     fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
     php-cs-fixer:
         name: PHP-CS-Fixer

--- a/.github/workflows/linter-doc.yaml
+++ b/.github/workflows/linter-doc.yaml
@@ -3,6 +3,9 @@ name: "Linter: Documentation"
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
     doctor-rst:
         name: DOCtor-RST

--- a/.github/workflows/test-upcoming-symfony.yaml
+++ b/.github/workflows/test-upcoming-symfony.yaml
@@ -10,6 +10,9 @@ on:
 env:
     fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
     tests:
         name: "Symfony ${{ matrix.symfony-version }} / PHP ${{ matrix.php-version }}"

--- a/.github/workflows/tests-linux.yaml
+++ b/.github/workflows/tests-linux.yaml
@@ -10,6 +10,9 @@ on:
 env:
     fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
     tests:
         name: "PHP ${{ matrix.php-version }}"

--- a/.github/workflows/tests-lowest-dependencies.yaml
+++ b/.github/workflows/tests-lowest-dependencies.yaml
@@ -10,6 +10,9 @@ on:
 env:
     fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
     tests:
         runs-on: 'ubuntu-latest'

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -10,6 +10,9 @@ on:
 env:
     fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
     tests:
         runs-on: 'macos-latest'

--- a/.github/workflows/tests-maintained-symfony.yaml
+++ b/.github/workflows/tests-maintained-symfony.yaml
@@ -10,6 +10,9 @@ on:
 env:
     fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
     tests:
         name: "Symfony ${{ matrix.symfony-version }} / PHP ${{ matrix.php-version }}"

--- a/.github/workflows/tests-upcoming-php.yaml
+++ b/.github/workflows/tests-upcoming-php.yaml
@@ -10,6 +10,9 @@ on:
 env:
     fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
     tests:
         runs-on: 'ubuntu-latest'

--- a/.github/workflows/tests-windows.yaml
+++ b/.github/workflows/tests-windows.yaml
@@ -10,6 +10,9 @@ on:
 env:
     fail-fast: true
 
+permissions:
+  contents: read
+
 jobs:
     tests:
         runs-on: 'windows-latest'


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
