### PR TITLE
Fix issue 5329

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -264,12 +264,18 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
     private function configureCrudForm(FieldDto $field, EntityDto $entityDto, string $propertyName, string $targetEntityFqcn, string $targetCrudControllerFqcn): void
     {
         $field->setFormType(CrudFormType::class);
+	$propertyAccessor = new PropertyAccessor();
+	
+        if (null === $entityDto->getInstance())
+        {
+            $associatedEntity = null;
+        } else {
+            $associatedEntity = $propertyAccessor->isReadable($entityDto->getInstance(), $propertyName)
+                ? $propertyAccessor->getValue($entityDto->getInstance(), $propertyName)
+                : null;
+        }
 
-        $propertyAccessor = new PropertyAccessor();
-        $associatedEntity = $propertyAccessor->isReadable($entityDto->getInstance(), $propertyName)
-            ? $propertyAccessor->getValue($entityDto->getInstance(), $propertyName)
-            : null;
-
+        
         if (null === $associatedEntity) {
             $targetCrudControllerAction = Action::NEW;
             $targetCrudControllerPageName = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_NEW_PAGE_NAME) ?? Crud::PAGE_NEW;


### PR DESCRIPTION
Fix the issue #5329 [BUG] Rendering filters on nested association fields fails (4.x)

When a nested association field is defined in ConfigureCrud,
in `src/Field/Configurator/AssociationConfigurator.php` configureCrudForm
`$entityDto->getInstance()` is NULL, isReadable expect object or array as first argument