### PR TITLE
Use formattedValue on code editor detail to display JSON fields

### DIFF
--- a/src/Resources/views/crud/field/code_editor.html.twig
+++ b/src/Resources/views/crud/field/code_editor.html.twig
@@ -5,7 +5,7 @@
     {# TODO: improve this to highlight code #}
     {% set configuredHeight = field.customOptions.get('height') %}
     <pre style="{{ configuredHeight is null ? 'max-height: 500px;' : 'max-height: unset; height: ' ~ configuredHeight ~ 'px' }}">
-        {{- field.value -}}
+        {{- field.formattedValue|escape -}}
     </pre>
 {% else %}
     {% set html_id = 'ea-code-editor-' ~ field.uniqueId %}


### PR DESCRIPTION
**Describe the bug**
[The documentation says](https://symfony.com/bundles/EasyAdminBundle/4.x/fields.html#mapping-between-doctrine-types-and-easyadmin-fields) to use `TextField`, `TextAreaField` or `CodeEditorField` field to display a Doctrine json type.

However, using `CodeEditorField` fails with:

> Array to string conversion

This could be worked around by using `->formatValue(fn ($value) => json_encode($value))` but the template [code_editor.html.twig](https://github.com/EasyCorp/EasyAdminBundle/blob/022358a1b0c4e59fb3cae7d743e8a5c9e3195722/src/Resources/views/crud/field/code_editor.html.twig) does not use it for the DETAIL view. 

The PR adds the formattedValue to the `code_editor` template so that it can be used

**To Reproduce**
EasyAdmin 4.6.1

1. Create a doctrine entity with a json field
2. Create a CrudController
3. Try to use the json field in a view

**Related Issues:**
https://github.com/EasyCorp/EasyAdminBundle/issues/5680
https://github.com/EasyCorp/EasyAdminBundle/issues/4388