### PR TITLE
fix #5526 #5527 #5532 by updating js style modifications to classes

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,6 +4,7 @@ require('../css/app.scss');
 import bootstrap from 'bootstrap/dist/js/bootstrap.bundle';
 import Mark from 'mark.js/src/vanilla';
 import Autocomplete from './autocomplete';
+import {toggleVisibilityClasses} from "./helpers";
 
 // Provide Bootstrap variable globally to allow custom backend pages to use it
 window.bootstrap = bootstrap;
@@ -260,16 +261,16 @@ class App {
                 const batchActions = content.querySelector('.batch-actions');
 
                 if (null !== contentTitle) {
-                    contentTitle.style.visibility = rowsAreSelected ? 'hidden' : 'visible';
+                    toggleVisibilityClasses(contentTitle, rowsAreSelected);
                 }
                 if (null !== filters) {
-                    filters.style.display = rowsAreSelected ? 'none' : 'block';
+                    toggleVisibilityClasses(filters, rowsAreSelected);
                 }
                 if (null !== globalActions) {
-                    globalActions.style.display = rowsAreSelected ? 'none' : 'block';
+                    toggleVisibilityClasses(globalActions, rowsAreSelected);
                 }
                 if (null !== batchActions) {
-                    batchActions.style.display = rowsAreSelected ? 'block' : 'none';
+                    toggleVisibilityClasses(batchActions, !rowsAreSelected);
                 }
             });
         });

--- a/assets/js/field-file-upload.js
+++ b/assets/js/field-file-upload.js
@@ -1,3 +1,5 @@
+import {toggleVisibilityClasses} from "./helpers";
+
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.ea-fileupload input[type="file"]').forEach((fileUploadElement) => {
         new FileUploadField(fileUploadElement);
@@ -50,7 +52,7 @@ class FileUploadField {
         }
         this.field.value = '';
         this.#getFieldCustomInput().innerHTML = '';
-        this.#getFieldDeleteButton().style.display = 'none';
+        toggleVisibilityClasses(this.#getFieldDeleteButton(), true);
 
         this.#getFieldSizeLabel().childNodes.forEach((fileSizeLabelChild) => {
             if (fileSizeLabelChild.nodeType === Node.TEXT_NODE) {
@@ -59,7 +61,7 @@ class FileUploadField {
         });
 
         if (null !== fieldListOfFiles) {
-            fieldListOfFiles.style.display = 'none';
+            toggleVisibilityClasses(fieldListOfFiles, true);
         }
     }
 

--- a/assets/js/helpers.js
+++ b/assets/js/helpers.js
@@ -1,0 +1,9 @@
+export function toggleVisibilityClasses(element, removeVisibility) {
+    if (removeVisibility) {
+        element.classList.remove('d-block')
+        element.classList.add('d-none')
+    } else {
+        element.classList.remove('d-none')
+        element.classList.add('d-block')
+    }
+}


### PR DESCRIPTION
I believe this addresses the items I missed in https://github.com/EasyCorp/EasyAdminBundle/pull/5504. Specifically, JavaScripts that modify HTML elements now use classes instead of styles.

This should close out issues #5526 #5527 and #5532.
