### PR TITLE
[Need Help] easyadmin 3.x: getImagePath() must be of the type string or null, object given

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -88,7 +88,7 @@ yield TextField::new('someField')->stripTags();
 ### Autocomplete Fields
 
 The `Select2` JavaScript library, which is based on jQuery, has been
-replaced bt `TomSelect`, a pure-JavaScript library. This change is
+replaced by `TomSelect`, a pure-JavaScript library. This change is
 transparent when using EasyAdmin features, but if you create custom
 form types and want to display autocomplete fields for your `<select>`
 lists, you must change the following:

--- a/src/Collection/ActionCollection.php
+++ b/src/Collection/ActionCollection.php
@@ -54,6 +54,7 @@ final class ActionCollection implements CollectionInterface
         return \array_key_exists($offset, $this->actions);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->actions[$offset];

--- a/src/Collection/EntityCollection.php
+++ b/src/Collection/EntityCollection.php
@@ -47,6 +47,7 @@ final class EntityCollection implements CollectionInterface
     /**
      * @return ?EntityDto
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->entities[$offset];

--- a/src/Collection/FieldCollection.php
+++ b/src/Collection/FieldCollection.php
@@ -100,6 +100,7 @@ final class FieldCollection implements CollectionInterface
     /**
      * @return ?FieldDto
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset): mixed
     {
         return $this->fields[$offset];

--- a/src/Collection/FilterCollection.php
+++ b/src/Collection/FilterCollection.php
@@ -50,6 +50,7 @@ final class FilterCollection implements CollectionInterface
     /**
      * @return ?FilterDto
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset): mixed
     {
         return $this->filters[$offset];

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -144,7 +144,7 @@ final class Actions
         return $this;
     }
 
-    public function getAsDto(string $pageName): ActionConfigDto
+    public function getAsDto(?string $pageName): ActionConfigDto
     {
         $this->dto->setPageName($pageName);
 

--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -36,7 +36,7 @@ final class ActionConfigDto
         }
     }
 
-    public function setPageName(string $pageName): void
+    public function setPageName(?string $pageName): void
     {
         $this->pageName = $pageName;
     }

--- a/src/EasyAdminBundle.php
+++ b/src/EasyAdminBundle.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class EasyAdminBundle extends Bundle
 {
-    public const VERSION = '3.5.23';
+    public const VERSION = '3.5.24-DEV';
     /** @deprecated use EA::CONTEXT_REQUEST_ATTRIBUTE */
     public const CONTEXT_ATTRIBUTE_NAME = EA::CONTEXT_REQUEST_ATTRIBUTE;
 

--- a/src/EasyAdminBundle.php
+++ b/src/EasyAdminBundle.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class EasyAdminBundle extends Bundle
 {
-    public const VERSION = '3.5.22-DEV';
+    public const VERSION = '3.5.23';
     /** @deprecated use EA::CONTEXT_REQUEST_ATTRIBUTE */
     public const CONTEXT_ATTRIBUTE_NAME = EA::CONTEXT_REQUEST_ATTRIBUTE;
 

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -128,7 +128,7 @@ final class AdminContextFactory
 
     private function getActionConfig(DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ?string $pageName): ActionConfigDto
     {
-        if (null === $crudController || null === $pageName) {
+        if (null === $crudController) {
             return new ActionConfigDto();
         }
 

--- a/tests/Controller/CategoryCrudControllerTest.php
+++ b/tests/Controller/CategoryCrudControllerTest.php
@@ -1,0 +1,482 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config\Action as AppAction;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CategoryCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\SecureDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+
+class CategoryCrudControllerTest extends WebTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    protected $client;
+
+    /**
+     * @var AdminUrlGenerator
+     */
+    protected $adminUrlGenerator;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    protected $entityManager;
+
+    /**
+     * @var EntityRepository
+     */
+    protected $categories;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createClient();
+        $this->client->followRedirects();
+
+        $container = static::getContainer();
+        $this->adminUrlGenerator = $container->get(AdminUrlGenerator::class);
+        $this->entityManager = $container->get(EntityManagerInterface::class);
+        $this->categories = $this->entityManager->getRepository(Category::class);
+    }
+
+    /**
+     * @dataProvider new
+     */
+    public function testNew(?string $invalidCsrfToken, ?string $expectedErrorMessage)
+    {
+        $this->client->request('GET', $this->generateNewCategoryFormUrl(), [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+
+        $form = [
+            'Category[name]' => 'Foo',
+            'Category[slug]' => 'foo',
+        ];
+        if (null !== $invalidCsrfToken) {
+            $form['Category[_token]'] = $invalidCsrfToken;
+        }
+
+        $this->client->submitForm('Create', $form);
+        if (null === $expectedErrorMessage) {
+            $this->assertSelectorNotExists('.global-invalid-feedback');
+            $this->assertInstanceOf(Category::class, $this->categories->findOneBy(['slug' => 'foo']));
+        } else {
+            $this->assertSelectorTextContains('.global-invalid-feedback', $expectedErrorMessage);
+            $this->assertNull($this->categories->findOneBy(['slug' => 'foo']));
+        }
+    }
+
+    public function new(): \Generator
+    {
+        yield 'Empty CSRF token' => [
+            '', // Manipulate the CSRF token to an empty value
+            'The CSRF token is invalid.',
+        ];
+        yield 'Invalid CSRF token' => [
+            '123abc', // Manipulate the CSRF token to this invalid value
+            'The CSRF token is invalid.',
+        ];
+        yield 'Success' => [
+            null, // Do not manipulate the CSRF token
+            null, // Do not expect any error
+        ];
+    }
+
+    /**
+     * @dataProvider edit
+     */
+    public function testEdit(?string $invalidCsrfToken, ?string $expectedErrorMessage)
+    {
+        $this->client->request(
+            'GET',
+            $this->generateEditCategoryFormUrl($this->categories->findOneBy([])->getId()),
+            [],
+            [],
+            ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']
+        );
+
+        $form = [
+            'Category[name]' => 'Bar',
+            'Category[slug]' => 'bar',
+        ];
+        if (null !== $invalidCsrfToken) {
+            $form['Category[_token]'] = $invalidCsrfToken;
+        }
+
+        $this->client->submitForm('Save changes', $form);
+
+        if (null === $expectedErrorMessage) {
+            $this->assertSelectorNotExists('.global-invalid-feedback');
+            $this->assertInstanceOf(Category::class, $this->categories->findOneBy(['slug' => 'bar']));
+        } else {
+            $this->assertSelectorTextContains('.global-invalid-feedback', $expectedErrorMessage);
+            $this->assertNull($this->categories->findOneBy(['slug' => 'bar']));
+        }
+    }
+
+    public function edit(): \Generator
+    {
+        yield 'Empty CSRF token' => [
+            '', // Manipulate the CSRF token to an empty value
+            'The CSRF token is invalid.',
+        ];
+        yield 'Invalid CSRF token' => [
+            '123abc', // Manipulate the CSRF token to this invalid value
+            'The CSRF token is invalid.',
+        ];
+        yield 'Success' => [
+            null, // Do not manipulate the CSRF token
+            null, // Do not expect any error
+        ];
+    }
+
+    /**
+     * @dataProvider delete
+     */
+    public function testDelete(?string $invalidCsrfToken, callable $expectedCategoriesCount)
+    {
+        $initialCategoriesCount = \count($this->categories->findAll());
+
+        // List all categories
+        $crawler = $this->client->request('GET', $this->generateCategoryIndexUrl(), [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $this->assertResultCount($initialCategoriesCount);
+
+        // Try to delete the first found category
+        $form = $crawler->filter('#delete-form')->form();
+        $form->getNode()->setAttribute(
+            'action',
+            $crawler->filter('a.action-delete')->first()->attr('formaction')
+        );
+        if (null !== $invalidCsrfToken) {
+            $form['token'] = $invalidCsrfToken;
+        }
+        $this->client->submit($form);
+
+        // List all categories again and see if the result count changed
+        $this->client->request('GET', $this->generateCategoryIndexUrl(), [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $this->assertResultCount($expectedCategoriesCount($initialCategoriesCount));
+    }
+
+    public function delete(): \Generator
+    {
+        yield 'Empty CSRF token' => [
+            '', // Manipulate the CSRF token to an empty value
+            function (int $initialCategoriesCount): int { return $initialCategoriesCount; },
+        ];
+        yield 'Invalid CSRF token' => [
+            '123abc', // Manipulate the CSRF token to this invalid value
+            function (int $initialCategoriesCount): int { return $initialCategoriesCount; },
+        ];
+        yield 'Success' => [
+            null, // Do not manipulate the CSRF token
+            function (int $initialCategoriesCount): int { return $initialCategoriesCount - 1; },
+        ];
+    }
+
+    public function testDetail()
+    {
+        /* @var Category $category */
+        $category = $this->categories->findOneBy([]);
+
+        $this->client->request('GET', $this->generateCategoryDetailUrl($category->getId()), [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+
+        $this->assertSelectorTextContains('.form-panel-body', $category->getId());
+        $this->assertSelectorTextContains('.form-panel-body', $category->getName());
+        $this->assertSelectorTextContains('.form-panel-body', $category->getSlug());
+        $this->assertSelectorTextContains('.form-panel-body', true === $category->isActive() ? 'Yes' : 'No');
+    }
+
+    /**
+     * @dataProvider toggle
+     */
+    public function testToggle(string $method, ?string $invalidCsrfToken, int $expectedStatusCode, bool $toggleIsExpectedToSucceed)
+    {
+        $this->markTestSkipped('Not yet implemented');
+
+        if (Response::HTTP_METHOD_NOT_ALLOWED === $expectedStatusCode) {
+            // needed to not display 'Uncaught PHP exception' messages in PHPUnit output
+            // see https://stackoverflow.com/questions/50456114/phpunit-dont-report-symfony-exceptions-rendered-to-http-errors/50465691
+            $this->expectException(MethodNotAllowedHttpException::class);
+            $this->client->catchExceptions(false);
+        }
+
+        // Find the first toggle URL in the category list
+        $crawler = $this->client->request('GET', $this->generateCategoryIndexUrl(), [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $firstFoundToggleUrl = $crawler->filter('td.field-boolean .form-switch input[type="checkbox"]')->first()->attr('data-toggle-url');
+
+        // Get the category's active state from the DB
+        parse_str(parse_url($firstFoundToggleUrl, \PHP_URL_QUERY), $parameters);
+        $categoryId = $parameters['entityId'];
+        $active = $this->categories->find($categoryId)->isActive();
+        $this->assertIsBool($active);
+
+        // Adapt the toggle URL, so it will change the category's active property to the opposite of what it is currently
+        $firstFoundToggleUrl .= sprintf('&newValue=%s', false === $active ? 'true' : 'false');
+
+        // Change the CSRF token
+        if (null !== $invalidCsrfToken) {
+            $firstFoundToggleUrl = preg_replace('/csrfToken=.+?&/', sprintf('csrfToken=%s&', $invalidCsrfToken), $firstFoundToggleUrl);
+        }
+
+        // Do the AJAX request
+        $this->client->request($method, $firstFoundToggleUrl, [], [], [
+            'HTTP_x-requested-with' => 'XMLHttpRequest',
+            'PHP_AUTH_USER' => 'admin',
+            'PHP_AUTH_PW' => '1234',
+        ]);
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+        /* @var Category $category */
+        $this->entityManager->refresh($category = $this->categories->find($categoryId)); // After the request refresh the category
+        $this->assertIsBool($category->isActive());
+        if (true === $toggleIsExpectedToSucceed) {
+            $this->assertNotSame($active, $category->isActive());
+        } else {
+            $this->assertSame($active, $category->isActive());
+        }
+    }
+
+    public function toggle(): \Generator
+    {
+        yield 'Bad HTTP Method' => [
+            'GET', // HTTP method
+            null, // Do not manipulate the CSRF token
+            Response::HTTP_METHOD_NOT_ALLOWED, // Response status code, fails because of wrong method "GET"
+            false, // Should the toggle successfully change the toggled property?
+        ];
+        yield 'Invalid CSRF token' => [
+            'PATCH',
+            '123abc', // Manipulate the CSRF token to this invalid value
+            Response::HTTP_UNAUTHORIZED, // Response status code, fails because of wrong CSRF token
+            false,
+        ];
+        yield 'Success' => [
+            'PATCH',
+            null, // Do not manipulate the CSRF token
+            Response::HTTP_OK,
+            true,
+        ];
+    }
+
+    /**
+     * @dataProvider search
+     */
+    public function testSearch(array $categories, string $query, int $expectedResultCount)
+    {
+        foreach ($categories as $category) {
+            $this->entityManager->persist($category);
+        }
+        $this->entityManager->flush();
+
+        $this->client->request('GET', $this->generateCategoryIndexUrl($query), [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $this->assertResultCount($expectedResultCount);
+    }
+
+    public function search(): \Generator
+    {
+        yield [
+            [],
+            'foobazfoobar',
+            0,
+        ];
+        yield [
+            [
+                (new Category())->setName('Foobaz')->setSlug('foobaz'),
+            ],
+            'foobaz',
+            1,
+        ];
+        yield [
+            [
+                (new Category())->setName('Bazbar')->setSlug('bazbar'),
+                (new Category())->setName('Bazbar 2')->setSlug('bazbar-2'),
+            ],
+            'bazbar',
+            2,
+        ];
+    }
+
+    /**
+     * @dataProvider filter
+     */
+    public function testFilter(array $categories, array $filters, int $expectedResultCount)
+    {
+        foreach ($categories as $category) {
+            $this->entityManager->persist($category);
+        }
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', $this->generateCategoryFilterFormUrl(), [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $form = $crawler->filter('form[name="filters"]')->form();
+        $form['filters'] = $filters;
+        $this->client->submit($form, [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $this->assertResultCount($expectedResultCount);
+    }
+
+    public function filter(): \Generator
+    {
+        yield [
+            [],
+            [
+                'name' => [
+                    'comparison' => 'like',
+                    'value' => 'foobazfoobar',
+                ],
+            ],
+            0,
+        ];
+        yield [
+            [
+                (new Category())->setName('Buzzbar')->setSlug('buzzbar'),
+            ],
+            [
+                'name' => [
+                    'comparison' => 'like',
+                    'value' => 'buzzb',
+                ],
+            ],
+            1,
+        ];
+        yield [
+            [
+                (new Category())->setName('Buzzfoo')->setSlug('buzzfoo')->setActive(true),
+                (new Category())->setName('Buzzfoo 2')->setSlug('buzzfoo-2')->setActive(true),
+                (new Category())->setName('Buzzfoo 3')->setSlug('buzzfoo-3')->setActive(false),
+            ],
+            [
+                'name' => [
+                    'comparison' => 'like',
+                    'value' => 'zzfoo',
+                ],
+                'active' => '1',
+            ],
+            2,
+        ];
+    }
+
+    /**
+     * @dataProvider customPage
+     */
+    public function testCustomPage(string $username, int $expectedStatusCode)
+    {
+        if (Response::HTTP_FORBIDDEN === $expectedStatusCode) {
+            // needed to not display 'Uncaught PHP exception' messages in PHPUnit output
+            // see https://stackoverflow.com/questions/50456114/phpunit-dont-report-symfony-exceptions-rendered-to-http-errors/50465691
+            $this->expectException(ForbiddenActionException::class);
+            $this->client->catchExceptions(false);
+        }
+
+        $this->client->request('GET', $this->generateCustomActionUrl(), [], [], ['PHP_AUTH_USER' => $username, 'PHP_AUTH_PW' => '1234']);
+
+        $this->assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    public function customPage(): \Generator
+    {
+        yield [$this->generateUsername('ROLE_USER'), Response::HTTP_FORBIDDEN];
+        yield [$this->generateUsername('ROLE_ADMIN'), Response::HTTP_OK];
+    }
+
+    private function assertResultCount(int $expectedResultCount): void
+    {
+        if (0 > $expectedResultCount) {
+            throw new \InvalidArgumentException();
+        }
+
+        if (0 === $expectedResultCount) {
+            $this->assertSelectorTextSame('.no-results', 'No results found.');
+        } else {
+            $this->assertSelectorTextSame('.list-pagination-counter strong', (string) $expectedResultCount);
+        }
+    }
+
+    private function generateCategoryIndexUrl(string $query = null): string
+    {
+        $adminUrlGenerator = $this->adminUrlGenerator
+            ->setDashboard(SecureDashboardController::class)
+            ->setController(CategoryCrudController::class)
+            ->setAction(Action::INDEX);
+
+        if (null !== $query) {
+            $adminUrlGenerator->set('query', $query);
+        }
+
+        return $adminUrlGenerator->generateUrl();
+    }
+
+    private function generateNewCategoryFormUrl(): string
+    {
+        return $this->adminUrlGenerator
+            ->setDashboard(SecureDashboardController::class)
+            ->setController(CategoryCrudController::class)
+            ->setAction(Action::NEW)
+            ->generateUrl();
+    }
+
+    /**
+     * @param string|int $id
+     */
+    private function generateEditCategoryFormUrl($id): string
+    {
+        return $this->adminUrlGenerator
+            ->setDashboard(SecureDashboardController::class)
+            ->setController(CategoryCrudController::class)
+            ->setAction(Action::EDIT)
+            ->setEntityId($id)
+            ->generateUrl();
+    }
+
+    /**
+     * @param string|int $id
+     */
+    private function generateCategoryDetailUrl($id): string
+    {
+        return $this->adminUrlGenerator
+            ->setDashboard(SecureDashboardController::class)
+            ->setController(CategoryCrudController::class)
+            ->setAction(Action::DETAIL)
+            ->setEntityId($id)
+            ->generateUrl();
+    }
+
+    private function generateCategoryFilterFormUrl(): string
+    {
+        // Use the index URL as referrer but remove scheme, host and port
+        $referrer = preg_replace('/^.*(\/.*)$/', '$1', $this->generateCategoryIndexUrl());
+
+        return $this->adminUrlGenerator
+            ->setDashboard(SecureDashboardController::class)
+            ->setController(CategoryCrudController::class)
+            ->setAction('renderFilters')
+            ->set('referrer', $referrer)
+            ->generateUrl();
+    }
+
+    private function generateCustomActionUrl(): string
+    {
+        return $this->adminUrlGenerator
+            ->setDashboard(SecureDashboardController::class)
+            ->setController(CategoryCrudController::class)
+            ->setAction(AppAction::CUSTOM_ACTION)
+            ->generateUrl();
+    }
+
+    private function generateUsername(string $role): string
+    {
+        switch ($role) {
+            case 'ROLE_USER':
+                return 'user';
+            case 'ROLE_ADMIN':
+                return 'admin';
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unknown role, use one of: %s', implode(', ', ['ROLE_USER', 'ROLE_ADMIN'])));
+    }
+}

--- a/tests/Controller/DashboardControllerTest.php
+++ b/tests/Controller/DashboardControllerTest.php
@@ -3,25 +3,26 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\HttpFoundation\Response;
 
 class DashboardControllerTest extends WebTestCase
 {
-    public function testDashboardAsAnonymousUser()
+    public function testWelcomePage()
     {
         $client = static::createClient();
         $client->followRedirects();
         $client->request('GET', '/admin');
 
-        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Welcome to EasyAdmin 3');
     }
 
     public function testDashboardAsLoggedUser()
     {
         $client = static::createClient();
         $client->followRedirects();
-        $client->request('GET', '/admin', [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $client->request('GET', '/secure_admin', [], [], ['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
 
         $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Welcome to EasyAdmin 3');
     }
 }

--- a/tests/TestApplication/config/packages/security.php
+++ b/tests/TestApplication/config/packages/security.php
@@ -9,6 +9,10 @@ $configuration = [
         'test_users' => [
             'memory' => [
                 'users' => [
+                    'user' => [
+                        'password' => '1234',
+                        'roles' => ['ROLE_USER'],
+                    ],
                     'admin' => [
                         'password' => '1234',
                         'roles' => ['ROLE_ADMIN'],
@@ -19,16 +23,20 @@ $configuration = [
     ],
 
     'firewalls' => [
-        'main' => [
-            'pattern' => '^/',
+        'secure_admin' => [
+            'pattern' => '^/secure_admin',
             'provider' => 'test_users',
             'http_basic' => null,
             'logout' => null,
         ],
     ],
 
+    'role_hierarchy' => [
+        'ROLE_ADMIN' => ['ROLE_USER'],
+    ],
+
     'access_control' => [
-        ['path' => '^/', 'roles' => ['ROLE_ADMIN']],
+        ['path' => '^/secure_admin', 'roles' => ['ROLE_USER']],
     ],
 ];
 

--- a/tests/TestApplication/src/Config/Action.php
+++ b/tests/TestApplication/src/Config/Action.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config;
+
+class Action
+{
+    public const CUSTOM_ACTION = 'customAction';
+}

--- a/tests/TestApplication/src/Controller/CategoryCrudController.php
+++ b/tests/TestApplication/src/Controller/CategoryCrudController.php
@@ -2,10 +2,20 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config\Action as AppAction;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use Symfony\Component\HttpFoundation\Response;
 
 class CategoryCrudController extends AbstractCrudController
 {
@@ -17,9 +27,36 @@ class CategoryCrudController extends AbstractCrudController
     public function configureFields(string $pageName): iterable
     {
         return [
-            IdField::new('id'),
+            IdField::new('id')->hideOnForm(),
             TextField::new('name'),
             TextField::new('slug'),
+            BooleanField::new('active'),
         ];
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $customPageAction = Action::new(AppAction::CUSTOM_ACTION)
+            ->createAsGlobalAction()
+            ->linkToCrudAction('customPage');
+
+        return $actions->add(Crud::PAGE_INDEX, $customPageAction)
+            ->setPermission(AppAction::CUSTOM_ACTION, 'ROLE_ADMIN');
+    }
+
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add('name')
+            ->add('active');
+    }
+
+    public function customAction(AdminContext $context): Response
+    {
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => AppAction::CUSTOM_ACTION, 'entity' => $context->getEntity()])) {
+            throw new ForbiddenActionException($context);
+        }
+
+        return new Response();
     }
 }

--- a/tests/TestApplication/src/Controller/SecureDashboardController.php
+++ b/tests/TestApplication/src/Controller/SecureDashboardController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class SecureDashboardController extends AbstractDashboardController
+{
+    /**
+     * @Route("/secure_admin", name="secure_admin")
+     */
+    public function index(): Response
+    {
+        return parent::index();
+    }
+
+    public function configureDashboard(): Dashboard
+    {
+        return Dashboard::new()
+            ->setTitle('EasyAdmin Tests');
+    }
+
+    public function configureMenuItems(): iterable
+    {
+        yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
+        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+    }
+}

--- a/tests/TestApplication/src/Entity/Category.php
+++ b/tests/TestApplication/src/Entity/Category.php
@@ -12,6 +12,8 @@ use Doctrine\ORM\Mapping as ORM;
 class Category
 {
     /**
+     * @var ?int
+     *
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -32,6 +34,13 @@ class Category
      * @ORM\ManyToMany(targetEntity=BlogPost::class, mappedBy="categories")
      */
     private $blogPosts;
+
+    /**
+     * @var bool
+     *
+     * @ORM\Column(type="boolean")
+     */
+    private $active = false;
 
     public function __construct()
     {
@@ -90,6 +99,18 @@ class Category
         if ($this->blogPosts->removeElement($blogPost)) {
             $blogPost->removeCategory($this);
         }
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): self
+    {
+        $this->active = $active;
 
         return $this;
     }


### PR DESCRIPTION
Argument 1 passed to EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ImageConfigurator::getImagePath() must be of the type string or null, object given, called in /var/www/App/vendor/easycorp/easyadmin-bundle/src/Field/Configurator/ImageConfigurator.php on line 36

consider i have an entity with a relationship OneToMany with Images entity what i want to have  is showing multiple Images with ImageField but i get this error every time  
$imageField = ImageField::new('images')
                        ->onlyOnForms()
                        ->setUploadDir('public/uploads/images')
                        ->setBasePath('public/uploads/images')
                        ->setFormTypeOption('multiple', true);

ImageConfigurator.php
...
34         $formattedValue = \is_array($field->getValue())
35         ? $this->getImagesPaths($field->getValue(), $configuredBasePath)
36         : $this->getImagePath($field->getValue(), $configuredBasePath);
...

