### PR TITLE
Optimize and simplify github workflow even more

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,13 +54,39 @@ jobs:
             - name: "Run PHPStan analysis"
               run: vendor/bin/phpstan analyse
 
-    maintained:
+    phpunit:
         strategy:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php_versions: ["8.1", "8.2"]
+                php_version: ["8.1", "8.2"]
                 symfony_version: ["5.4", "6.0", "6.1", "6.2", "6.3"]
+                include:
+                    # Latest Symfony version support
+                    - os: macos-latest
+                      php_version: "8.2"
+                      symfony_version: "6.3"
+                    - os: windows-latest
+                      php_version: "8.2"
+                      symfony_version: "6.3"
+                    # LTS Symfony version support
+                    - os: macos-latest
+                      php_version: "8.2"
+                      symfony_version: "5.4"
+                    - os: windows-latest
+                      php_version: "8.2"
+                      symfony_version: "5.4"
+                    # Lowest deps support
+                    - os: ubuntu-latest
+                      php_version: "8.0.2"
+                      composer_args: "--prefer-lowest"
+                    # Lowest php version support. Remove when it is dropped
+                    - os: ubuntu-latest
+                      php_version: "8.0"
+                      symfony_version: "5.4"
+                    - os: ubuntu-latest
+                      php_version: "8.0"
+                      symfony_version: "6.0"
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3
@@ -68,123 +94,24 @@ jobs:
             - name: Setup PHP, with composer and extensions
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.php_versions }}
+                  php-version: ${{ matrix.php_version }}
                   coverage: none
                   extensions: mbstring, intl, pdo, pdo_sqlite, sqlite3
                   ini-values: date.timezone=UTC
 
             - name: symfony/flex is required to install the correct symfony version
+              if: ${{ matrix.symfony_version }}
               run: |
                   composer global config --no-plugins allow-plugins.symfony/flex true
                   composer global require symfony/flex
 
-            - name: Install dependencies
-              run: |
-                  composer config extra.symfony.require "${{ matrix.symfony_version }}"
-                  composer install
-                  vendor/bin/simple-phpunit install
-
-            - name: Run tests
-              env:
-                  SYMFONY_DEPRECATIONS_HELPER: "weak"
-              run: vendor/bin/simple-phpunit
-
-    # This job is separated from `maintained` as only Symfony 5.4 and 6.0 support PHP 8.0.
-    # Once the support is dropped, we can simply remove this job.
-    maintained-8_0:
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest]
-                php_versions: ["8.0"]
-                symfony_version: ["5.4", "6.0"]
-        runs-on: ${{ matrix.os }}
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Setup PHP, with composer and extensions
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php_versions }}
-                  coverage: none
-                  extensions: mbstring, intl, pdo, pdo_sqlite, sqlite3
-                  ini-values: date.timezone=UTC
-
-            - name: symfony/flex is required to install the correct symfony version
-              run: |
-                  composer global config --no-plugins allow-plugins.symfony/flex true
-                  composer global require symfony/flex
+            - name: Configure Symfony version for symfony/flex
+              if: ${{ matrix.symfony_version }}
+              run: composer config extra.symfony.require "${{ matrix.symfony_version }}"
 
             - name: Install dependencies
               run: |
-                  composer config extra.symfony.require "${{ matrix.symfony_version }}"
-                  composer install
-                  vendor/bin/simple-phpunit install
-
-            - name: Run tests
-              env:
-                  SYMFONY_DEPRECATIONS_HELPER: "weak"
-              run: vendor/bin/simple-phpunit
-
-    lowest:
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest]
-                php_versions: ["8.0.2"]
-        runs-on: ${{ matrix.os }}
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Setup PHP, with composer and extensions
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php_versions }}
-                  coverage: none
-                  extensions: mbstring, intl, pdo, pdo_sqlite, sqlite3
-                  ini-values: date.timezone=UTC
-
-            # We don't need `symfony/flex` and `composer config extra.symfony.require` here.
-            # `--prefer-lowest` will always install symfony 5.4
-            - name: Install dependencies
-              run: |
-                  composer update --no-progress --prefer-lowest
-                  vendor/bin/simple-phpunit install
-
-            - name: Run tests
-              env:
-                  SYMFONY_DEPRECATIONS_HELPER: "weak"
-              run: vendor/bin/simple-phpunit
-
-    # Will use latest LTS and current Symfony versions only.
-    win_mac:
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [macos-latest, windows-latest]
-                php_versions: ["8.2"]
-                symfony_version: ["5.4", "6.3"]
-        runs-on: ${{ matrix.os }}
-        steps:
-            - uses: actions/checkout@v3
-
-            - name: Setup PHP, with composer and extensions
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php_versions }}
-                  coverage: none
-                  extensions: mbstring, intl, pdo, pdo_sqlite, sqlite3
-                  ini-values: date.timezone=UTC
-
-            - name: symfony/flex is required to install the correct symfony version
-              run: |
-                  composer global config --no-plugins allow-plugins.symfony/flex true
-                  composer global require symfony/flex
-
-            - name: Install dependencies
-              run: |
-                  composer config extra.symfony.require "${{ matrix.symfony_version }}"
-                  composer install
+                  composer update ${{ matrix.composer_args }}
                   vendor/bin/simple-phpunit install
 
             - name: Run tests


### PR DESCRIPTION
Hello! I propose to optimize and simplify github workflow even more:

- Renamed "maintained" job to "phpunit";
- Replaced jobs "maintained-8_0", "lowest", and "win_mac" with matrix includes to "phpunit" job;
- Renamed php_versions to php_version;
- composer install replaced by composer update for all jobs to support prefer-lowest option;

Number of jobs are the same (19)

Here is documentation regarding matrix: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs