### PR TITLE
Fix an issue when using Symfony form data transformers

### DIFF
--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -211,7 +211,7 @@ final class EntityDto
 
     public function setInstance(?object $newEntityInstance): void
     {
-        if (null !== $this->instance && !$newEntityInstance instanceof $this->fqcn) {
+        if (null !== $this->instance && null !== $newEntityInstance && !$newEntityInstance instanceof $this->fqcn) {
             throw new \InvalidArgumentException(sprintf('The new entity instance must be of the same type as the previous instance (original instance: "%s", new instance: "%s").', $this->fqcn, \get_class($newEntityInstance)));
         }
 


### PR DESCRIPTION
My use case is this:

(1) In a CRUD controller, I override the `createNewFormBuilder()` and `createEditFormBuilder()` methods to add a data transformer:

```php
    public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface
    {
        return parent::createNewFormBuilder($entityDto, $formOptions, $context)
            ->addModelTransformer(new SomeTransformer());
    }
```

(2) In the transformer, when there's an error I do the usual expected triggering:

```php
$exception = new TransformationFailedException('...');
$exception->setInvalidMessage('...);

throw $exception;
```

(3) Then I see an error caused by EasyAdmin.

The error is that in this code block, `$newEntityInstance` is `null` and `get_class($newEntityInstance)` fails:

https://github.com/EasyCorp/EasyAdminBundle/blob/76d8585b25d400a75234d714a83962d76ab0aeb1/src/Dto/EntityDto.php#L214-L216

Why is `$newEntityInstance` value `null`?

Because when the DataTransformer fails, the form data in this point is `null`:

https://github.com/EasyCorp/EasyAdminBundle/blob/76d8585b25d400a75234d714a83962d76ab0aeb1/src/Controller/AbstractCrudController.php#L307-L308

(4) The fact that `get_class($newEntityInstance)` fails is not the important thing in my opinion.

That's why in this PR, we fixed this differently and we modify that code to not throw that exception when `$newEntityInstance` is `null`.

(5) I think this change makes sense. After this change, everything works in my app as expected.

But I wish someone with deep knowledge of Symfony forms could verify this change. Thanks!