### PR TITLE
Update EntityRepository.php

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -106,7 +106,7 @@ final class EntityRepository implements EntityRepositoryInterface
 
                     if (!\in_array($associatedEntityName, $entitiesAlreadyJoined, true)) {
                         $parentEntityName = 0 === $i ? 'entity' : $associatedProperties[$i - 1];
-                        $queryBuilder->leftJoin($parentEntityName.'.'.$associatedEntityName, $associatedEntityAlias);
+                        $queryBuilder->leftJoin(Escaper::escapeDqlAlias($parentEntityName).'.'.$associatedEntityName, $associatedEntityAlias);
                         $entitiesAlreadyJoined[] = $associatedEntityName;
                     }
 


### PR DESCRIPTION
Error using reserved words in setSearchFields (like order). There was a partial fix using escapeDqlAlias method, that should be also applied to the parentEntityName in ManytoOne relation joins

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
