### PR TITLE
Lower the impact of EA on non-admin requests

### DIFF
--- a/src/DependencyInjection/CreateControllerRegistriesPass.php
+++ b/src/DependencyInjection/CreateControllerRegistriesPass.php
@@ -26,13 +26,18 @@ class CreateControllerRegistriesPass implements CompilerPassInterface
     {
         $dashboardControllersFqcn = array_keys($container->findTaggedServiceIds(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER, true));
 
+        $controllerFqcnToContextIdMap = [];
+        foreach ($dashboardControllersFqcn as $controllerFqcn) {
+            $controllerFqcnToContextIdMap[$controllerFqcn] = substr(sha1($container->getParameter('kernel.secret').$controllerFqcn), 0, 7);
+        }
+
         $container
             ->register(DashboardControllerRegistry::class, DashboardControllerRegistry::class)
             ->setPublic(false)
             ->setArguments([
-                $container->getParameter('kernel.secret'),
                 $container->getParameter('kernel.cache_dir'),
-                $dashboardControllersFqcn,
+                $controllerFqcnToContextIdMap,
+                array_flip($controllerFqcnToContextIdMap),
             ]);
     }
 
@@ -40,12 +45,24 @@ class CreateControllerRegistriesPass implements CompilerPassInterface
     {
         $crudControllersFqcn = array_keys($container->findTaggedServiceIds(EasyAdminExtension::TAG_CRUD_CONTROLLER, true));
 
+        $crudFqcnToEntityFqcnMap = $crudFqcnToCrudIdMap = [];
+
+        foreach ($crudControllersFqcn as $controllerFqcn) {
+            $crudFqcnToEntityFqcnMap[$controllerFqcn] = $controllerFqcn::getEntityFqcn();
+            $crudFqcnToCrudIdMap[$controllerFqcn] = substr(sha1($container->getParameter('kernel.secret').$controllerFqcn), 0, 7);
+        }
+
         $container
             ->register(CrudControllerRegistry::class, CrudControllerRegistry::class)
             ->setPublic(false)
             ->setArguments([
-                $container->getParameter('kernel.secret'),
-                $crudControllersFqcn,
+                $crudFqcnToEntityFqcnMap,
+                $crudFqcnToCrudIdMap,
+                // more than one controller can manage the same entity, so this map will
+                // only contain the last controller associated to that repeated entity. That's why
+                // several methods in other classes allow to define the CRUD controller explicitly
+                array_flip($crudFqcnToEntityFqcnMap),
+                array_flip($crudFqcnToCrudIdMap),
             ]);
     }
 }

--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -14,7 +14,6 @@ use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
-use Twig\Environment;
 
 /**
  * This subscriber acts as a "proxy" of all backend requests. First, if the
@@ -36,16 +35,14 @@ class AdminRouterSubscriber implements EventSubscriberInterface
     private ControllerResolverInterface $controllerResolver;
     private UrlGeneratorInterface $urlGenerator;
     private RequestMatcherInterface $requestMatcher;
-    private Environment $twig;
 
-    public function __construct(AdminContextFactory $adminContextFactory, ControllerFactory $controllerFactory, ControllerResolverInterface $controllerResolver, UrlGeneratorInterface $urlGenerator, RequestMatcherInterface $requestMatcher, Environment $twig)
+    public function __construct(AdminContextFactory $adminContextFactory, ControllerFactory $controllerFactory, ControllerResolverInterface $controllerResolver, UrlGeneratorInterface $urlGenerator, RequestMatcherInterface $requestMatcher)
     {
         $this->adminContextFactory = $adminContextFactory;
         $this->controllerFactory = $controllerFactory;
         $this->controllerResolver = $controllerResolver;
         $this->urlGenerator = $urlGenerator;
         $this->requestMatcher = $requestMatcher;
-        $this->twig = $twig;
     }
 
     public static function getSubscribedEvents(): array
@@ -82,9 +79,6 @@ class AdminRouterSubscriber implements EventSubscriberInterface
         }
 
         $request->attributes->set(EA::CONTEXT_REQUEST_ATTRIBUTE, $adminContext);
-
-        // this makes the AdminContext available in all templates as a short named variable
-        $this->twig->addGlobal('ea', $adminContext);
     }
 
     /**

--- a/src/Registry/CrudControllerRegistry.php
+++ b/src/Registry/CrudControllerRegistry.php
@@ -7,23 +7,23 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
  */
 final class CrudControllerRegistry
 {
-    private array $crudFqcnToEntityFqcnMap = [];
+    private array $crudFqcnToEntityFqcnMap;
     private array $entityFqcnToCrudFqcnMap;
-    private array $crudFqcnToCrudIdMap = [];
+    private array $crudFqcnToCrudIdMap;
     private array $crudIdToCrudFqcnMap;
 
-    public function __construct(string $kernelSecret, array $crudControllersFqcn)
+    /**
+     * @param array<string, string> $crudFqcnToEntityFqcnMap
+     * @param array<string, string> $crudFqcnToCrudIdMap
+     * @param array<string, string> $crudIdToCrudFqcnMap
+     * @param array<string, string> $entityFqcnToCrudFqcnMap
+     */
+    public function __construct(array $crudFqcnToEntityFqcnMap, array $crudFqcnToCrudIdMap, array $entityFqcnToCrudFqcnMap, array $crudIdToCrudFqcnMap)
     {
-        foreach ($crudControllersFqcn as $controllerFqcn) {
-            $this->crudFqcnToEntityFqcnMap[$controllerFqcn] = $controllerFqcn::getEntityFqcn();
-            $this->crudFqcnToCrudIdMap[$controllerFqcn] = substr(sha1($kernelSecret.$controllerFqcn), 0, 7);
-        }
-
-        // more than one controller can manage the same entity, so this map will
-        // only contain the last controller associated to that repeated entity. That's why
-        // several methods in other classes allow to define the CRUD controller explicitly
-        $this->entityFqcnToCrudFqcnMap = array_flip($this->crudFqcnToEntityFqcnMap);
-        $this->crudIdToCrudFqcnMap = array_flip($this->crudFqcnToCrudIdMap);
+        $this->crudFqcnToEntityFqcnMap = $crudFqcnToEntityFqcnMap;
+        $this->crudFqcnToCrudIdMap = $crudFqcnToCrudIdMap;
+        $this->entityFqcnToCrudFqcnMap = $entityFqcnToCrudFqcnMap;
+        $this->crudIdToCrudFqcnMap = $crudIdToCrudFqcnMap;
     }
 
     public function findCrudFqcnByEntityFqcn(string $entityFqcn): ?string

--- a/src/Registry/DashboardControllerRegistry.php
+++ b/src/Registry/DashboardControllerRegistry.php
@@ -15,13 +15,14 @@ final class DashboardControllerRegistry
     private array $controllerFqcnToRouteMap = [];
     private array $routeToControllerFqcnMap;
 
-    public function __construct(string $kernelSecret, string $cacheDir, array $dashboardControllersFqcn)
+    /**
+     * @param string[] $controllerFqcnToContextIdMap
+     * @param string[] $contextIdToControllerFqcnMap
+     */
+    public function __construct(string $cacheDir, array $controllerFqcnToContextIdMap, array $contextIdToControllerFqcnMap)
     {
-        foreach ($dashboardControllersFqcn as $controllerFqcn) {
-            $this->controllerFqcnToContextIdMap[$controllerFqcn] = substr(sha1($kernelSecret.$controllerFqcn), 0, 7);
-        }
-
-        $this->contextIdToControllerFqcnMap = array_flip($this->controllerFqcnToContextIdMap);
+        $this->controllerFqcnToContextIdMap = $controllerFqcnToContextIdMap;
+        $this->contextIdToControllerFqcnMap = $contextIdToControllerFqcnMap;
 
         $dashboardRoutesCachePath = $cacheDir.'/'.CacheWarmer::DASHBOARD_ROUTES_CACHE;
         $dashboardControllerRoutes = !file_exists($dashboardRoutesCachePath) ? [] : require $dashboardRoutesCachePath;

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -128,7 +128,8 @@ return static function (ContainerConfigurator $container) {
             // service whenever we generate a new URL, Maybe it's enough with the route parameter
             // initialization done after generating each URL
             ->arg(0, service('service_locator_'.AdminUrlGenerator::class))
-            ->arg(1, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->arg(1, service(AdminContextProvider::class))
+            ->arg(2, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
             ->tag('twig.extension')
 
         ->set(EaCrudFormTypeExtension::class)
@@ -161,7 +162,6 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, service('controller_resolver'))
             ->arg(3, service('router'))
             ->arg(4, service('router'))
-            ->arg(5, service('twig'))
             ->tag('kernel.event_subscriber')
 
         ->set(ControllerFactory::class)

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -5,29 +5,35 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Twig;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldLayoutDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldLayoutFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\ExtensionInterface;
+use Twig\Extension\GlobalsInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 /**
  * Defines the filters and functions used to render the bundle's templates.
+ * Also injects the admin context into Twig global variables as `ea` in order
+ * to be used by admin templates.
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class EasyAdminTwigExtension extends AbstractExtension
+class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterface
 {
     private ServiceLocator $serviceLocator;
+    private AdminContextProvider $adminContextProvider;
     private ?CsrfTokenManagerInterface $csrfTokenManager;
 
-    public function __construct(ServiceLocator $serviceLocator, ?CsrfTokenManagerInterface $csrfTokenManager)
+    public function __construct(ServiceLocator $serviceLocator, AdminContextProvider $adminContextProvider, ?CsrfTokenManagerInterface $csrfTokenManager)
     {
         $this->serviceLocator = $serviceLocator;
+        $this->adminContextProvider = $adminContextProvider;
         $this->csrfTokenManager = $csrfTokenManager;
     }
 
@@ -49,6 +55,19 @@ class EasyAdminTwigExtension extends AbstractExtension
             new TwigFilter('ea_apply_filter_if_exists', [$this, 'applyFilterIfExists'], ['needs_environment' => true]),
             new TwigFilter('ea_as_string', [$this, 'representAsString']),
         ];
+    }
+
+    public function getGlobals(): array
+    {
+        $context = $this->adminContextProvider->getContext();
+        if (null !== $context) {
+            // this makes the AdminContext available in all templates as a short named variable
+            return [
+                'ea' => $context,
+            ];
+        }
+
+        return [];
     }
 
     /**


### PR DESCRIPTION
Hi!

I think I found what can be a nice performance improvement to reduce the impact of EasyAdmin when not in actual use (requests that are not served using an admin controller), in particular for API requests that do not use Twig.

Currently, the `AdminRouterSubscriber` forces Twig initialization to inject the `ea` variable, even if Twig is not used (API endpoint for example).
Also, the `CrudControllerRegistry` causes the load and initialization of every single admin class, plus this registry and `DashboardControllerRegistry` are doing array computation in their constructors, but because of the way things are wired and that AdminRouterSubscriber listens to `kernel.request`, this happens on every single request served by the Symfony app.

With this patch, I managed to bring a fast API endpoint from about 30 ms down to about 18 ms, and from 7.69 MB of memory down to 4.84 MB.
:warning: Disclaimer: those measures have been done against EA3.

It is important to note that not every project would get exactly the same performance boost as it highly depends on how much time is required to initialize Twig.
Though I believe it is nice to allow projects to reach this level of performance when needed.
Also, even a couple of milliseconds and hundreds of kB of memory won by not loading the admin controllers and dashboards is still a win for everyone :)