### PR TITLE
Example code update because of deprecations

### DIFF
--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -557,8 +557,8 @@ of them:
     {# templates/admin/business_stats/index.html.twig #}
     {% extends '@EasyAdmin/page/content.html.twig' %}
 
-    {% block page_title 'Business Stats' %}
-    {% block page_content %}
+    {% block content_title 'Business Stats' %}
+    {% block main %}
         <table>
             <thead> {# ... #} </thead>
             <tbody>


### PR DESCRIPTION
The "page_content" and "page_title" block has been deprecated and changed into 'main' and 'content_title'.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
