### PR TITLE
[PATCH] Fix custom error pages

### DIFF
--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -78,7 +78,7 @@ final class AdminContext
         return $this->crudControllers;
     }
 
-    public function getEntity(): EntityDto
+    public function getEntity(): ?EntityDto
     {
         return $this->entityDto;
     }

--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -75,8 +75,7 @@ class AdminRouterSubscriber implements EventSubscriberInterface
 
         try {
             $adminContext = $this->getAdminContext($request);
-        }
-        catch(\Throwable $e) {
+        } catch (\Throwable $e) {
             $brokenContextFailedWithException = $e;
         }
 
@@ -97,13 +96,13 @@ class AdminRouterSubscriber implements EventSubscriberInterface
         }
     }
 
-    public function getAdminContext(Request $request, bool $ignore_exception = false): ?AdminContext {
+    public function getAdminContext(Request $request, bool $ignore_exception = false): ?AdminContext
+    {
         $adminContext = null;
 
         if (null === $dashboardControllerFqcn = $this->getDashboardControllerFqcn($request)) {
             return $adminContext;
         }
-
 
         if (null === $dashboardControllerInstance = $this->getDashboardControllerInstance($dashboardControllerFqcn, $request)) {
             return $adminContext;
@@ -116,13 +115,14 @@ class AdminRouterSubscriber implements EventSubscriberInterface
             $adminContext = $this
                 ->adminContextFactory
                 ->create(
-                    $request, 
-                    $dashboardControllerInstance, 
-                    $crudControllerInstance, 
+                    $request,
+                    $dashboardControllerInstance,
+                    $crudControllerInstance,
                     $ignore_exception
                 )
             ;
         }
+
         return $adminContext;
     }
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 
+use EasyCorp\Bundle\EasyAdminBundle\Context\ExceptionContext;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\BaseException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\FlattenException;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
@@ -42,11 +43,14 @@ final class ExceptionListener
             return;
         }
 
-        if ($this->kernelDebug || !$exception instanceof BaseException) {
+        if ($this->kernelDebug) {
             return;
         }
 
-        // TODO: check why these custom error pages don't work
+        if (!$exception instanceof BaseException) {
+            $exception = new BaseException(new ExceptionContext($exception->getMessage()));
+        }
+
         $event->setResponse($this->createExceptionResponse(FlattenException::create($exception)));
     }
 

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -240,4 +240,3 @@ final class AdminContextFactory
         return $this->entityFactory->create($crudDto->getEntityFqcn(), $request->query->get(EA::ENTITY_ID), $crudDto->getEntityPermission(), $ignore_errors);
     }
 }
-

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -144,10 +144,11 @@ final class EntityFactory
         $entityManager = $this->getEntityManager($entityFqcn);
         if (null === $entityInstance = $entityManager->getRepository($entityFqcn)->find($entityIdValue)) {
             $entityIdName = $entityManager->getClassMetadata($entityFqcn)->getIdentifierFieldNames()[0];
-            if (! $ignore_errors) {
+            if (!$ignore_errors) {
                 throw new EntityNotFoundException(['entity_name' => $entityFqcn, 'entity_id_name' => $entityIdName, 'entity_id_value' => $entityIdValue]);
             }
         }
+
         return $entityInstance;
     }
 }

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -65,9 +65,9 @@ final class EntityFactory
         return $this->actionFactory->processGlobalActions($actionConfigDto);
     }
 
-    public function create(string $entityFqcn, $entityId = null, ?string $entityPermission = null): EntityDto
+    public function create(string $entityFqcn, $entityId = null, ?string $entityPermission = null, bool $ignore_errors = false): EntityDto
     {
-        return $this->doCreate($entityFqcn, $entityId, $entityPermission);
+        return $this->doCreate($entityFqcn, $entityId, $entityPermission, null, $ignore_errors);
     }
 
     public function createForEntityInstance($entityInstance): EntityDto
@@ -104,10 +104,10 @@ final class EntityFactory
         return $entityMetadata;
     }
 
-    private function doCreate(?string $entityFqcn = null, $entityId = null, ?string $entityPermission = null, $entityInstance = null): EntityDto
+    private function doCreate(?string $entityFqcn = null, $entityId = null, ?string $entityPermission = null, $entityInstance = null, bool $ignore_errors = false): EntityDto
     {
         if (null === $entityInstance && null !== $entityFqcn) {
-            $entityInstance = null === $entityId ? null : $this->getEntityInstance($entityFqcn, $entityId);
+            $entityInstance = null === $entityId ? null : $this->getEntityInstance($entityFqcn, $entityId, $ignore_errors);
         }
 
         if (null !== $entityInstance && null === $entityFqcn) {
@@ -139,15 +139,15 @@ final class EntityFactory
         return $entityManager;
     }
 
-    private function getEntityInstance(string $entityFqcn, $entityIdValue): object
+    private function getEntityInstance(string $entityFqcn, $entityIdValue, bool $ignore_errors = false): ?object
     {
         $entityManager = $this->getEntityManager($entityFqcn);
         if (null === $entityInstance = $entityManager->getRepository($entityFqcn)->find($entityIdValue)) {
             $entityIdName = $entityManager->getClassMetadata($entityFqcn)->getIdentifierFieldNames()[0];
-
-            throw new EntityNotFoundException(['entity_name' => $entityFqcn, 'entity_id_name' => $entityIdName, 'entity_id_value' => $entityIdValue]);
+            if (! $ignore_errors) {
+                throw new EntityNotFoundException(['entity_name' => $entityFqcn, 'entity_id_name' => $entityIdName, 'entity_id_value' => $entityIdValue]);
+            }
         }
-
         return $entityInstance;
     }
 }

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -24,6 +24,6 @@ final class AdminContextProvider
     {
         $currentRequest = $this->requestStack->getCurrentRequest();
 
-        return null !== $currentRequest ? $currentRequest->get(EA::CONTEXT_REQUEST_ATTRIBUTE) : null;
+        return null !== $currentRequest ? $currentRequest->attributes->get(EA::CONTEXT_REQUEST_ATTRIBUTE) : null;
     }
 }


### PR DESCRIPTION
Hi @javiereguiluz !

When Doctrine entity not found custom error message did not show up.
After some investigation I found out that exception template without ```ea``` variable is unusable.
Exception occurred on attempt to build required admin context object in ```AdminContextFactory::getEntityDto()``` and then everything failed.

In this proposal I use the following _technique_:
1) try to create ```AdminContext``` object as usual
2) if it fails then save thrown exception
4) try again to create ```AdminContext``` object BUT catching all Doctrine exception
5) setup even incomplete ```ea``` variable in twig as expected
6) and now throw previously saved exception
7) ```ExceptionListener``` catch it  and correctly show to the user
<img width="421" alt="Screenshot 2022-11-20 at 16 10 41" src="https://user-images.githubusercontent.com/230304/202903797-67db6de7-df12-4591-9d1b-4d9c478d63da.png">

PS: Also as quick workaround someone could use twig template ```templates/bundles/TwigBundle/Exception/error.html.twig``` (see more info here https://symfony.com/doc/current/controller/error_pages.html)
