### PR TITLE
To be able change the label vich_uploader.form_label.delete_confirm

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -344,7 +344,7 @@
             </div>
 
             {% if form.delete is defined %}
-                {{ form_row(form.delete, { label: 'vich_uploader.form_label.delete_confirm'|trans({}, 'VichUploaderBundle') }) }}
+                {{ form_row(form.delete) }}
             {% endif %}
         </div>
         <div class="small" id="{{ form.file.vars.id }}_new_file_name"></div>
@@ -404,7 +404,7 @@
             </div>
 
             {% if form.delete is defined %}
-                {{ form_row(form.delete, { label: 'vich_uploader.form_label.delete_confirm'|trans({}, 'VichUploaderBundle') }) }}
+                {{ form_row(form.delete) }}
             {% endif %}
         </div>
         <div class="small" id="{{ form.file.vars.id }}_new_file_name"></div>


### PR DESCRIPTION
Vich provides an option to change the delete_label in case the allow_delete option is true. 

The option delete_label allows to change the default label "vich_uploader.form_label.delete_confirm" however easyadmin forces the default label in the template.

```
{% if form.delete is defined %}
       {{ form_row(form.delete, { label: 'vich_uploader.form_label.delete_confirm'|trans({}, 'VichUploaderBundle') }) }}
{% endif %}
```

This PR fixes that.