### PR TITLE
Added `renderAsHtml` option to `TextEditorField`.

### DIFF
--- a/src/Field/TextEditorField.php
+++ b/src/Field/TextEditorField.php
@@ -16,6 +16,7 @@ final class TextEditorField implements FieldInterface
 
     public const OPTION_NUM_OF_ROWS = 'numOfRows';
     public const OPTION_TRIX_EDITOR_CONFIG = 'trixEditorConfig';
+    public const OPTION_RENDER_AS_HTML = TextField::OPTION_RENDER_AS_HTML;
 
     /**
      * @param TranslatableInterface|string|false|null $label
@@ -32,7 +33,8 @@ final class TextEditorField implements FieldInterface
             ->addJsFiles(Asset::fromEasyAdminAssetPackage('field-text-editor.js')->onlyOnForms())
             ->setDefaultColumns('col-md-9 col-xxl-7')
             ->setCustomOption(self::OPTION_NUM_OF_ROWS, null)
-            ->setCustomOption(self::OPTION_TRIX_EDITOR_CONFIG, null);
+            ->setCustomOption(self::OPTION_TRIX_EDITOR_CONFIG, null)
+            ->setCustomOption(self::OPTION_RENDER_AS_HTML, false);
     }
 
     public function setNumOfRows(int $rows): self
@@ -42,6 +44,13 @@ final class TextEditorField implements FieldInterface
         }
 
         $this->setCustomOption(self::OPTION_NUM_OF_ROWS, $rows);
+
+        return $this;
+    }
+
+    public function renderAsHtml(bool $asHtml = true): self
+    {
+        $this->setCustomOption(self::OPTION_RENDER_AS_HTML, $asHtml);
 
         return $this;
     }

--- a/src/Resources/views/crud/field/text_editor.html.twig
+++ b/src/Resources/views/crud/field/text_editor.html.twig
@@ -1,8 +1,9 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
+{% set render_as_html = field.customOptions.get('renderAsHtml') %}
 {% if ea.crud.currentAction == 'detail' %}
-    {{ field.formattedValue|nl2br }}
+    {{ render_as_html ? field.formattedValue|raw|nl2br : field.formattedValue|nl2br }}
 {% else %}
     {% set html_id = 'ea-text-editor-' ~ field.uniqueId %}
     <a href="#" data-bs-toggle="modal" data-bs-target="#{{ html_id }}">


### PR DESCRIPTION
Allows to render the field in a built-in or custom page as HTML using field template (No need to create a custom one for this purpose).
If `TextAreaField` and also `TextField` have this option, why not `TextEditorField`?
This avoid using a `TextEditorField` for EDIT page and `TextAreaField` for DETAIL or custom page where rendering as HTML is needed.