### PR TITLE
Allow searching by associated fields with the same name

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -86,7 +86,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 'text_query' => '%'.$lowercaseQueryTerm.'%',
             ];
 
-            foreach ($searchablePropertiesConfig as $propertyName => $propertyConfig) {
+            foreach ($searchablePropertiesConfig as $propertyConfig) {
                 $entityName = $propertyConfig['entity_name'];
 
                 // this complex condition is needed to avoid issues on PostgreSQL databases
@@ -96,19 +96,19 @@ final class EntityRepository implements EntityRepositoryInterface
                     || ($propertyConfig['is_numeric'] && $isNumericQueryTerm)
                 ) {
                     $parameterName = sprintf('query_for_numbers_%d', $queryTermIndex);
-                    $queryBuilder->orWhere(sprintf('%s.%s = :%s', $entityName, $propertyName, $parameterName))
+                    $queryBuilder->orWhere(sprintf('%s.%s = :%s', $entityName, $propertyConfig['property_name'], $parameterName))
                         ->setParameter($parameterName, $dqlParameters['numeric_query']);
                 } elseif ($propertyConfig['is_guid'] && $isUuidQueryTerm) {
                     $parameterName = sprintf('query_for_uuids_%d', $queryTermIndex);
-                    $queryBuilder->orWhere(sprintf('%s.%s = :%s', $entityName, $propertyName, $parameterName))
+                    $queryBuilder->orWhere(sprintf('%s.%s = :%s', $entityName, $propertyConfig['property_name'], $parameterName))
                         ->setParameter($parameterName, $dqlParameters['uuid_query'], 'uuid' === $propertyConfig['property_data_type'] ? 'uuid' : null);
                 } elseif ($propertyConfig['is_ulid'] && $isUlidQueryTerm) {
                     $parameterName = sprintf('query_for_ulids_%d', $queryTermIndex);
-                    $queryBuilder->orWhere(sprintf('%s.%s = :%s', $entityName, $propertyName, $parameterName))
+                    $queryBuilder->orWhere(sprintf('%s.%s = :%s', $entityName, $propertyConfig['property_name'], $parameterName))
                         ->setParameter($parameterName, $dqlParameters['uuid_query'], 'ulid');
                 } elseif ($propertyConfig['is_text']) {
                     $parameterName = sprintf('query_for_text_%d', $queryTermIndex);
-                    $queryBuilder->orWhere(sprintf('LOWER(%s.%s) LIKE :%s', $entityName, $propertyName, $parameterName))
+                    $queryBuilder->orWhere(sprintf('LOWER(%s.%s) LIKE :%s', $entityName, $propertyConfig['property_name'], $parameterName))
                         ->setParameter($parameterName, $dqlParameters['text_query']);
                 }
             }
@@ -263,9 +263,10 @@ final class EntityRepository implements EntityRepositoryInterface
                 }
             }
 
-            $searchablePropertiesConfig[$propertyName] = [
+            $searchablePropertiesConfig[] = [
                 'entity_name' => $entityName,
                 'property_data_type' => $propertyDataType,
+                'property_name' => $propertyName,
                 'is_boolean' => $isBoolean,
                 'is_small_integer' => $isSmallIntegerProperty,
                 'is_integer' => $isIntegerProperty,

--- a/tests/Controller/Search/CustomCrudSearchControllerTest.php
+++ b/tests/Controller/Search/CustomCrudSearchControllerTest.php
@@ -39,6 +39,7 @@ class CustomCrudSearchControllerTest extends AbstractCrudTestCase
         // properties used by the search engine. That's why results are not the default ones
         $totalNumberOfPosts = 20;
         $numOfPostsWrittenByEachAuthor = 4;
+        $numOfPostsPublishedByEachUser = 2;
 
         yield 'search by blog post title yields no results' => [
             'blog post',
@@ -50,19 +51,19 @@ class CustomCrudSearchControllerTest extends AbstractCrudTestCase
             0,
         ];
 
-        yield 'search by author email' => [
+        yield 'search by author or publisher email' => [
             '@example.com',
             $totalNumberOfPosts,
         ];
 
-        yield 'quoted search by author email' => [
+        yield 'quoted search by author or published email' => [
             '"user4@"',
-            $numOfPostsWrittenByEachAuthor,
+            $numOfPostsWrittenByEachAuthor + $numOfPostsPublishedByEachUser,
         ];
 
-        yield 'multiple search by author email (partial or complete)' => [
+        yield 'multiple search by author or publisher email (partial or complete)' => [
             '"user2@example.com" "user4@"',
-            2 * $numOfPostsWrittenByEachAuthor,
+            2 * $numOfPostsWrittenByEachAuthor + 2 * $numOfPostsPublishedByEachUser,
         ];
     }
 }

--- a/tests/TestApplication/src/Controller/Search/CustomCrudSearchController.php
+++ b/tests/TestApplication/src/Controller/Search/CustomCrudSearchController.php
@@ -16,6 +16,6 @@ class CustomCrudSearchController extends AbstractCrudController
     public function configureCrud(Crud $crud): Crud
     {
         return parent::configureCrud($crud)
-            ->setSearchFields(['id', 'author.email']);
+            ->setSearchFields(['id', 'author.email', 'publisher.email']);
     }
 }

--- a/tests/TestApplication/src/DataFixtures/AppFixtures.php
+++ b/tests/TestApplication/src/DataFixtures/AppFixtures.php
@@ -40,6 +40,12 @@ class AppFixtures extends Fixture
                 ->addCategory($this->getReference('category'.($i % 10), Category::class))
                 ->setAuthor($this->getReference('user'.($i % 5), User::class));
 
+            if ($i < 10) {
+                $blogPost->setPublisher(
+                    $this->getReference('user'.(($i + 1) % 5), User::class)
+                );
+            }
+
             $manager->persist($blogPost);
         }
 

--- a/tests/TestApplication/src/Entity/BlogPost.php
+++ b/tests/TestApplication/src/Entity/BlogPost.php
@@ -36,6 +36,9 @@ class BlogPost
     #[ORM\JoinColumn(nullable: false)]
     private $author;
 
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    private $publisher;
+
     public function __construct()
     {
         $this->categories = new ArrayCollection();
@@ -140,5 +143,15 @@ class BlogPost
         $this->author = $author;
 
         return $this;
+    }
+
+    public function getPublisher()
+    {
+        return $this->publisher;
+    }
+
+    public function setPublisher(?User $publisher): void
+    {
+        $this->publisher = $publisher;
     }
 }


### PR DESCRIPTION
This little change handles the case when we have custom search fields defined in CRUD configuration, but each pointing to a field with the same name. Example taken from my daily project:

Entity `Department` has (among others) 2 associations - `City` and `Company`. In CRUD I'd like to easily search by department name and both company name and city name, so:
`->setSearchFields(['id', 'name', 'city.name', 'company.name'])`

The way it's done in `EntityRepository` makes it only search by `company.name`, as field name is taken as the key for search fields configuration. I moved the field name to a property and return a list from `getSearchablePropertiesConfig()` to mitigate the issue.

This time around I was able to work with tests - I have extended `BlogPost` fixture to include optional publisher association and then search by both `author` and `publisher`. It fails without this little change and works as expected after.