### PR TITLE
remove inline styles for better compatibility with strict csp environment

### DIFF
--- a/assets/css/easyadmin-theme/datagrids.scss
+++ b/assets/css/easyadmin-theme/datagrids.scss
@@ -154,6 +154,9 @@ table.datagrid {
       padding: 2px 8px;
     }
   }
+  td.actions-as-dropdown-table-head {
+    width: 10px;
+  }
   tr:not(.selected-row):hover .dropdown-toggle {
     background: var(--dropdown-toggle-bg);
     border-color: var(--dropdown-toggle-border-color);

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -548,8 +548,7 @@
 {# EasyAdmin's TextEditor form type #}
 {% block ea_text_editor_widget %}
     {{ form_widget(form, { attr: attr|merge({
-        style: 'display: none',
-        class: 'ea-text-editor-content',
+        class: 'ea-text-editor-content d-none',
         'data-number-of-rows': form.vars.ea_crud_form.ea_field.customOptions.get('numOfRows')|default(5),
         'data-trix-editor-config': form.vars.ea_crud_form.ea_field.customOptions.get('trixEditorConfig')|default(null)|json_encode,
     }) }) }}
@@ -609,7 +608,7 @@
     <div class="form-widget-compound">
         {{ form_row(form.comparison) }}
         {{ form_row(form.value) }}
-        <div data-ea-value2-of-comparison-id="{{ form.comparison.vars.id }}" {% if form.comparison.vars.value != 'between' %}style="display: none"{% endif %}>
+        <div data-ea-value2-of-comparison-id="{{ form.comparison.vars.id }}" class="{{ form.comparison.vars.value != 'between' ? 'd-none' }}">
             {{ form_row(form.value2) }}
         </div>
     </div>
@@ -635,7 +634,7 @@
                 {% endif %}
             {% endif %}
             <div class="custom-file">
-                {{ form_widget(form.file, { attr: form.file.vars.attr|merge({ placeholder: placeholder, title: title, 'data-files-label': filesLabel, style: 'display: none' }) }) }}
+                {{ form_widget(form.file, { attr: form.file.vars.attr|merge({ placeholder: placeholder, title: title, 'data-files-label': filesLabel, class: 'd-none' }) }) }}
                 {{ form_label(form.file, placeholder, { label_attr: { class: 'custom-file-label' }}) }}
             </div>
             <div class="input-group-text">
@@ -647,7 +646,7 @@
                     {% endif %}
                 {%- endif -%}
                 {% if allow_delete %}
-                    <label class="btn ea-fileupload-delete-btn" {% if currentFiles is empty %}style="display: none"{% endif %} for="{{ form.delete.vars.id }}">
+                    <label class="btn ea-fileupload-delete-btn {{ currentFiles is empty ? 'd-none' }}" for="{{ form.delete.vars.id }}">
                         <i class="fa fa-trash-o"></i>
                     </label>
                 {% endif %}
@@ -677,7 +676,7 @@
             </div>
         {% endif %}
         {% if allow_delete %}
-            <div style="display: none">{{ form_widget(form.delete, { label: false }) }}</div>
+            <div class="d-none">{{ form_widget(form.delete, { label: false }) }}</div>
         {% endif %}
     </div>
     {{ form_errors(form.file) }}
@@ -744,7 +743,7 @@
             </div>
         {% endif %}
         {% if allow_delete %}
-            <div style="display: none">{{ form_widget(form.delete, { label: false }) }}</div>
+            <div class="d-none">{{ form_widget(form.delete, { label: false }) }}</div>
         {% endif %}
     </div>
 

--- a/src/Resources/views/crud/includes/_delete_form.html.twig
+++ b/src/Resources/views/crud/includes/_delete_form.html.twig
@@ -1,5 +1,5 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-<form method="post" id="delete-form" style="display: none">
+<form class="d-none" method="post" id="delete-form">
     <input type="hidden" name="token" value="{{ ea_csrf_token('ea-delete') }}" />
 </form>
 

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -73,7 +73,7 @@
     {% endblock global_actions %}
     {% block batch_actions %}
         {% if has_batch_actions %}
-            <div class="batch-actions" style="display: none">
+            <div class="batch-actions d-none">
                 {% for action in batch_actions %}
                     {{ include(action.templatePath, { action: action }, with_context = false) }}
                 {% endfor %}
@@ -123,7 +123,7 @@
                         </th>
                     {% endfor %}
 
-                    <th {% if ea.crud.showEntityActionsAsDropdown %}style="width: 10px"{% endif %} dir="{{ ea.i18n.textDirection }}">
+                    <th class="{{ ea.crud.showEntityActionsAsDropdown ? 'actions-as-dropdown-table-head' }}" dir="{{ ea.i18n.textDirection }}">
                         <span class="sr-only">{{ t('action.entity_actions', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}</span>
                     </th>
                 </tr>


### PR DESCRIPTION
I've removed some inline styles in favor of CSS classes. One CSS class was added.

The motivation is better compatibility with strict Content Security Policies.