### PR TITLE
Allow to use stream as upload dir for FileUploadType

### DIFF
--- a/src/Field/Configurator/ImageConfigurator.php
+++ b/src/Field/Configurator/ImageConfigurator.php
@@ -52,7 +52,11 @@ final class ImageConfigurator implements FieldConfiguratorInterface
             throw new \InvalidArgumentException(sprintf('The "%s" image field must define the directory where the images are uploaded using the setUploadDir() method.', $field->getProperty()));
         }
         $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
-        $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
+        if (filter_var($relativeUploadDir, \FILTER_VALIDATE_URL)) {
+            $absoluteUploadDir = $relativeUploadDir;
+        } else {
+            $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
+        }
         $field->setFormTypeOption('upload_dir', $absoluteUploadDir);
     }
 

--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -139,7 +139,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
                 $value .= \DIRECTORY_SEPARATOR;
             }
 
-            if (!str_starts_with($value, $this->projectDir)) {
+            if (!filter_var($value, \FILTER_VALIDATE_URL) && !str_starts_with($value, $this->projectDir)) {
                 $value = $this->projectDir.'/'.$value;
             }
 


### PR DESCRIPTION
As mention in #5136 and #5464, EasyAdmin is tight linked to local filesystem. This is an issue when one wants to use a s3 bucket to store images uploaded through `FileUploadType`.
Instead of override `upload_new` and `upload_delete` closure to move the file to the bucket (tip from SymfonyCast), you can use the stream wrapper of s3 client :
- call `registerStreamWrapper` after instantiate S3 client
- set `ImageField` `uploadDir to `s3://bucket-name/`
- no need to set `upload_new` nor `upload_delete` type options

But doing this isn't enough because EasyAdmin check uploadDir existence prepended with project directory (in order to have an absolute directory name).

I propose with this PR to not prepend project directory when the uploadDir is an url.
