### PR TITLE
Fix highlighting on action pages

### DIFF
--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -65,7 +65,7 @@ class MenuItemMatcher implements MenuItemMatcherInterface
      */
     private function filterIrrelevantQueryParameters(array $queryStringParameters): array
     {
-        $paramsToRemove = [EA::REFERRER, EA::PAGE, EA::FILTERS, EA::SORT];
+        $paramsToRemove = [EA::REFERRER, EA::PAGE, EA::FILTERS, EA::SORT, EA::CRUD_ACTION];
 
         return array_filter($queryStringParameters, static fn ($k) => !\in_array($k, $paramsToRemove, true), \ARRAY_FILTER_USE_KEY);
     }

--- a/tests/Menu/MenuItemMatcherTest.php
+++ b/tests/Menu/MenuItemMatcherTest.php
@@ -68,9 +68,6 @@ class MenuItemMatcherTest extends KernelTestCase
 
         $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', action: Crud::PAGE_DETAIL, entityId: '57');
         $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller, entity ID and action match');
-
-        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', action: 'NOT_'.Crud::PAGE_DETAIL, entityId: '57');
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller and entity ID match but the action does not match');
     }
 
     public function testIsSelectedWithRoutes()


### PR DESCRIPTION
After v4.5.0, we have a new function to check if a menu item or submenu item is selected. Unfortunately, this only works for the index page, not for other pages. So I'm removing the crudAction checker and this will fix our problem.

Issue: https://github.com/EasyCorp/EasyAdminBundle/issues/5543
