### PR TITLE
Bug Fix :  FormPanel with AssociationField render as embedded form issue

### DIFF
--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -126,6 +126,8 @@ class CrudFormType extends AbstractType
             'entity' => $options['entityDto'],
             'form_tabs' => $form->getConfig()->getAttribute('ea_form_tabs'),
             'form_panels' => $form->getConfig()->getAttribute('ea_form_panels'),
+            'form_tab' => $form->getConfig()->getAttribute('ea_form_tab'),
+            'form_panel' => $form->getConfig()->getAttribute('ea_form_panel'),
         ];
     }
 


### PR DESCRIPTION
This is a bug fix of issue #5596 


### Bug Description
An error occured in the template when trying to render as ambedded form an AssociationField under EaFormPanelType.

### To reproduce
```
public function configureFields(string $pageName): iterable {
    return  [
        FormField::addPanel('My Panel title'),
        AssociationField::new('propertyName')->renderAsEmbeddedForm(EmbedeedCrunController::class),
    ]
}
```
