### PR TITLE
Priority of the getDashboardDto routeName fixed.

### DIFF
--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -73,9 +73,10 @@ final class AdminContextFactory
         $dashboardControllerRoutes = !file_exists($dashboardRoutesCachePath) ? [] : require $dashboardRoutesCachePath;
         $dashboardController = $dashboardControllerInstance::class.'::index';
         $dashboardRouteName = null;
+        $currentRouteName = $request->attributes->get('_route');
 
         foreach ($dashboardControllerRoutes as $routeName => $controller) {
-            if ($controller === $dashboardController) {
+            if ($controller === $dashboardController && $currentRouteName === $routeName) {
                 // if present, remove the suffix of i18n route names (it's a two-letter locale at the end
                 // of the route name; e.g. 'dashboard.en' -> remove '.en', 'admin.index.es' -> remove '.es')
                 $dashboardRouteName = preg_replace('~\.\w{2}$~', '', $routeName);


### PR DESCRIPTION
In our application, when we log in using the "/customer/admin" URL, the login process is successful. However, there is an unexpected behavior with the "AdminUrlGenerator" object while generating URLs. Instead of producing the "customer_admin" value, it produces the "publisher_admin" value. This issue is occurring because the "publisher_admin" route definition takes precedence over the "customer_admin" route definition.

Looking at our code, we have a controller named "DashboardController" with a method named "index":
```php
#[Route('/publisher/admin', name: 'publisher_admin')]
#[Route('/customer/admin', name: 'customer_admin')]
public function index(): Response
{
$adminUrlGenerator = $this->container->get(AdminUrlGenerator::class);

    return $this->redirect($adminUrlGenerator->setRoute('my_route')->generateUrl());
}
```



The root cause of the issue is that the "getDashboardDto" method is unable to select the correct route definition. Since the "publisher_admin" route definition comes before the "customer_admin" route definition, the method prioritizes it, resulting in users being redirected to the "/publisher/admin" URL and encountering "Access denied" errors.

To resolve this problem;


```php
// AdminContextFactory.php
private function getDashboardDto(Request $request, DashboardControllerInterface $dashboardControllerInstance): DashboardDto
{
    $dashboardRoutesCachePath = $this->cacheDir.'/'.CacheWarmer::DASHBOARD_ROUTES_CACHE;
    $dashboardControllerRoutes = !file_exists($dashboardRoutesCachePath) ? [] : require $dashboardRoutesCachePath; // [ "publisher_admin" => "App\Controller\Admin\DashboardController::index" "customer_admin" => "App\Controller\Admin\DashboardController::index" ]
    $dashboardController = $dashboardControllerInstance::class.'::index';
    $dashboardRouteName = null;
    $currentRouteName = $request->attributes->get('_route');

    foreach ($dashboardControllerRoutes as $routeName => $controller) {
        if ($controller === $dashboardController && $currentRouteName === $routeName) {
        
            $dashboardRouteName = preg_replace('~\.\w{2}$~', '', $routeName);
            
            break;
        }
    }

    .
    .
    .
    
    $dashboardDto = $dashboardControllerInstance->configureDashboard()->getAsDto();
    $dashboardDto->setRouteName($dashboardRouteName);
    
    return $dashboardDto;
}
```