### PR TITLE
Update the profiler panel for Symfony 6.2

### DIFF
--- a/src/Resources/views/inspector/data_collector.html.twig
+++ b/src/Resources/views/inspector/data_collector.html.twig
@@ -1,25 +1,8 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
-{% block toolbar %}
-    {% if collector.isEasyAdminRequest %}
-        {% set icon %}
-            {{ include('@EasyAdmin/inspector/icon.svg.twig', { fill_color: '#AAA', height: '20' }) }}
-        {% endset %}
-
-        {% set text %}
-            <div class="sf-toolbar-info-piece">
-                <b>EasyAdmin version</b>
-                <span class="sf-toolbar-status">{{ constant('EasyCorp\\Bundle\\EasyAdminBundle\\EasyAdminBundle::VERSION') }}</span>
-            </div>
-        {% endset %}
-
-        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { 'link': true }) }}
-    {% endif %}
-{% endblock %}
-
 {% block menu %}
     <span class="label {{ not collector.isEasyAdminRequest ? 'disabled' }}">
-        <span class="icon">{{ include('@EasyAdmin/inspector/icon.svg.twig') }}</span>
+        <span class="icon">{{ include(profiler_markup_version >= 3 ? '@EasyAdmin/inspector/icon-v3.svg.twig' : '@EasyAdmin/inspector/icon.svg.twig') }}</span>
         <strong>EasyAdmin</strong>
     </span>
 {% endblock %}

--- a/src/Resources/views/inspector/icon-v3.svg.twig
+++ b/src/Resources/views/inspector/icon-v3.svg.twig
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" data-icon-name="icon-tabler-table" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+    <rect x="4" y="4" width="16" height="16" rx="2" />
+    <line x1="4" y1="10" x2="20" y2="10" />
+    <line x1="10" y1="4" x2="10" y2="20" />
+</svg>


### PR DESCRIPTION
Symfony 6.2 includes a redesigned profiler, so let's update our panel to be compatible with it.

Also, I've removed the EasyAdmin icon from the toolbar because it doesn't provide any useful information and it takes space that it's better to use it for more important panels.

It looks like this:

<img width="293" alt="profiler-panel" src="https://user-images.githubusercontent.com/73419/198700232-cdec0853-2deb-41a9-8f55-f5b8a8a19acc.png">
