### PR TITLE
The error page can't be rendered without the context

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -46,6 +46,10 @@ final class ExceptionListener
             return;
         }
 
+        if (null === $this->adminContextProvider->getContext()) {
+            return;
+        }
+
         // TODO: check why these custom error pages don't work
         $event->setResponse($this->createExceptionResponse(FlattenException::create($exception)));
     }


### PR DESCRIPTION
```
Uncaught PHP Exception EasyCorp\Bundle\EasyAdminBundle\Exception\EntityNotFoundException: "The "App\Entity\Order" entity with "orderId = " does not exist in the database. The entity may have been deleted by mistake or by a "cascade={"remove"}" operation executed by Doctrine." at /app/vendor/easycorp/easyadmin-bundle/src/Factory/EntityFactory.php line 153
Uncaught Error: Symfony\Bridge\Twig\Extension\AssetExtension::getAssetUrl(): Argument #1 ($path) must be of type string, null given, called in /app/var/cache/prod/twig/ff/ffe222c63463562719428a9eb08ba9a2.php on line 206
Uncaught PHP Exception TypeError: "Symfony\Bridge\Twig\Extension\AssetExtension::getAssetUrl(): Argument #1 ($path) must be of type string, null given, called in /app/var/cache/prod/twig/ff/ffe222c63463562719428a9eb08ba9a2.php on line 206" at /app/vendor/symfony/twig-bridge/Extension/AssetExtension.php line 46
```

In production `EntityNotFoundException` turns from 404 into 500 because the rendering failed here. Pretty annoying because 404s can just be ignored but 500 is something that should probably be looked at.

There's also https://github.com/EasyCorp/EasyAdminBundle/pull/5477 which fixes this but this is should be a lot simpler
