### PR TITLE
Hide add and delete buttons on disabled collections

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -166,7 +166,7 @@
         {% set attr = attr|merge({'data-empty-collection': block('empty_collection') }) %}
     {% endif %}
 
-    {% if allow_add|default(false) %}
+    {% if allow_add|default(false) and not disabled %}
         <button type="button" class="btn btn-link field-collection-add-button">
             <i class="fa fa-plus pr-1"></i>
             {{ 'action.add_new_item'|trans({}, 'EasyAdminBundle') }}
@@ -189,7 +189,7 @@
     <div class="field-collection-item {{ is_complex ? 'field-collection-item-complex' }}">
         {% if is_array_field|default(false) %}
             {{ form_widget(form) }}
-            {% if allows_deleting_items %}
+            {% if allows_deleting_items and not disabled %}
                 {{ delete_item_button }}
             {% endif %}
         {% else %}
@@ -200,7 +200,7 @@
                         {{ value|ea_as_string }}
                     </button>
 
-                    {% if allows_deleting_items %}
+                    {% if allows_deleting_items and not disabled %}
                         {{ delete_item_button }}
                     {% endif %}
                 </h2>


### PR DESCRIPTION
A field based on a simple array of strings like this:
```
CollectionField::new('tags')
    ->renderExpanded()
    ->setDisabled()
```
Results in this:
![image](https://user-images.githubusercontent.com/44525318/213317275-2aaf7842-f08c-4e96-9042-1dd5c976e092.png)

I'm not sure if the add and delete buttons are supposed to be visible in disabled collections?
If they're not then this PR hides them.