### PR TITLE
Highlight menu items automatically based on the Request data

### DIFF
--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -154,10 +154,8 @@ final class AdminContext
 
         $configuredMenuItems = $this->dashboardControllerInstance->configureMenuItems();
         $mainMenuItems = \is_array($configuredMenuItems) ? $configuredMenuItems : iterator_to_array($configuredMenuItems, false);
-        $selectedMenuIndex = $this->request->query->getInt(EA::MENU_INDEX, -1);
-        $selectedMenuSubIndex = $this->request->query->getInt(EA::SUBMENU_INDEX, -1);
 
-        return $this->mainMenuDto = $this->menuFactory->createMainMenu($mainMenuItems, $selectedMenuIndex, $selectedMenuSubIndex);
+        return $this->mainMenuDto = $this->menuFactory->createMainMenu($mainMenuItems);
     }
 
     public function getUserMenu(): UserMenuDto

--- a/src/Dto/MainMenuDto.php
+++ b/src/Dto/MainMenuDto.php
@@ -8,17 +8,13 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 final class MainMenuDto
 {
     private array $items;
-    private int $selectedIndex;
-    private int $selectedSubIndex;
 
     /**
      * @param MenuItemDto[] $items
      */
-    public function __construct(array $items, int $selectedIndex, int $selectedSubIndex)
+    public function __construct(array $items)
     {
         $this->items = $items;
-        $this->selectedIndex = $selectedIndex;
-        $this->selectedSubIndex = $selectedSubIndex;
     }
 
     /**
@@ -29,13 +25,19 @@ final class MainMenuDto
         return $this->items;
     }
 
+    /** @deprecated Don't use this method; the selected menu item is now detected automatically using
+     *              the Request data instead of having to deal with menuIndex/submenuIndex query params
+     */
     public function isSelected(MenuItemDto $menuItemDto): bool
     {
-        return $menuItemDto->getIndex() === $this->selectedIndex && $menuItemDto->getSubIndex() === $this->selectedSubIndex;
+        return $menuItemDto->isSelected();
     }
 
+    /** @deprecated Don't use this method; the expanded menu item is now detected automatically using
+     *              the Request data instead of having to deal with menuIndex/submenuIndex query params
+     */
     public function isExpanded(MenuItemDto $menuItemDto): bool
     {
-        return $menuItemDto->getIndex() === $this->selectedIndex && -1 !== $this->selectedSubIndex;
+        return $menuItemDto->isExpanded();
     }
 }

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -19,8 +19,8 @@ final class MenuItemDto
     public const TYPE_ROUTE = 'route';
 
     private ?string $type = null;
-    private ?int $index = null;
-    private ?int $subIndex = null;
+    private bool $selected = false;
+    private bool $expanded = false;
     private TranslatableInterface|string|null $label = null;
     private ?string $icon = null;
     private string $cssClass = '';
@@ -45,24 +45,62 @@ final class MenuItemDto
         $this->type = $type;
     }
 
+    /** @deprecated This was used in the past to get the selected menu item
+     *              Now the active menu item is detected automatically via the Request data
+     */
     public function getIndex(): int
     {
-        return $this->index;
+        return -1;
     }
 
+    /** @deprecated This was used in the past to set the selected menu item
+     *              Now the active menu item is detected automatically via the Request data
+     */
     public function setIndex(int $index): void
     {
-        $this->index = $index;
+        // do nothing...
     }
 
+    /** @deprecated This was used in the past to get the selected menu subitem
+     *              Now the active menu item is detected automatically via the Request data
+     */
     public function getSubIndex(): int
     {
-        return $this->subIndex;
+        return -1;
     }
 
+    /** @deprecated This was used in the past to set the selected menu subitem
+     *              Now the active menu item is detected automatically via the Request data
+     */
     public function setSubIndex(int $subIndex): void
     {
-        $this->subIndex = $subIndex;
+        // do nothing
+    }
+
+    /**
+     * @return bool Returns true when this menu item is the selected one
+     */
+    public function isSelected(): bool
+    {
+        return $this->selected;
+    }
+
+    public function setSelected(bool $isSelected): void
+    {
+        $this->selected = $isSelected;
+    }
+
+    /**
+     * @return bool Returns true when any of its subitems is selected
+     */
+    public function isExpanded(): bool
+    {
+        return $this->expanded;
+    }
+
+    public function setExpanded(bool $isExpanded): void
+    {
+        $this->expanded = $isExpanded;
     }
 
     public function getLabel(): TranslatableInterface|string

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -170,7 +170,7 @@ final class ActionFactory
                 $routeParameters = $routeParameters($entityInstance);
             }
 
-            return $this->adminUrlGenerator->unsetAllExcept(EA::MENU_INDEX, EA::SUBMENU_INDEX)->includeReferrer()->setRoute($routeName, $routeParameters)->generateUrl();
+            return $this->adminUrlGenerator->unsetAll()->includeReferrer()->setRoute($routeName, $routeParameters)->generateUrl();
         }
 
         $requestParameters = [
@@ -185,7 +185,7 @@ final class ActionFactory
             $requestParameters[EA::ENTITY_ID] = $entityDto->getPrimaryKeyValueAsString();
         }
 
-        return $this->adminUrlGenerator->unsetAllExcept(EA::MENU_INDEX, EA::SUBMENU_INDEX, EA::FILTERS, EA::PAGE)->setAll($requestParameters)->generateUrl();
+        return $this->adminUrlGenerator->unsetAllExcept(EA::FILTERS, EA::PAGE)->setAll($requestParameters)->generateUrl();
     }
 
     private function generateReferrerUrl(Request $request, ActionDto $actionDto, string $currentAction): ?string

--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Menu;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class MenuItemMatcher implements MenuItemMatcherInterface
+{
+    public function __construct(private AdminContextProvider $adminContextProvider)
+    {
+    }
+
+    public function isSelected(MenuItemDto $menuItemDto): bool
+    {
+        $adminContext = $this->adminContextProvider->getContext();
+        if (null === $adminContext || $menuItemDto->isMenuSection()) {
+            return false;
+        }
+
+        $currentPageQueryParameters = $adminContext->getRequest()->query->all();
+        $menuItemQueryString = null === $menuItemDto->getLinkUrl() ? null : parse_url($menuItemDto->getLinkUrl(), \PHP_URL_QUERY);
+        $menuItemQueryParameters = [];
+        if (null !== $menuItemQueryString) {
+            parse_str($menuItemQueryString, $menuItemQueryParameters);
+        }
+
+        if ([] === $menuItemQueryParameters || [] === $currentPageQueryParameters) {
+            return $menuItemDto->getLinkUrl() === $adminContext->getRequest()->getUri();
+        }
+
+        $menuItemQueryParameters = $this->filterIrrelevantQueryParameters($menuItemQueryParameters);
+        $currentPageQueryParameters = $this->filterIrrelevantQueryParameters($currentPageQueryParameters);
+
+        // needed so you can pass route parameters in any order
+        sort($menuItemQueryParameters);
+        sort($currentPageQueryParameters);
+
+        return $menuItemQueryParameters === $currentPageQueryParameters;
+    }
+
+    public function isExpanded(MenuItemDto $menuItemDto): bool
+    {
+        if ([] === $menuSubitems = $menuItemDto->getSubItems()) {
+            return false;
+        }
+
+        foreach ($menuSubitems as $submenuItem) {
+            if ($submenuItem->isSelected()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Removes from the given list of query parameters all the parameters that
+     * should be ignored when deciding if some menu item matches the current page
+     * (such as the applied filters or sorting, the listing page number, etc.).
+     */
+    private function filterIrrelevantQueryParameters(array $queryStringParameters): array
+    {
+        $paramsToRemove = [EA::REFERRER, EA::PAGE, EA::FILTERS, EA::SORT];
+
+        return array_filter($queryStringParameters, static fn ($k) => !\in_array($k, $paramsToRemove, true), \ARRAY_FILTER_USE_KEY);
+    }
+}

--- a/src/Menu/MenuItemMatcherInterface.php
+++ b/src/Menu/MenuItemMatcherInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Menu;
+
+use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+interface MenuItemMatcherInterface
+{
+    /**
+     * @return bool Returns true when this menu item is the selected one
+     */
+    public function isSelected(MenuItemDto $menuItemDto): bool;
+
+    /**
+     * @return bool Returns true when any of the subitems of the menu item is selected
+     */
+    public function isExpanded(MenuItemDto $menuItemDto): bool;
+}

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -67,6 +67,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Inspector\DataCollector;
 use EasyCorp\Bundle\EasyAdminBundle\Intl\IntlFormatter;
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
+use EasyCorp\Bundle\EasyAdminBundle\Menu\MenuItemMatcher;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityPaginator;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityUpdater;
@@ -194,10 +195,14 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, '%kernel.secret%')
 
         ->set(MenuFactory::class)
-            ->arg(0, new Reference(AdminContextProvider::class))
-            ->arg(1, new Reference(AuthorizationChecker::class))
-            ->arg(2, new Reference('security.logout_url_generator'))
-            ->arg(3, new Reference(AdminUrlGenerator::class))
+            ->arg(0, service(AdminContextProvider::class))
+            ->arg(1, service(AuthorizationChecker::class))
+            ->arg(2, service('security.logout_url_generator'))
+            ->arg(3, service(AdminUrlGenerator::class))
+            ->arg(4, service(MenuItemMatcher::class))
+
+        ->set(MenuItemMatcher::class)
+            ->arg(0, service(AdminContextProvider::class))
 
         ->set(EntityRepository::class)
             ->arg(0, service(AdminContextProvider::class))

--- a/src/Resources/views/menu.html.twig
+++ b/src/Resources/views/menu.html.twig
@@ -6,14 +6,14 @@
         {% block main_menu %}
             {% for menuItem in ea.mainMenu.items %}
                 {% block menu_item %}
-                    <li class="{{ menuItem.isMenuSection ? 'menu-header' : 'menu-item' }} {{ menuItem.hasSubItems ? 'has-submenu' }} {{ ea.mainMenu.isSelected(menuItem) ? 'active' }} {{ ea.mainMenu.isExpanded(menuItem) ? 'expanded' }}">
+                    <li class="{{ menuItem.isMenuSection ? 'menu-header' : 'menu-item' }} {{ menuItem.hasSubItems ? 'has-submenu' }} {{ menuItem.isSelected ? 'active' }} {{ menuItem.isExpanded ? 'expanded' }}">
                         {{ _self.render_menu_item(menuItem) }}
 
                         {% if menuItem.hasSubItems %}
                             <ul class="submenu">
                                 {% for menuSubItem in menuItem.subItems %}
                                     {% block menu_subitem %}
-                                        <li class="{{ menuSubItem.isMenuSection ? 'menu-header' : 'menu-item' }} {{ ea.mainMenu.isSelected(menuSubItem) ? 'active' }}">
+                                        <li class="{{ menuSubItem.isMenuSection ? 'menu-header' : 'menu-item' }} {{ menuSubItem.isSelected ? 'active' }}">
                                             {{ _self.render_menu_item(menuSubItem) }}
                                         </li>
                                     {% endblock menu_subitem %}

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -59,7 +59,7 @@ final class AdminUrlGenerator
 
     public function setRoute(string $routeName, array $routeParameters = []): self
     {
-        $this->unsetAllExcept(EA::MENU_INDEX, EA::SUBMENU_INDEX, EA::DASHBOARD_CONTROLLER_FQCN);
+        $this->unsetAllExcept(EA::DASHBOARD_CONTROLLER_FQCN);
         $this->setRouteParameter(EA::ROUTE_NAME, $routeName);
         $this->setRouteParameter(EA::ROUTE_PARAMS, $routeParameters);
 
@@ -84,6 +84,15 @@ final class AdminUrlGenerator
 
     public function set(string $paramName, $paramValue): self
     {
+        if (\in_array($paramName, [EA::MENU_INDEX, EA::SUBMENU_INDEX], true)) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.5.0',
+                'Using the "%s" query parameter is deprecated. Menu items are now highlighted automatically based on the Request data, so you don\'t have to deal with menu items manually anymore.',
+                '$paramName'
+            );
+        }
+
         $this->setRouteParameter($paramName, $paramValue);
 
         return $this;

--- a/tests/Menu/MenuItemMatcherTest.php
+++ b/tests/Menu/MenuItemMatcherTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Menu;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use EasyCorp\Bundle\EasyAdminBundle\Menu\MenuItemMatcher;
+use EasyCorp\Bundle\EasyAdminBundle\Menu\MenuItemMatcherInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class MenuItemMatcherTest extends KernelTestCase
+{
+    public function testIsSelectedWhenContextIsNull()
+    {
+        $menuItemMatcher = $this->getMenuItemMatcher(useNullContext: true);
+
+        $this->assertFalse($menuItemMatcher->isSelected(new MenuItemDto()));
+    }
+
+    public function testIsSelectedWhenMenuItemIsSection()
+    {
+        $menuItemMatcher = $this->getMenuItemMatcher();
+
+        $menuItemDto = new MenuItemDto();
+        $menuItemDto->setType(MenuItemDto::TYPE_SECTION);
+
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+    }
+
+    public function testIsSelectedWithCrudControllers()
+    {
+        $menuItemMatcher = $this->getMenuItemMatcher(
+            getControllerFqcn: 'App\Controller\Admin\SomeController',
+        );
+
+        $menuItemDto = $this->getMenuItemDto();
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+
+        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'NOT_App\Controller\Admin\SomeController');
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller does not match');
+
+        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController');
+        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller matches');
+
+        $menuItemMatcher = $this->getMenuItemMatcher(
+            getControllerFqcn: 'App\Controller\Admin\SomeController',
+            getPrimaryKeyValue: '57',
+        );
+
+        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', entityId: '57');
+        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller and the entity ID match');
+
+        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', entityId: 'NOT_57');
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The entity ID of the menu item does not match');
+
+        $menuItemMatcher = $this->getMenuItemMatcher(
+            getControllerFqcn: 'App\Controller\Admin\SomeController',
+            getPrimaryKeyValue: '57',
+            getCurrentAction: 'detail',
+        );
+
+        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', action: Crud::PAGE_DETAIL, entityId: '57');
+        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller, entity ID and action match');
+
+        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', action: 'NOT_'.Crud::PAGE_DETAIL, entityId: '57');
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller and entity ID match but the action does not match');
+    }
+
+    public function testIsSelectedWithRoutes()
+    {
+        $menuItemMatcher = $this->getMenuItemMatcher(
+            routeName: 'some_route',
+        );
+
+        $menuItemDto = $this->getMenuItemDto(routeName: 'some_route');
+        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The route name matches');
+
+        $menuItemDto = $this->getMenuItemDto(routeName: 'some_route', routeParameters: ['foo' => 'bar']);
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+
+        $menuItemMatcher = $this->getMenuItemMatcher(
+            routeName: 'some_route',
+            routeParameters: ['foo1' => 'bar1', 'foo2' => 'bar2'],
+        );
+
+        $menuItemDto = $this->getMenuItemDto(routeName: 'some_route');
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+
+        $menuItemDto = $this->getMenuItemDto(routeName: 'some_route', routeParameters: ['foo1' => 'bar1']);
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+
+        $menuItemDto = $this->getMenuItemDto(routeName: 'some_route', routeParameters: ['foo1' => 'bar1', 'foo2' => 'bar2']);
+        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto));
+
+        $menuItemDto = $this->getMenuItemDto(routeName: 'some_route', routeParameters: ['foo2' => 'bar2', 'foo1' => 'bar1']);
+        // CHECK THIS - It should be TRUE
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+    }
+
+    public function testIsSelectedWithUrls()
+    {
+        $menuItemMatcher = $this->getMenuItemMatcher(
+            getUri: 'https://example.com/foo?bar=baz',
+        );
+
+        $menuItemDto = new MenuItemDto();
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The URL does not match');
+
+        $menuItemDto = new MenuItemDto();
+        $menuItemDto->setLinkUrl('https://example.com');
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The URL does not match');
+
+        $menuItemDto = new MenuItemDto();
+        $menuItemDto->setLinkUrl('https://example.com/foo');
+        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The URL does not match');
+
+        $menuItemDto = new MenuItemDto();
+        $menuItemDto->setLinkUrl('https://example.com/foo?bar=baz');
+        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The URL matches');
+    }
+
+    /**
+     * For tests we need to simulate that the MenuItemDto has been fully built as
+     * done in MenuFactory. To simplify tests, we just append the needed query parameters
+     * to build the final menu item URL.
+     */
+    private function getMenuItemDto(string $crudControllerFqcn = null, string $action = null, string $entityId = null, string $routeName = null, array $routeParameters = null): MenuItemDto
+    {
+        $menuItemDto = new MenuItemDto();
+        $menuItemRouteParameters = [];
+
+        if (null !== $crudControllerFqcn) {
+            $menuItemRouteParameters[EA::CRUD_CONTROLLER_FQCN] = $crudControllerFqcn;
+        }
+
+        if (null !== $action) {
+            $menuItemRouteParameters[EA::CRUD_ACTION] = $action;
+        }
+
+        if (null !== $entityId) {
+            $menuItemRouteParameters[EA::ENTITY_ID] = $entityId;
+        }
+
+        if (null !== $routeName) {
+            $menuItemRouteParameters[EA::ROUTE_NAME] = $routeName;
+        }
+
+        if (null !== $routeParameters) {
+            $menuItemRouteParameters[EA::ROUTE_PARAMS] = $routeParameters;
+        }
+
+        $menuItemDto->setRouteParameters($menuItemRouteParameters);
+        $menuItemDto->setLinkUrl('/?'.http_build_query($menuItemDto->getRouteParameters()));
+
+        return $menuItemDto;
+    }
+
+    private function getMenuItemMatcher(bool $useNullContext = false, string $getControllerFqcn = null, string $getPrimaryKeyValue = null, string $getCurrentAction = null, string $routeName = null, array $routeParameters = null, string $getUri = null): MenuItemMatcherInterface
+    {
+        $queryParameters = [];
+        $adminContextProviderMock = $this->getMockBuilder(AdminContextProvider::class)->disableOriginalConstructor()->getMock();
+
+        if ($useNullContext) {
+            $adminContextProviderMock->method('getContext')->willReturn(null);
+
+            return new MenuItemMatcher($adminContextProviderMock);
+        }
+
+        $adminContextMock = $this->getMockBuilder(AdminContext::class)->disableOriginalConstructor()->getMock();
+
+        if (null !== $getControllerFqcn || null !== $getCurrentAction) {
+            $crudDtoMock = $this->getMockBuilder(CrudDto::class)->disableOriginalConstructor()->getMock();
+        }
+        if (null !== $getControllerFqcn) {
+            $queryParameters[EA::CRUD_CONTROLLER_FQCN] = $getControllerFqcn;
+            $crudDtoMock->method('getControllerFqcn')->willReturn($getControllerFqcn);
+            $adminContextMock->method('getCrud')->willReturn($crudDtoMock);
+        }
+        if (null !== $getCurrentAction) {
+            $queryParameters[EA::CRUD_ACTION] = $getCurrentAction;
+            $crudDtoMock->method('getCurrentAction')->willReturn($getCurrentAction);
+        }
+        if (null !== $getControllerFqcn || null !== $getCurrentAction) {
+            $adminContextMock->method('getCrud')->willReturn($crudDtoMock);
+        }
+
+        if (null !== $getPrimaryKeyValue) {
+            $queryParameters[EA::ENTITY_ID] = $getPrimaryKeyValue;
+            $entityDtoMock = $this->getMockBuilder(EntityDto::class)->disableOriginalConstructor()->getMock();
+            $entityDtoMock->method('getPrimaryKeyValue')->willReturn($getPrimaryKeyValue);
+            $adminContextMock->method('getEntity')->willReturn($entityDtoMock);
+        }
+
+        if (null !== $routeName) {
+            $queryParameters[EA::ROUTE_NAME] = $routeName;
+        }
+        if (null !== $routeParameters) {
+            $queryParameters[EA::ROUTE_PARAMS] = $routeParameters;
+        }
+
+        $request = $this->getMockBuilder(Request::class)->getMock();
+        $request->query = new InputBag($queryParameters);
+        if (null !== $getUri) {
+            $request->method('getUri')->willReturn($getUri);
+        } else {
+            $request->method('getUri')->willReturn('/?'.http_build_query($queryParameters));
+        }
+        $adminContextMock->method('getRequest')->willReturn($request);
+
+        $adminContextProviderMock->expects($this->any())->method('getContext')->willReturn($adminContextMock);
+
+        return new MenuItemMatcher($adminContextProviderMock);
+    }
+}

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -175,12 +175,21 @@ class AdminUrlGeneratorTest extends WebTestCase
         $this->assertNull($adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
 
         $adminUrlGenerator->setController('App\Controller\Admin\SomeCrudController');
-        $adminUrlGenerator->set(EA::MENU_INDEX, 3);
         $adminUrlGenerator->set('foo', 'bar');
         $adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
 
         $this->assertNull($adminUrlGenerator->get(EA::CRUD_CONTROLLER_FQCN));
         $this->assertNull($adminUrlGenerator->get('foo'));
+    }
+
+    /**
+     * @legacy
+     */
+    public function testLegacyParameters()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+        $adminUrlGenerator->set(EA::MENU_INDEX, 3);
+
         $this->assertSame(3, $adminUrlGenerator->get(EA::MENU_INDEX));
     }
 


### PR DESCRIPTION
So far, we display selected menu items based on two query parameters: `menuIndex` and `submenuIndex`. In addition to being a bit ugly, it requires handling things manually and it breaks when using advanced things such as showing/hiding menu items based on permissions.

This PR removes those two query parameters and deprecates all methods related to them. From now on, the selected menu item is detected automatically for you based on the request data. This is similar to what https://github.com/KnpLabs/KnpMenu/ does. I looked into that project but it looked overkill to use it in our project because our needs are very simple. So I ended up creating a single class and its related interface and tests.

I think this change is BC because we kept certain methods that are no longer used (so your code won't break). Also, you can still add those query params without issues ... but we'll ignore them completely and we'll try to select the right menu item based on the request data.