### PR TITLE
[PATCH] Fix php-cs-fixer's issues enums related

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -50,7 +50,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         // support for enums
         if ($enumsAreSupported) {
             $elementIsEnum = array_unique(array_map(static function ($element): bool {
-                return \is_object($element) && enum_exists($element::class) && $element;
+                return \is_object($element) && enum_exists($element::class);
             }, $choices));
             $allChoicesAreEnums = false === \in_array(false, $elementIsEnum, true);
 

--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -50,6 +50,10 @@ class ChoiceFieldTest extends AbstractFieldTest
 
     public function testFieldWithUnitEnumChoices(): void
     {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('PHP 8.1 or higher is required to run this test.');
+        }
+
         $field = ChoiceField::new('foo')->setChoices(PriorityUnitEnum::cases());
 
         $field->setValue(PriorityUnitEnum::High);
@@ -62,6 +66,10 @@ class ChoiceFieldTest extends AbstractFieldTest
 
     public function testFieldWithBackedEnumChoices(): void
     {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('PHP 8.1 or higher is required to run this test.');
+        }
+
         $field = ChoiceField::new('foo')->setChoices(StatusBackedEnum::cases());
 
         $field->setValue(StatusBackedEnum::Draft);

--- a/tests/Field/Fixtures/ChoiceField/PriorityUnitEnum.php
+++ b/tests/Field/Fixtures/ChoiceField/PriorityUnitEnum.php
@@ -3,7 +3,8 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Fixtures\ChoiceField;
 
 if (\PHP_VERSION_ID >= 80100) {
-    enum PriorityUnitEnum {
+    enum PriorityUnitEnum
+    {
         case High;
         case Normal;
         case Low;

--- a/tests/Field/Fixtures/ChoiceField/StatusBackedEnum.php
+++ b/tests/Field/Fixtures/ChoiceField/StatusBackedEnum.php
@@ -3,7 +3,8 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Fixtures\ChoiceField;
 
 if (\PHP_VERSION_ID >= 80100) {
-    enum StatusBackedEnum: string {
+    enum StatusBackedEnum: string
+    {
         case Draft = 'draft';
         case Published = 'published';
         case Deleted = 'deleted';


### PR DESCRIPTION
PHP CS Fixer

```diff
 if (\PHP_VERSION_ID >= 80100) {
-    enum StatusBackedEnum: string {
+    enum StatusBackedEnum: string
+    {

 if (\PHP_VERSION_ID >= 80100) {
-    enum PriorityUnitEnum {
+    enum PriorityUnitEnum
+    {

 $elementIsEnum = array_unique(array_map(static function ($element): bool {
-    return \is_object($element) && enum_exists($element::class) && $element;
+   return \is_object($element) && enum_exists($element::class);
 }, $choices));

public function testFieldWithUnitEnumChoices(): void
{
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('PHP 8.1 or higher is required to run this test.');
+        }
        $field = ChoiceField::new('foo')->setChoices(PriorityUnitEnum::cases());
 
```
