### PR TITLE
Fix PHP 8.1 deprecation in CollectionInterface implementations

### DIFF
--- a/src/Collection/ActionCollection.php
+++ b/src/Collection/ActionCollection.php
@@ -54,6 +54,7 @@ final class ActionCollection implements CollectionInterface
         return \array_key_exists($offset, $this->actions);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->actions[$offset];

--- a/src/Collection/EntityCollection.php
+++ b/src/Collection/EntityCollection.php
@@ -47,6 +47,7 @@ final class EntityCollection implements CollectionInterface
     /**
      * @return ?EntityDto
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->entities[$offset];

--- a/src/Collection/FieldCollection.php
+++ b/src/Collection/FieldCollection.php
@@ -100,6 +100,7 @@ final class FieldCollection implements CollectionInterface
     /**
      * @return ?FieldDto
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset): mixed
     {
         return $this->fields[$offset];

--- a/src/Collection/FilterCollection.php
+++ b/src/Collection/FilterCollection.php
@@ -50,6 +50,7 @@ final class FilterCollection implements CollectionInterface
     /**
      * @return ?FilterDto
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset): mixed
     {
         return $this->filters[$offset];


### PR DESCRIPTION
The return types have been added on 4.x so there is nothing more to do. Cheers!

Fixes: 
> During inheritance of ArrayAccess: Uncaught ErrorException: Return type of EasyCorp\Bundle\EasyAdminBundle\Collection\ActionCollection::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /app/vendor/easycorp/easyadmin-bundle/src/Collection/ActionCollection.php:57
