### PR TITLE
Fix grouped choices in ChoiceFields

### DIFF
--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -8,7 +8,7 @@ use function Symfony\Component\Translation\t;
 
 class ChoiceFieldTest extends AbstractFieldTest
 {
-    private $choices;
+    private array $choices;
 
     protected function setUp(): void
     {
@@ -23,6 +23,21 @@ class ChoiceFieldTest extends AbstractFieldTest
     {
         $field = ChoiceField::new('foo');
         self::assertSame([], $this->configure($field)->getFormTypeOption(ChoiceField::OPTION_CHOICES));
+    }
+
+    public function testFieldWithGroupedChoices(): void
+    {
+        $field = ChoiceField::new('foo')->setChoices([
+            'a' => 1,
+            'My group name' => [
+                'b' => 2,
+            ],
+        ]);
+
+        $field->setValue(1);
+        self::assertSame('a', (string) $this->configure($field)->getFormattedValue());
+        $field->setValue(2);
+        self::assertSame('b', (string) $this->configure($field)->getFormattedValue());
     }
 
     public function testFieldWithChoiceGeneratorCallback()


### PR DESCRIPTION
Replaces https://github.com/EasyCorp/EasyAdminBundle/pull/4094

Remarks:
- I also renamed the following variables for better readability
  - `selectedChoices` -> `choiceMessages` 
  - `selectedChoice` -> `selectedLabel` 
  - `choiceValue` -> `choiceMessage`
 - I think I found an unrelated bug (translatable choices cannot be grouped) but I will open another issue for that