### PR TITLE
Remove doubled default in variables-bootstrap.scss

### DIFF
--- a/assets/css/easyadmin-theme/variables-bootstrap.scss
+++ b/assets/css/easyadmin-theme/variables-bootstrap.scss
@@ -62,7 +62,7 @@ $form-check-input-border: 1px solid var(--gray-400) !default;
 $form-group-margin-bottom: 0 !default;
 $input-group-addon-bg: hsl(210, 45%, 98%) !default; // var(--form-input-group-bg);
 $legend-color: var(--gray-800) !default;
-$legend-border-color: #e5e5e5 !default !default;
+$legend-border-color: #e5e5e5 !default;
 
 $border-radius-base: var(--border-radius) !default;
 $border-radius-large: var(--border-radius) !default;


### PR DESCRIPTION
In the variables-bootstrap.scss  we have a doubled default : `!default !default!` which leads to a deprecation warning "!default should only be written once for each variable."