### PR TITLE
Allow to add action to custom Action page

### DIFF
--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -58,7 +58,7 @@ final class ActionConfigDto
 
     public function appendAction(string $pageName, ActionDto $actionDto): void
     {
-        $this->actions[$pageName] = array_merge([$actionDto->getName() => $actionDto], $this->actions[$pageName]);
+        $this->actions[$pageName] = array_merge([$actionDto->getName() => $actionDto], $this->actions[$pageName] ?? []);
     }
 
     public function setAction(string $pageName, ActionDto $actionDto): void

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use EasyCorp\Bundle\EasyAdminBundle\Cache\CacheWarmer;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextDirection;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
@@ -48,9 +47,7 @@ final class AdminContextFactory
 
     public function create(Request $request, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController): AdminContext
     {
-        $crudAction = $request->query->get(EA::CRUD_ACTION);
-        $validPageNames = [Crud::PAGE_INDEX, Crud::PAGE_DETAIL, Crud::PAGE_EDIT, Crud::PAGE_NEW];
-        $pageName = \in_array($crudAction, $validPageNames, true) ? $crudAction : null;
+        $pageName = $request->query->get(EA::CRUD_ACTION);
 
         $dashboardDto = $this->getDashboardDto($request, $dashboardController);
         $assetDto = $this->getAssetDto($dashboardController, $crudController, $pageName);


### PR DESCRIPTION
Without this , doing 
```
          return $actions
              // without this the "id" is not clickable in the listing
              ->add(Crud::PAGE_INDEX, Action::DETAIL) 
              ->add('detailsBalance' , Action::DETAIL)      
```
and the using in the custom controller method 

```
$this->container->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
```

to finally display all the actions using the standard code

```

{% block page_actions %}
    {% for action in entity.actions %}
        {{ include(action.templatePath, { action: action }, with_context = false) }}
    {% endfor %}
{% endblock %}
```

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
