### PR TITLE
Allow to have empty page titles

### DIFF
--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -163,7 +163,7 @@ final class CrudDto
             $title = null !== $entityInstance ? $title($entityInstance) : $title();
         }
 
-        if (null === $title || '' === $title) {
+        if (null === $title) {
             return null;
         }
 


### PR DESCRIPTION
Fixes #5545.

The proposed behavior (`null` === use the default title; `(empty string)` === don't show any title) fits well with the behavior of the rest of features of this bundle.

As @Lustmored said, the only issue is that you'll see a new "missing translation" for the empty string:

<img width="964" alt="missing-translation" src="https://user-images.githubusercontent.com/73419/209708276-2c321204-4e7b-40c6-9386-0779a7ac4bf7.png">

I think someone could send a PR to Symfony to "fix" this and to simply output an empty string when "translating" an empty string.