### PR TITLE
replace annotations by attributes in test entities

### DIFF
--- a/tests/TestApplication/config/packages/doctrine.php
+++ b/tests/TestApplication/config/packages/doctrine.php
@@ -13,7 +13,7 @@ $container->loadFromExtension('doctrine', [
         'mappings' => [
             'TestEntities' => [
                 'is_bundle' => false,
-                'type' => 'annotation',
+                'type' => 'attribute',
                 'dir' => '%kernel.project_dir%/src/Entity',
                 'prefix' => 'EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity',
                 'alias' => 'app',

--- a/tests/TestApplication/src/Entity/BlogPost.php
+++ b/tests/TestApplication/src/Entity/BlogPost.php
@@ -6,52 +6,34 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class BlogPost
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private $id;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
+    #[ORM\Column(type: 'string', length: 255)]
     private $title;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
+    #[ORM\Column(type: 'string', length: 255)]
     private $slug;
 
-    /**
-     * @ORM\Column(type="text")
-     */
+    #[ORM\Column(type: 'text')]
     private $content;
 
-    /**
-     * @ORM\ManyToMany(targetEntity=Category::class, inversedBy="blogPosts")
-     */
+    #[ORM\ManyToMany(targetEntity: Category::class, inversedBy: 'blogPosts')]
     private $categories;
 
-    /**
-     * @ORM\Column(type="datetime")
-     */
+    #[ORM\Column(type: 'datetime')]
     private $createdAt;
 
-    /**
-     * @ORM\Column(type="datetime_immutable", nullable=true)
-     */
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $publishedAt;
 
-    /**
-     * @ORM\ManyToOne(targetEntity=User::class, inversedBy="blogPosts")
-     * @ORM\JoinColumn(nullable=false)
-     */
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'blogPosts')]
+    #[ORM\JoinColumn(nullable: false)]
     private $author;
 
     public function __construct()

--- a/tests/TestApplication/src/Entity/Category.php
+++ b/tests/TestApplication/src/Entity/Category.php
@@ -6,36 +6,24 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Category
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private $id;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
+    #[ORM\Column(type: 'string', length: 255)]
     private $name;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
+    #[ORM\Column(type: 'string', length: 255)]
     private $slug;
 
-    /**
-     * @ORM\ManyToMany(targetEntity=BlogPost::class, mappedBy="categories")
-     */
+    #[ORM\ManyToMany(targetEntity: BlogPost::class, mappedBy: 'categories')]
     private $blogPosts;
 
-    /**
-     * @ORM\Column(type="boolean")
-     */
+    #[ORM\Column(type: 'boolean')]
     private bool $active = false;
 
     public function __construct()

--- a/tests/TestApplication/src/Entity/User.php
+++ b/tests/TestApplication/src/Entity/User.php
@@ -6,32 +6,22 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="`user`")
- */
+#[ORM\Entity]
+#[ORM\Table(name: '`user`')]
 class User
 {
-    /**
-     * @ORM\Id
-     * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
-     */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     private $id;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
+    #[ORM\Column(type: 'string', length: 255)]
     private $name;
 
-    /**
-     * @ORM\Column(type="string", length=255)
-     */
+    #[ORM\Column(type: 'string', length: 255)]
     private $email;
 
-    /**
-     * @ORM\OneToMany(targetEntity=BlogPost::class, mappedBy="author", orphanRemoval=true)
-     */
+    #[ORM\OneToMany(targetEntity: BlogPost::class, mappedBy: 'author', orphanRemoval: true)]
     private $blogPosts;
 
     public function __construct()


### PR DESCRIPTION
The tests jobs of my previous PR (#5555) failed with errors : 
```
The service "doctrine.orm.default_annotation_metadata_driver" has a dependency on a non-existent service doctrine.orm.metadata.annotation_reader".
```
This PR replaces annotations by PHP 8 attributes.

This change allows tests to pass for PR #5555 

(The actual code change in entities has been made by rector)