### PR TITLE
Fixed doc block

### DIFF
--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -233,7 +233,7 @@ class Crud
     }
 
     /**
-     * @param $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
+     * @param array $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
      */
     public function setDefaultSort(array $sortFieldsAndOrder): self
     {

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -76,7 +76,7 @@ final class CrudMenuItem implements MenuItemInterface
     }
 
     /**
-     * @param $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
+     * @param array $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
      */
     public function setDefaultSort(array $sortFieldsAndOrder): self
     {

--- a/src/Config/Menu/MenuItemTrait.php
+++ b/src/Config/Menu/MenuItemTrait.php
@@ -54,12 +54,12 @@ trait MenuItemTrait
     }
 
     /**
-     * @param $content  This is rendered as the value of the badge; it can be anything that can be casted to
-     *                  a string (numbers, stringable objects, etc.)
-     * @param $style    Pass one of these values for predefined styles: 'primary', 'secondary', 'success',
-     *                  'danger', 'warning', 'info', 'light', 'dark'
-     *                  Otherwise, the passed value is applied "as is" to the `style` attribute of the HTML
-     *                  element of the badge
+     * @param mixed  $content This is rendered as the value of the badge; it can be anything that can be cast to
+     *                        a string (numbers, stringable objects, etc.)
+     * @param string $style   Pass one of these values for predefined styles: 'primary', 'secondary', 'success',
+     *                        'danger', 'warning', 'info', 'light', 'dark'
+     *                        Otherwise, the passed value is applied "as is" to the `style` attribute of the HTML
+     *                        element of the badge
      */
     public function setBadge(/* \Stringable|string|int|float|bool|null */ $content, string $style = 'secondary'): self
     {

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -197,7 +197,7 @@ final class FieldDto
     }
 
     /**
-     * @param $optionName You can use "dot" notation to set nested options (e.g. 'attr.class')
+     * @param string $optionName You can use "dot" notation to set nested options (e.g. 'attr.class')
      */
     public function setFormTypeOption(string $optionName, mixed $optionValue): void
     {
@@ -205,7 +205,7 @@ final class FieldDto
     }
 
     /**
-     * @param $optionName You can use "dot" notation to set nested options (e.g. 'attr.class')
+     * @param string $optionName You can use "dot" notation to set nested options (e.g. 'attr.class')
      */
     public function setFormTypeOptionIfNotSet(string $optionName, mixed $optionValue): void
     {

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -376,8 +376,8 @@ trait FieldTrait
     }
 
     /**
-     * @param $cols An integer with the number of columns that this field takes (e.g. 6),
-     *              or a string with responsive col CSS classes (e.g. 'col-6 col-sm-4 col-lg-3')
+     * @param int|string $cols An integer with the number of columns that this field takes (e.g. 6),
+     *                         or a string with responsive col CSS classes (e.g. 'col-6 col-sm-4 col-lg-3')
      */
     public function setColumns(int|string $cols): self
     {


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a complex new feature,
please open an issue first so we can discuss it.

Note: all your contributions adhere implicitly to the MIT license
-->

When working with EasyAdminBundle in PHPStorm, there is a doc block issue about method parameters types: when the param does not type declared PHPStorm takes the first word after the parameter name. See screenshots:

![image](https://user-images.githubusercontent.com/41155673/226094226-e20bfac6-c4ce-4736-9ec7-b872f3194c71.png)

![image](https://user-images.githubusercontent.com/41155673/226093996-1252bccd-a407-4564-b652-15f89ded1ae8.png)

So I added explicit types `mixed` and `string` for PHPStorm to understand the correct parameter type.
