### PR TITLE
Make FilterInterface extend Stringable, simplify Filters phpdoc

### DIFF
--- a/src/Config/Filters.php
+++ b/src/Config/Filters.php
@@ -24,9 +24,6 @@ final class Filters
         return new self($dto);
     }
 
-    /**
-     * @param (FilterInterface & \Stringable)|string $propertyNameOrFilter
-     */
     public function add(FilterInterface|string $propertyNameOrFilter): self
     {
         $filterPropertyName = \is_string($propertyNameOrFilter) ? $propertyNameOrFilter : (string) $propertyNameOrFilter;

--- a/src/Contracts/Filter/FilterInterface.php
+++ b/src/Contracts/Filter/FilterInterface.php
@@ -11,7 +11,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-interface FilterInterface
+interface FilterInterface extends \Stringable
 {
     public function apply(QueryBuilder $queryBuilder, FilterDataDto $filterDataDto, ?FieldDto $fieldDto, EntityDto $entityDto): void;
 


### PR DESCRIPTION
v4.4.3 changes causes small problems in projects with more strict PHPStan levels, where it doesn't recognize filter classes using `FilterTrait` an instance of \`Stringable`.  

This change makes `FilterInterface` extend `Stringable`, which seems to make sense as FilterTrait contains ` __toString()` method anyway. Also simplifies phpdocs/types in Filters class