### PR TITLE
Make *-To-Many relations sortable

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -613,7 +613,7 @@ Misc. Options
 
     TextField::new('firstName', 'Name')
         // if TRUE, listing can be sorted by this field (default: TRUE)
-        // unmapped fields and Doctrine associations cannot be sorted
+        // unmapped fields cannot be sorted
         ->setSortable(false)
 
         // help message displayed for this field in the 'detail', 'edit' and 'new' pages

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -195,9 +195,6 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
     {
         $field->setCustomOption(AssociationField::OPTION_DOCTRINE_ASSOCIATION_TYPE, 'toMany');
 
-        // associations different from *-to-one cannot be sorted
-        $field->setSortable(false);
-
         $field->setFormTypeOptionIfNotSet('multiple', true);
 
         /* @var PersistentCollection $collection */

--- a/tests/Orm/BillSortTest.php
+++ b/tests/Orm/BillSortTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Orm;
+
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort\BillCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Bill;
+
+class BillSortTest extends AbstractCrudTestCase
+{
+    private $repository;
+
+    protected function getControllerFqcn(): string
+    {
+        return BillCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->repository = $this->entityManager->getRepository(Bill::class);
+    }
+
+    /**
+     * @dataProvider sorting
+     */
+    public function testSorting(array $query, ?string $sortFunction, string $expectedSortIcon)
+    {
+        // Arrange
+        $expectedAmountMapping = [];
+
+        /**
+         * @var Bill $entity
+         */
+        foreach ($this->repository->findAll() as $entity) {
+            $expectedAmountMapping[$entity->getName()] = $entity->getCustomers()->count();
+        }
+
+        if (null !== $sortFunction) {
+            $sortFunction($expectedAmountMapping);
+        }
+
+        // Act
+        $crawler = $this->client->request('GET', $this->generateIndexUrl().'&'.http_build_query($query));
+
+        // Assert
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextSame('th.header-for-field-association > a', 'Customers');
+        $this->assertSelectorExists('th.header-for-field-association i.'.$expectedSortIcon);
+
+        $index = 1;
+
+        foreach ($expectedAmountMapping as $expectedName => $expectedValue) {
+            $expectedRow = $index++;
+
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(2)', $expectedName, sprintf('Expected "%s" in row %d', $expectedName, $expectedRow));
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(3)', $expectedValue, sprintf('Expected "%s" in row %d', $expectedValue, $expectedRow));
+        }
+    }
+
+    public function sorting(): \Generator
+    {
+        yield [
+            [],
+            null,
+            'fa-sort',
+        ];
+
+        yield [
+            ['sort' => ['customers' => 'ASC']],
+            'asort',
+            'fa-arrow-up',
+        ];
+
+        yield [
+            ['sort' => ['customers' => 'DESC']],
+            'arsort',
+            'fa-arrow-down',
+        ];
+    }
+}

--- a/tests/Orm/CustomerSortTest.php
+++ b/tests/Orm/CustomerSortTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Orm;
+
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort\CustomerCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Customer;
+
+class CustomerSortTest extends AbstractCrudTestCase
+{
+    private $repository;
+
+    protected function getControllerFqcn(): string
+    {
+        return CustomerCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->repository = $this->entityManager->getRepository(Customer::class);
+    }
+
+    /**
+     * @dataProvider sorting
+     */
+    public function testSorting(array $query, ?string $sortFunction, string $expectedSortIcon)
+    {
+        // Arrange
+        $expectedAmountMapping = [];
+
+        /**
+         * @var Customer $entity
+         */
+        foreach ($this->repository->findAll() as $entity) {
+            $expectedAmountMapping[$entity->getName()] = $entity->getBills()->count();
+        }
+
+        if (null !== $sortFunction) {
+            $sortFunction($expectedAmountMapping);
+        }
+
+        // Act
+        $crawler = $this->client->request('GET', $this->generateIndexUrl().'&'.http_build_query($query));
+
+        // Assert
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextSame('th.header-for-field-association > a', 'Bills');
+        $this->assertSelectorExists('th.header-for-field-association i.'.$expectedSortIcon);
+
+        $index = 1;
+
+        foreach ($expectedAmountMapping as $expectedName => $expectedValue) {
+            $expectedRow = $index++;
+
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(2)', $expectedName, sprintf('Expected "%s" in row %d', $expectedName, $expectedRow));
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(3)', $expectedValue, sprintf('Expected "%s" in row %d', $expectedValue, $expectedRow));
+        }
+    }
+
+    public function sorting(): \Generator
+    {
+        yield [
+            [],
+            null,
+            'fa-sort',
+        ];
+
+        yield [
+            ['sort' => ['bills' => 'ASC']],
+            'asort',
+            'fa-arrow-up',
+        ];
+
+        yield [
+            ['sort' => ['bills' => 'DESC']],
+            'arsort',
+            'fa-arrow-down',
+        ];
+    }
+}

--- a/tests/Orm/PageSortTest.php
+++ b/tests/Orm/PageSortTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Orm;
+
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort\PageCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Page;
+
+class PageSortTest extends AbstractCrudTestCase
+{
+    private $repository;
+
+    protected function getControllerFqcn(): string
+    {
+        return PageCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->repository = $this->entityManager->getRepository(Page::class);
+    }
+
+    /**
+     * @dataProvider sorting
+     */
+    public function testSorting(array $query, ?string $sortFunction, string $expectedSortIcon)
+    {
+        // Arrange
+        $expectedAmountMapping = [];
+
+        /**
+         * @var Page $entity
+         */
+        foreach ($this->repository->findAll() as $entity) {
+            $expectedAmountMapping[$entity->getName()] = $entity->getWebsite()->getName();
+        }
+
+        if (null !== $sortFunction) {
+            $sortFunction($expectedAmountMapping);
+        }
+
+        // Act
+        $crawler = $this->client->request('GET', $this->generateIndexUrl().'&'.http_build_query($query));
+
+        // Assert
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextSame('th.header-for-field-association > a', 'Website');
+        $this->assertSelectorExists('th.header-for-field-association i.'.$expectedSortIcon);
+
+        $index = 1;
+
+        foreach ($expectedAmountMapping as $expectedName => $expectedValue) {
+            $expectedRow = $index++;
+
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(2)', $expectedName, sprintf('Expected "%s" in row %d', $expectedName, $expectedRow));
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(3)', $expectedValue, sprintf('Expected "%s" in row %d', $expectedValue, $expectedRow));
+        }
+    }
+
+    public function sorting(): \Generator
+    {
+        yield [
+            [],
+            null,
+            'fa-sort',
+        ];
+
+        yield [
+            ['sort' => ['website' => 'ASC']],
+            'asort',
+            'fa-arrow-up',
+        ];
+
+        yield [
+            ['sort' => ['website' => 'DESC']],
+            'arsort',
+            'fa-arrow-down',
+        ];
+    }
+}

--- a/tests/Orm/WebsiteSortTest.php
+++ b/tests/Orm/WebsiteSortTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Orm;
+
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort\WebsiteCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Website;
+
+class WebsiteSortTest extends AbstractCrudTestCase
+{
+    private $repository;
+
+    protected function getControllerFqcn(): string
+    {
+        return WebsiteCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->repository = $this->entityManager->getRepository(Website::class);
+    }
+
+    /**
+     * @dataProvider sorting
+     */
+    public function testSorting(array $query, ?string $sortFunction, string $expectedSortIcon)
+    {
+        // Arrange
+        $expectedAmountMapping = [];
+
+        /**
+         * @var Website $entity
+         */
+        foreach ($this->repository->findAll() as $entity) {
+            $expectedAmountMapping[$entity->getName()] = $entity->getPages()->count();
+        }
+
+        if (null !== $sortFunction) {
+            $sortFunction($expectedAmountMapping);
+        }
+
+        // Act
+        $crawler = $this->client->request('GET', $this->generateIndexUrl().'&'.http_build_query($query));
+
+        // Assert
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextSame('th.header-for-field-association > a', 'Pages');
+        $this->assertSelectorExists('th.header-for-field-association i.'.$expectedSortIcon);
+
+        $index = 1;
+
+        foreach ($expectedAmountMapping as $expectedName => $expectedValue) {
+            $expectedRow = $index++;
+
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(2)', $expectedName, sprintf('Expected "%s" in row %d', $expectedName, $expectedRow));
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(3)', $expectedValue, sprintf('Expected "%s" in row %d', $expectedValue, $expectedRow));
+        }
+    }
+
+    public function sorting(): \Generator
+    {
+        yield [
+            [],
+            null,
+            'fa-sort',
+        ];
+
+        yield [
+            ['sort' => ['pages' => 'ASC']],
+            'asort',
+            'fa-arrow-up',
+        ];
+
+        yield [
+            ['sort' => ['pages' => 'DESC']],
+            'arsort',
+            'fa-arrow-down',
+        ];
+    }
+}

--- a/tests/TestApplication/src/Controller/Sort/BillCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/BillCrudController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Bill;
+
+class BillCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Bill::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('name'),
+            AssociationField::new('customers'),
+        ];
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setPaginatorPageSize(100);
+    }
+}

--- a/tests/TestApplication/src/Controller/Sort/CustomerCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/CustomerCrudController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Customer;
+
+class CustomerCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Customer::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('name'),
+            AssociationField::new('bills'),
+        ];
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setPaginatorPageSize(100);
+    }
+}

--- a/tests/TestApplication/src/Controller/Sort/PageCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/PageCrudController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Page;
+
+class PageCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Page::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('name'),
+            AssociationField::new('website'),
+        ];
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setPaginatorPageSize(100);
+    }
+}

--- a/tests/TestApplication/src/Controller/Sort/WebsiteCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/WebsiteCrudController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Website;
+
+class WebsiteCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Website::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('name'),
+            AssociationField::new('pages'),
+        ];
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setPaginatorPageSize(100);
+    }
+}

--- a/tests/TestApplication/src/DataFixtures/AppFixtures.php
+++ b/tests/TestApplication/src/DataFixtures/AppFixtures.php
@@ -4,9 +4,13 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\DataFixtures;
 
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Bill;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Customer;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Page;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\User;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Website;
 
 class AppFixtures extends Fixture
 {
@@ -49,6 +53,85 @@ class AppFixtures extends Fixture
             $manager->persist($blogPost);
         }
 
+        $this->addAssociationFixtures($manager);
+
         $manager->flush();
+    }
+
+    private function addAssociationFixtures(ObjectManager $manager)
+    {
+        // Customer <-Many-To-Many-> Bill
+
+        // Add 10 Bills
+        for ($i = 0; $i < 10; ++$i) {
+            $bill = (new Bill())
+                ->setName('Bill '.$i);
+
+            $this->addReference('bill'.$i, $bill);
+            $manager->persist($bill);
+        }
+
+        // Pregenerated random amount of elements for each Bill
+        $manyToManyAmount = [3, 0, 0, 1, 4, 0, 2, 2, 1, 1];
+
+        // Amount of elements is the sum of the manyToManyAmount array (Generation was implemented in a way that does not include duplicates)
+        $manyToManyMapping = [6, 5, 6, 3, 1, 7, 2, 9, 4, 6, 2, 6, 1, 4, 0, 2, 4, 1, 6, 0, 9, 6, 7, 9, 8, 5, 2, 4, 9, 4, 0, 8, 7, 1, 3, 2, 1, 8, 4, 9, 7, 5, 3, 0, 6];
+        $manyToManyIndex = 0;
+
+        // Add 10 Customer
+        for ($i = 0; $i < 10; ++$i) {
+            $customer = (new Customer())
+                ->setName('Customer '.$i);
+
+            $amount = $manyToManyAmount[$i];
+
+            if ($amount > 0) {
+                for ($j = 0; $j < $amount; ++$j) {
+                    $customer->addBill(
+                        $this->getReference('bill'.$manyToManyMapping[$manyToManyIndex++], Bill::class)
+                    );
+                }
+            }
+
+            $this->addReference('customer'.$i, $customer);
+            $manager->persist($customer);
+        }
+
+        // Page <-Many-To-One-> Website
+
+        // Add 10 Page
+        for ($i = 0; $i < 10; ++$i) {
+            $page = (new Page())
+                ->setName('Page '.$i);
+
+            $this->addReference('page'.$i, $page);
+            $manager->persist($page);
+        }
+
+        // Pregenerated random amount of elements for each Website
+        $oneToManyAmount = [4, 1, 2, 5, 4, 4, 0, 4, 4, 3];
+
+        // Amount of elements is the sum of the oneToManyAmount array (Generation was implemented in a way that does not include duplicates)
+        $oneToManyMapping = [3, 8, 0, 7, 4, 0, 5, 2, 0, 1, 0, 8, 2, 4, 3, 3, 2, 5, 4, 7, 9, 2, 0, 1, 9, 6, 8, 5, 2, 9, 5, 0, 6, 1, 3, 8, 6, 9, 2, 0, 4, 8, 3, 7, 1];
+        $oneToManyIndex = 0;
+
+        // Add 10 Website
+        for ($i = 0; $i < 10; ++$i) {
+            $website = (new Website())
+                ->setName('Website '.$i);
+
+            $amount = $oneToManyAmount[$i];
+
+            if ($amount > 0) {
+                for ($j = 0; $j < $amount; ++$j) {
+                    $website->addPage(
+                        $this->getReference('page'.$oneToManyMapping[$oneToManyIndex++], Page::class)
+                    );
+                }
+            }
+
+            $this->addReference('website'.$i, $website);
+            $manager->persist($website);
+        }
     }
 }

--- a/tests/TestApplication/src/Entity/Bill.php
+++ b/tests/TestApplication/src/Entity/Bill.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`bill`')]
+class Bill
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\ManyToMany(targetEntity: Customer::class, inversedBy: 'bills')]
+    private $customers;
+
+    public function __construct()
+    {
+        $this->customers = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Customer[]
+     */
+    public function getCustomers(): Collection
+    {
+        return $this->customers;
+    }
+
+    public function addCustomer(Customer $customer): self
+    {
+        if (!$this->customers->contains($customer)) {
+            $this->customers[] = $customer;
+        }
+
+        return $this;
+    }
+
+    public function removeCustomer(Customer $customer): self
+    {
+        $this->customers->removeElement($customer);
+
+        return $this;
+    }
+}

--- a/tests/TestApplication/src/Entity/Customer.php
+++ b/tests/TestApplication/src/Entity/Customer.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`customer`')]
+class Customer
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\ManyToMany(targetEntity: Bill::class, mappedBy: 'customers')]
+    private $bills;
+
+    public function __construct()
+    {
+        $this->bills = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Bill[]
+     */
+    public function getBills(): Collection
+    {
+        return $this->bills;
+    }
+
+    public function addBill(Bill $bill): self
+    {
+        if (!$this->bills->contains($bill)) {
+            $this->bills[] = $bill;
+            $bill->addCustomer($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBill(Bill $bill): self
+    {
+        if ($this->bills->removeElement($bill)) {
+            $bill->addCustomer($this);
+        }
+
+        return $this;
+    }
+}

--- a/tests/TestApplication/src/Entity/Page.php
+++ b/tests/TestApplication/src/Entity/Page.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`page`')]
+class Page
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\ManyToOne(targetEntity: Website::class, inversedBy: 'pages')]
+    #[ORM\JoinColumn(nullable: false)]
+    private $website;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getWebsite()
+    {
+        return $this->website;
+    }
+
+    public function setWebsite(?Website $website)
+    {
+        $this->website = $website;
+
+        return $this;
+    }
+}

--- a/tests/TestApplication/src/Entity/Website.php
+++ b/tests/TestApplication/src/Entity/Website.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`website`')]
+class Website implements \Stringable
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\OneToMany(targetEntity: Page::class, mappedBy: 'website', orphanRemoval: true)]
+    private $pages;
+
+    public function __construct()
+    {
+        $this->pages = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Page[]
+     */
+    public function getPages(): Collection
+    {
+        return $this->pages;
+    }
+
+    public function addPage(Page $page): self
+    {
+        if (!$this->pages->contains($page)) {
+            $this->pages[] = $page;
+            $page->setWebsite($this);
+        }
+
+        return $this;
+    }
+
+    public function removePage(Page $page): self
+    {
+        if ($this->pages->removeElement($page)) {
+            // set the owning side to null (unless already changed)
+            if ($page->getWebsite() === $this) {
+                $page->setWebsite(null);
+            }
+        }
+
+        return $this;
+    }
+
+    public function __toString()
+    {
+        return $this->name;
+    }
+}


### PR DESCRIPTION
In a project I've a several *-To-Many relations which I need to be sortable, to have better insight into the data.

I tested One-To-Many and Many-To-Many and also the `setDefaultSort` in `configureCrud`, works as expected.
~~Haven't tested ManyToMany, but I think they should work, too.~~ Didn't worked, but I found a solution.

As it wasn't working before, I made it Opt-In.

- [x] Add tests **Can Someone help me out here? Not sure about the testing structure.**
- [x] Update docs? (Removed the limits so far, I don't think there is something we could add)
- [x] Test ManyToMany

Cheers

## Many-To-Many

### Foo

<img width="1553" alt="Screenshot 2023-07-23 at 8 16 37 PM" src="https://github.com/EasyCorp/EasyAdminBundle/assets/1337562/28fcebc6-c4d2-4a96-943e-f41f9df38601">

<img width="1553" alt="Screenshot 2023-07-23 at 8 16 48 PM" src="https://github.com/EasyCorp/EasyAdminBundle/assets/1337562/b26eed84-4737-4faa-aab7-2e8492cb08ac">

### Bar

<img width="1553" alt="Screenshot 2023-07-23 at 8 17 27 PM" src="https://github.com/EasyCorp/EasyAdminBundle/assets/1337562/ad71e64f-b379-4a0d-beea-296f8f9add8a">

<img width="1553" alt="Screenshot 2023-07-23 at 8 17 15 PM" src="https://github.com/EasyCorp/EasyAdminBundle/assets/1337562/afe5b625-6ed8-4fce-9e9a-14d752267481">

## One-To-Many

<img width="1553" alt="Screenshot 2023-07-23 at 8 18 25 PM" src="https://github.com/EasyCorp/EasyAdminBundle/assets/1337562/1991e589-4a4f-4455-84c4-28b2346b4807">

<img width="1553" alt="Screenshot 2023-07-23 at 8 18 41 PM" src="https://github.com/EasyCorp/EasyAdminBundle/assets/1337562/b2d62fb7-fc84-4bba-88e8-c00cdbed0dd5">

