### PR TITLE
Fix BC break for fields with deep objects

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -11,6 +11,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AvatarField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
+use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use function Symfony\Component\String\u;
 use function Symfony\Component\Translation\t;
@@ -44,7 +45,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         if (null === $value = $field->getValue()) {
             try {
                 $value = null === $entityDto->getInstance() ? null : $this->propertyAccessor->getValue($entityDto->getInstance(), $field->getProperty());
-            } catch (AccessException) {
+            } catch (AccessException|UnexpectedTypeException) {
                 $isReadable = false;
             }
 


### PR DESCRIPTION
Since version 4.4 (#5343) having a field declared as:

```php
TextField::new('period.start');
```
will throw an exception if `period` is `null`.
This is because (as per documentation)

```php
   /**
     * ......
     * @throws Exception\InvalidArgumentException If the property path is invalid
     * @throws Exception\AccessException          If a property/index does not exist or is not public
     * @throws Exception\UnexpectedTypeException  If a value within the path is neither object
     *                                            nor array
     */
    public function getValue(object|array $objectOrArray, string|PropertyPathInterface $propertyPath): mixed;
```

`UnexpectedTypeException` is thrown if any object in the path is `null`.


This PR fixes this by catching the exception and simply marking it not readable to keep the BC
