### PR TITLE
fix for overwrite duplicate filename on imagefield upload

### DIFF
--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -93,6 +93,7 @@ class StringToFileTransformer implements DataTransformerInterface
 
             $filename = $this->uploadDir.($this->uploadFilename)($value);
             $filename = ($this->uploadValidate)($filename);
+
             return substr($filename, \strlen($this->uploadDir));
         }
 

--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -91,9 +91,9 @@ class StringToFileTransformer implements DataTransformerInterface
                 throw new TransformationFailedException($value->getErrorMessage());
             }
 
-            $filename = ($this->uploadFilename)($value);
-
-            return ($this->uploadValidate)($filename);
+            $filename = $this->uploadDir.($this->uploadFilename)($value);
+            $filename = ($this->uploadValidate)($filename);
+            return substr($filename, strlen($this->uploadDir));
         }
 
         if ($value instanceof File) {

--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -93,7 +93,7 @@ class StringToFileTransformer implements DataTransformerInterface
 
             $filename = $this->uploadDir.($this->uploadFilename)($value);
             $filename = ($this->uploadValidate)($filename);
-            return substr($filename, strlen($this->uploadDir));
+            return substr($filename, \strlen($this->uploadDir));
         }
 
         if ($value instanceof File) {


### PR DESCRIPTION
This should fix #5321 by prepending the target uploadDir before checking for duplicates, and stripping it afterwards so only the filename is saved.


