### PR TITLE
Throw RuntimeError when unable to load twig filter

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -100,6 +100,11 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
      */
     public function applyFilterIfExists(Environment $environment, $value, string $filterName, ...$filterArguments)
     {
+        /**
+         * Twig v2 will return TwigFilter|false
+         *
+         * @var TwigFilter|null|false $filter
+         */
         $filter = $environment->getFilter($filterName);
         if (null === $filter || false === $filter) {
             return $value;

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -101,7 +101,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
     public function applyFilterIfExists(Environment $environment, $value, string $filterName, ...$filterArguments)
     {
         $filter = $environment->getFilter($filterName);
-        if (null === $filter || $filter === false) {
+        if (null === $filter || false === $filter) {
             return $value;
         }
 

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -101,9 +101,9 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
     public function applyFilterIfExists(Environment $environment, $value, string $filterName, ...$filterArguments)
     {
         /**
-         * Twig v2 will return TwigFilter|false
+         * Twig v2 will return TwigFilter|false.
          *
-         * @var TwigFilter|null|false $filter
+         * @var TwigFilter|false|null $filter
          */
         $filter = $environment->getFilter($filterName);
         if (null === $filter || false === $filter) {

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -100,7 +100,8 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
      */
     public function applyFilterIfExists(Environment $environment, $value, string $filterName, ...$filterArguments)
     {
-        if (null === $filter = $environment->getFilter($filterName)) {
+        $filter = $environment->getFilter($filterName);
+        if (null === $filter || $filter === false) {
             return $value;
         }
 

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -96,7 +96,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
     /**
      * Code adapted from https://stackoverflow.com/a/48606773/2804294 (License: CC BY-SA 3.0).
      *
-     * @throws RuntimeError When twig runtime can't find `$class`
+     * @throws RuntimeError when twig runtime can't find the specified filter
      */
     public function applyFilterIfExists(Environment $environment, $value, string $filterName, ...$filterArguments)
     {
@@ -109,16 +109,16 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
             return \call_user_func($callback, $value, ...$filterArguments);
         }
 
-        if (!\is_array($callback)) {
-            return null;
-        }
+        if (\is_array($callback) && 2 === \count($callback)) {
+            $callback[0] = $environment->getRuntime($callback[0]);
+            if (!\is_callable($callback)) {
+                throw new RuntimeError(sprintf('Unable to load runtime for filter: "%s"', $filterName));
+            }
 
-        $callback[0] = $environment->getRuntime($callback[0]);
-        if (\is_callable($callback)) {
             return \call_user_func($callback, $value, ...$filterArguments);
         }
 
-        return null;
+        throw new RuntimeError(sprintf('Invalid callback for filter: "%s"', $filterName));
     }
 
     public function representAsString($value): string


### PR DESCRIPTION
Throw a `RuntimeError` as mentioned in https://github.com/EasyCorp/EasyAdminBundle/pull/5786#discussion_r1237440949

Also, simplify function `applyFilterIfExists` and modify test cases.