### PR TITLE
Darker background color for readonly inputs in dark mode

### DIFF
--- a/assets/css/easyadmin-theme/variables-theme.scss
+++ b/assets/css/easyadmin-theme/variables-theme.scss
@@ -444,7 +444,7 @@
     --pagination-disabled-color: var(--true-gray-600);
     --form-label-color: var(--true-gray-300);
     --form-control-bg: var(--true-gray-700);
-    --form-control-disabled-bg: var(--true-gray-700);
+    --form-control-disabled-bg: var(--true-gray-800);
     --form-control-disabled-color: #939393;
     --form-input-border-color: var(--true-gray-600);
     --form-input-error-border-color: var(--red-500);


### PR DESCRIPTION
fixes https://github.com/EasyCorp/EasyAdminBundle/issues/5700

before:
![image](https://user-images.githubusercontent.com/3840367/230592694-a8534484-8fb1-4196-8935-204d1e3fc879.png)


after:
![image](https://user-images.githubusercontent.com/3840367/230592573-14c803c9-d21e-4366-98f8-f9773f1bd1e1.png)
