### PR TITLE
Fix ChoiceField with EnumType

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -116,7 +116,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
         }
 
         if (\is_array($callback) && 2 === \count($callback)) {
-            $callback[0] = $environment->getRuntime($callback[0]);
+            $callback = [$environment->getRuntime(array_shift($callback)), ...$callback];
             if (!\is_callable($callback)) {
                 throw new RuntimeError(sprintf('Unable to load runtime for filter: "%s"', $filterName));
             }

--- a/tests/Field/Configurator/ChoiceConfiguratorTest.php
+++ b/tests/Field/Configurator/ChoiceConfiguratorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Configurator;
+
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ChoiceConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Field\AbstractFieldTest;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Fixtures\ChoiceField\PriorityUnitEnum;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Fixtures\ChoiceField\StatusBackedEnum;
+
+class ChoiceConfiguratorTest extends AbstractFieldTest
+{
+    private const ENTITY_CLASS = 'AppTestBundle\Entity\UnitTests\Category';
+    private const PROPERTY_NAME = 'foo';
+
+    private ?EntityDto $entity = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new ChoiceConfigurator();
+
+        $metadata = new ClassMetadataInfo(self::ENTITY_CLASS);
+        $metadata->setIdentifier(['id']);
+        $this->entity = new EntityDto(self::ENTITY_CLASS, $metadata);
+    }
+
+    /**
+     * @dataProvider fieldTypes
+     */
+    public function testSupporsField(string $fieldType, bool $expectedResult): void
+    {
+        $this->checkPhpVersion();
+
+        $field = new FieldDto();
+        $field->setFieldFqcn($fieldType);
+
+        $this->assertSame($this->configurator->supports($field, $this->entity), $expectedResult);
+    }
+
+    public function testBackedEnumTypeChoices(): void
+    {
+        $this->checkPhpVersion();
+
+        $field = ChoiceField::new(self::PROPERTY_NAME);
+        $field->getAsDto()->setDoctrineMetadata(['enumType' => StatusBackedEnum::class]);
+
+        $this->assertSame($this->configure($field)->getFormTypeOption('choices'), StatusBackedEnum::cases());
+    }
+
+    public function testBackedEnumChoices(): void
+    {
+        $this->checkPhpVersion();
+
+        $field = ChoiceField::new(self::PROPERTY_NAME);
+        $field->setCustomOptions(['choices' => StatusBackedEnum::cases()]);
+
+        $expected = [];
+        foreach (StatusBackedEnum::cases() as $case) {
+            $expected[$case->name] = $case->value;
+        }
+
+        $this->assertSame($this->configure($field)->getFormTypeOption('choices'), $expected);
+    }
+
+    public function testUnitEnumTypeChoices(): void
+    {
+        $this->checkPhpVersion();
+
+        $field = ChoiceField::new(self::PROPERTY_NAME);
+        $field->getAsDto()->setDoctrineMetadata(['enumType' => PriorityUnitEnum::class]);
+
+        $this->assertSame($this->configure($field)->getFormTypeOption('choices'), PriorityUnitEnum::cases());
+    }
+
+    public function testUnitEnumChoices(): void
+    {
+        $this->checkPhpVersion();
+
+        $field = ChoiceField::new(self::PROPERTY_NAME);
+        $field->setCustomOptions(['choices' => PriorityUnitEnum::cases()]);
+
+        $expected = [];
+        foreach (PriorityUnitEnum::cases() as $case) {
+            $expected[$case->name] = $case->name;
+        }
+
+        $this->assertSame($this->configure($field)->getFormTypeOption('choices'), $expected);
+    }
+
+    public function fieldTypes(): iterable
+    {
+        yield [ChoiceField::class, true];
+        yield [TextField::class, false];
+        yield [IdField::class, false];
+    }
+
+    private function checkPhpVersion(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('PHP 8.1 or higher is required to run this test.');
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/EasyCorp/EasyAdminBundle/issues/5641.

The simplest way to reproduce the case is:
1. `App\Enum\Status` enum:
```php
<?php

namespace App\Enum;

enum Status: int
{
    case DRAFT = 1;
    case PUBLISHED = 2;
}
```
2.  `App\Entity\BlogPost` entity:
```php
<?php

namespace App\Entity;

use App\Enum\Status;
use App\Repository\BlogPostRepository;
use Doctrine\ORM\Mapping as ORM;

#[ORM\Entity(repositoryClass: BlogPostRepository::class)]
class BlogPost
{
    #[ORM\Id]
    #[ORM\GeneratedValue]
    #[ORM\Column]
    private ?int $id = null;

    #[ORM\Column(length: 255)]
    private ?string $title = null;

    #[ORM\Column(type: 'smallint', enumType: Status::class)]
    private ?Status $status = null;

    public function getId(): ?int
    {
        return $this->id;
    }

    public function getTitle(): ?string
    {
        return $this->title;
    }

    public function setTitle(string $title): static
    {
        $this->title = $title;

        return $this;
    }

    public function getStatus(): ?Status
    {
        return $this->status;
    }

    public function setStatus(Status $status): static
    {
        $this->status = $status;

        return $this;
    }
}
```
3. `App\Controller\Admin\BlogPostCrudController` CURD controller:
```php
<?php

namespace App\Controller\Admin;

use App\Entity\BlogPost;
use App\Enum\Status;
use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
use Symfony\Component\Form\Extension\Core\Type\EnumType;

class BlogPostCrudController extends AbstractCrudController
{
    public static function getEntityFqcn(): string
    {
        return BlogPost::class;
    }

    public function configureFields(string $pageName): iterable
    {
        return [
            IdField::new('id')->hideOnForm(),
            TextField::new('title'),
            ChoiceField::new('status')
                ->setFormType(EnumType::class)
                ->setFormTypeOption('class', Status::class),
        ];
    }
}
```

Currently, the hacky fix is to specify `choice_label`, `choice_value` and `setter`:
```php
    public function configureFields(string $pageName): iterable
    {
        return [
            IdField::new('id')->hideOnForm(),
            TextField::new('title'),
            ChoiceField::new('status')
                ->setFormType(EnumType::class)
                ->setFormTypeOption('class', Status::class)
                ->setFormTypeOption('choice_label',function (Status|int|string $choice): string {
                    return ($enum = Status::tryFrom($choice)) ? $enum->name : $choice;
                })
                ->setFormTypeOption('choice_value', function (Status|int|string|null $value): ?string {
                    if (null === $value) {
                        return null;
                    }

                    return (string) ($value instanceof Status ? $value->value : $value);
                })
                ->setFormTypeOption('setter', function (BlogPost $entity, int $value): void {
                    $entity->setStatus(Status::tryFrom($value));
                }),
        ];
    }
```