### PR TITLE
Allow javascript in CodeEditorField

### DIFF
--- a/src/Field/CodeEditorField.php
+++ b/src/Field/CodeEditorField.php
@@ -20,7 +20,7 @@ final class CodeEditorField implements FieldInterface
     public const OPTION_TAB_SIZE = 'tabSize';
     public const OPTION_SHOW_LINE_NUMBERS = 'showLineNumbers';
 
-    private const ALLOWED_LANGUAGES = ['css', 'dockerfile', 'js', 'markdown', 'nginx', 'php', 'shell', 'sql', 'twig', 'xml', 'yaml-frontmatter', 'yaml'];
+    private const ALLOWED_LANGUAGES = ['css', 'dockerfile', 'js', 'javascript', 'markdown', 'nginx', 'php', 'shell', 'sql', 'twig', 'xml', 'yaml-frontmatter', 'yaml'];
 
     /**
      * @param TranslatableInterface|string|false|null $label


### PR DESCRIPTION
with `js`

![image](https://github.com/EasyCorp/EasyAdminBundle/assets/3840367/439c9c31-649e-4b89-b777-4ac4eb1273ea)

with `javascript`

![image](https://github.com/EasyCorp/EasyAdminBundle/assets/3840367/ab2d9c4f-61d7-47ac-834e-c697c42a3875)

Kept `js` there for BC reasons but maybe it should be deprecated?