### PR TITLE
Fix #5577: relative dashboard URL must reset query parameters

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -257,7 +257,7 @@ final class AdminUrlGenerator
 
         $context = $this->adminContextProvider->getContext();
         $urlType = null !== $context && false === $context->getAbsoluteUrls() ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_URL;
-        $url = $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType);
+        $url = $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType) ?: '?';
 
         // this is important to start the generation a each URL from the same initial state
         // otherwise, some parameters used when generating some URL could leak to other URLs


### PR DESCRIPTION
See issue. This simple fix will ensure dashboard url is generated as `href="?"` and thus link to `/admin` in relative URL scenarios.