### PR TITLE
Fix the required attribute for associations

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AvatarField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
@@ -23,10 +24,12 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 final class CommonPreConfigurator implements FieldConfiguratorInterface
 {
     private PropertyAccessorInterface $propertyAccessor;
+    private EntityFactory $entityFactory;
 
-    public function __construct(PropertyAccessorInterface $propertyAccessor)
+    public function __construct(PropertyAccessorInterface $propertyAccessor, EntityFactory $entityFactory)
     {
         $this->propertyAccessor = $propertyAccessor;
+        $this->entityFactory = $entityFactory;
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
@@ -192,8 +195,12 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
 
         // If at least one join column of an association field isn't nullable then the field is "required" by default, otherwise the field is optional
         if ($entityDto->isAssociation($field->getProperty())) {
+            $associatedEntityMetadata = $this->entityFactory->getEntityMetadata($doctrinePropertyMetadata->get('targetEntity'));
             foreach ($doctrinePropertyMetadata->get('joinColumns', []) as $joinColumn) {
-                if (\array_key_exists('nullable', $joinColumn) && false === $joinColumn['nullable']) {
+                $propertyNameInAssociatedEntity = $joinColumn['referencedColumnName'];
+                $associatedPropertyMetadata = $associatedEntityMetadata->fieldMappings[$propertyNameInAssociatedEntity] ?? [];
+                $isNullable = $associatedPropertyMetadata['nullable'] ?? true;
+                if (false === $isNullable) {
                     return true;
                 }
             }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -304,6 +304,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set(CommonPreConfigurator::class)
             ->arg(0, new Reference('property_accessor'))
+            ->arg(1, service(EntityFactory::class))
             ->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR, ['priority' => 9999])
 
         ->set(CountryConfigurator::class)

--- a/tests/Field/Configurator/CommonPreConfiguratorTest.php
+++ b/tests/Field/Configurator/CommonPreConfiguratorTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Configurator;
 
+use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CommonPreConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Field\AbstractFieldTest;
@@ -16,7 +17,8 @@ class CommonPreConfiguratorTest extends AbstractFieldTest
         /** @var PropertyAccessorInterface $propertyAccessor */
         $container = self::$kernel->getContainer()->get('test.service_container');
         $propertyAccessor = $container->get(PropertyAccessorInterface::class);
-        $this->configurator = new CommonPreConfigurator($propertyAccessor);
+        $entityFactory = $container->get(EntityFactory::class);
+        $this->configurator = new CommonPreConfigurator($propertyAccessor, $entityFactory);
     }
 
     public function testShouldKeepExistingValue()


### PR DESCRIPTION
When you have an associated property (e.g. `author` property in `post` entity CRUD controller) the `required` attribute is not determined properly. We need to get the Doctrine metadata of the related property and then check if it's nullable or not.