### PR TITLE
Fix some issues related to icons

### DIFF
--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -38,6 +38,7 @@ final class FormField implements FieldInterface
     public static function addPanel($label = false, ?string $icon = null): self
     {
         $field = new self();
+        $icon = $field->fixIconFormat($icon, 'FormField::addPanel()');
 
         return $field
             ->setFieldFqcn(__CLASS__)
@@ -81,6 +82,7 @@ final class FormField implements FieldInterface
     public static function addTab(TranslatableInterface|string $label, ?string $icon = null): self
     {
         $field = new self();
+        $icon = $field->fixIconFormat($icon, 'FormField::addTab()');
 
         return $field
             ->setFieldFqcn(__CLASS__)
@@ -95,6 +97,7 @@ final class FormField implements FieldInterface
 
     public function setIcon(string $iconCssClass): self
     {
+        $iconCssClass = $this->fixIconFormat($iconCssClass, 'FormField::setIcon()');
         $this->setCustomOption(self::OPTION_ICON, $iconCssClass);
 
         return $this;
@@ -128,5 +131,20 @@ final class FormField implements FieldInterface
         // don't use empty() because the label can contain only white spaces (it's a valid edge-case)
         return (null !== $this->dto->getLabel() && '' !== $this->dto->getLabel())
             || null !== $this->dto->getCustomOption(self::OPTION_ICON);
+    }
+
+    private function fixIconFormat(?string $icon, string $methodName): ?string
+    {
+        if (null === $icon) {
+            return $icon;
+        }
+
+        if (!str_contains($icon, 'fa-') && !str_contains($icon, 'far-') && !str_contains($icon, 'fab-')) {
+            trigger_deprecation('easycorp/easyadmin-bundle', '4.4.0', 'The value passed as the $icon argument in "%s" method must be the full FontAwesome CSS class of the icon. For example, if you passed "user" before, you now must pass "fa fa-user" (or any style variant like "fa fa-solid fa-user").', $methodName);
+
+            $icon = sprintf('fa fa-%s', $icon);
+        }
+
+        return $icon;
     }
 }

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -72,8 +72,8 @@
                 {% for tab in field_layout.tabs %}
                     <li class="nav-item">
                         <a class="nav-link {% if loop.first %}active{% endif %}" href="#tab-pane-{{ tab.uniqueId }}" id="tab-{{ tab.uniqueId }}" data-bs-toggle="tab">
-                            {%- if tab.icon|default(false) -%}
-                                <i class="fa fa-fw fa-{{ tab.icon }}"></i>
+                            {%- if tab.customOption('icon') -%}
+                                <i class="fa-fw {{ tab.customOption('icon') }}"></i>
                             {%- endif -%}
                             {{ tab.label|trans(domain = ea.i18n.translationDomain)|trans(domain = 'EasyAdminBundle') }}
                         </a>

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -411,7 +411,7 @@
                         <li class="nav-item">
                             <a class="nav-link {% if tab_config.active %}active{% endif %}" href="#{{ tab_config['id'] }}" id="{{ tab_config['id'] }}-tab" data-bs-toggle="tab">
                                 {%- if tab_config.icon|default(false) -%}
-                                    <i class="fa fa-fw fa-{{ tab_config.icon }}"></i>
+                                    <i class="fa-fw {{ tab_config.icon }}"></i>
                                 {%- endif -%}
                                 {{ tab_config['label']|trans(domain = ea.i18n.translationDomain) }}
                                 {%- if tab_config.errors > 0 -%}


### PR DESCRIPTION
This fixes #5397.

It also introduces some deprecations related to icons. On most of the EA features, we require the full FontAwesome CSS class to define an icon (e.g. `fa fa-user`). On form tabs and panels we didn't and they still used the legacy prefix-less version of the icons. So, let's make both ways work, but let's deprecate when not adding the `fa*` prefixes.