### PR TITLE
add custom autocomplete url for external api

### DIFF
--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -14,6 +14,7 @@ final class AssociationField implements FieldInterface
     use FieldTrait;
 
     public const OPTION_AUTOCOMPLETE = 'autocomplete';
+    public const OPTION_AUTOCOMPLETE_ENDPOINT_URL = 'autocomplete-endpoint-url';
     public const OPTION_CRUD_CONTROLLER = 'crudControllerFqcn';
     public const OPTION_WIDGET = 'widget';
     public const OPTION_QUERY_BUILDER_CALLABLE = 'queryBuilderCallable';

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -108,7 +108,6 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                     throw new \RuntimeException(sprintf('The "%s" field cannot be autocompleted because it doesn\'t define the related CRUD controller FQCN with the "setCrudController()" method.', $field->getProperty()));
                 }
 
-                $field->setFormType(CrudAutocompleteType::class);
                 $autocompleteEndpointUrl = $this->adminUrlGenerator
                     ->unsetAll()
                     ->set('page', 1) // The autocomplete should always start on the first page
@@ -121,6 +120,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                     ])
                     ->generateUrl();
             }
+            $field->setFormType(CrudAutocompleteType::class);
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);
         } else {
             $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($field) {

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -100,7 +100,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
 
         if (true === $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE)) {
-            if($field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_ENDPOINT_URL)) {
+            if ($field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_ENDPOINT_URL)) {
                 $autocompleteEndpointUrl = $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_ENDPOINT_URL);
             } else {
                 $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER);

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -100,24 +100,27 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
 
         if (true === $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE)) {
-            $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER);
-            if (null === $targetCrudControllerFqcn) {
-                throw new \RuntimeException(sprintf('The "%s" field cannot be autocompleted because it doesn\'t define the related CRUD controller FQCN with the "setCrudController()" method.', $field->getProperty()));
+            if($field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_ENDPOINT_URL)) {
+                $autocompleteEndpointUrl = $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE_ENDPOINT_URL);
+            } else {
+                $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER);
+                if (null === $targetCrudControllerFqcn) {
+                    throw new \RuntimeException(sprintf('The "%s" field cannot be autocompleted because it doesn\'t define the related CRUD controller FQCN with the "setCrudController()" method.', $field->getProperty()));
+                }
+
+                $field->setFormType(CrudAutocompleteType::class);
+                $autocompleteEndpointUrl = $this->adminUrlGenerator
+                    ->unsetAll()
+                    ->set('page', 1) // The autocomplete should always start on the first page
+                    ->setController($field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER))
+                    ->setAction('autocomplete')
+                    ->set(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT, [
+                        EA::CRUD_CONTROLLER_FQCN => $context->getRequest()->query->get(EA::CRUD_CONTROLLER_FQCN),
+                        'propertyName' => $propertyName,
+                        'originatingPage' => $context->getCrud()->getCurrentPage(),
+                    ])
+                    ->generateUrl();
             }
-
-            $field->setFormType(CrudAutocompleteType::class);
-            $autocompleteEndpointUrl = $this->adminUrlGenerator
-                ->unsetAll()
-                ->set('page', 1) // The autocomplete should always start on the first page
-                ->setController($field->getCustomOption(AssociationField::OPTION_CRUD_CONTROLLER))
-                ->setAction('autocomplete')
-                ->set(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT, [
-                    EA::CRUD_CONTROLLER_FQCN => $context->getRequest()->query->get(EA::CRUD_CONTROLLER_FQCN),
-                    'propertyName' => $propertyName,
-                    'originatingPage' => $context->getCrud()->getCurrentPage(),
-                ])
-                ->generateUrl();
-
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);
         } else {
             $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($field) {


### PR DESCRIPTION
Custom autocomplete url (for external api) now could be added to **AssociationFeld**.

To do this **CustomOption** "**AssociationField::OPTION_AUTOCOMPLETE_ENDPOINT_URL**" need to be set in **CRUDController** for **AssociationField**

Example:
```php
<?php

namespace App\Controller\Admin\Food\Product;

use App\Entity\Food\Product\Product;
use App\Overrides\CustomAssociationField;
use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
use Symfony\Component\Routing\RouterInterface;

class ProductCrudController extends AbstractCrudController
{
    private RouterInterface $router;

    public function __construct(RouterInterface $router)
    {
        $this->router = $router;
    }
    
    /**
     * @param string $pageName
     * @return iterable
     */
    public function configureFields(string $pageName): iterable
    {
        yield AssociationField::new('nutrientProfile', 'Nutrient Profile')
            ->autocomplete()
            ->setCustomOption(
                AssociationField:: OPTION_AUTOCOMPLETE_ENDPOINT_URL,
                $this->router->generate('find_nutrient_lists') . '?'
            );
    }

    public static function getEntityFqcn(): string
    {
        return Product::class;
    }
}
```