### PR TITLE
Fix search in JSON fields for PostgreSQL databases

### DIFF
--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -17,7 +17,7 @@ use Twig\Markup;
  */
 final class CommonPostConfigurator implements FieldConfiguratorInterface
 {
-    private AdminContextProvider$adminContextProvider;
+    private AdminContextProvider $adminContextProvider;
     private string $charset;
 
     public function __construct(AdminContextProvider $adminContextProvider, string $charset)


### PR DESCRIPTION
Without this, I see this exception:

```
An exception ocurred while executing a query: SQLSTATE[42883]:
Undefined function: 7 ERROR: function lower(json) does not exist.
```

If I remove the `lower()` call, then I see an exception related to the `LIKE` operator. If I use the `::text` PostgreSQL operator to turn the JSON contents to text, then I see a Doctrine DBAL parser error.

So, let's remove this until someone smart can find a better solution. Thanks.