### PR TITLE
Tests : fix entity row selector

### DIFF
--- a/src/Command/MakeCrudControllerCommand.php
+++ b/src/Command/MakeCrudControllerCommand.php
@@ -72,7 +72,7 @@ class MakeCrudControllerCommand extends Command
 
         $guessedNamespace = u($controllerDir)->equalsTo('src')
             ? 'App'
-            : u($controllerDir)->replace('/', ' ')->replace('\\', ' ')->replace('src ', 'app ')->title(true)->replace(' ', '\\')->trimEnd(\DIRECTORY_SEPARATOR);
+            : u($controllerDir)->replace('/', ' ')->replace('\\', ' ')->replace('src ', 'app ')->title(true)->replace('App App ', 'App ')->replace(' ', '\\')->trimEnd(\DIRECTORY_SEPARATOR);
         $namespace = $io->ask(
             'Namespace of the generated CRUD controller',
             $guessedNamespace,

--- a/src/Resources/translations/EasyAdminBundle.el.php
+++ b/src/Resources/translations/EasyAdminBundle.el.php
@@ -2,7 +2,7 @@
 
 return [
     'page_title' => [
-        // 'dashboard' => '',
+        'dashboard' => 'Πίνακας ελέγχου',
         'detail' => '%entity_as_string%',
         'edit' => 'Επεξεργασία %entity_label_singular%',
         'index' => '%entity_label_plural%',
@@ -11,7 +11,7 @@ return [
     ],
 
     'datagrid' => [
-        // 'hidden_results' => '',
+        'hidden_results' => 'Ορισμένα αποτελέσματα δεν μπορούν να εμφανιστούν επειδή δεν έχετε αρκετά δικαιώματα',
         'no_results' => 'Δεν βρέθηκαν αποτελέσματα.',
     ],
 
@@ -21,7 +21,7 @@ return [
         'next' => 'Επόμενη',
         'last' => 'Τελευταία',
         'counter' => '<strong>%start%</strong> - <strong>%end%</strong> από <strong>%results%</strong>',
-        // 'results' => '',
+        'results' => '{0} Δεν βρέθηκαν εγγραφές |{1} <strong>1</strong> εγγραφή|]1,Inf] <strong>%count%</strong> εγγραφές',
     ],
 
     'label' => [
@@ -36,8 +36,8 @@ return [
     ],
 
     'field' => [
-        // 'code_editor.view_code' => '',
-        // 'text_editor.view_content' => '',
+         'code_editor.view_code' => 'Προβολή κώδικα',
+         'text_editor.view_content' => 'Προβολή περιεχομένου',
     ],
 
     'action' => [
@@ -49,22 +49,22 @@ return [
         'delete' => 'Διαγραφή',
         'cancel' => 'Άκυρο',
         'index' => 'Επιστροφή στην λίστα',
-        // 'deselect' => '',
+        'deselect' => 'Αποεπιλογή',
         'add_new_item' => 'Δημιουργία νέου αντικειμένου',
         'remove_item' => 'Αφαίρεση αντικειμένου',
         'choose_file' => 'Επιλογή αρχείου',
-        // 'close' => '',
-        // 'create' => '',
-        // 'create_and_add_another' => '',
-        // 'create_and_continue' => '',
-        // 'save' => '',
-        // 'save_and_continue' => '',
+        'close' => 'Κλείσιμο',
+        'create' => 'Δημιουργία',
+        'create_and_add_another' => 'Δημιουργία και προσθήκη άλλου',
+        'create_and_continue' => 'Δημιουργία και συνέχιση επεξεργασίας',
+        'save' => 'Αποθήκευση αλλαγών',
+        'save_and_continue' => 'Αποθήκευση και συνέχιση επεξεργασία',
     ],
 
     'batch_action_modal' => [
-        // 'title' => '',
-        // 'content' => '',
-        // 'action' => '',
+        'title' => 'Θα εφαρμόσετε την ενέργεια "%action_name%" στο %num_items% αντικείμενο(α).',
+        'content' => 'Αυτή η ενέργεια δεν αναιρείται.',
+        'action' => 'Συνεχίστε.',
     ],
 
     'delete_modal' => [
@@ -73,33 +73,34 @@ return [
     ],
 
     'filter' => [
-        // 'title' => '',
-        // 'button.clear' => '',
-        // 'button.apply' => '',
-        // 'label.is_equal_to' => '',
-        // 'label.is_not_equal_to' => '',
-        // 'label.is_greater_than' => '',
-        // 'label.is_greater_than_or_equal_to' => '',
-        // 'label.is_less_than' => '',
-        // 'label.is_less_than_or_equal_to' => '',
-        // 'label.is_between' => '',
-        // 'label.contains' => '',
-        // 'label.not_contains' => '',
-        // 'label.starts_with' => '',
-        // 'label.ends_with' => '',
-        // 'label.exactly' => '',
-        // 'label.not_exactly' => '',
-        // 'label.is_same' => '',
-        // 'label.is_not_same' => '',
-        // 'label.is_after' => '',
-        // 'label.is_after_or_same' => '',
-        // 'label.is_before' => '',
-        // 'label.is_before_or_same' => '',
+         'title' => 'Φίλτρα',
+         'button.clear' => 'Καθαρισμός',
+         'button.apply' => 'Εφαρμογή',
+         'label.is_equal_to' => 'είναι ίσο με',
+         'label.is_not_equal_to' => 'δεν είναι ίσο με',
+         'label.is_greater_than' => 'είναι μεγαλύτερο από',
+         'label.is_greater_than_or_equal_to' => 'είναι μεγαλύτερο ή ίσο με',
+         'label.is_less_than' => 'είναι μικρότερο από',
+         'label.is_less_than_or_equal_to' => 'είναι μικρότερο ή ίσο με',
+         'label.is_between' => 'είναι μεταξύ',
+         'label.contains' => 'περιέχει',
+         'label.not_contains' => 'δεν περιέχει',
+         'label.starts_with' => 'ξεκινάει με',
+         'label.ends_with' => 'τελειώνει με',
+         'label.exactly' => 'ακριβώς',
+         'label.not_exactly' => 'όχι ακριβώς',
+         'label.is_same' => 'είναι ίδιο',
+         'label.is_not_same' => 'δεν είναι το ίδιο',
+         'label.is_after' => 'είναι μετά',
+         'label.is_after_or_same' => 'είναι μετά ή το ίδιο',
+         'label.is_before' => 'είναι πριν',
+         'label.is_before_or_same' => 'είναι πριν ή το ίδιο',
     ],
 
     'form' => [
         'are_you_sure' => 'Δεν έχετε αποθηκεύσει τις αλλαγές που έχετε κάνει στην φόρμα.',
         'tab.error_badge_title' => 'Μη αποδεκτή τιμή|%count% μη αποδεκτές τιμές',
+        'slug.confirm_text' => 'Εάν αλλάξετε τον εναλλακτικό τίτλο, μπορείτε να διακόψετε συνδέσμους σε άλλες σελίδες',
     ],
 
     'user' => [
@@ -121,10 +122,10 @@ return [
     ],
 
     'login_page' => [
-        'username' => 'Username',
-        'password' => 'Password',
-        'sign_in' => 'Sign in',
-        // 'forgot_password' => '',
+        'username' => 'Όνομα χρήστη',
+        'password' => 'Κωδικός πρόσβασης',
+        'sign_in' => 'Συνδεθείτε',
+        'forgot_password' => 'Ξεχάσατε τον κωδικό σας?',
         'remember_me' => 'Να με θυμάσαι',
     ],
 
@@ -132,12 +133,12 @@ return [
         'entity_not_found' => 'Αυτό το αντικείμενο δεν είναι πλέον διαθέσιμο.',
         'entity_remove' => 'Το αντικείμενο δεν είναι δυνατόν να διαγραφεί διότη υπάρχουν αντικείμενο που βασίζονται σε αυτό.',
         'forbidden_action' => 'Η ενέργεια αυτή είναι αδύνατον να εφαρμοστεί σε αυτό το αντικείμενο.',
-        // 'insufficient_entity_permission' => 'You don't have permission to access this item.',
+        'insufficient_entity_permission' => 'Δεν έχετε δικαιώματα πρόσβασης σε αυτό το αντικείμενο',
     ],
 
     'autocomplete' => [
         'no-results-found' => 'Δεν βρέθηκαν αποτελέσματα',
-        // 'no-more-results' => 'No more results',
+        'no-more-results' => 'Δεν υπάρχουν άλλα αποτελέσματα',
         'loading-more-results' => 'Φόρτωση περισσότερων αποτελεσμάτων…',
     ],
 ];

--- a/src/Test/Trait/CrudTestSelectors.php
+++ b/src/Test/Trait/CrudTestSelectors.php
@@ -11,7 +11,7 @@ trait CrudTestSelectors
 
     protected function getIndexEntityRowSelector(string|int $entityId): string
     {
-        return sprintf('tbody tr[data-id=%s]', (string) $entityId);
+        return sprintf('tbody tr[data-id="%s"]', (string) $entityId);
     }
 
     protected function getActionSelector(string $action): string


### PR DESCRIPTION
I found in the Tests implementation an issue when using ids as UUid : the getIndexEntityRowSelector from the CrudTestSelectors was not working correctly. 

There is no entity in the TestApplication with UUids to be able to test. If ok, I can add one entity with UUid as id to the Test Application just for the sake of testing it @javiereguiluz ok to leave it like that or shall I update the TestApplication?
