### PR TITLE
add symfony/flex to require-dev

### DIFF
--- a/.github/workflows/test-upcoming-symfony.yaml
+++ b/.github/workflows/test-upcoming-symfony.yaml
@@ -37,7 +37,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer config extra.symfony.require "${{ matrix.symfony-version }}"
                   composer update --no-interaction --prefer-dist --optimize-autoloader || exit 0
                   vendor/bin/simple-phpunit install || exit 0

--- a/.github/workflows/tests-linux.yaml
+++ b/.github/workflows/tests-linux.yaml
@@ -36,7 +36,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-lowest-dependencies.yaml
+++ b/.github/workflows/tests-lowest-dependencies.yaml
@@ -32,7 +32,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --prefer-lowest
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -32,7 +32,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-maintained-symfony.yaml
+++ b/.github/workflows/tests-maintained-symfony.yaml
@@ -37,7 +37,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer config extra.symfony.require "${{ matrix.symfony-version }}"
                   composer update --no-interaction --prefer-dist --optimize-autoloader
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-upcoming-php.yaml
+++ b/.github/workflows/tests-upcoming-php.yaml
@@ -32,7 +32,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer config extra.symfony.require "5.4"
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --ignore-platform-req=php
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-windows.yaml
+++ b/.github/workflows/tests-windows.yaml
@@ -32,7 +32,6 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
-                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/doctrine-bridge": "^5.4|^6.0",
         "symfony/event-dispatcher": "^5.4|^6.0",
         "symfony/filesystem": "^5.4|^6.0",
+        "symfony/flex": "^2.2",
         "symfony/form": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/http-foundation": "^5.4|^6.0",


### PR DESCRIPTION
Follow-up of #5330

There's no need to require `symfony/flex` on the CI, it can be added to `required-dev`.

This is the same idea than https://github.com/symfony/symfony-docs/pull/17031