### PR TITLE
The actions factory did not handle properly the route parameters as callable for the BatchAction and GlobalAction.

### DIFF
--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -168,7 +168,7 @@ final class ActionFactory
             $routeParameters = $actionDto->getRouteParameters();
             if ($actionDto->isBatchAction() || $actionDto->isGlobalAction()) {
                 $routeParameters = [];
-            } elseif(\is_callable($routeParameters) && null !== $entityInstance = $entityDto->getInstance()) {
+            } elseif (\is_callable($routeParameters) && null !== $entityInstance = $entityDto->getInstance()) {
                 $routeParameters = $routeParameters($entityInstance);
             }
 

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -166,7 +166,9 @@ final class ActionFactory
 
         if (null !== $routeName = $actionDto->getRouteName()) {
             $routeParameters = $actionDto->getRouteParameters();
-            if (\is_callable($routeParameters) && null !== $entityInstance = $entityDto->getInstance()) {
+            if ($actionDto->isBatchAction() || $actionDto->isGlobalAction()) {
+                $routeParameters = [];
+            } elseif(\is_callable($routeParameters) && null !== $entityInstance = $entityDto->getInstance()) {
                 $routeParameters = $routeParameters($entityInstance);
             }
 


### PR DESCRIPTION
For the BatchAction and GlobalAction, there's no $entityDto, so the code was throwing a 500