### PR TITLE
Updated Ukrainian translation.

### DIFF
--- a/src/Resources/translations/EasyAdminBundle.uk.php
+++ b/src/Resources/translations/EasyAdminBundle.uk.php
@@ -128,7 +128,7 @@ return [
 
     'autocomplete' => [
         'no-results-found' => 'Нічого не знайдено',
-        // 'no-more-results' => 'No more results',
+        'no-more-results' => 'Більше немає результатів',
         'loading-more-results' => 'Завантаження інших результатів…',
     ],
 ];


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a complex new feature,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

Updated Ukrainian translation: added translation for `autocomplete.no-more-results` key.
