### PR TITLE
Helper methods for `Translatable` objects in filters

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -657,7 +657,7 @@ for a given postal address. This is the class you could create for the field::
         use FieldTrait;
 
         /**
-         * @param string|false|null $label
+         * @param TranslatableInterface|string|false|null $label
          */
         public static function new(string $propertyName, $label = null): self
         {

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -24,7 +24,7 @@ final class FormField implements FieldInterface
     /**
      * @internal Use the other named constructors instead (addPanel(), etc.)
      *
-     * @param string|false|null $label
+     * @param TranslatableInterface|string|false|null $label
      */
     public static function new(string $propertyName, $label = null)
     {

--- a/src/Filter/ArrayFilter.php
+++ b/src/Filter/ArrayFilter.php
@@ -37,6 +37,14 @@ final class ArrayFilter implements FilterInterface
         return $this;
     }
 
+    public function setTranslatableChoices(array $choiceGenerator): self
+    {
+        $this->dto->setFormTypeOption('value_type_options.choices', array_keys($choiceGenerator));
+        $this->dto->setFormTypeOption('value_type_options.choice_label', fn ($value) => $choiceGenerator[$value]);
+
+        return $this;
+    }
+
     public function canSelectMultiple(bool $selectMultiple = true): self
     {
         $this->dto->setFormTypeOption('value_type_options.multiple', $selectMultiple);

--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -36,6 +36,14 @@ final class ChoiceFilter implements FilterInterface
         return $this;
     }
 
+    public function setTranslatableChoices(array $choiceGenerator): self
+    {
+        $this->dto->setFormTypeOption('value_type_options.choices', array_keys($choiceGenerator));
+        $this->dto->setFormTypeOption('value_type_options.choice_label', fn ($value) => $choiceGenerator[$value]);
+
+        return $this;
+    }
+
     public function renderExpanded(bool $isExpanded = true): self
     {
         $this->dto->setFormTypeOption('value_type_options.expanded', $isExpanded);

--- a/src/Filter/NullFilter.php
+++ b/src/Filter/NullFilter.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Filter\Type\NullFilterType;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -29,12 +30,26 @@ final class NullFilter implements FilterInterface
             ->setFormType(NullFilterType::class);
     }
 
-    public function setChoiceLabels(string $nullChoiceLabel, string $notNullChoiceLabel): self
+    public function setChoiceLabels(string|TranslatableInterface $nullChoiceLabel, string|TranslatableInterface $notNullChoiceLabel): self
     {
-        $this->dto->setFormTypeOption('choices', [
-            $nullChoiceLabel => self::CHOICE_VALUE_NULL,
-            $notNullChoiceLabel => self::CHOICE_VALUE_NOT_NULL,
-        ]);
+        if (
+            $nullChoiceLabel instanceof TranslatableInterface
+            || $notNullChoiceLabel instanceof TranslatableInterface
+        ) {
+            $this->dto->setFormTypeOption('choices', [
+                self::CHOICE_VALUE_NULL,
+                self::CHOICE_VALUE_NOT_NULL,
+            ]);
+            $this->dto->setFormTypeOption(
+                'choice_label',
+                fn ($value) => self::CHOICE_VALUE_NULL === $value ? $nullChoiceLabel : $notNullChoiceLabel,
+            );
+        } else {
+            $this->dto->setFormTypeOption('choices', [
+                $nullChoiceLabel => self::CHOICE_VALUE_NULL,
+                $notNullChoiceLabel => self::CHOICE_VALUE_NOT_NULL,
+            ]);
+        }
 
         return $this;
     }


### PR DESCRIPTION
This simple PR introduces support for translatable objects in a few places missed before - the filters:
- A new `setTranslatableChoices` method is added to the `ChoiceFilter` and `ArrayFilter`, working exactly like the same method in `ChoiceField`,
- Translatable objects are now allowed as arguments to `NullFilter::setChoiceLabels` method,
- as an added value I have fixed two docblocks that allow `TranslatableInterface`, but weren't updated before.

I have tested those changes on my daily project and they work as expected. I see that tests for filters are verifying their filtering capabilities and not passing configuration, so I found no place to add tests for those changes.