### PR TITLE
Add empty blocks for easier extending

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -239,6 +239,7 @@
                     {% set has_search = ea.crud is not null and ea.crud.isSearchEnabled %}
                     <aside class="content-top {{ has_search ? 'ea-search-enabled' : 'ea-search-disabled' }}">
                         {% block content_top_header %}
+                            {% block content_top_start %}{# For use while extending this template #}{% endblock %}
                             <div class="content-search">
                                 {% if has_search %}
                                     {% block search %}
@@ -297,6 +298,7 @@
                                     {% endblock search %}
                                 {% endif %}
                             </div>
+                            {% block content_top_after_search %}{# For use while extending this template #}{% endblock %}
 
                             <div class="navbar-custom-menu">
                                 {% block header_custom_menu %}
@@ -312,8 +314,10 @@
                                     </div>
                                 {% endblock header_custom_menu %}
                             </div>
+                            {% block content_top_after_custom_menu %}{# For use while extending this template #}{% endblock %}
 
                             {{ settings_dropdown }}
+                            {% block content_top_end %}{# For use while extending this template #}{% endblock %}
                         {% endblock content_top_header %}
                     </aside>
 


### PR DESCRIPTION
Currently while extending the layout.html.twig template, we can override blocks but unfortunately this means we also override quite a bit of HTML. This could cause issues if the HTML changes in the future, something which I personally wouldn't consider a breaking change. My code would be outdated, could stop working or cause an exception.

For this, I would like to propose a solution. Some empty blocks ready for the user to extend.
- These are named after where they are in, and their position at the start, end, or after certain existing elements.
- Developers can safely add their own content, being sure it will not break outside of major versions.

I've done this for the topbar now, this logic can be extended to more places, but I felt this was a nice small start.