### PR TITLE
add missing argument in example code function

### DIFF
--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -420,9 +420,10 @@ If you do that, EasyAdmin will inject a DTO with all the batch action data::
 
         public function approveUsers(BatchActionDto $batchActionDto)
         {
-            $entityManager = $this->container->get('doctrine')->getManagerForClass($batchActionDto->getEntityFqcn());
+            $className = $batchActionDto->getEntityFqcn();
+            $entityManager = $this->container->get('doctrine')->getManagerForClass($className);
             foreach ($batchActionDto->getEntityIds() as $id) {
-                $user = $entityManager->find($id);
+                $user = $entityManager->find($className, $id);
                 $user->approve();
             }
 


### PR DESCRIPTION
The ObjectManager interface `find` function has two arguments, the first one being the entity classname. It was missing in the documentation and creating error if copying directly the code.