### PR TITLE
Fix panels, rows and tabs when working with lazy ghost proxies

### DIFF
--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -50,7 +50,8 @@ final class FormField implements FieldInterface
             ->setFormTypeOptions(['mapped' => false, 'required' => false])
             ->setCustomOption(self::OPTION_ICON, $icon)
             ->setCustomOption(self::OPTION_COLLAPSIBLE, false)
-            ->setCustomOption(self::OPTION_COLLAPSED, false);
+            ->setCustomOption(self::OPTION_COLLAPSED, false)
+            ->setValue(true);
     }
 
     /**
@@ -73,7 +74,8 @@ final class FormField implements FieldInterface
             ->setFormType(EaFormRowType::class)
             ->addCssClass('field-form_row')
             ->setFormTypeOptions(['mapped' => false, 'required' => false])
-            ->setCustomOption(self::OPTION_ROW_BREAKPOINT, $breakpointName);
+            ->setCustomOption(self::OPTION_ROW_BREAKPOINT, $breakpointName)
+            ->setValue(true);
     }
 
     /**
@@ -92,7 +94,8 @@ final class FormField implements FieldInterface
             ->setFormType(EasyAdminTabType::class)
             ->addCssClass('field-form_tab')
             ->setFormTypeOptions(['mapped' => false, 'required' => false])
-            ->setCustomOption(self::OPTION_ICON, $icon);
+            ->setCustomOption(self::OPTION_ICON, $icon)
+            ->setValue(true);
     }
 
     public function setIcon(string $iconCssClass): self


### PR DESCRIPTION
This fixes #5624

The problem occurs when `PropertyAccessor` is trying to access a non-existent property of a lazy ghost object. They emit user notice right now, while EasyAdmin expects an exception to be thrown.

But in fact the value of tabs, panels and rows are never used and have no meaning. Their keys are randomly generated, so they never exist on entities and call to property accessor is pointless. Setting the value to `true` by default makes them mitigate property accessor at all and the problem outlined in the linked issue.