### PR TITLE
Inject router service instead of router.default 

### DIFF
--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -183,7 +183,7 @@ return static function (ContainerConfigurator $container) {
             // initialization done after generating each URL
             ->share(false)
             ->arg(0, service(AdminContextProvider::class))
-            ->arg(1, service('router.default'))
+            ->arg(1, service('router'))
             ->arg(2, service(DashboardControllerRegistry::class))
 
         ->set('service_locator_'.AdminUrlGenerator::class, ServiceLocator::class)


### PR DESCRIPTION

fixes [https://github…com/EasyCorp/EasyAdminBundle/issues/5502](https://github.com/EasyCorp/EasyAdminBundle/issues/5502)

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

From what I understand of Symfony router services, `router` should be used as the service. `router.default` should be kept as a reference to the original Symfony Router.

Furthermore, all other EasyAdmin services have `router` injected, and not `router.default`
