### PR TITLE
Add an opportunity to load entity in an embedded form

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -282,15 +282,22 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             $targetCrudControllerPageName = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_EDIT_PAGE_NAME) ?? Crud::PAGE_EDIT;
         }
 
+        try {
+            $metadata = $this->entityFactory->getEntityMetadata($targetEntityFqcn);
+            $relatedEntityId = $propertyAccessor->getValue($entityDto->getInstance(), $propertyName.'.'.$metadata->getIdentifierFieldNames()[0]);
+        } catch (UnexpectedTypeException) {
+            // this may crash if something in the tree is null, so just do nothing then
+        }
+
         $field->setFormTypeOption(
             'entityDto',
-            $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, $targetCrudControllerAction, $targetCrudControllerPageName),
+            $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, $targetCrudControllerAction, $targetCrudControllerPageName, $relatedEntityId ?? null),
         );
     }
 
-    private function createEntityDto(string $entityFqcn, string $crudControllerFqcn, string $crudControllerAction, string $crudControllerPageName): EntityDto
+    private function createEntityDto(string $entityFqcn, string $crudControllerFqcn, string $crudControllerAction, string $crudControllerPageName, ?string $entityId = null): EntityDto
     {
-        $entityDto = $this->entityFactory->create($entityFqcn);
+        $entityDto = $this->entityFactory->create($entityFqcn, $entityId);
 
         $crudController = $this->controllerFactory->getCrudControllerInstance(
             $crudControllerFqcn,


### PR DESCRIPTION
I encountered a problem where the embedded form entity DTO does not have an instance of the entity. Specifically, this issue occurs in the EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\MoneyConfigurator::getCurrency method.

In my particular case, I have a controller where I render an association field as an embedded form on the create and update pages. This association includes a money field configured as follows:

```php
yield MoneyField::new('targetAmount')
    ->setCurrencyPropertyPath('relation.currency');
```
However, when the MoneyConfigurator is executed, the field value is null, causing the configuration process to stop at this point:

```php
if (null === $field->getValue()) {
    return;
}
```

By implementing the suggested changes, it will be possible to improve the field configuration.





