### PR TITLE
Add the country name as a title of the flag image in CountryField

### DIFF
--- a/src/Resources/views/crud/field/country.html.twig
+++ b/src/Resources/views/crud/field/country.html.twig
@@ -9,7 +9,7 @@
 {% if show_flag and not show_name %}
     {% for flag_code, country_name in field.formattedValue %}
         {% if flag_code is not null %}
-            <img class="country-flag" alt="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
+            <img class="country-flag" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
         {% endif %}
     {% endfor %}
 {% elseif show_name and not show_flag  %}
@@ -19,7 +19,7 @@
         <span>
             {%- if show_flag -%}
                 {%- if flag_code is not null -%}
-                    <img class="country-flag" alt="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
+                    <img class="country-flag" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
                 {%- endif -%}
             {%- endif -%}
 


### PR DESCRIPTION
While working on a new EasyAdmin backend project, I realized that you can't see the country name by pointing your mouse on a flag image. To do so, we need to add the `title` attribute, not only the `alt` attribute.