### PR TITLE
Fix: Search

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -131,6 +131,7 @@ final class EntityRepository implements EntityRepositoryInterface
             $isTextProperty = \in_array($propertyDataType, ['string', 'text', 'citext', 'array', 'simple_array']);
             $isGuidProperty = \in_array($propertyDataType, ['guid', 'uuid']);
             $isUlidProperty = 'ulid' === $propertyDataType;
+            $isJsonProperty = 'json' === $propertyDataType;
 
             if (!$isBoolean &&
                 !$isSmallIntegerProperty &&
@@ -138,12 +139,16 @@ final class EntityRepository implements EntityRepositoryInterface
                 !$isNumericProperty &&
                 !$isTextProperty &&
                 !$isGuidProperty &&
-                !$isUlidProperty
+                !$isUlidProperty &&
+                !$isJsonProperty
             ) {
-                $idClassName = (new \ReflectionProperty($entityDto->getFqcn(), $propertyName))->getType()->getName();
+                $idClassType = (new \ReflectionProperty($entityDto->getFqcn(), $propertyName))->getType();
 
-                $isUlidProperty = (new \ReflectionClass($idClassName))->isSubclassOf(Ulid::class);
-                $isGuidProperty = (new \ReflectionClass($idClassName))->isSubclassOf(Uuid::class);
+                if (null !== $idClassType) {
+                    $idClassName = $idClassType->getName();
+                    $isUlidProperty = (new \ReflectionClass($idClassName))->isSubclassOf(Ulid::class);
+                    $isGuidProperty = (new \ReflectionClass($idClassName))->isSubclassOf(Uuid::class);
+                }
             }
 
             // this complex condition is needed to avoid issues on PostgreSQL databases


### PR DESCRIPTION
closes #5456
closes #5452

In following scenario i could reproduce the issue:

// src/Entity/User.php
```php
<?php

declare(strict_types=1);

namespace App\Entity;

use App\Domain\Identifier\UserId;
use App\Repository\UserRepository;
use Doctrine\DBAL\Types\Types;
use Doctrine\ORM\Mapping\Column;
use Doctrine\ORM\Mapping\Entity;
use Doctrine\ORM\Mapping\Id;
use Doctrine\ORM\Mapping\Table;

#[Entity(repositoryClass: UserRepository::class)]
#[Table(name: '`users`')]

class User
{
    #[Id]
    #[Column(type: 'user_id', unique: true)]
    private UserId $id;

    #[Column(type: Types::STRING)]
    private string $name;

    #[Column(type: Types::STRING, unique: true)]
    private string $email;

    /**
     * @var string[]
     */
    #[Column(type: Types::JSON)]
    private array $roles = [];

// etc...
}
```

//src/Controller/Admin/UserCrudController.php
```php
<?php

declare(strict_types=1);

namespace App\Controller\Admin;

use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;

final class UserCrudController extends AbstractCrudController
{
    public function configureCrud(Crud $crud): Crud
    {
        return $crud
            ->setDefaultSort([
                'id' => 'DESC',
            ])
            ->setEntityLabelInSingular('User')
            ->setEntityLabelInPlural('Users')
            ->setSearchFields([
                'id',
                'email',
                'name',
                'roles',
            ])
            ->setPaginatorPageSize(100)
            ->overrideTemplates([
                'crud/edit' => 'admin/pages/user/edit.html.twig',
            ]);
    }

//etc ...
}
```
If i remove `roles` (type `json`) from the `setSearchFields()` array it works without any exception. With this Json type i get an exception, which is described in the issues mentioned before.

Here is the fix that JSON is getting also checked. 
The funny part: Even though with or without this fix i am not able to search any `json` property. 

This fixes the Exception but you are still not able to search through `json`.