### PR TITLE
Fix: keep existing formatted value

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -42,7 +42,9 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         if (null === $field->getValue()) {
             $value = $this->buildValueOption($field, $entityDto);
             $field->setValue($value);
-            $field->setFormattedValue($value);
+            if (null === $field->getFormattedValue()) {
+                $field->setFormattedValue($value);
+            }
         }
 
         $label = $this->buildLabelOption($field, $translationDomain, $context->getCrud()->getCurrentPage());

--- a/tests/Field/AbstractFieldTest.php
+++ b/tests/Field/AbstractFieldTest.php
@@ -47,7 +47,7 @@ abstract class AbstractFieldTest extends KernelTestCase
 
         $adminContextMock = $this->getMockBuilder(AdminContext::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCrud', 'getI18n'])
+            ->setMethods(['getCrud', 'getI18n', 'getTemplatePath'])
             ->getMock();
         $adminContextMock
             ->expects($this->any())
@@ -57,6 +57,10 @@ abstract class AbstractFieldTest extends KernelTestCase
             ->expects($this->any())
             ->method('getI18n')
             ->willReturn($i18nMock);
+        $adminContextMock
+            ->expects($this->any())
+            ->method('getTemplatePath')
+            ->willReturn('@EasyAdmin/layout.html.twig'); // return any path to avoid injecting a TemplateRegistry
 
         $this->adminContext = $adminContextMock;
     }

--- a/tests/Field/Configurator/CommonPreConfiguratorTest.php
+++ b/tests/Field/Configurator/CommonPreConfiguratorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Configurator;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CommonPreConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Field\AbstractFieldTest;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+
+class CommonPreConfiguratorTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var PropertyAccessorInterface $propertyAccessor */
+        $container = self::$kernel->getContainer()->get('test.service_container');
+        $propertyAccessor = $container->get(PropertyAccessorInterface::class);
+        $this->configurator = new CommonPreConfigurator($propertyAccessor);
+    }
+
+    public function testShouldKeepExistingValue()
+    {
+        $field = Field::new('foo')->setValue('bar');
+
+        $this->assertSame('bar', $this->configure($field)->getValue());
+    }
+
+    public function testShouldKeepExistingFormattedValue()
+    {
+        $field = Field::new('foo')->setFormattedValue('bar');
+
+        $this->assertSame('bar', $this->configure($field)->getFormattedValue());
+    }
+}


### PR DESCRIPTION
This PR allows for overriding the `formattedValue` via `Field::setFormattedValue`.

In my application I used something like this:
```php
        yield CollectionField::new('foo')
            ->setFormattedValue("bar");
```
However it wasn't respected and I still got only the count of items in the datatable on index page.

~~This PR also sets the _formattedValue_, when the fields _value_ was set manually.
I don't think it is desired to not set the _formattedValue_ at least equal to the _value_ itself, even though the _value_ was manually provided.~~

I also added a test case äquivilent to those for the Fields.
It feels a bit weird to use `AbstractFieldTest` for a Configurator, however the necessary functionality was provided through set class.