### PR TITLE
Don't use some deprecated methods in tests

### DIFF
--- a/tests/Field/AbstractFieldTest.php
+++ b/tests/Field/AbstractFieldTest.php
@@ -31,7 +31,7 @@ abstract class AbstractFieldTest extends KernelTestCase
 
         $crudMock = $this->getMockBuilder(CrudDto::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCurrentPage', 'getDatePattern', 'getDateTimePattern', 'getTimePattern'])
+            ->onlyMethods(['getCurrentPage', 'getDatePattern', 'getDateTimePattern', 'getTimePattern'])
             ->getMock();
         $crudMock->method('getCurrentPage')->willReturn(Crud::PAGE_INDEX);
         $crudMock->method('getDatePattern')->willReturn(DateTimeField::FORMAT_MEDIUM);
@@ -40,14 +40,14 @@ abstract class AbstractFieldTest extends KernelTestCase
 
         $i18nMock = $this->getMockBuilder(I18nDto::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getTranslationParameters', 'getTranslationDomain'])
+            ->onlyMethods(['getTranslationParameters', 'getTranslationDomain'])
             ->getMock();
         $i18nMock->method('getTranslationParameters')->willReturn([]);
         $i18nMock->method('getTranslationDomain')->willReturn('messages');
 
         $adminContextMock = $this->getMockBuilder(AdminContext::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getCrud', 'getI18n', 'getTemplatePath'])
+            ->onlyMethods(['getCrud', 'getI18n', 'getTemplatePath'])
             ->getMock();
         $adminContextMock
             ->expects($this->any())

--- a/tests/Field/DateFieldTest.php
+++ b/tests/Field/DateFieldTest.php
@@ -15,7 +15,7 @@ class DateFieldTest extends AbstractFieldTest
 
         $intlFormatterMock = $this->getMockBuilder(IntlFormatter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['formatDate'])
+            ->onlyMethods(['formatDate'])
             ->getMock();
         $intlFormatterMock->method('formatDate')->willReturnCallback(
             static function ($value, ?string $dateFormat = 'medium', string $pattern = '', $timezone = null, string $calendar = 'gregorian', string $locale = null) { return sprintf('value: %s | dateFormat: %s | pattern: %s | timezone: %s | calendar: %s | locale: %s', $value instanceof \DateTimeInterface ? $value->format('Y-m-d H:i:s') : $value, $dateFormat, $pattern, $timezone, $calendar, $locale); }

--- a/tests/Field/DateTimeFieldTest.php
+++ b/tests/Field/DateTimeFieldTest.php
@@ -14,7 +14,7 @@ class DateTimeFieldTest extends AbstractFieldTest
 
         $intlFormatterMock = $this->getMockBuilder(IntlFormatter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['formatDateTime'])
+            ->onlyMethods(['formatDateTime'])
             ->getMock();
         $intlFormatterMock->method('formatDateTime')->willReturnCallback(
             static function ($value, ?string $dateFormat = 'medium', ?string $timeFormat = 'medium', string $pattern = '', $timezone = null, string $calendar = 'gregorian', string $locale = null) { return sprintf('value: %s | dateFormat: %s | timeFormat: %s | pattern: %s | timezone: %s | calendar: %s | locale: %s', $value->format('Y-m-d'), $dateFormat, $timeFormat, $pattern, $timezone, $calendar, $locale); }

--- a/tests/Field/MoneyFieldTest.php
+++ b/tests/Field/MoneyFieldTest.php
@@ -15,7 +15,7 @@ class MoneyFieldTest extends AbstractFieldTest
 
         $intlFormatterMock = $this->getMockBuilder(IntlFormatter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['formatCurrency'])
+            ->onlyMethods(['formatCurrency'])
             ->getMock();
         $intlFormatterMock->method('formatCurrency')->willReturnCallback(
             function ($value) { return $value.'€'; }
@@ -23,7 +23,7 @@ class MoneyFieldTest extends AbstractFieldTest
 
         $propertyAccessorMock = $this->getMockBuilder(PropertyAccessor::class)
             ->disableOriginalConstructor()
-            ->setMethods(['isReadable', 'getValue'])
+            ->onlyMethods(['isReadable', 'getValue'])
             ->getMock();
         $propertyAccessorMock->method('isReadable')->willReturn(true);
         $propertyAccessorMock->method('getValue')->willReturn('USD');

--- a/tests/Field/TimeFieldTest.php
+++ b/tests/Field/TimeFieldTest.php
@@ -15,7 +15,7 @@ class TimeFieldTest extends AbstractFieldTest
 
         $intlFormatterMock = $this->getMockBuilder(IntlFormatter::class)
             ->disableOriginalConstructor()
-            ->setMethods(['formatDate', 'formatTime'])
+            ->onlyMethods(['formatDate', 'formatTime'])
             ->getMock();
         $intlFormatterMock->method('formatDate')->willReturnCallback(
             static function ($value, ?string $dateFormat = 'medium', string $pattern = '', $timezone = null, string $calendar = 'gregorian', string $locale = null) { return sprintf('value: %s | dateFormat: %s | pattern: %s | timezone: %s | calendar: %s | locale: %s', $value instanceof \DateTimeInterface ? $value->format('Y-m-d H:i:s') : $value, $dateFormat, $pattern, $timezone, $calendar, $locale); }


### PR DESCRIPTION
The `setMethods()` method was deprecated in previous PhpUnit versions and removed in PhpUnit 10 ... so let's not use it to ease compatibility with next PhpUnit versions.