### PR TITLE
[BUG] Fix autocomplete widget creation

### DIFF
--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -18,6 +18,8 @@ export default class Autocomplete
             return this.#createAutocompleteWithHtmlContents(element);
         }
 
+        if (! element.hasAttribute("value")) return;
+
         return this.#createAutocomplete(element);
     }
 


### PR DESCRIPTION
I ran into this situation today. The ```between``` filter on the date type field stopped working. 
When opening filters in the console, a strange error appeared when initializing TomSelect ```t.value is undefined```. After investigation it turned out that this happens sometimes, for example when ChoiceFilter is used WITHOUT autocompletion in expanded mode, the element is mistakenly assigned the ```data-ea-widget``` attribute  with a value of ```ea-autocomplete```. 
Since this is an exceptional situation, further JavaScript code responsible for "between" logic stops being executed.
```php
    public function configureFilters(Filters $filters): Filters
    {
        return $filters
            ->add('id')
            ->add('title')
            ->add(ChoiceFilter::new('state', 'admin_label.common.field.state')
                ->renderExpanded(true)->canSelectMultiple(true)
                ->setChoices(PaymentState::choices())
                ->setFormTypeOption('translation_domain', 'messages'))
            ->add('desiredPaymentDate')
            ->add('actualPaymentDate')
[...]
        ;
   }
```
This can happen in one of three places in the field configurators and cannot always be fixed as in this case (you can't set OPTION_WIDGET for ChoiceFilter for example):
```php
// src\Field\Configurator\ChoiceConfigurator.php:88-91:
        if (ChoiceField::WIDGET_AUTOCOMPLETE === $field->getCustomOption(ChoiceField::OPTION_WIDGET)) {
            $field->setFormTypeOption('attr.data-ea-widget', 'ea-autocomplete');
            $field->setDefaultColumns($isMultipleChoice ? 'col-md-8 col-xxl-6' : 'col-md-6 col-xxl-5');
        }
```
<img width="554" alt="Screenshot 2023-04-07 at 18 58 44" src="https://user-images.githubusercontent.com/230304/230642224-06ec0df7-739d-433c-bc0f-a06032904b28.png">

To avoid such consequences I suggest minimizing risks by one line of code and to disable autocomplete creation if the target element does not contain the ```value``` attribute necessary for normal functioning of Tom Select widget.
