### PR TITLE
[BUGFIX] Ensure proper context for embedded CRUD controllers

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -13,6 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\AdminContextFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
@@ -33,13 +34,15 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
     private AdminUrlGenerator $adminUrlGenerator;
     private RequestStack $requestStack;
     private ControllerFactory $controllerFactory;
+    private AdminContextFactory $adminContextFactory;
 
-    public function __construct(EntityFactory $entityFactory, AdminUrlGenerator $adminUrlGenerator, RequestStack $requestStack, ControllerFactory $controllerFactory)
+    public function __construct(EntityFactory $entityFactory, AdminUrlGenerator $adminUrlGenerator, RequestStack $requestStack, ControllerFactory $controllerFactory, AdminContextFactory $adminContextFactory)
     {
         $this->entityFactory = $entityFactory;
         $this->adminUrlGenerator = $adminUrlGenerator;
         $this->requestStack = $requestStack;
         $this->controllerFactory = $controllerFactory;
+        $this->adminContextFactory = $adminContextFactory;
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
@@ -81,7 +84,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 );
             }
 
-            $this->configureCrudForm($field, $entityDto, $propertyName, $targetEntityFqcn, $targetCrudControllerFqcn);
+            $this->configureCrudForm($field, $entityDto, $propertyName, $targetEntityFqcn, $targetCrudControllerFqcn, $context);
 
             return;
         }
@@ -261,7 +264,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         return 0;
     }
 
-    private function configureCrudForm(FieldDto $field, EntityDto $entityDto, string $propertyName, string $targetEntityFqcn, string $targetCrudControllerFqcn): void
+    private function configureCrudForm(FieldDto $field, EntityDto $entityDto, string $propertyName, string $targetEntityFqcn, string $targetCrudControllerFqcn, AdminContext $context): void
     {
         $field->setFormType(CrudFormType::class);
         $propertyAccessor = new PropertyAccessor();
@@ -277,30 +280,48 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         if (null === $associatedEntity) {
             $targetCrudControllerAction = Action::NEW;
             $targetCrudControllerPageName = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_NEW_PAGE_NAME) ?? Crud::PAGE_NEW;
+            $entityPK = null;
         } else {
             $targetCrudControllerAction = Action::EDIT;
             $targetCrudControllerPageName = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_EDIT_PAGE_NAME) ?? Crud::PAGE_EDIT;
+            $entityMeta = $this->entityFactory->getEntityMetadata($targetEntityFqcn);
+            $entityPK = $entityMeta->getIdentifierValues($associatedEntity)[$entityMeta->getIdentifierFieldNames()[0]];
         }
 
         $field->setFormTypeOption(
             'entityDto',
-            $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, $targetCrudControllerAction, $targetCrudControllerPageName),
+            $this->createEntityDto($targetEntityFqcn, $entityPK, $targetCrudControllerFqcn, $targetCrudControllerAction, $targetCrudControllerPageName, $context),
         );
     }
 
-    private function createEntityDto(string $entityFqcn, string $crudControllerFqcn, string $crudControllerAction, string $crudControllerPageName): EntityDto
+    private function createEntityDto(string $entityFqcn, ?string $entityPK, string $crudControllerFqcn, string $crudControllerAction, string $crudControllerPageName, AdminContext $context): EntityDto
     {
         $entityDto = $this->entityFactory->create($entityFqcn);
+
+        $currReq = $this->requestStack->getCurrentRequest();
+        $subReqQuery = [EA::CRUD_ACTION => $crudControllerPageName, EA::CRUD_CONTROLLER_FQCN => $crudControllerFqcn];
+        if (null !== $entityPK) {
+            $subReqQuery[EA::ENTITY_ID] = $entityPK;
+        }
+        $subReq = $currReq->duplicate($subReqQuery);
+        $subReq->attributes->remove(EA::CONTEXT_REQUEST_ATTRIBUTE);
 
         $crudController = $this->controllerFactory->getCrudControllerInstance(
             $crudControllerFqcn,
             $crudControllerAction,
-            $this->requestStack->getMainRequest()
+            $subReq
         );
+        $dashboardController = $this->controllerFactory->getDashboardControllerInstance($context->getDashboardControllerFqcn(), $subReq);
+        $embeddedCtx = $this->adminContextFactory->create($subReq, $dashboardController, $crudController);
+        $subReq->attributes->set(EA::CONTEXT_REQUEST_ATTRIBUTE, $embeddedCtx);
 
-        $fields = $crudController->configureFields($crudControllerPageName);
-
-        $this->entityFactory->processFields($entityDto, FieldCollection::new($fields));
+        $this->requestStack->push($subReq);
+        try {
+            $fields = $crudController->configureFields($crudControllerPageName);
+            $this->entityFactory->processFields($entityDto, FieldCollection::new($fields));
+        } finally {
+            $this->requestStack->pop();
+        }
 
         return $entityDto;
     }

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -6,10 +6,12 @@ use Doctrine\ORM\PersistentCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\AdminContextFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
@@ -31,12 +33,14 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
     private RequestStack $requestStack;
     private EntityFactory $entityFactory;
     private ControllerFactory $controllerFactory;
+    private AdminContextFactory $adminContextFactory;
 
-    public function __construct(RequestStack $requestStack, EntityFactory $entityFactory, ControllerFactory $controllerFactory)
+    public function __construct(RequestStack $requestStack, EntityFactory $entityFactory, ControllerFactory $controllerFactory, AdminContextFactory $adminContextFactory)
     {
         $this->requestStack = $requestStack;
         $this->entityFactory = $entityFactory;
         $this->controllerFactory = $controllerFactory;
+        $this->adminContextFactory = $adminContextFactory;
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
@@ -100,11 +104,10 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             }
 
             $crudEditPageName = $field->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_EDIT_PAGE_NAME) ?? Crud::PAGE_EDIT;
-            $editEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::EDIT, $crudEditPageName);
+            $editEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::EDIT, $crudEditPageName, $context);
             $field->setFormTypeOption('entry_options.entityDto', $editEntityDto);
-
             $crudNewPageName = $field->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_NEW_PAGE_NAME) ?? Crud::PAGE_NEW;
-            $newEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::NEW, $crudNewPageName);
+            $newEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::NEW, $crudNewPageName, $context);
 
             try {
                 $field->setFormTypeOption('prototype_options.entityDto', $newEntityDto);
@@ -152,19 +155,32 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
         return 0;
     }
 
-    private function createEntityDto(string $targetEntityFqcn, string $targetCrudControllerFqcn, string $crudAction, string $pageName): EntityDto
+    private function createEntityDto(string $targetEntityFqcn, string $targetCrudControllerFqcn, string $crudAction, string $pageName, AdminContext $context): EntityDto
     {
         $entityDto = $this->entityFactory->create($targetEntityFqcn);
+
+        $currReq = $this->requestStack->getCurrentRequest();
+        $subReqQuery = [EA::CRUD_ACTION => $pageName, EA::CRUD_CONTROLLER_FQCN => $targetCrudControllerFqcn, EA::ENTITY_ID => null];
+        $subReq = $currReq->duplicate($subReqQuery);
+        $subReq->attributes->remove(EA::CONTEXT_REQUEST_ATTRIBUTE);
 
         $crudController = $this->controllerFactory->getCrudControllerInstance(
             $targetCrudControllerFqcn,
             $crudAction,
-            $this->requestStack->getMainRequest()
+            $subReq
         );
 
-        $fields = $crudController->configureFields($pageName);
+        $dashboardController = $this->controllerFactory->getDashboardControllerInstance($context->getDashboardControllerFqcn(), $subReq);
+        $embeddedCtx = $this->adminContextFactory->create($subReq, $dashboardController, $crudController);
+        $subReq->attributes->set(EA::CONTEXT_REQUEST_ATTRIBUTE, $embeddedCtx);
 
-        $this->entityFactory->processFields($entityDto, FieldCollection::new($fields));
+        $this->requestStack->push($subReq);
+        try {
+            $fields = $crudController->configureFields($pageName);
+            $this->entityFactory->processFields($entityDto, FieldCollection::new($fields));
+        } finally {
+            $this->requestStack->pop();
+        }
 
         return $entityDto;
     }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -291,6 +291,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(1, new Reference(AdminUrlGenerator::class))
             ->arg(2, service('request_stack'))
             ->arg(3, service(ControllerFactory::class))
+            ->arg(4, service(AdminContextFactory::class))
 
         ->set(AvatarConfigurator::class)
 
@@ -350,6 +351,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, service('request_stack'))
             ->arg(1, service(EntityFactory::class))
             ->arg(2, service(ControllerFactory::class))
+            ->arg(3, service(AdminContextFactory::class))
 
         ->set(SlugConfigurator::class)
 


### PR DESCRIPTION
Functionality introduced in https://github.com/EasyCorp/EasyAdminBundle/pull/5353 rendered sub-CRUD controller with context of the primary CRUD controller. With invalid context some functions, like default fields generation, aren't working properly. 

This attempts to fix https://github.com/EasyCorp/EasyAdminBundle/issues/5512