### PR TITLE
Add search for json properties

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -106,7 +106,7 @@ final class EntityRepository implements EntityRepositoryInterface
                     $parameterName = sprintf('query_for_ulids_%d', $queryTermIndex);
                     $queryBuilder->orWhere(sprintf('%s.%s = :%s', $entityName, $propertyName, $parameterName))
                         ->setParameter($parameterName, $dqlParameters['uuid_query'], 'ulid');
-                } elseif ($propertyConfig['is_text']) {
+                } elseif ($propertyConfig['is_text'] || $propertyConfig['is_json']) {
                     $parameterName = sprintf('query_for_text_%d', $queryTermIndex);
                     $queryBuilder->orWhere(sprintf('LOWER(%s.%s) LIKE :%s', $entityName, $propertyName, $parameterName))
                         ->setParameter($parameterName, $dqlParameters['text_query']);


### PR DESCRIPTION
Hello 👋🏽 

I realized that when searching in a CRUD, json properties were ignored despite being accounted for in the code (thanks to #5458 even if the code changed since, it's still essentially the same in that regard).

I've used this little "fix" in a project, and it worked fine.
It's honestly a copy/paste of what is done for text properties (since the DB column is really a `longtext`), and it can definitely be improved, I simply do not know how 😄 

I figured opening this PR could at least open a discussion about the issue 🚀 