### PR TITLE
[DOC] remove IdField::new('id', 'Id')->setDisabled() before FormField…

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -355,8 +355,6 @@ the "panels" created with the special ``FormField`` object::
     public function configureFields(string $pageName): iterable
     {
         return [
-            IdField::new('id')->hideOnForm(),
-
             // panels usually display only a title
             FormField::addPanel('User Details'),
             TextField::new('firstName'),


### PR DESCRIPTION

This little change is related to #5722.

Just removing the `IdField::new('id')->hideOnForm()` before `FormField::addPanel('User Details')` to avoid errors.