### PR TITLE
Allow to pass no choices no the Choice field

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -31,9 +31,6 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         $isMultipleChoice = $field->getCustomOption(ChoiceField::OPTION_ALLOW_MULTIPLE_CHOICES);
 
         $choices = $this->getChoices($field->getCustomOption(ChoiceField::OPTION_CHOICES), $entityDto, $field);
-        if (empty($choices)) {
-            throw new \InvalidArgumentException(sprintf('The "%s" choice field must define its possible choices using the setChoices() method.', $field->getProperty()));
-        }
 
         if ($areChoicesTranslatable) {
             $field->setFormTypeOptionIfNotSet('choices', array_keys($choices));

--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -21,10 +21,8 @@ class ChoiceFieldTest extends AbstractFieldTest
 
     public function testFieldWithoutChoices()
     {
-        $this->expectException(\InvalidArgumentException::class);
-
         $field = ChoiceField::new('foo');
-        $this->configure($field);
+        self::assertSame([], $this->configure($field)->getFormTypeOption(ChoiceField::OPTION_CHOICES));
     }
 
     public function testFieldWithChoiceGeneratorCallback()


### PR DESCRIPTION
Fixes #3688.

Folks doing advanced things with JS (e.g. dependent lists) might need to add an empty choice field which is populated later.