### PR TITLE
Fix MoneyConfigurator in case of numDecimal != 2

### DIFF
--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -42,13 +42,13 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
         $field->setFormTypeOption('scale', $numDecimals);
 
         $isStoredAsCents = true === $field->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS);
-        $field->setFormTypeOption('divisor', 10 ** $numDecimals);
+        $field->setFormTypeOption('divisor', $isStoredAsCents ? 10 ** $numDecimals : 1);
 
         if (null === $field->getValue()) {
             return;
         }
 
-        $amount = $field->getValue() / (10 ** $numDecimals);
+        $amount = $isStoredAsCents ? $field->getValue() / (10 ** $numDecimals) : $field->getValue();
 
         $formattedValue = $this->intlFormatter->formatCurrency($amount, $currencyCode, ['fraction_digit' => $numDecimals]);
         $field->setFormattedValue($formattedValue);

--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -42,13 +42,13 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
         $field->setFormTypeOption('scale', $numDecimals);
 
         $isStoredAsCents = true === $field->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS);
-        $field->setFormTypeOption('divisor', $isStoredAsCents ? 100 : 1);
+        $field->setFormTypeOption('divisor', $isStoredAsCents ? pow(10, $numDecimals) : 1);
 
         if (null === $field->getValue()) {
             return;
         }
 
-        $amount = $isStoredAsCents ? $field->getValue() / 100 : $field->getValue();
+        $amount = $isStoredAsCents ? $field->getValue() / pow(10, $numDecimals) : $field->getValue();
 
         $formattedValue = $this->intlFormatter->formatCurrency($amount, $currencyCode, ['fraction_digit' => $numDecimals]);
         $field->setFormattedValue($formattedValue);

--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -42,13 +42,13 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
         $field->setFormTypeOption('scale', $numDecimals);
 
         $isStoredAsCents = true === $field->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS);
-        $field->setFormTypeOption('divisor', $isStoredAsCents ? pow(10, $numDecimals) : 1);
+        $field->setFormTypeOption('divisor', 10 ** $numDecimals);
 
         if (null === $field->getValue()) {
             return;
         }
 
-        $amount = $isStoredAsCents ? $field->getValue() / pow(10, $numDecimals) : $field->getValue();
+        $amount = $field->getValue() / (10 ** $numDecimals);
 
         $formattedValue = $this->intlFormatter->formatCurrency($amount, $currencyCode, ['fraction_digit' => $numDecimals]);
         $field->setFormattedValue($formattedValue);


### PR DESCRIPTION
MoneyField doesn't work when we use `setNumDecimals()` with a value not equals to 2.

It is because MoneyConfigurator uses constantly 100 to format the value in the view (L51) and to set the divisor option of MoneyField (L45).

We can instead use 10^$numDecimals:
- numDecimal = 0 => 10^0 = 1
- numDecimal = 2 => 10^2 = 100
- numDecimal = 3 => 10^3 = 1000
- ...