### PR TITLE
Remove symfony/flex from composer require dev

### DIFF
--- a/.github/workflows/test-upcoming-symfony.yaml
+++ b/.github/workflows/test-upcoming-symfony.yaml
@@ -37,6 +37,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer config extra.symfony.require "${{ matrix.symfony-version }}"
                   composer update --no-interaction --prefer-dist --optimize-autoloader || exit 0
                   vendor/bin/simple-phpunit install || exit 0

--- a/.github/workflows/tests-linux.yaml
+++ b/.github/workflows/tests-linux.yaml
@@ -36,6 +36,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-lowest-dependencies.yaml
+++ b/.github/workflows/tests-lowest-dependencies.yaml
@@ -32,6 +32,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --prefer-lowest
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -32,6 +32,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/.github/workflows/tests-maintained-symfony.yaml
+++ b/.github/workflows/tests-maintained-symfony.yaml
@@ -37,6 +37,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer config extra.symfony.require "${{ matrix.symfony-version }}"
                   composer update --no-interaction --prefer-dist --optimize-autoloader
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-upcoming-php.yaml
+++ b/.github/workflows/tests-upcoming-php.yaml
@@ -32,6 +32,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer config extra.symfony.require "5.4"
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable --ignore-platform-req=php
                   vendor/bin/simple-phpunit install

--- a/.github/workflows/tests-windows.yaml
+++ b/.github/workflows/tests-windows.yaml
@@ -32,6 +32,7 @@ jobs:
 
             - name: 'Install project dependencies'
               run: |
+                  composer require --no-progress --no-scripts --no-plugins symfony/flex
                   composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
                   vendor/bin/simple-phpunit install
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/css-selector": "^5.4|^6.0",
         "symfony/dom-crawler": "^5.4|^6.0",
-        "symfony/flex": "^2.2",
         "symfony/phpunit-bridge": "^5.4|^6.0"
     },
     "config": {


### PR DESCRIPTION
With the changes from #5346, cloning this project and running `composer install` will run the recipes from Symfony, it will add many files that we don't want:

```bash
$ composer install
[…]
$ git status
On branch 4.x
Your branch is up to date with 'origin/4.x'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   .gitignore
	modified:   composer.json
	modified:   phpunit.xml.dist

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.env
	.env.test
	bin/
	config/
	docker-compose.override.yml
	docker-compose.yml
	public/
	src/Controller/.gitignore
	src/DataFixtures/
	src/Entity/
	src/Kernel.php
	src/Repository/
	symfony.lock
	templates/
	translations/
```

This PR revert this.

I apologize, I should have tested that before assuming that `symfony/flex` would not intervene.

