### PR TITLE
Changed method name in "Customizing the Dashboard Contents"

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -326,7 +326,7 @@ and render them in your own Twig template::
         // ...
 
         #[Route('/admin')]
-        public function index(ChartBuilderInterface $chartBuilder): Response
+        public function admin(ChartBuilderInterface $chartBuilder): Response
         {
             $chart = $chartBuilder->createChart(Chart::TYPE_LINE);
             // ...set chart data and options somehow
@@ -336,6 +336,12 @@ and render them in your own Twig template::
             ]);
         }
     }
+
+.. note::
+
+    Since ``index()`` is part of the Dashboard interface, you cannot add arguments
+    to it to inject dependencies. Instead, you can use another method name that is not defined in the
+    interface (e.g. ``admin()``).
 
 Another popular option is to make the dashboard redirect to the most common task
 for people working on the backend. This requires :ref:`generating admin URLs <generate-admin-urls>`,


### PR DESCRIPTION
As `index()` is defined in the interface you cannot inject dependencies in it as described currently (`public function index(ChartBuilderInterface $chartBuilder): Response` but by changing the method name to something that is not defined (e.g. `admin()` this example will work.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
