### PR TITLE
Fix passing TranslatableInterface Choices to ChoiceField

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -111,8 +111,8 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         $flippedChoices = $areChoicesTranslatable ? $choices : array_flip($this->flatten($choices));
         foreach ((array) $fieldValue as $selectedValue) {
             if (null !== $selectedLabel = $flippedChoices[$selectedValue] ?? null) {
-                if ($selectedValue instanceof TranslatableInterface) {
-                    $choiceMessage = $selectedValue;
+                if ($selectedLabel instanceof TranslatableInterface) {
+                    $choiceMessage = $selectedLabel;
                 } else {
                     $choiceMessage = t(
                         $selectedLabel,


### PR DESCRIPTION
The code checking whether a choice should be passed "untouched" because it already is Translatable (from #5066) is always false because it checks against the wrong variable. This results in the actual TranslatableMessage being thrown away.

Here `$selectedValue` is always an array key, so a string; the intention was probably to check against `$selectedLabel`.