### PR TITLE
[FEATURE] Admin URL generator improvement

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInte
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -202,6 +203,11 @@ final class AdminUrlGenerator
     public function __toString(): string
     {
         return $this->generateUrl();
+    }
+
+    public function redirect(int $status = 302): RedirectResponse
+    {
+        return new RedirectResponse($this->generateUrl(), 302);
     }
 
     public function generateUrl(): string


### PR DESCRIPTION
This MR adds redirect method that returns new Symfony `RedirectResponse` object instance with generated URL.

The justification for this change is that it will help to reduce code and make it more readable. For example, to redirect we would write the code:

```
<?php

namespace Akme\Controller;

class MyController
{
    public function myAction()
    {
        return $this->redirect(
            $this->adminUrlGenerator
                ->setDashboard(MyDashboardController::class)
                ->setController(MyCrudController::class)
                ->setAction('myAnotherAction')
                ->generateUrl()
        );
    }
}
```

With the proposed changes, we can rewrite this code to:

```
<?php

namespace Akme\Controller;

class MyController
{
    public function myAction(): RedirectResponse
    {
        return $this->adminUrlGenerator
            ->setDashboard(MyDashboardController::class)
            ->setController(MyCrudController::class)
            ->setAction('myAnotherAction')
            ->redirect()
        );
    }
}
```
