### PR TITLE
Add CRUD form option for to-one associations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ tests-coverage-view-in-browser: ## Open the generated HTML coverage in your defa
 
 ## —— Linters —————————————————————————————————
 linter-code-syntax: ## Lint PHP code (in dry-run mode, does not edit files)
-	docker run --rm -it -w=/app -v $(shell pwd):/app oskarstark/php-cs-fixer-ga:latest --diff -vvv --dry-run --using-cache=no
+	docker run --rm -it --pull always -w=/app -v $(shell pwd):/app oskarstark/php-cs-fixer-ga:latest --diff -vvv --dry-run --using-cache=no
 linter-docs: ## Lint docs
-	docker run --rm -it -e DOCS_DIR='/docs' -v $(shell pwd)/doc:/docs oskarstark/doctor-rst:latest --short
+	docker run --rm -it --pull always -e DOCS_DIR='/docs' -v $(shell pwd)/doc:/docs oskarstark/doctor-rst:latest --short
 
 ## —— Development —————————————————————————————
 build: ## Initially build the package before development

--- a/doc/fields/AssociationField.rst
+++ b/doc/fields/AssociationField.rst
@@ -98,6 +98,27 @@ Or if you prefer using the repository of the entity::
         fn (QueryBuilder $queryBuilder) => $queryBuilder->getEntityManager()->getRepository(Foo::class)->findBySomeCriteria();
     );
 
+``useCrudForm``
+~~~~~~~~~~~~~~~
+
+If the association is a to-one association the field can be rendered using an EasyAdmin
+CRUD Form. The ``useCrudForm()`` method defines the EasyAdmin CRUD form used to render
+the field::
+
+    yield AssociationField::new('...')->useCrudForm();
+
+By default, EasyAdmin finds the CRUD controller associated to the property automatically.
+If you need better control about which CRUD controller to use, pass the fully-qualified
+class name of the controller as the first argument::
+
+    yield AssociationField::new('...')->useCrudForm(CategoryCrudController::class);
+
+    // the other optional arguments are the CRUD page names to pass to the configureFields()
+    // method when creating and editing entries respectively
+    yield AssociationField::new('...')->useCrudForm(
+        CategoryCrudController::class, 'new_category_on_article_page', 'edit_category_on_article_page'
+    );
+
 .. _`TomSelect`: https://tom-select.js.org/
 .. _`EntityType`: https://symfony.com/doc/current/reference/forms/types/entity.html
 .. _`query_builder option`: https://symfony.com/doc/current/reference/forms/types/entity.html#query-builder

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -28,6 +28,12 @@ final class AssociationField implements FieldInterface
     /** @internal this option is intended for internal use only */
     public const PARAM_AUTOCOMPLETE_CONTEXT = 'autocompleteContext';
 
+    /** @internal this option is intended for internal use only */
+    public const OPTION_USES_CRUD_FORM = 'usesCrudController';
+
+    public const OPTION_CRUD_NEW_PAGE_NAME = 'crudNewPageName';
+    public const OPTION_CRUD_EDIT_PAGE_NAME = 'crudEditPageName';
+
     /**
      * @param TranslatableInterface|string|false|null $label
      */
@@ -45,7 +51,10 @@ final class AssociationField implements FieldInterface
             ->setCustomOption(self::OPTION_WIDGET, self::WIDGET_AUTOCOMPLETE)
             ->setCustomOption(self::OPTION_QUERY_BUILDER_CALLABLE, null)
             ->setCustomOption(self::OPTION_RELATED_URL, null)
-            ->setCustomOption(self::OPTION_DOCTRINE_ASSOCIATION_TYPE, null);
+            ->setCustomOption(self::OPTION_DOCTRINE_ASSOCIATION_TYPE, null)
+            ->setCustomOption(self::OPTION_USES_CRUD_FORM, false)
+            ->setCustomOption(self::OPTION_CRUD_NEW_PAGE_NAME, null)
+            ->setCustomOption(self::OPTION_CRUD_EDIT_PAGE_NAME, null);
     }
 
     public function autocomplete(): self
@@ -72,6 +81,16 @@ final class AssociationField implements FieldInterface
     public function setQueryBuilder(\Closure $queryBuilderCallable): self
     {
         $this->setCustomOption(self::OPTION_QUERY_BUILDER_CALLABLE, $queryBuilderCallable);
+
+        return $this;
+    }
+
+    public function useCrudForm(?string $crudControllerFqcn = null, ?string $crudNewPageName = null, ?string $crudEditPageName = null): self
+    {
+        $this->setCustomOption(self::OPTION_USES_CRUD_FORM, true);
+        $this->setCustomOption(self::OPTION_CRUD_CONTROLLER, $crudControllerFqcn);
+        $this->setCustomOption(self::OPTION_CRUD_NEW_PAGE_NAME, $crudNewPageName);
+        $this->setCustomOption(self::OPTION_CRUD_EDIT_PAGE_NAME, $crudEditPageName);
 
         return $this;
     }

--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -94,10 +94,17 @@ class CrudFormType extends AbstractType
                 continue;
             }
 
+            // Pass the current panel and tab down to nested CRUD forms, the nested
+            // CRUD form fields are forced to use their parents panel and tab
+            if (self::class === $formFieldType) {
+                $formFieldOptions['ea_form_panel'] = $currentFormPanel;
+                $formFieldOptions['ea_form_tab'] = $currentFormTab;
+            }
+
             $formField = $builder->getFormFactory()->createNamedBuilder($name, $formFieldType, null, $formFieldOptions);
             $formField->setAttribute('ea_entity', $entityDto);
-            $formField->setAttribute('ea_form_panel', $currentFormPanel);
-            $formField->setAttribute('ea_form_tab', $currentFormTab);
+            $formField->setAttribute('ea_form_panel', $options['ea_form_panel'] ?? $currentFormPanel);
+            $formField->setAttribute('ea_form_tab', $options['ea_form_tab'] ?? $currentFormTab);
             $formField->setAttribute('ea_field', $fieldDto);
 
             $builder->add($formField);
@@ -128,7 +135,7 @@ class CrudFormType extends AbstractType
                 'allow_extra_fields' => true,
                 'data_class' => static fn (Options $options, $dataClass) => $dataClass ?? $options['entityDto']->getFqcn(),
             ])
-            ->setDefined(['entityDto'])
+            ->setDefined(['entityDto', 'ea_form_panel', 'ea_form_tab'])
             ->setRequired(['entityDto']);
     }
 

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -286,6 +286,8 @@ return static function (ContainerConfigurator $container) {
         ->set(AssociationConfigurator::class)
             ->arg(0, new Reference(EntityFactory::class))
             ->arg(1, new Reference(AdminUrlGenerator::class))
+            ->arg(2, service('request_stack'))
+            ->arg(3, service(ControllerFactory::class))
 
         ->set(AvatarConfigurator::class)
 

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -448,9 +448,18 @@
 
                             <div class="row">
                                 {% if tab_name is defined and tab_name %}
-                                    {% for field in form|filter(field => not ea_crud_form.form_panels|filter((panel_config, form_panel) => form_panel == field.vars.ea_crud_form.form_panel) and field.vars.ea_crud_form.form_tab == tab_name) %}
-                                        {{ form_row(field) }}
-                                    {% endfor %}
+                                    {% macro recursiveTabForm(form, ea_crud_form, tab_name) %}
+                                        {% for field in form|filter(field => not ea_crud_form.form_panels|filter((panel_config, form_panel) => form_panel == field.vars.ea_crud_form.form_panel) and ((field.vars.ea_crud_form.form_tab is defined and field.vars.ea_crud_form.form_tab == tab_name) or field.vars.ea_crud_form.form_tabs is defined)) %}
+                                            {% if field.vars.ea_crud_form.form_tabs is defined %}
+                                                {# If the field is a nested CRUD form then only render it's children #}
+                                                {{ _self.recursiveTabForm(field, ea_crud_form, tab_name) }}
+                                            {% else %}
+                                                {# Render all other fields #}
+                                                {{ form_row(field) }}
+                                            {% endif %}
+                                        {% endfor %}
+                                    {% endmacro %}
+                                    {{ _self.recursiveTabForm(form, ea_crud_form, tab_name) }}
                                 {% endif %}
                                 {{ block('ea_crud_widget_panels') }}
                             </div>
@@ -513,9 +522,18 @@
             </div>
         </div>
     {% else %}
-        {% for field in form|filter(field => 'hidden' not in field.vars.block_prefixes and not field.vars.ea_crud_form.form_tab) %}
-            {{ form_row(field) }}
-        {% endfor %}
+        {% macro recursivePanelForm(form) %}
+            {% for field in form|filter(field => 'hidden' not in field.vars.block_prefixes and ((field.vars.ea_crud_form.form_tab is defined and not field.vars.ea_crud_form.form_tab) or field.vars.ea_crud_form.form_tabs is defined)) %}
+                {% if field.vars.ea_crud_form.form_tabs is defined %}
+                    {# If the field is a nested CRUD form then only render it's children #}
+                    {{ _self.recursivePanelForm(field) }}
+                {% else %}
+                    {# Render all other fields #}
+                    {{ form_row(field) }}
+                {% endif %}
+            {% endfor %}
+        {% endmacro %}
+        {{ _self.recursivePanelForm(form) }}
     {% endfor %}
 {% endblock ea_crud_widget_panels %}
 


### PR DESCRIPTION
Without this PR the association field renders a a dropdown and you cannot edit the associated entity but just select an already existing entity. If you want to edit an associated entity you cannot use `AssociationField` and so you have to create a custom EA field. Creating a custom EA field doesn't allow using EA fields and could sometimes kind of duplicate the CRUD form of the associated entity. This PR would enable you to use the CRUD form for `AssociationField` if it is a to-one association (for to-many associations `CollectionField` can be used).

I createad a reproducer: https://github.com/michaelKaefer/ea-reproducer/tree/association-field-use-crud-form.

Similar to https://github.com/EasyCorp/EasyAdminBundle/pull/5210.