### PR TITLE
Fix dynamic property deprecation notice

### DIFF
--- a/tests/Test/Trait/CrudTestFormAssertsTraitTest.php
+++ b/tests/Test/Trait/CrudTestFormAssertsTraitTest.php
@@ -19,6 +19,7 @@ final class CrudTestFormAssertsTraitTest extends WebTestCase
 
     protected KernelBrowser $client;
     protected EntityManagerInterface $entityManager;
+    private AdminUrlGenerator $adminUrlGenerator;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
This PR will add the missing property left by PR #5621 to fix dynamic property deprecation notice

```txt
  26x: Creation of dynamic property EasyCorp\Bundle\EasyAdminBundle\Tests\Test\Trait\CrudTestFormAssertsTraitTest::$adminUrlGenerator is deprecated
    26x in CrudTestFormAssertsTraitTest::setUp from EasyCorp\Bundle\EasyAdminBundle\Tests\Test\Trait
```