### PR TITLE
Tweak the new AbstractCrudTestCase feature

### DIFF
--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -1,30 +1,27 @@
 Tests
-======
+=====
 
-As EasyAdmin is based on Symfony, functionally testing the admin pages can leverage the
-`Symfony functional testing workflow`_ extending the :code:`WebTestCase` class.
+As EasyAdmin is based on Symfony, you can add functional tests for the admin pages
+extending the ``WebTestCase`` class and using the `Symfony functional testing workflow`_ .
 
-But, as EasyAdmin uses specific defined ways of displaying the data in its Crud pages,
-a custom test class is provided : :code:`AbstractCrudTestCase`. The
-class is based on traits which defines custom asserts and custom helpers.
+However, as EasyAdmin uses specific defined ways of displaying the data in its
+CRUD pages, a custom test class is provided: ``AbstractCrudTestCase``. The
+class is based on traits which defines custom asserts and helpers:
 
-
-1. `Functional Test Case Example`_
-2. `Url Generation`_
-3. `Asserts`_
-4. `Selector Helpers`_
+#. `Functional Test Case Example`_
+#. `Url Generation`_
+#. `Asserts`_
+#. `Selector Helpers`_
 
 
 Functional Test Case Example
--------------------------------------------
+----------------------------
 
-Suppose you have a `Dashboard`_ named :code:`App\\Controller\\Admin\\AppDashboardController` and
-a `Category Crud Controller`_ named :code:`App\\Controller\\Admin\\CategoryCrudController`. Here's an
-example of a functional test class for that Controller.
+Suppose you have a :doc:`Dashboard </dashboards>` named ``App\Controller\Admin\AppDashboardController``
+and a ``Category`` :doc:`Crud Controller </crud>` named ``App\Controller\Admin\CategoryCrudController``.
+Here's an example of a functional test class for that controller.
 
-First, your test class need to extend the :code:`AbstractCrudTestCase`.  
-
-.. code-block:: php
+First, your test class need to extend the ``AbstractCrudTestCase``::
 
     # tests/Admin/Controller/CategoryCrudControllerTest.php
     namespace App\Tests\Admin\Controller;
@@ -47,110 +44,125 @@ First, your test class need to extend the :code:`AbstractCrudTestCase`.
 
         public function testIndexPage(): void
         {
-            // no use of security here, up to you to ensure the login in your test in case it's necessary
+            // this examples doesn't use security; in your application you may
+            // need to ensure that the user is logged before the test
             $this->client->request("GET", $this->generateIndexUrl());
             static::assertResponseIsSuccessful();
         }
     }
 
+URL Generation
+--------------
 
-Url Generation
-------------------------
-Used by the :code:`AbstractCrudTestCase`, :code:`CrudTestUrlGeneration` is an url generation trait which helps to generate the specific of
-the EasyAdmin urls.
+Used by the ``AbstractCrudTestCase``, ``CrudTestUrlGeneration`` is an
+URL generation trait which helps to generate the specific of the EasyAdmin
+URLs.
 
-.. note:: 
+.. note::
 
-    The trait can, of course, be used on its own but in that case, the class that is using it needs either:
+    The trait can be used on its own but, in that case, the class that is using
+    it needs either:
 
-    - to define the 2 functions :code:`getControllerFqcn` and :code:`getDashboardFqcn`
-    - to add the DashboardFqcn (class name) and ControllerFqcn (class name) as input to the url generation functions
+    * to define the two functions ``getControllerFqcn()`` and ``getDashboardFqcn()``
+    * to add the DashboardFqcn (class name) and ControllerFqcn (class name) as
+      input to the URL generation functions
 
-Here is the list of the url generation functions that are all providing url based on provided Dashboard 
-& Controller class names:
+Here is the list of the URL generation functions that are all providing URL
+based on provided Dashboard and Controller class names:
 
-- :code:`getCrudUrl` : is the main function that allows for a complete generation with all possible options.
-- :code:`generateIndexUrl` : generates the url for the index page (based on the Dashboard and Controller defined)
-- :code:`generateNewFormUrl` : generates the url for the New form page (based on the Dashboard and Controller defined)
-- :code:`generateEditFormUrl` : generates the url for the Edit form page of a specific entity (based on the Dashboard and Controller defined and the entity Id)
-- :code:`generateDetailUrl` : generates the url for the Detail page of a specific entity (based on the Dashboard and Controller defined and the entity Id)
-- :code:`generateFilterRenderUrl` : generates the url to get the rendering of the filters (based on the Dashboard and Controller defined)
+* ``getCrudUrl()``: is the main function that allows for a complete generation
+  with all possible options;
+* ``generateIndexUrl()``: generates the URL for the index page (based on the
+  Dashboard and Controller defined);
+* ``generateNewFormUrl()``: generates the URL for the New form page (based on
+  the Dashboard and Controller defined);
+* ``generateEditFormUrl()``: generates the URL for the Edit form page of a
+  specific entity (based on the Dashboard and Controller defined and the entity ID);
+* ``generateDetailUrl()``: generates the URL for the Detail page of a specific
+  entity (based on the Dashboard and Controller defined and the entity ID);
+* ``generateFilterRenderUrl()``: generates the URL to get the rendering of the
+  filters (based on the Dashboard and Controller defined).
 
 Asserts
-------------------------
-Used by the `AbstractCrudTestCase`, are 2 traits filled with specific asserts for EasyAdmin web testing:
+-------
 
-- :code:`CrudTestIndexAsserts`: providing asserts for the index page of EasyAdmin
-- :code:`CrudTestFormAsserts` : providing asserts for the form page of EasyAdmin
+Used by the ``AbstractCrudTestCase``, are two traits filled with specific
+asserts for EasyAdmin web testing:
+
+* ``CrudTestIndexAsserts``: providing asserts for the index page of EasyAdmin;
+* ``CrudTestFormAsserts`` : providing asserts for the form page of EasyAdmin.
 
 .. note:: 
 
-    The trait can, of course, be used on its own but in that case, the class that is using it needs both:
+    The trait can be used on its own but, in that case, the class that is using
+    it needs both:
 
-    - a class property :code:`client` : instance of :code:`Symfony\\Bundle\\FrameworkBundle\\KernelBrowser`
-    - a class property :code:`entitytManager` : instance of :code:`Doctrine\\ORM\\EntityManagerInterface`
-  
+    * a class property ``client``: instance of ``Symfony\Bundle\FrameworkBundle\KernelBrowser``
+    * a class property ``entitytManager``: instance of ``Doctrine\ORM\EntityManagerInterface``
 
 CrudTestIndexAsserts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-As EasyAdmin uses specific layout, the goal of these Asserts is to ease the way you're testing your EasyAdmin backend by providing specific asserts linked to the Index page.
+~~~~~~~~~~~~~~~~~~~~
 
-The following asserts are existing:
+As EasyAdmin uses specific layout, the goal of these asserts is to ease the way
+you're testing your EasyAdmin backend by providing specific asserts linked to
+the index page.
 
-- :code:`assertIndexFullEntityCount`
-- :code:`assertIndexPageEntityCount`
-- :code:`assertIndexPagesCount`
-- :code:`assertIndexEntityActionExists`
-- :code:`assertIndexEntityActionNotExists`
-- :code:`assertIndexEntityActionTextSame`
-- :code:`assertIndexEntityActionNotTextSame`
-- :code:`assertGlobalActionExists`
-- :code:`assertGlobalActionNotExists`
-- :code:`assertGlobalActionDisplays`
-- :code:`assertGlobalActionNotDisplays`
-- :code:`assertIndexColumnExists`
-- :code:`assertIndexColumnNotExists`
-- :code:`assertIndexColumnHeaderContains`
-- :code:`assertIndexColumnHeaderNotContains`
+The following asserts are provided:
 
+* ``assertIndexFullEntityCount()``
+* ``assertIndexPageEntityCount()``
+* ``assertIndexPagesCount()``
+* ``assertIndexEntityActionExists()``
+* ``assertIndexEntityActionNotExists()``
+* ``assertIndexEntityActionTextSame()``
+* ``assertIndexEntityActionNotTextSame()``
+* ``assertGlobalActionExists()``
+* ``assertGlobalActionNotExists()``
+* ``assertGlobalActionDisplays()``
+* ``assertGlobalActionNotDisplays()``
+* ``assertIndexColumnExists()``
+* ``assertIndexColumnNotExists()``
+* ``assertIndexColumnHeaderContains()``
+* ``assertIndexColumnHeaderNotContains()``
 
 CrudTestFormAsserts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-As EasyAdmin uses specific layout, the goal of these Asserts is to ease the way you're testing your EasyAdmin backend by providing specific asserts linked to the **Form** (New or Edit) page.
+~~~~~~~~~~~~~~~~~~~
 
-The following asserts are existing:
+As EasyAdmin uses specific layout, the goal of these asserts is to ease the way
+you're testing your EasyAdmin backend by providing specific asserts linked to
+the **form** (new or edit) page.
 
-- :code:`assertFormFieldExists`
-- :code:`assertFormFieldNotExists`
-- :code:`assertFormFieldHasLabel`
-- :code:`assertFormFieldNotHasLabel`
+The following asserts are provided:
 
+* ``assertFormFieldExists()``
+* ``assertFormFieldNotExists()``
+* ``assertFormFieldHasLabel()``
+* ``assertFormFieldNotHasLabel()``
 
 Selector Helpers
-------------------------
-Used by the Asserts to locate elements, the Trait :code:`CrudTestSelectors` is defining a specific amounts of selector helpers linked to the specificities of EasyAdmin layout. 
+----------------
 
-.. note:: 
+Used by the Asserts to locate elements, the Trait ``CrudTestSelectors`` is
+defining a specific amounts of selector helpers linked to the specifics of
+EasyAdmin layout.
 
-    The trait can, of course, be used on its own. It only defines selector strings. 
+.. note::
 
-The following helpers are existing:
- 
+    The trait can be used on its own. It only defines selector strings.
 
-- :code:`getActionSelector` 
-- :code:`getGlobalActionSelector` 
-- :code:`getIndexEntityActionSelector` 
-- :code:`getIndexEntityRowSelector` 
-- :code:`getIndexColumnSelector` 
-- :code:`getIndexHeaderColumnSelector` 
-- :code:`getIndexHeaderRowSelector` 
-- :code:`getFormEntity`
-- :code:`getEntityFormSelector`  
-- :code:`getFormFieldIdValue` 
-- :code:`getFormFieldSelector` 
-- :code:`getFormFieldLabelSelector` 
+The following helpers are provided:
 
+* ``getActionSelector()``
+* ``getGlobalActionSelector()``
+* ``getIndexEntityActionSelector()``
+* ``getIndexEntityRowSelector()``
+* ``getIndexColumnSelector()``
+* ``getIndexHeaderColumnSelector()``
+* ``getIndexHeaderRowSelector()``
+* ``getFormEntity()``
+* ``getEntityFormSelector()``
+* ``getFormFieldIdValue()``
+* ``getFormFieldSelector()``
+* ``getFormFieldLabelSelector()``
 
 .. _`Symfony functional testing workflow`: https://symfony.com/doc/current/testing.html#application-tests
-.. _Dashboard: https://symfony.com/bundles/EasyAdminBundle/4.x/dashboards.html
-.. _`Category Crud Controller`: https://symfony.com/bundles/EasyAdminBundle/4.x/crud.html

--- a/src/Test/AbstractCrudTestCase.php
+++ b/src/Test/AbstractCrudTestCase.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Test;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/src/Test/Exception/InvalidClassPropertyTypeException.php
+++ b/src/Test/Exception/InvalidClassPropertyTypeException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Test\Exception;
 
 final class InvalidClassPropertyTypeException extends \Exception

--- a/src/Test/Exception/MissingClassMethodException.php
+++ b/src/Test/Exception/MissingClassMethodException.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Test\Exception;
 
 final class MissingClassMethodException extends \Exception

--- a/src/Test/Trait/CrudTestActions.php
+++ b/src/Test/Trait/CrudTestActions.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Test\Trait;
 
 use function PHPUnit\Framework\assertCount;

--- a/src/Test/Trait/CrudTestFormAsserts.php
+++ b/src/Test/Trait/CrudTestFormAsserts.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Test\Trait;
 
 use PHPUnit\Framework\Constraint\LogicalNot;

--- a/src/Test/Trait/CrudTestIndexAsserts.php
+++ b/src/Test/Trait/CrudTestIndexAsserts.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Test\Trait;
 
 trait CrudTestIndexAsserts

--- a/src/Test/Trait/CrudTestSelectors.php
+++ b/src/Test/Trait/CrudTestSelectors.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Test\Trait;
 
 trait CrudTestSelectors

--- a/src/Test/Trait/CrudTestUrlGeneration.php
+++ b/src/Test/Trait/CrudTestUrlGeneration.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Test\Trait;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;

--- a/tests/Test/Trait/CrudTestActionsTraitTest.php
+++ b/tests/Test/Trait/CrudTestActionsTraitTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Test\Trait;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/tests/Test/Trait/CrudTestFormAssertsTraitTest.php
+++ b/tests/Test/Trait/CrudTestFormAssertsTraitTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Test\Trait;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/tests/Test/Trait/CrudTestIndexAssertsTraitTest.php
+++ b/tests/Test/Trait/CrudTestIndexAssertsTraitTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Test\Trait;
 
 use Doctrine\ORM\EntityManagerInterface;

--- a/tests/Test/Trait/CrudTestUrlGenerationTraitTest.php
+++ b/tests/Test/Trait/CrudTestUrlGenerationTraitTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Test\Trait;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;


### PR DESCRIPTION
Add some very minor tweaks to #5621.

@yalit you may see many changes in this PR, but in fact, they are not that much:

* The changes in RST docs is because we prefer to follow the same formatting and practices as Symfony docs, so I had to tweak some minor things in the formatting.
* The removal of `declare(strict_types=1);` is because we use the same practices as Symfony for the code, so we cannot add this. Of course you did it right by adding those, but because of the practices we follow, we must remove them.

Thanks!