### PR TITLE
Revert the check of the route name

### DIFF
--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -73,13 +73,9 @@ final class AdminContextFactory
         $dashboardControllerRoutes = !file_exists($dashboardRoutesCachePath) ? [] : require $dashboardRoutesCachePath;
         $dashboardController = $dashboardControllerInstance::class.'::index';
         $dashboardRouteName = null;
-        $currentRouteName = $request->attributes->get('_route');
 
         foreach ($dashboardControllerRoutes as $routeName => $controller) {
-            // checking if the route name matches is needed because the same
-            // dashboard controller can be associated to more than one route
-            // (see https://github.com/EasyCorp/EasyAdminBundle/pull/5853)
-            if ($controller === $dashboardController && $currentRouteName === $routeName) {
+            if ($controller === $dashboardController) {
                 // if present, remove the suffix of i18n route names (it's a two-letter locale at the end
                 // of the route name; e.g. 'dashboard.en' -> remove '.en', 'admin.index.es' -> remove '.es')
                 $dashboardRouteName = preg_replace('~\.\w{2}$~', '', $routeName);


### PR DESCRIPTION
Let's revert #5853 until we can fix the bugs reported in:

* https://github.com/EasyCorp/EasyAdminBundle/commit/8e350822daa35ff4761e20e02cd0f126bf9b3ae5#commitcomment-123618904
* https://github.com/EasyCorp/EasyAdminBundle/issues/5864

@inalbilal I want to fix the bug that you originally reported in #5853, but I think we'll need to use a different fix because some people reported exceptions after applying this change in their applications. Thanks.