### PR TITLE
Make data providers static for PHPUnit 10

### DIFF
--- a/tests/Controller/CategoryCrudControllerTest.php
+++ b/tests/Controller/CategoryCrudControllerTest.php
@@ -61,7 +61,7 @@ class CategoryCrudControllerTest extends WebTestCase
         }
     }
 
-    public function new(): \Generator
+    public static function new(): \Generator
     {
         yield [
             '', // Manipulate the CSRF token to an empty value
@@ -102,7 +102,7 @@ class CategoryCrudControllerTest extends WebTestCase
         }
     }
 
-    public function edit(): \Generator
+    public static function edit(): \Generator
     {
         yield [
             '', // Manipulate the CSRF token to an empty value
@@ -145,7 +145,7 @@ class CategoryCrudControllerTest extends WebTestCase
         $this->assertResultCount($expectedCategoriesCount($initialCategoriesCount));
     }
 
-    public function delete(): \Generator
+    public static function delete(): \Generator
     {
         yield [
             '', // Manipulate the CSRF token to an empty value
@@ -265,7 +265,7 @@ class CategoryCrudControllerTest extends WebTestCase
         $this->assertSame('foobar1234', $this->getParameterFromUrlQueryString($nextPagePageUrl, 'CUSTOM_param'));
     }
 
-    public function toggle(): \Generator
+    public static function toggle(): \Generator
     {
         yield [
             'GET', // HTTP method
@@ -301,7 +301,7 @@ class CategoryCrudControllerTest extends WebTestCase
         $this->assertResultCount($expectedResultCount);
     }
 
-    public function search(): \Generator
+    public static function search(): \Generator
     {
         yield [
             [],
@@ -342,7 +342,7 @@ class CategoryCrudControllerTest extends WebTestCase
         $this->assertResultCount($expectedResultCount);
     }
 
-    public function filter(): \Generator
+    public static function filter(): \Generator
     {
         yield [
             [],
@@ -400,10 +400,10 @@ class CategoryCrudControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame($expectedStatusCode);
     }
 
-    public function customPage(): \Generator
+    public static function customPage(): \Generator
     {
-        yield [$this->generateUsername('ROLE_USER'), Response::HTTP_FORBIDDEN];
-        yield [$this->generateUsername('ROLE_ADMIN'), Response::HTTP_OK];
+        yield [self::generateUsername('ROLE_USER'), Response::HTTP_FORBIDDEN];
+        yield [self::generateUsername('ROLE_ADMIN'), Response::HTTP_OK];
     }
 
     private function assertResultCount(int $expectedResultCount): void
@@ -484,7 +484,7 @@ class CategoryCrudControllerTest extends WebTestCase
             ->generateUrl();
     }
 
-    private function generateUsername(string $role): string
+    private static function generateUsername(string $role): string
     {
         switch ($role) {
             case 'ROLE_USER':

--- a/tests/DependencyInjection/CommandTest.php
+++ b/tests/DependencyInjection/CommandTest.php
@@ -23,7 +23,7 @@ class CommandTest extends KernelTestCase
         $this->assertNotEmpty($command->getHelp());
     }
 
-    public function provideCommands()
+    public static function provideCommands()
     {
         yield ['make:admin:crud'];
         yield ['make:admin:dashboard'];

--- a/tests/Dto/CrudDtoTest.php
+++ b/tests/Dto/CrudDtoTest.php
@@ -31,7 +31,7 @@ class CrudDtoTest extends TestCase
         $this->assertSame($expectedGetLabel, $crudDto->getEntityLabelInPlural($entityInstance));
     }
 
-    public function provideLabels()
+    public static function provideLabels()
     {
         yield [null, null];
         yield ['', ''];

--- a/tests/Form/Filter/Type/ArrayFilterTypeTest.php
+++ b/tests/Form/Filter/Type/ArrayFilterTypeTest.php
@@ -29,7 +29,7 @@ class ArrayFilterTypeTest extends FilterTypeTest
         $this->assertSameDoctrineParams($params, $this->qb->getParameters()->toArray());
     }
 
-    public function getDataProvider(): iterable
+    public static function getDataProvider(): iterable
     {
         yield [
             ['comparison' => ComparisonType::CONTAINS, 'value' => ['bar']],

--- a/tests/Form/Filter/Type/BooleanFilterTypeTest.php
+++ b/tests/Form/Filter/Type/BooleanFilterTypeTest.php
@@ -28,7 +28,7 @@ class BooleanFilterTypeTest extends FilterTypeTest
         $this->assertSameDoctrineParams($params, $this->qb->getParameters()->toArray());
     }
 
-    public function getDataProvider(): iterable
+    public static function getDataProvider(): iterable
     {
         yield [
             '1',

--- a/tests/Form/Filter/Type/ChoiceFilterTypeTest.php
+++ b/tests/Form/Filter/Type/ChoiceFilterTypeTest.php
@@ -30,7 +30,7 @@ class ChoiceFilterTypeTest extends FilterTypeTest
         $this->assertSameDoctrineParams($params, $this->qb->getParameters()->toArray());
     }
 
-    public function getDataProvider(): iterable
+    public static function getDataProvider(): iterable
     {
         yield [
             ['comparison' => ComparisonType::EQ, 'value' => null],

--- a/tests/Form/Filter/Type/ComparisonFilterTypeTest.php
+++ b/tests/Form/Filter/Type/ComparisonFilterTypeTest.php
@@ -34,7 +34,7 @@ class ComparisonFilterTypeTest extends FilterTypeTest
         $this->assertSameDoctrineParams($params, $this->qb->getParameters()->toArray());
     }
 
-    public function getDataProvider(): iterable
+    public static function getDataProvider(): iterable
     {
         yield [
             ['comparison' => ComparisonType::LT, 'value' => '23'],

--- a/tests/Form/Filter/Type/DateTimeFilterTypeTest.php
+++ b/tests/Form/Filter/Type/DateTimeFilterTypeTest.php
@@ -35,7 +35,7 @@ class DateTimeFilterTypeTest extends FilterTypeTest
         }
     }
 
-    public function getDataProvider(): iterable
+    public static function getDataProvider(): iterable
     {
         yield [
             ['comparison' => ComparisonType::EQ, 'value' => '2019-06-17 14:39:00', 'value2' => null],

--- a/tests/Form/Filter/Type/EntityFilterTypeTest.php
+++ b/tests/Form/Filter/Type/EntityFilterTypeTest.php
@@ -98,7 +98,7 @@ class EntityFilterTypeTest extends FilterTypeTest
         $this->assertSameDoctrineParams($params, $this->qb->getParameters()->toArray());
     }
 
-    public function getDataProviderToOneAssoc(): iterable
+    public static function getDataProviderToOneAssoc(): iterable
     {
         $entity1 = new SingleIntIdEntity(1, 'Foo');
         $entity2 = new SingleIntIdEntity(2, 'Bar');
@@ -160,7 +160,7 @@ class EntityFilterTypeTest extends FilterTypeTest
         ];
     }
 
-    public function getDataProviderToManyAssoc(): iterable
+    public static function getDataProviderToManyAssoc(): iterable
     {
         $entity1 = new SingleIntIdEntity(1, 'Foo');
         $entity2 = new SingleIntIdEntity(2, 'Bar');

--- a/tests/Form/Filter/Type/NumericFilterTypeTest.php
+++ b/tests/Form/Filter/Type/NumericFilterTypeTest.php
@@ -34,7 +34,7 @@ class NumericFilterTypeTest extends FilterTypeTest
         }
     }
 
-    public function getDataProvider(): iterable
+    public static function getDataProvider(): iterable
     {
         yield [
             ['comparison' => ComparisonType::EQ, 'value' => '23', 'value2' => null],

--- a/tests/Form/Filter/Type/TextFilterTypeTest.php
+++ b/tests/Form/Filter/Type/TextFilterTypeTest.php
@@ -28,7 +28,7 @@ class TextFilterTypeTest extends FilterTypeTest
         $this->assertSameDoctrineParams($params, $this->qb->getParameters()->toArray());
     }
 
-    public function getDataProvider(): iterable
+    public static function getDataProvider(): iterable
     {
         yield [
             ['comparison' => ComparisonType::CONTAINS, 'value' => 'abc'],

--- a/tests/Intl/IntlFormatterTest.php
+++ b/tests/Intl/IntlFormatterTest.php
@@ -55,7 +55,7 @@ class IntlFormatterTest extends TestCase
         $this->assertSame($expectedResult, $formattedDateTimeWithNormalizedSpaces);
     }
 
-    public function provideFormatDate()
+    public static function provideFormatDate()
     {
         yield [null, null, 'medium', '', null, 'gregorian', null];
 
@@ -82,7 +82,7 @@ class IntlFormatterTest extends TestCase
         yield ['Nov 7, 2020', new \DateTime('2020-11-07'), 'medium', '', null, 'traditional', 'en'];
     }
 
-    public function provideFormatTime()
+    public static function provideFormatTime()
     {
         yield [null, null, 'medium', '', null, 'gregorian', null];
 
@@ -106,7 +106,7 @@ class IntlFormatterTest extends TestCase
         yield ['/Pacific (Standard|Daylight) Time Pacific Time -0(7|8):00/', new \DateTime('15:04:05 CET'), null, 'zzzz vvvv xxxxx', new \DateTimeZone('PST'), 'gregorian', 'en', 'assertMatchesRegularExpression'];
     }
 
-    public function provideFormatDateTime()
+    public static function provideFormatDateTime()
     {
         yield [null, null, 'medium', 'medium', '', null, 'gregorian', null];
 

--- a/tests/Router/UrlSignerTest.php
+++ b/tests/Router/UrlSignerTest.php
@@ -33,7 +33,7 @@ class UrlSignerTest extends TestCase
         $this->assertSame($expectedResult, $urlSigner->check($url));
     }
 
-    public function provideSignData()
+    public static function provideSignData()
     {
         // the host/user/pass/port URL parts don't affect the signature
         yield ['https://example.com/', 'https://example.com/?signature=bS2fxhAzf4E6G4WGnsIUEplAhgVDrQQwjYc1f2wBM_Y'];


### PR DESCRIPTION
The entire ecosystem is doing this change to prepare for PHPUnit 10.