### PR TITLE
allow to use custom base url for assets so that we can provide a CDN url

### DIFF
--- a/src/Asset/AssetPackage.php
+++ b/src/Asset/AssetPackage.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Asset;
 use Symfony\Component\Asset\Context\RequestStackContext;
 use Symfony\Component\Asset\PackageInterface;
 use Symfony\Component\Asset\PathPackage;
+use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Asset\VersionStrategy\JsonManifestVersionStrategy;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -23,13 +24,21 @@ final class AssetPackage implements PackageInterface
 
     private PackageInterface $package;
 
-    public function __construct(RequestStack $requestStack)
+    public function __construct(RequestStack $requestStack, ?string $baseUrl)
     {
-        $this->package = new PathPackage(
-            '/bundles/easyadmin',
-            new JsonManifestVersionStrategy(__DIR__.'/../Resources/public/manifest.json'),
-            new RequestStackContext($requestStack)
-        );
+        if (null === $baseUrl) {
+            $this->package = new UrlPackage(
+                $baseUrl.'/bundles/easyadmin',
+                new JsonManifestVersionStrategy(__DIR__.'/../Resources/public/manifest.json'),
+                new RequestStackContext($requestStack)
+            );
+        } else {
+            $this->package = new PathPackage(
+                '/bundles/easyadmin',
+                new JsonManifestVersionStrategy(__DIR__.'/../Resources/public/manifest.json'),
+                new RequestStackContext($requestStack)
+            );
+        }
     }
 
     public function getUrl(string $assetPath): string

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -81,6 +81,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Security\AuthorizationChecker;
 use EasyCorp\Bundle\EasyAdminBundle\Security\SecurityVoter;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
@@ -362,9 +363,18 @@ return static function (ContainerConfigurator $container) {
         ->set(TimezoneConfigurator::class)
 
         ->set(UrlConfigurator::class)
-
-        ->set(AssetPackage::class)
-            ->arg(0, service('request_stack'))
-            ->tag('assets.package', ['package' => AssetPackage::PACKAGE_NAME])
     ;
+
+    $baseUrl = null;
+    try {
+        // this will trigger the use of UrlPackage allowing absolute URL
+        $baseUrl = param('easyadmin_base_url');
+    } catch (RuntimeException $exception) {
+        // Do nothing, just mute the exception
+    }
+    $services
+        ->set(AssetPackage::class)
+        ->arg(0, service('request_stack'))
+        ->arg(1, $baseUrl)
+        ->tag('assets.package', ['package' => AssetPackage::PACKAGE_NAME]);
 };


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

Hi,

Im trying to solve this issue: https://github.com/EasyCorp/EasyAdminBundle/issues/5382 then i trying to build this mr.

What was the problem.
The main problem is that as the manifest.json is build with relative url, twig asset function will just give relative url.

Our admin is on a first url https://admin.url1.com
and all our assets are on a second url like https://assets.url1.com

solution:
use UrlPackage is baseUrl is provided then twig asset function will do the job
In this mr, if you set the parameter `easyadmin_base_url`, you can now use a custom url for assets, in particular in twig asset function.

Thanks for your review