### PR TITLE
Fix deprecation message coming from `AdminUrlGenerator`

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -89,7 +89,7 @@ final class AdminUrlGenerator
                 'easycorp/easyadmin-bundle',
                 '4.5.0',
                 'Using the "%s" query parameter is deprecated. Menu items are now highlighted automatically based on the Request data, so you don\'t have to deal with menu items manually anymore.',
-                '$paramName'
+                $paramName,
             );
         }
 

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -193,6 +193,16 @@ class AdminUrlGeneratorTest extends WebTestCase
         $this->assertSame(3, $adminUrlGenerator->get(EA::MENU_INDEX));
     }
 
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedParameterMessage()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+        $this->expectDeprecation('Since easycorp/easyadmin-bundle 4.5.0: Using the "menuIndex" query parameter is deprecated. Menu items are now highlighted automatically based on the Request data, so you don\'t have to deal with menu items manually anymore.');
+        $adminUrlGenerator->set('menuIndex', 1);
+    }
+
     public function testIncludeReferrer()
     {
         $adminUrlGenerator = $this->getAdminUrlGenerator();


### PR DESCRIPTION
Without this patch, we get the following deprecation message:

> Since easycorp/easyadmin-bundle 4.5.0: Using the "$paramName" query parameter is deprecated. Menu items are now highlighted automatically based on the Request data, so you don't have to deal with menu items manually anymore.

With the patch:

> Since easycorp/easyadmin-bundle 4.5.0: Using the "menuIndex" query parameter is deprecated. Menu items are now highlighted automatically based on the Request data, so you don't have to deal with menu items manually anymore.