### PR TITLE
ability to use flysystem to manage uploaded files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php_version }}
                   coverage: none
-                  extensions: mbstring, intl, pdo, pdo_sqlite, sqlite3
+                  extensions: mbstring, intl, pdo, pdo_sqlite, sqlite3, fileinfo
                   ini-values: date.timezone=UTC
 
             - name: symfony/flex is required to install the correct symfony version

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.4",
+        "league/flysystem-bundle": "^3.0",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-phpunit": "^1.2",
@@ -73,5 +74,8 @@
         "branch-alias": {
             "dev-master": "4.0.x-dev"
         }
+    },
+    "suggest": {
+        "league/flysystem-bundle": "Allows to manage uploaded file destination"
     }
 }

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -599,11 +599,12 @@ abstract class AbstractCrudController extends AbstractController implements Crud
                 continue;
             }
 
+            $filesystemOperator = $config->getOption('filesystem_operator');
             $uploadDelete = $config->getOption('upload_delete');
 
             if ($state->hasCurrentFiles() && ($state->isDelete() || (!$state->isAddAllowed() && $state->hasUploadedFiles()))) {
                 foreach ($state->getCurrentFiles() as $file) {
-                    $uploadDelete($file);
+                    $uploadDelete($file, $filesystemOperator);
                 }
                 $state->setCurrentFiles([]);
             }
@@ -613,8 +614,8 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             $uploadNew = $config->getOption('upload_new');
 
             foreach ($state->getUploadedFiles() as $index => $file) {
-                $fileName = u($filePaths[$index])->replace($uploadDir, '')->toString();
-                $uploadNew($file, $uploadDir, $fileName);
+                $fileName = u($filePaths[$index]);
+                $uploadNew($file, $uploadDir, $fileName, $filesystemOperator);
             }
         }
     }

--- a/src/Decorator/FlysystemFile.php
+++ b/src/Decorator/FlysystemFile.php
@@ -3,7 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Decorator;
 
 use League\Flysystem\FilesystemOperator;
-use Symfony\Component\HttpFoundation\File\File as File;
+use Symfony\Component\HttpFoundation\File\File;
 
 class FlysystemFile extends File
 {

--- a/src/Decorator/FlysystemFile.php
+++ b/src/Decorator/FlysystemFile.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Decorator;
+
+use League\Flysystem\FilesystemOperator;
+use Symfony\Component\HttpFoundation\File\File as File;
+
+class FlysystemFile extends File
+{
+    private FilesystemOperator $filesystemOperator;
+
+    public function __construct(FilesystemOperator $filesystemOperator, string $path)
+    {
+        $this->filesystemOperator = $filesystemOperator;
+
+        parent::__construct($path, false);
+    }
+
+    public function getSize(): int
+    {
+        return $this->filesystemOperator->fileSize($this->getPathname());
+    }
+
+    public function getMTime(): int
+    {
+        return $this->filesystemOperator->lastModified($this->getPathname());
+    }
+}

--- a/src/Field/Configurator/ImageConfigurator.php
+++ b/src/Field/Configurator/ImageConfigurator.php
@@ -78,7 +78,7 @@ final class ImageConfigurator implements FieldConfiguratorInterface
 
     private function getImagePath(?string $imagePath, ?string $basePath, ?FilesystemOperator $filesystemOperator): ?string
     {
-        if (null !==$filesystemOperator && null !== $imagePath) {
+        if (null !== $filesystemOperator && null !== $imagePath) {
             try {
                 return $filesystemOperator->publicUrl($imagePath);
             } catch (UnableToGeneratePublicUrl $e) {

--- a/src/Field/Configurator/ImageConfigurator.php
+++ b/src/Field/Configurator/ImageConfigurator.php
@@ -8,6 +8,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\UnableToGeneratePublicUrl;
 use function Symfony\Component\String\u;
 
 /**
@@ -30,10 +32,11 @@ final class ImageConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $configuredBasePath = $field->getCustomOption(ImageField::OPTION_BASE_PATH);
+        $filesystemOperator = $field->getCustomOption(ImageField::OPTION_FILESYSTEM_OPERATOR);
 
         $formattedValue = \is_array($field->getValue())
-            ? $this->getImagesPaths($field->getValue(), $configuredBasePath)
-            : $this->getImagePath($field->getValue(), $configuredBasePath);
+            ? $this->getImagesPaths($field->getValue(), $configuredBasePath, $filesystemOperator)
+            : $this->getImagePath($field->getValue(), $configuredBasePath, $filesystemOperator);
         $field->setFormattedValue($formattedValue);
 
         $field->setFormTypeOption('upload_filename', $field->getCustomOption(ImageField::OPTION_UPLOADED_FILE_NAME_PATTERN));
@@ -47,32 +50,41 @@ final class ImageConfigurator implements FieldConfiguratorInterface
             return;
         }
 
-        $relativeUploadDir = $field->getCustomOption(ImageField::OPTION_UPLOAD_DIR);
-        if (null === $relativeUploadDir) {
-            throw new \InvalidArgumentException(sprintf('The "%s" image field must define the directory where the images are uploaded using the setUploadDir() method.', $field->getProperty()));
+        if (null !== $relativeUploadDir = $field->getCustomOption(ImageField::OPTION_UPLOAD_DIR)) {
+            $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
+            $isStreamWrapper = filter_var($relativeUploadDir, \FILTER_VALIDATE_URL);
+            if ($isStreamWrapper) {
+                $absoluteUploadDir = $relativeUploadDir;
+            } else {
+                $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
+            }
+            $field->setFormTypeOption('upload_dir', $absoluteUploadDir);
         }
-        $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
-        $isStreamWrapper = filter_var($relativeUploadDir, \FILTER_VALIDATE_URL);
-        if ($isStreamWrapper) {
-            $absoluteUploadDir = $relativeUploadDir;
-        } else {
-            $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
+
+        if (null !== $filesystemOperator = $field->getCustomOption(ImageField::OPTION_FILESYSTEM_OPERATOR)) {
+            $field->setFormTypeOption('filesystem_operator', $filesystemOperator);
         }
-        $field->setFormTypeOption('upload_dir', $absoluteUploadDir);
     }
 
-    private function getImagesPaths(?array $images, ?string $basePath): array
+    private function getImagesPaths(?array $images, ?string $basePath, ?FilesystemOperator $filesystemOperator): array
     {
         $imagesPaths = [];
         foreach ($images as $image) {
-            $imagesPaths[] = $this->getImagePath($image, $basePath);
+            $imagesPaths[] = $this->getImagePath($image, $basePath, $filesystemOperator);
         }
 
         return $imagesPaths;
     }
 
-    private function getImagePath(?string $imagePath, ?string $basePath): ?string
+    private function getImagePath(?string $imagePath, ?string $basePath, ?FilesystemOperator $filesystemOperator): ?string
     {
+        if (null !==$filesystemOperator && null !== $imagePath) {
+            try {
+                return $filesystemOperator->publicUrl($imagePath);
+            } catch (UnableToGeneratePublicUrl $e) {
+                // do nothing : try to get image path with logic below
+            }
+        }
         // add the base path only to images that are not absolute URLs (http or https) or protocol-relative URLs (//)
         if (null === $imagePath || 0 !== preg_match('/^(http[s]?|\/\/)/i', $imagePath)) {
             return $imagePath;

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -86,7 +86,7 @@ final class ImageField implements FieldInterface
      * - move uploaded file to its final destination
      * - delete the previously uploaded file
      * - retrieve file public url
-     * See https://github.com/thephpleague/flysystem-bundle
+     * See https://github.com/thephpleague/flysystem-bundle.
      */
     public function setFilesystemOperator(FilesystemOperator $filesystemOperator): self
     {

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -6,6 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
+use League\Flysystem\FilesystemOperator;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
@@ -18,6 +19,7 @@ final class ImageField implements FieldInterface
     public const OPTION_BASE_PATH = 'basePath';
     public const OPTION_UPLOAD_DIR = 'uploadDir';
     public const OPTION_UPLOADED_FILE_NAME_PATTERN = 'uploadedFileNamePattern';
+    public const OPTION_FILESYSTEM_OPERATOR = 'filesystemOperator';
 
     /**
      * @param TranslatableInterface|string|false|null $label
@@ -35,7 +37,9 @@ final class ImageField implements FieldInterface
             ->setTextAlign(TextAlign::CENTER)
             ->setCustomOption(self::OPTION_BASE_PATH, null)
             ->setCustomOption(self::OPTION_UPLOAD_DIR, null)
-            ->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, '[name].[extension]');
+            ->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, '[name].[extension]')
+            ->setCustomOption(self::OPTION_FILESYSTEM_OPERATOR, null)
+        ;
     }
 
     public function setBasePath(string $path): self
@@ -73,6 +77,20 @@ final class ImageField implements FieldInterface
     public function setUploadedFileNamePattern($patternOrCallable): self
     {
         $this->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, $patternOrCallable);
+
+        return $this;
+    }
+
+    /**
+     * File system to use in order to :
+     * - move uploaded file to its final destination
+     * - delete the previously uploaded file
+     * - retrieve file public url
+     * See https://github.com/thephpleague/flysystem-bundle
+     */
+    public function setFilesystemOperator(FilesystemOperator $filesystemOperator): self
+    {
+        $this->setCustomOption(self::OPTION_FILESYSTEM_OPERATOR, $filesystemOperator);
 
         return $this;
     }

--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -2,11 +2,11 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\DataTransformer;
 
+use EasyCorp\Bundle\EasyAdminBundle\Decorator\FlysystemFile;
 use League\Flysystem\FilesystemOperator;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\HttpFoundation\File\File;
-use EasyCorp\Bundle\EasyAdminBundle\Decorator\FlysystemFile;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**

--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -29,7 +29,7 @@ class StringToFileTransformer implements DataTransformerInterface
         $this->filesystemOperator = $filesystemOperator;
     }
 
-    public function transform($value): mixed
+    public function transform($value): null|File|array
     {
         if (null === $value || [] === $value) {
             return null;
@@ -46,7 +46,7 @@ class StringToFileTransformer implements DataTransformerInterface
         return array_map([$this, 'doTransform'], $value);
     }
 
-    public function reverseTransform($value): mixed
+    public function reverseTransform($value): null|string|array
     {
         if (null === $value || [] === $value) {
             return null;

--- a/tests/Field/ImageFieldTest.php
+++ b/tests/Field/ImageFieldTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ImageConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
+use League\Flysystem\FilesystemOperator;
+
+class ImageFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $projectDir = __DIR__.'/../TestApplication';
+        $this->configurator = new ImageConfigurator($projectDir);
+    }
+
+    public function testFilesystemOperator(): void
+    {
+        $filesystemOperator = $this->createStub(FilesystemOperator::class);
+
+        $field = ImageField::new('foo')->setFilesystemOperator($filesystemOperator);
+        $fieldDto = $this->configure($field);
+
+        self::assertNotNull($fieldDto->getCustomOption(ImageField::OPTION_FILESYSTEM_OPERATOR));
+    }
+}

--- a/tests/Form/DataTransformer/StringToFileTransformerTest.php
+++ b/tests/Form/DataTransformer/StringToFileTransformerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\DataTransformer;
+
+use EasyCorp\Bundle\EasyAdminBundle\Decorator\FlysystemFile;
+use EasyCorp\Bundle\EasyAdminBundle\Form\DataTransformer\StringToFileTransformer;
+use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\TestCase;
+
+class StringToFileTransformerTest extends TestCase
+{
+
+    public function testTransform(): void
+    {
+        $uploadFilename = static fn($value) => 'foo';
+        $uploadValidate = static fn($filename) => 'foo';
+        $filesystemOperatorMock = $this->createStub(FilesystemOperator::class);
+        $filesystemOperatorMock
+            ->method('fileExists')
+            ->willReturn(true)
+        ;
+
+        $stringToFileTransformer = new StringToFileTransformer(null, $uploadFilename, $uploadValidate, false, $filesystemOperatorMock);
+
+        $transformedFile = $stringToFileTransformer->transform('bar');
+
+        self::assertInstanceOf(FlysystemFile::class, $transformedFile);
+    }
+}

--- a/tests/Form/DataTransformer/StringToFileTransformerTest.php
+++ b/tests/Form/DataTransformer/StringToFileTransformerTest.php
@@ -9,11 +9,10 @@ use PHPUnit\Framework\TestCase;
 
 class StringToFileTransformerTest extends TestCase
 {
-
     public function testTransform(): void
     {
-        $uploadFilename = static fn($value) => 'foo';
-        $uploadValidate = static fn($filename) => 'foo';
+        $uploadFilename = static fn ($value) => 'foo';
+        $uploadValidate = static fn ($filename) => 'foo';
         $filesystemOperatorMock = $this->createStub(FilesystemOperator::class);
         $filesystemOperatorMock
             ->method('fileExists')


### PR DESCRIPTION
When using `ImageField`, the downloaded image goes to local file system. With this PR, easy admin user can configure a `FilesystemOperator` in order to abstract file system and therefor choose where to put the images. It can bee anything supported by [Flysystem](https://flysystem.thephpleague.com/) such as S3 bucket or FTP directory.

The `FilesystemOperator` instance has to be configured with the [Flysystem Symfony bundle](https://github.com/thephpleague/flysystem-bundle)

Closes #5544 