### PR TITLE
Fix some issues on EnumType

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -48,6 +48,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         }
 
         // support for enums
+        $elementIsEnum = false;
         if ($enumsAreSupported) {
             $elementIsEnum = array_unique(array_map(static function ($element): bool {
                 return \is_object($element) && enum_exists($element::class);
@@ -72,7 +73,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
             $field->setFormTypeOptionIfNotSet('choices', array_keys($choices));
             $field->setFormTypeOptionIfNotSet('choice_label', fn ($value) => $choices[$value]);
         } else {
-            if(false === $elementIsEnum) {
+            if (false === $elementIsEnum) {
                 $field->setFormTypeOptionIfNotSet('choices', $choices);   
             }
         }

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -72,7 +72,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
             $field->setFormTypeOptionIfNotSet('choices', array_keys($choices));
             $field->setFormTypeOptionIfNotSet('choice_label', fn ($value) => $choices[$value]);
         } else {
-            if($elementIsEnum === false) {
+            if(false === $elementIsEnum) {
                 $field->setFormTypeOptionIfNotSet('choices', $choices);   
             }
         }

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -72,7 +72,9 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
             $field->setFormTypeOptionIfNotSet('choices', array_keys($choices));
             $field->setFormTypeOptionIfNotSet('choice_label', fn ($value) => $choices[$value]);
         } else {
-            $field->setFormTypeOptionIfNotSet('choices', $choices);
+            if($elementIsEnum === false) {
+                $field->setFormTypeOptionIfNotSet('choices', $choices);   
+            }
         }
         $field->setFormTypeOptionIfNotSet('multiple', $isMultipleChoice);
         $field->setFormTypeOptionIfNotSet('expanded', $isExpanded);


### PR DESCRIPTION
Fix:
Symfony\Component\Form\Extension\Core\Type\EnumType::Symfony\Component\Form\Extension\Core\Type\{closure}(): Argument #1 ($choice) must be of type ?BackedEnum, string given, called in /vendor/symfony/form/ChoiceList/ArrayChoiceList.php on line 182

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
