### PR TITLE
Fix Ulid/Guid property resolution when it's an association

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -144,8 +144,13 @@ final class EntityRepository implements EntityRepositoryInterface
                 !$isUlidProperty &&
                 !$isJsonProperty
             ) {
+
+                $entityFqcn = 'entity' !== $entityName && isset($associatedEntityDto)
+                    ? $associatedEntityDto->getFqcn()
+                    : $entityDto->getFqcn()
+                ;
                 /** @var \ReflectionNamedType|\ReflectionUnionType|null $idClassType */
-                $idClassType = (new \ReflectionProperty($entityDto->getFqcn(), $propertyName))->getType();
+                $idClassType = (new \ReflectionProperty($entityFqcn, $propertyName))->getType();
 
                 if (null !== $idClassType) {
                     $idClassName = $idClassType->getName();


### PR DESCRIPTION
Whenever a custom doctrine type is used in association the fallback Ulid/Guid resolution fails because it tries to reflect the property on the main entity instead of taking into account that the property is the associated entity's property.

<img width="1044" alt="Screenshot 2022-11-25 at 13 40 03" src="https://user-images.githubusercontent.com/226394/203979436-45bf934b-4285-4448-9817-00dc997b6672.png">

<img width="694" alt="Screenshot 2022-11-25 at 13 40 57" src="https://user-images.githubusercontent.com/226394/203979457-bc71f441-e805-44b7-aedb-98d592f9338b.png">
