### PR TITLE
[Feature] Allow to pass custom params to linkToCrudAction()

### DIFF
--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -172,9 +172,10 @@ final class Action
         return $this;
     }
 
-    public function linkToCrudAction(string $crudActionName): self
+    public function linkToCrudAction(string $crudActionName, array $crudRequestParameters = []): self
     {
         $this->dto->setCrudActionName($crudActionName);
+        $this->dto->setCrudRequestParameters($crudRequestParameters);
 
         return $this;
     }

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -20,6 +20,7 @@ final class ActionDto
     private ?string $linkUrl = null;
     private ?string $templatePath = null;
     private ?string $crudActionName = null;
+    private ?array $crudRequestParameters = null;
     private ?string $routeName = null;
     private $routeParameters = [];
     /* @var callable|string|null */
@@ -150,6 +151,16 @@ final class ActionDto
     public function setCrudActionName(string $crudActionName): void
     {
         $this->crudActionName = $crudActionName;
+    }
+
+    public function getCrudRequestParameters(): ?array
+    {
+        return $this->crudRequestParameters;
+    }
+
+    public function setCrudRequestParameters(array $crudRequestParameters): void
+    {
+        $this->crudRequestParameters = $crudRequestParameters;
     }
 
     public function getRouteName(): ?string

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -20,7 +20,7 @@ final class ActionDto
     private ?string $linkUrl = null;
     private ?string $templatePath = null;
     private ?string $crudActionName = null;
-    private ?array $crudRequestParameters = null;
+    private array $crudRequestParameters = [];
     private ?string $routeName = null;
     private $routeParameters = [];
     /* @var callable|string|null */
@@ -153,7 +153,7 @@ final class ActionDto
         $this->crudActionName = $crudActionName;
     }
 
-    public function getCrudRequestParameters(): ?array
+    public function getCrudRequestParameters(): array
     {
         return $this->crudRequestParameters;
     }

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -185,6 +185,8 @@ final class ActionFactory
             $requestParameters[EA::ENTITY_ID] = $entityDto->getPrimaryKeyValueAsString();
         }
 
+        $requestParameters += $actionDto->getCrudRequestParameters();
+
         return $this->adminUrlGenerator->unsetAllExcept(EA::FILTERS, EA::PAGE)->setAll($requestParameters)->generateUrl();
     }
 


### PR DESCRIPTION
Currently, if you want to redirect users to a route that is CRUD-registered but requires an additional request parameter, you have to do something along these lines:

```php
public function configureActions(Actions $actions): Actions
{
    $url = $this->adminUrlGenerator
        ->setController(self::class)
        ->setAction('myAction');

    $myEntity = Action::new('myAction', 'My action')
        ->linkToUrl(function ($entity) use ($url) {
            if ($entity !== null) {
                $url->setEntityId($entity->getId());
            }

            return $url->generateUrl() . '&param=value';
        });

    return $actions->add(Crud::PAGE_INDEX, $myEntity);
}
```

thanks to these changes, all this boilerplate becomes:

```php
public function configureActions(Actions $actions): Actions
{
    $myEntity = Action::new('myAction', 'My action')
        ->linkToCrudAction('myAction', [
            'param' => 'value',
        ]);

    return $actions->add(Crud::PAGE_INDEX, $myEntity);
}

```