### PR TITLE
[BUGFIX] Do not execute browser-side-validation, if novalidate is set

### DIFF
--- a/assets/js/form.js
+++ b/assets/js/form.js
@@ -41,6 +41,10 @@ class Form {
                     document.querySelectorAll('.form-tabs .nav-item .badge-danger.badge').forEach( (badge) => {
                         badge.parentElement.removeChild(badge);
                     });
+                    
+                    if(null !== form.getAttribute('novalidate')) {
+                        return;
+                    }
 
                     form.querySelectorAll('input,select,textarea').forEach( (input) => {
                         if (!input.disabled && !input.validity.valid) {


### PR DESCRIPTION
This PR fixes the small issue #5564 

I'm not sure if the early-return is ok. If not, I can of course put the logic inside the condition.

P.S.: Thanks for all your work on this nice bundle!