### PR TITLE
Better typehint for `FieldInterface::new(..., $label)`

### DIFF
--- a/src/Contracts/Field/FieldInterface.php
+++ b/src/Contracts/Field/FieldInterface.php
@@ -9,7 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
  */
 interface FieldInterface
 {
-    public static function new(string $propertyName, ?string $label = null);
+    public static function new(string $propertyName, ?string /* TranslatableInterface|string|false|null */ $label = null);
 
     public function getAsDto(): FieldDto;
 }


### PR DESCRIPTION
Working on a project I noticed that `FieldInterface::new` method has `$label` typehinted as `?string`, while all fields support `TranslatableInterface|string|false|null` (per Dto).

Changing it would be a BC change, but I suggest keeping it commented (as in other parts) so that it won't be missed during major bump.