### PR TITLE
Add compatibility with ValueResolverInterface

### DIFF
--- a/src/ArgumentResolver/AdminContextResolver.php
+++ b/src/ArgumentResolver/AdminContextResolver.php
@@ -5,13 +5,12 @@ namespace EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
-/**
+/*
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AdminContextResolver implements ArgumentValueResolverInterface
+final class AdminContextResolver implements CompatValueResolverInterface
 {
     private AdminContextProvider $adminContextProvider;
 
@@ -27,6 +26,10 @@ final class AdminContextResolver implements ArgumentValueResolverInterface
 
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
+        if (AdminContext::class !== $argument->getType()) {
+            return [];
+        }
+
         yield $this->adminContextProvider->getContext();
     }
 }

--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -7,13 +7,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\BatchActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
-/**
+/*
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class BatchActionDtoResolver implements ArgumentValueResolverInterface
+final class BatchActionDtoResolver implements CompatValueResolverInterface
 {
     private AdminContextProvider $adminContextProvider;
     private AdminUrlGenerator $adminUrlGenerator;
@@ -31,6 +30,10 @@ final class BatchActionDtoResolver implements ArgumentValueResolverInterface
 
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
+        if (BatchActionDto::class !== $argument->getType()) {
+            return [];
+        }
+
         if (null === $context = $this->adminContextProvider->getContext()) {
             throw new \RuntimeException(sprintf('Some of your controller actions have type-hinted an argument with the "%s" class but that\'s only available for actions run to serve EasyAdmin requests. Remove the type-hint or make sure the action is part of an EasyAdmin request.', BatchActionDto::class));
         }

--- a/src/ArgumentResolver/CompatValueResolverInterface.php
+++ b/src/ArgumentResolver/CompatValueResolverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+
+// TODO: remove this file when all supported Symfony versions include ValueResolverInterface
+if (class_exists(ValueResolverInterface::class)) {
+    class_alias(ValueResolverInterface::class, CompatValueResolverInterface::class);
+} else {
+    class_alias(ArgumentValueResolverInterface::class, CompatValueResolverInterface::class);
+}


### PR DESCRIPTION
This avoids a deprecation when upgrading to Symfony 6.2. See https://github.com/symfony/symfony/pull/47363