### PR TITLE
fix BC break in AssociationField

### DIFF
--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -15,6 +15,8 @@ final class AssociationField implements FieldInterface
 
     public const OPTION_AUTOCOMPLETE = 'autocomplete';
     public const OPTION_EMBEDDED_CRUD_FORM_CONTROLLER = 'crudControllerFqcn';
+    /** @deprecated since easycorp/easyadmin-bundle 4.4.3 use AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER */
+    public const OPTION_CRUD_CONTROLLER = self::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER;
     public const OPTION_WIDGET = 'widget';
     public const OPTION_QUERY_BUILDER_CALLABLE = 'queryBuilderCallable';
     /** @internal this option is intended for internal use only */


### PR DESCRIPTION
`AssociationField::OPTION_CRUD_CONTROLLER` was renamed `AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER` in 4.4.3

<img width="1772" alt="Screenshot 2022-11-28 at 12 35 10" src="https://user-images.githubusercontent.com/5607440/204272441-06a372ad-a42f-4d33-9236-f23b3a02224c.png">

https://github.com/EasyCorp/EasyAdminBundle/compare/v4.4.2...v4.4.3#diff-b5073fad11abf5f9aca7f553b70b951e6d023cdcb068ef72317c13da368ab5c8L17-R17

It's a public constant, and not marked as internal and the change is done in a patch update (4.4.2 to 4.4.3), not Major update. We need a BC compatibility and remove `AssociationField::OPTION_CRUD_CONTROLLER` in the next major update `5.0.0`