### PR TITLE
Fix incorrect HTTP status code for form validation errors

### DIFF
--- a/src/EventListener/CrudResponseListener.php
+++ b/src/EventListener/CrudResponseListener.php
@@ -41,12 +41,14 @@ final class CrudResponseListener
 
         // to make parameters easier to modify, we pass around FormInterface objects
         // so we must convert those values to FormView before rendering the template
+        $formErrorCount = 0;
         foreach ($templateParameters as $paramName => $paramValue) {
             if ($paramValue instanceof FormInterface) {
                 $templateParameters[$paramName] = $paramValue->createView();
+                $formErrorCount = max($formErrorCount, \count($paramValue->getErrors(true)));
             }
         }
-
-        $event->setResponse(new Response($this->twig->render($templatePath, $templateParameters)));
+        $httpCode = $formErrorCount > 0 ? Response::HTTP_UNPROCESSABLE_ENTITY : Response::HTTP_OK;
+        $event->setResponse(new Response($this->twig->render($templatePath, $templateParameters), $httpCode));
     }
 }

--- a/tests/Controller/CategoryCrudControllerTest.php
+++ b/tests/Controller/CategoryCrudControllerTest.php
@@ -64,6 +64,7 @@ class CategoryCrudControllerTest extends AbstractCrudTestCase
             static::assertSelectorNotExists('.global-invalid-feedback');
             static::assertInstanceOf(Category::class, $this->categories->findOneBy(['slug' => 'foo']));
         } else {
+            $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
             static::assertSelectorTextContains('.global-invalid-feedback', $expectedErrorMessage);
             static::assertNull($this->categories->findOneBy(['slug' => 'foo']));
         }
@@ -105,6 +106,7 @@ class CategoryCrudControllerTest extends AbstractCrudTestCase
             static::assertSelectorNotExists('.global-invalid-feedback');
             static::assertInstanceOf(Category::class, $this->categories->findOneBy(['slug' => 'bar']));
         } else {
+            $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
             static::assertSelectorTextContains('.global-invalid-feedback', $expectedErrorMessage);
             static::assertNull($this->categories->findOneBy(['slug' => 'bar']));
         }

--- a/tests/TestApplication/src/Entity/Category.php
+++ b/tests/TestApplication/src/Entity/Category.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity]
 class Category
@@ -14,6 +15,7 @@ class Category
     #[ORM\Column(type: 'integer')]
     private $id;
 
+    #[Assert\NotBlank]
     #[ORM\Column(type: 'string', length: 255)]
     private $name;
 


### PR DESCRIPTION
This PR will fix #5768 

**Before**

![000](https://github.com/EasyCorp/EasyAdminBundle/assets/79239132/75cc902e-1766-48f2-bfb5-00d4f0cc7036)


**After**

![001](https://github.com/EasyCorp/EasyAdminBundle/assets/79239132/f88999b8-f2f5-42dd-a121-af691c68d1e3)
