### PR TITLE
chore(docs): Remove `translation` from `index.rst`

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,7 +27,6 @@ Table of Contents
     actions
     security
     events
-    translation
     upgrade
 
 Technical Requirements


### PR DESCRIPTION
`translation.rst` documentation page has been removed, but it has not been removed from `Table of Content` on `index.rst`
