### PR TITLE
Make EntityDto generic

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Parameter \\#2 \\$value \\(EasyCorp\\\\Bundle\\\\EasyAdminBundle\\\\Dto\\\\EntityDto\\<TInstance of object\\>\\) of method EasyCorp\\\\Bundle\\\\EasyAdminBundle\\\\Collection\\\\EntityCollection\\:\\:offsetSet\\(\\) should be contravariant with parameter \\$value \\(mixed\\) of method ArrayAccess\\<mixed,mixed\\>\\:\\:offsetSet\\(\\)$#"
+			count: 2
+			path: src/Collection/EntityCollection.php
+
+		-
 			message: "#^Cannot unset offset string on array\\<int, EasyCorp\\\\Bundle\\\\EasyAdminBundle\\\\Dto\\\\ActionDto\\>\\.$#"
 			count: 1
 			path: src/Dto/ActionConfigDto.php

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -7,5 +7,6 @@ parameters:
         - src/
     bootstrapFiles:
         - vendor/bin/.phpunit/phpunit/vendor/autoload.php
+    treatPhpDocTypesAsCertain: false
     ignoreErrors:
         - '#Cannot use array destructuring on callable.#'

--- a/src/Collection/EntityCollection.php
+++ b/src/Collection/EntityCollection.php
@@ -6,30 +6,38 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Collection\CollectionInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 
 /**
+ * @template TInstance of object
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class EntityCollection implements CollectionInterface
 {
     /**
-     * @param EntityDto[] $entities
+     * @param EntityDto<TInstance>[] $entities
      */
     private function __construct(private array $entities)
     {
     }
 
     /**
-     * @param EntityDto[] $entities
+     * @param EntityDto<TInstance>[] $entities
      */
     public static function new(array $entities): self
     {
         return new self($entities);
     }
 
+    /**
+     * @return EntityDto<TInstance>|null
+     */
     public function get(string $entityId): ?EntityDto
     {
         return $this->entities[$entityId] ?? null;
     }
 
+    /**
+     * @param EntityDto<TInstance> $newOrUpdatedEntity
+     */
     public function set(EntityDto $newOrUpdatedEntity): void
     {
         $this->entities[$newOrUpdatedEntity->getPrimaryKeyValueAsString()] = $newOrUpdatedEntity;
@@ -40,11 +48,17 @@ final class EntityCollection implements CollectionInterface
         return \array_key_exists($offset, $this->entities);
     }
 
+    /**
+     * @return EntityDto<TInstance>
+     */
     public function offsetGet(mixed $offset): EntityDto
     {
         return $this->entities[$offset];
     }
 
+    /**
+     * @param EntityDto<TInstance> $value
+     */
     public function offsetSet(mixed $offset, mixed $value): void
     {
         $this->entities[$offset] = $value;
@@ -61,7 +75,7 @@ final class EntityCollection implements CollectionInterface
     }
 
     /**
-     * @return \ArrayIterator<EntityDto>
+     * @return \ArrayIterator<EntityDto<TInstance>>
      */
     public function getIterator(): \ArrayIterator
     {

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -23,6 +23,8 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * A context object that stores all the state and config of the current admin request.
  *
+ * @template TInstance of object
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class AdminContext
@@ -31,6 +33,7 @@ final class AdminContext
     private ?UserInterface $user;
     private I18nDto $i18nDto;
     private CrudControllerRegistry $crudControllers;
+    /** @var EntityDto<TInstance>|null */
     private ?EntityDto $entityDto;
     private DashboardDto $dashboardDto;
     private DashboardControllerInterface $dashboardControllerInstance;
@@ -42,6 +45,9 @@ final class AdminContext
     private ?MainMenuDto $mainMenuDto = null;
     private ?UserMenuDto $userMenuDto = null;
 
+    /**
+     * @param EntityDto<TInstance>|null $entityDto
+     */
     public function __construct(Request $request, ?UserInterface $user, I18nDto $i18nDto, CrudControllerRegistry $crudControllers, DashboardDto $dashboardDto, DashboardControllerInterface $dashboardController, AssetsDto $assetDto, ?CrudDto $crudDto, ?EntityDto $entityDto, ?SearchDto $searchDto, MenuFactory $menuFactory, TemplateRegistry $templateRegistry)
     {
         $this->request = $request;
@@ -78,6 +84,9 @@ final class AdminContext
         return $this->crudControllers;
     }
 
+    /**
+     * @return EntityDto<TInstance>
+     */
     public function getEntity(): EntityDto
     {
         return $this->entityDto;

--- a/src/Contracts/Controller/CrudControllerInterface.php
+++ b/src/Contracts/Controller/CrudControllerInterface.php
@@ -21,10 +21,15 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
+ * @template TInstance of object
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 interface CrudControllerInterface
 {
+    /**
+     * @return class-string<TInstance>
+     */
     public static function getEntityFqcn(): string;
 
     public function configureCrud(Crud $crud): Crud;
@@ -42,40 +47,96 @@ interface CrudControllerInterface
      */
     public function configureFields(string $pageName): iterable;
 
-    /** @return KeyValueStore|Response */
+    /**
+     * @param AdminContext<TInstance> $context
+     *
+     * @return KeyValueStore|Response
+     */
     public function index(AdminContext $context);
 
-    /** @return KeyValueStore|Response */
+    /**
+     * @param AdminContext<TInstance> $context
+     *
+     * @return KeyValueStore|Response
+     */
     public function detail(AdminContext $context);
 
-    /** @return KeyValueStore|Response */
+    /**
+     * @param AdminContext<TInstance> $context
+     *
+     * @return KeyValueStore|Response
+     */
     public function edit(AdminContext $context);
 
-    /** @return KeyValueStore|Response */
+    /**
+     * @param AdminContext<TInstance> $context
+     *
+     * @return KeyValueStore|Response
+     */
     public function new(AdminContext $context);
 
-    /** @return KeyValueStore|Response */
+    /**
+     * @param AdminContext<TInstance> $context
+     *
+     * @return KeyValueStore|Response
+     */
     public function delete(AdminContext $context);
 
+    /**
+     * @param AdminContext<TInstance> $context
+     */
     public function autocomplete(AdminContext $context): JsonResponse;
 
     public function configureResponseParameters(KeyValueStore $responseParameters): KeyValueStore;
 
+    /**
+     * @param EntityDto<TInstance> $entityDto
+     */
     public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder;
 
+    /**
+     * @param class-string<TInstance> $entityFqcn
+     *
+     * @return TInstance
+     */
     public function createEntity(string $entityFqcn);
 
+    /**
+     * @param TInstance $entityInstance
+     */
     public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void;
 
+    /**
+     * @param TInstance $entityInstance
+     */
     public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void;
 
+    /**
+     * @param TInstance $entityInstance
+     */
     public function deleteEntity(EntityManagerInterface $entityManager, $entityInstance): void;
 
+    /**
+     * @param EntityDto<TInstance>    $entityDto
+     * @param AdminContext<TInstance> $context
+     */
     public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface;
 
+    /**
+     * @param EntityDto<TInstance>    $entityDto
+     * @param AdminContext<TInstance> $context
+     */
     public function createEditForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface;
 
+    /**
+     * @param EntityDto<TInstance>    $entityDto
+     * @param AdminContext<TInstance> $context
+     */
     public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface;
 
+    /**
+     * @param EntityDto<TInstance>    $entityDto
+     * @param AdminContext<TInstance> $context
+     */
     public function createNewForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface;
 }

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -63,12 +63,14 @@ use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use function Symfony\Component\String\u;
 
 /**
+ * @template TInstance of object
+ *
+ * @implements CrudControllerInterface<TInstance>
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 abstract class AbstractCrudController extends AbstractController implements CrudControllerInterface
 {
-    abstract public static function getEntityFqcn(): string;
-
     public function configureCrud(Crud $crud): Crud
     {
         return $crud;
@@ -392,6 +394,9 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $this->redirect($this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->unset(EA::ENTITY_ID)->generateUrl());
     }
 
+    /**
+     * @param AdminContext<TInstance> $context
+     */
     public function batchDelete(AdminContext $context, BatchActionDto $batchActionDto): Response
     {
         $event = new BeforeCrudActionEvent($context);
@@ -475,6 +480,9 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $this->container->get(EntityRepository::class)->createQueryBuilder($searchDto, $entityDto, $fields, $filters);
     }
 
+    /**
+     * @param AdminContext<TInstance> $context
+     */
     public function renderFilters(AdminContext $context): KeyValueStore
     {
         $fields = FieldCollection::new($this->configureFields(Crud::PAGE_INDEX));
@@ -548,11 +556,17 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $responseParameters;
     }
 
+    /**
+     * @return AdminContext<TInstance>|null
+     */
     protected function getContext(): ?AdminContext
     {
         return $this->container->get(AdminContextProvider::class)->getContext();
     }
 
+    /**
+     * @param EntityDto<TInstance> $entityDto
+     */
     protected function ajaxEdit(EntityDto $entityDto, ?string $propertyName, bool $newValue): AfterCrudActionEvent
     {
         $this->container->get(EntityUpdater::class)->updateProperty($entityDto, $propertyName, $newValue);
@@ -619,6 +633,9 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         }
     }
 
+    /**
+     * @param AdminContext<TInstance> $context
+     */
     protected function getRedirectResponseAfterSave(AdminContext $context, string $action): RedirectResponse
     {
         $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];

--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -10,14 +10,18 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
+ * @template TInstance of object
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class EntityDto
 {
     private bool $isAccessible = true;
+    /** @var class-string<TInstance> */
     private string $fqcn;
     /** @var ClassMetadataInfo */
     private ClassMetadata $metadata;
+    /** @var TInstance|null */
     private $instance;
     private $primaryKeyName;
     private mixed $primaryKeyValue = null;
@@ -26,7 +30,9 @@ final class EntityDto
     private ?ActionCollection $actions = null;
 
     /**
+     * @param class-string<TInstance>         $entityFqcn
      * @param ClassMetadata&ClassMetadataInfo $entityMetadata
+     * @param TInstance|null                  $entityInstance
      */
     public function __construct(string $entityFqcn, ClassMetadata $entityMetadata, ?string $entityPermission = null, /* ?object */ $entityInstance = null)
     {
@@ -55,6 +61,9 @@ final class EntityDto
         return $this->toString();
     }
 
+    /**
+     * @return class-string<TInstance>
+     */
     public function getFqcn(): string
     {
         return $this->fqcn;
@@ -78,6 +87,9 @@ final class EntityDto
         return sprintf('%s #%s', $this->getName(), substr($this->getPrimaryKeyValueAsString(), 0, 16));
     }
 
+    /**
+     * @return TInstance|null
+     */
     public function getInstance()/* : ?object */
     {
         return $this->instance;
@@ -209,6 +221,9 @@ final class EntityDto
         return \array_key_exists($propertyNameParts[0], $this->metadata->embeddedClasses);
     }
 
+    /**
+     * @param TInstance|null $newEntityInstance
+     */
     public function setInstance(?object $newEntityInstance): void
     {
         if (null !== $this->instance && null !== $newEntityInstance && !$newEntityInstance instanceof $this->fqcn) {
@@ -219,6 +234,9 @@ final class EntityDto
         $this->primaryKeyValue = null;
     }
 
+    /**
+     * @param TInstance $newEntityInstance
+     */
     public function newWithInstance(/* object */ $newEntityInstance): self
     {
         if (!\is_object($newEntityInstance)) {
@@ -233,7 +251,7 @@ final class EntityDto
             );
         }
 
-        if (null !== $this->instance && !$newEntityInstance instanceof $this->fqcn) {
+        if (!$newEntityInstance instanceof $this->fqcn) {
             throw new \InvalidArgumentException(sprintf('The new entity instance must be of the same type as the previous instance (original instance: "%s", new instance: "%s").', $this->fqcn, \get_class($newEntityInstance)));
         }
 

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -66,16 +66,39 @@ final class EntityFactory
         return $this->actionFactory->processGlobalActions($actionConfigDto);
     }
 
+    /**
+     * @template TInstance of object
+     *
+     * @param class-string<TInstance> $entityFqcn
+     * @param mixed                   $entityId
+     *
+     * @return EntityDto<TInstance>
+     */
     public function create(string $entityFqcn, $entityId = null, ?string $entityPermission = null): EntityDto
     {
         return $this->doCreate($entityFqcn, $entityId, $entityPermission);
     }
 
+    /**
+     * @template TInstance of object
+     *
+     * @param TInstance $entityInstance
+     *
+     * @return EntityDto<TInstance>
+     */
     public function createForEntityInstance($entityInstance): EntityDto
     {
         return $this->doCreate(null, null, null, $entityInstance);
     }
 
+    /**
+     * @template TInstance of object
+     *
+     * @param EntityDto<TInstance> $entityDto
+     * @param iterable<TInstance>  $entityInstances
+     *
+     * @return EntityCollection<TInstance>
+     */
     public function createCollection(EntityDto $entityDto, ?iterable $entityInstances): EntityCollection
     {
         $entityDtos = [];
@@ -94,6 +117,8 @@ final class EntityFactory
     }
 
     /**
+     * @param class-string $entityFqcn
+     *
      * @return ClassMetadata&ClassMetadataInfo
      */
     public function getEntityMetadata(string $entityFqcn): ClassMetadata
@@ -109,6 +134,15 @@ final class EntityFactory
         return $entityMetadata;
     }
 
+    /**
+     * @template TInstance of object
+     *
+     * @param class-string<TInstance>|null $entityFqcn
+     * @param mixed                        $entityId
+     * @param TInstance|null               $entityInstance
+     *
+     * @return EntityDto<TInstance>
+     */
     private function doCreate(?string $entityFqcn = null, $entityId = null, ?string $entityPermission = null, $entityInstance = null): EntityDto
     {
         if (null === $entityInstance && null !== $entityFqcn) {
@@ -135,6 +169,9 @@ final class EntityFactory
         return $entityDto;
     }
 
+    /**
+     * @param class-string $entityFqcn
+     */
     private function getEntityManager(string $entityFqcn): ObjectManager
     {
         if (null === $entityManager = $this->doctrine->getManagerForClass($entityFqcn)) {
@@ -144,6 +181,14 @@ final class EntityFactory
         return $entityManager;
     }
 
+    /**
+     * @template TInstance of object
+     *
+     * @param class-string<TInstance> $entityFqcn
+     * @param mixed                   $entityIdValue
+     *
+     * @return TInstance
+     */
     private function getEntityInstance(string $entityFqcn, $entityIdValue): object
     {
         $entityManager = $this->getEntityManager($entityFqcn);

--- a/tests/TestApplication/src/Controller/CategoryCrudController.php
+++ b/tests/TestApplication/src/Controller/CategoryCrudController.php
@@ -9,29 +9,19 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
-use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config\Action as AppAction;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @extends AbstractCrudController<Category>
+ */
 class CategoryCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string
     {
         return Category::class;
-    }
-
-    public function configureFields(string $pageName): iterable
-    {
-        return [
-            IdField::new('id')->hideOnForm(),
-            TextField::new('name'),
-            TextField::new('slug'),
-            BooleanField::new('active'),
-        ];
     }
 
     public function configureActions(Actions $actions): Actions
@@ -51,6 +41,9 @@ class CategoryCrudController extends AbstractCrudController
             ->add('active');
     }
 
+    /**
+     * @param AdminContext<Category> $context
+     */
     public function customAction(AdminContext $context): Response
     {
         if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => AppAction::CUSTOM_ACTION, 'entity' => $context->getEntity()])) {


### PR DESCRIPTION
Adding these annotations will provide types to the app. I'm tired of writing tones of `@var` annotations and `assert()`s.

Usage:
```php
/**
 * @extends AbstractCrudController<Category>
 */
class CategoryCrudController extends AbstractCrudController
{
    public static function getEntityFqcn(): string
    {
        return Category::class;
    }

    public function detail(AdminContext $context)
    {
        $instance = $context->getEntity()->getInstance();
        \PHPStan\dumpType($instance); // $instance is Category
    }
}
```

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
