### PR TITLE
Fix Error 500 on nested association in crudController

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -265,6 +265,15 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
     {
         $field->setFormType(CrudFormType::class);
 
+        if (null === $entityDto->getInstance())
+        {
+            $associatedEntity = null;
+        } else{
+            $associatedEntity = $propertyAccessor->isReadable($entityDto->getInstance(), $propertyName)
+                ? $propertyAccessor->getValue($entityDto->getInstance(), $propertyName)
+                : null;
+        }
+
         $propertyAccessor = new PropertyAccessor();
         $associatedEntity = $propertyAccessor->isReadable($entityDto->getInstance(), $propertyName)
             ? $propertyAccessor->getValue($entityDto->getInstance(), $propertyName)


### PR DESCRIPTION
Fix the issue #5329 [BUG] Rendering filters on nested association fields fails (4.x)

When a nested association field is defined in ConfigureCrud, 
in `src/Field/Configurator/AssociationConfigurator.php`  configureCrudForm
`$entityDto->getInstance()` is NULL, isReadable expect object or array as first argument