### PR TITLE
Fix a double translation of tab labels in details view

### DIFF
--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -75,7 +75,7 @@
                             {%- if tab.customOption('icon') -%}
                                 <i class="fa-fw {{ tab.customOption('icon') }}"></i>
                             {%- endif -%}
-                            {{ tab.label|trans(domain = ea.i18n.translationDomain)|trans(domain = 'EasyAdminBundle') }}
+                            {{ tab.label|trans(domain = ea.i18n.translationDomain)|raw }}
                         </a>
                     </li>
                 {% endfor %}


### PR DESCRIPTION
Fixes #5657.

As @sgautier pointed in #5657, this causes a double translation error. I think the current code doesn't make any sense ... and in other templates, like the form theme, we don't do the same:

https://github.com/EasyCorp/EasyAdminBundle/blob/f8232febc6f17f0e154a512a8683bc3e72f25a31/src/Resources/views/crud/form_theme.html.twig#L416
