### PR TITLE
Bug: code re-applies your filters on searches

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -246,24 +246,28 @@
                                         <form class="form-action-search" method="get">
                                             {% block search_form %}
                                                 {% block search_form_filters %}
-                                                    {% for field, array in ea.search.appliedFilters %}
-                                                        {% for key, value in array %}
-                                                            {# This code re-applies your filters on searches, an iterable check is needed in cases we have more than one object for a filter #}
-                                                            {% if value is iterable %}
-                                                                {% for index, iterValue in value %}
-                                                                    {# This sub-level iterable check is needed in cases we have more complex filters like the DateTimeFilter cf. issue #5038 #}
-                                                                    {% if iterValue is iterable %}
-                                                                        {% for subIndex, subIterValue in iterValue %}
-                                                                            <input type="hidden" name="filters[{{ field }}][{{ key }}][{{ index }}][{{ subIndex }}]" value="{{ subIterValue }}">
-                                                                        {% endfor %}
-                                                                    {% else %}
-                                                                        <input type="hidden" name="filters[{{ field }}][{{ key }}][{{ index }}]" value="{{ iterValue }}">
-                                                                    {% endif %}
-                                                                {% endfor %}
-                                                            {% else %}
-                                                                <input type="hidden" name="filters[{{ field }}][{{ key }}]" value="{{ value }}">
-                                                            {% endif %}
-                                                        {% endfor %}
+                                                    {% for field, fieldValue in ea.search.appliedFilters %}
+                                                        {% if fieldValue is iterable %}
+                                                            {% for key, value in fieldValue %}
+                                                                {# This code re-applies your filters on searches, an iterable check is needed in cases we have more than one object for a filter #}
+                                                                {% if value is iterable %}
+                                                                    {% for index, iterValue in value %}
+                                                                        {# This sub-level iterable check is needed in cases we have more complex filters like the DateTimeFilter cf. issue #5038 #}
+                                                                        {% if iterValue is iterable %}
+                                                                            {% for subIndex, subIterValue in iterValue %}
+                                                                                <input type="hidden" name="filters[{{ field }}][{{ key }}][{{ index }}][{{ subIndex }}]" value="{{ subIterValue }}">
+                                                                            {% endfor %}
+                                                                        {% else %}
+                                                                            <input type="hidden" name="filters[{{ field }}][{{ key }}][{{ index }}]" value="{{ iterValue }}">
+                                                                        {% endif %}
+                                                                    {% endfor %}
+                                                                {% else %}
+                                                                    <input type="hidden" name="filters[{{ field }}][{{ key }}]" value="{{ value }}">
+                                                                {% endif %}
+                                                            {% endfor %}
+                                                        {% else %}
+                                                            <input type="hidden" name="filters[{{ field }}]" value="{{ fieldValue }}">
+                                                        {% endif %}
                                                     {% endfor %}
                                                 {% endblock %}
 


### PR DESCRIPTION
"Re-apply your filters on searches" must work with any data structure. Right now it doesn't work, if filter data is like 
`"manager" => "Anna"`
it always requires an array