### PR TITLE
Update polish pluralization translation

### DIFF
--- a/src/Resources/translations/EasyAdminBundle.pl.php
+++ b/src/Resources/translations/EasyAdminBundle.pl.php
@@ -7,7 +7,7 @@ return [
         'edit' => '%entity_label_singular%',
         'index' => '%entity_label_plural%',
         'new' => 'Dodaj nowy %entity_label_singular%',
-        'exception' => 'Błąd|Błędy',
+        'exception' => 'Błąd|Błędy|Błędy',
     ],
 
     'datagrid' => [
@@ -99,7 +99,7 @@ return [
 
     'form' => [
         'are_you_sure' => 'Nie zapisano zmian wprowadzonych w tym formularzu.',
-        'tab.error_badge_title' => 'Wystąpił jeden błąd|Ilość błędów: %count%',
+        'tab.error_badge_title' => 'Wystąpił jeden błąd|Wystąpiły %count% błędy|Wystąpiło %count% błędów',
         'slug.confirm_text' => 'Jeśli zmienisz slug, linki mogą przestać działać na innych stronach.',
     ],
 


### PR DESCRIPTION
With recent enough Symfony the translation component expects 3 pluralization variants for polish language (which is more on par with our language than 2 variants), thus throwing exception when one of the following translations are used with specific `count` parameters: `form.tab.error_badge_title`, `page_title.exception`. This simple PR fixes the issue and allows working validation for polish language with tabs.