### PR TITLE
Fix CRUD config phpdoc

### DIFF
--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -43,7 +43,9 @@ class Crud
     }
 
     /**
-     * @param $label The callable signature is: fn ($entityInstance, $pageName): string
+     * @param TranslatableInterface|string|callable $label The callable signature is: fn ($entityInstance, $pageName): string
+     *
+     * @psalm-param mixed $label
      */
     public function setEntityLabelInSingular(/* @var TranslatableInterface|string|callable */ $label): self
     {
@@ -65,7 +67,9 @@ class Crud
     }
 
     /**
-     * @param $label The callable signature is: fn ($entityInstance, $pageName): string
+     * @param TranslatableInterface|string|callable $label The callable signature is: fn ($entityInstance, $pageName): string
+     *
+     * @psalm-param mixed $label
      */
     public function setEntityLabelInPlural(/* @var TranslatableInterface|string|callable */ $label): self
     {
@@ -87,7 +91,9 @@ class Crud
     }
 
     /**
-     * @param $title The callable signature is: fn ($entityInstance): string
+     * @param TranslatableInterface|string|callable $title The callable signature is: fn ($entityInstance): string
+     *
+     * @psalm-param mixed $title
      */
     public function setPageTitle(string $pageName, /* @var TranslatableInterface|string|callable */ $title): self
     {


### PR DESCRIPTION
PHPdoc blocks containing callable signature on `Crud` confid class were missing type declarations. This causes them to be parsed (at least by PHPStorm) to be referencing `The` class, which doesn't exists.

This little patch fixes this problem.