### PR TITLE
Update FieldFactory.php

### DIFF
--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -47,6 +47,7 @@ final class FieldFactory
         Types::DECIMAL => NumberField::class,
         Types::FLOAT => NumberField::class,
         Types::GUID => TextField::class,
+        'uuid' => TextField::class, // doctrine doesnt define such a type
         Types::INTEGER => IntegerField::class,
         Types::JSON => TextField::class,
         Types::OBJECT => TextField::class,


### PR DESCRIPTION
Hi,

If you have a doctrine entity such as

```php
#[ORM\Entity(repositoryClass: ProductRepository::class)]
class Product
{
    #[ORM\Id]
    #[ORM\GeneratedValue]
    #[ORM\Column(type: 'integer')]
    private $id;

    #[ORM\Column(type: 'uuid')]
    private UuidV6 $uuid;
    ...
```

If one of the fields is a "uuid" type, FieldFactory wont recognize it.

If you make a ea crud for such an entity you will get a crash when you will try to edit it with error `The Doctrine type of the "uuid" field is "uuid", which is not supported by EasyAdmin. For Doctrine's Custom Mapping Types have a look at EasyAdmin's field docs.` error.

My fix is surely not the most proper way to do this but works for me.