### PR TITLE
Fixed duplicate CSS rule in theme variables

### DIFF
--- a/assets/css/easyadmin-theme/variables-theme.scss
+++ b/assets/css/easyadmin-theme/variables-theme.scss
@@ -214,7 +214,7 @@
     --badge-light-box-shadow: none;
     --badge-light-color: var(--text-color);
     --badge-dark-bg: var(--gray-900);
-    --badge-light-box-shadow: none;
+    --badge-dark-box-shadow: none;
     --badge-dark-color: var(--gray-50);
     --alert-primary-bg: var(--indigo-100);
     --alert-primary-color: var(--indigo-800);


### PR DESCRIPTION
It's all in the title, it's possibly a typo introduced in a previous commit.