### PR TITLE
[FEATURE] Add body_attr twig block at body tag

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -49,7 +49,7 @@
 </head>
 
 {% block body %}
-    <body
+    <body {% block body_attr %}{% endblock %}
         id="{% block body_id %}{% endblock %}"
         class="ea {% block body_class %}{% endblock %}"
         data-ea-content-width="{{ ea.crud.contentWidth ?? ea.dashboardContentWidth ?? 'normal' }}"


### PR DESCRIPTION
It's very useful when you are using some components from the [Symfony UX initiative](https://ux.symfony.com) (i.e. [Symfony UX Swup](https://symfony.com/bundles/ux-swup/current/index.html)).

![swup_AdobeExpress-2](https://user-images.githubusercontent.com/230304/204078074-53b06075-b6a0-49ba-8fc4-85f3a31721e3.gif)

The above video demonstrating [Swup component](https://ux.symfony.com/swup/3) simple usage generated with the following easy setup:
```twig
{# /templates/base.html #}
{% extends '@EasyAdmin/layout.html.twig' %}

{% block body_attr %}
{{ stimulus_controller('symfony/ux-swup/swup', { 
    containers: ['section.main-content'] 
}) }}
{% endblock body_attr %}

{% block head_javascript %}{{ parent() }}
    {{ encore_entry_script_tags('app') }}    
{% endblock head_javascript %}

```