### PR TITLE
Prepend external URLs with scheme

### DIFF
--- a/src/Resources/views/crud/field/url.html.twig
+++ b/src/Resources/views/crud/field/url.html.twig
@@ -6,5 +6,5 @@
 {% if ea.crud.currentAction == 'detail' %}
     <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.value }}</a>
 {% else %}
-    <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.formattedValue }}</a>
+    <a target="_blank" rel="noopener" href="{{ field.value matches '{^https?://}' ? field.value : 'https://' ~ field.value }}">{{ field.formattedValue }}</a>
 {% endif %}


### PR DESCRIPTION
If URL values are stored normalized, scheme might be missing.
This usually leads to external links being prepended with the
server's base URL. In such cases prepend with the `https` scheme
instead.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
