### PR TITLE
Fixed CSS when an entity has too many action

### DIFF
--- a/assets/css/easyadmin-theme/base.scss
+++ b/assets/css/easyadmin-theme/base.scss
@@ -525,7 +525,9 @@ body.ea-edit .content-header {
     margin-right: 10px;
 }
 .content-header .page-actions {
-    align-items: center;
+    justify-content: right;
+    flex-wrap: wrap;
+    row-gap: 1em;
     display: flex;
     flex-direction: row;
     margin: 10px 0 15px;
@@ -533,7 +535,6 @@ body.ea-edit .content-header {
     &:empty { display: none; }
 
     @media(min-width: 768px) {
-        justify-content: space-between;
         margin: 2px 1px 0 10px;
     }
 


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/408368/218748574-5eeb8d52-9166-4e35-8fd2-deff507efa65.png)

We need to scrool

## After

![image](https://user-images.githubusercontent.com/408368/218748669-9ec7c057-f1f1-4e9a-8ab2-3aeb991d32e0.png)

no more scrool

And it scales on all devices

![image](https://user-images.githubusercontent.com/408368/218748787-d1698796-dc99-400b-ab53-71174dab0475.png)

![image](https://user-images.githubusercontent.com/408368/218748858-649d9380-d227-4331-a2c1-d8445237ff30.png)

![image](https://user-images.githubusercontent.com/408368/218748906-ba7e3bbf-26e0-48a7-aba0-7d4941fb911b.png)
