### PR TITLE
Remove potential locale part of route name

### DIFF
--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -77,7 +77,7 @@ final class AdminContextFactory
         foreach ($dashboardControllerRoutes as $routeName => $controller) {
             if ($controller === $dashboardController) {
                 // needed for i18n routes, whose name follows the pattern "route_name.locale"
-                $dashboardRouteName = explode('.', $routeName, 2)[0];
+                $dashboardRouteName = preg_replace('~\.\w{2}$~', '', $routeName);
 
                 break;
             }

--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -89,7 +89,7 @@ class CrudFormType extends AbstractType
 
                 // plain arrays are not enough for tabs because they are modified in the
                 // lifecycle of a form (e.g. add info about form errors). Use an ArrayObject instead.
-                $formTabs[$currentFormTab] = new ArrayObject($metadata);
+                $formTabs[$currentFormTab] = new \ArrayObject($metadata);
 
                 continue;
             }

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -239,7 +239,7 @@ final class AdminUrlGenerator
         }
 
         // needed for i18n routes, whose name follows the pattern "route_name.locale"
-        $this->dashboardRoute = explode('.', $this->dashboardRoute, 2)[0];
+        $this->dashboardRoute = preg_replace('~\.\w{2}$~', '', $this->dashboardRoute);
 
         // this removes any parameter with a NULL value
         $routeParameters = array_filter(


### PR DESCRIPTION
This addresses issue #5461. With this change, your route can have any number of `.`s — or none.

I couldn't find any existing tests for the `AdminContextFactory`, so I'm assuming that there are none. If I just couldn't find any, please point me towards the correct test and I'll add plenty of test-cases :)