### PR TITLE
Add an option to hide true/false values in boolean fields

### DIFF
--- a/doc/fields/BooleanField.rst
+++ b/doc/fields/BooleanField.rst
@@ -28,6 +28,40 @@ Basic Information
 Options
 -------
 
+``hideWhenFalse``
+~~~~~~~~~~~~~~~~
+
+Use this option to not display anything when the field value is ``false``. This
+is useful to reduce the "visual noise" in listings where most rows have the same
+``false`` value and you want to ignore those and better highlight the rows with
+the ``true`` value::
+
+    yield BooleanField::new('...')->hideWhenFalse();
+
+Keep in mind that:
+
+* This option is ignored when using the ``renderAsSwitch()`` option, which always
+  displays a switch/toggle with the field value;
+* This option is only applied to the ``index`` page; in the ``detail`` page you
+  will always see the field value to avoid any confussion.
+
+``hideWhenTrue``
+~~~~~~~~~~~~~~~~
+
+Use this option to not display anything when the field value is ``true``. This
+is useful to reduce the "visual noise" in listings where most rows have the same
+``true`` value and you want to ignore those and better highlight the rows with
+the ``false`` value::
+
+    yield BooleanField::new('...')->hideWhenTrue();
+
+Keep in mind that:
+
+* This option is ignored when using the ``renderAsSwitch()`` option, which always
+  displays a switch/toggle with the field value;
+* This option is only applied to the ``index`` page; in the ``detail`` page you
+  will always see the field value to avoid any confussion.
+
 ``renderAsSwitch``
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/Field/BooleanField.php
+++ b/src/Field/BooleanField.php
@@ -16,6 +16,8 @@ final class BooleanField implements FieldInterface
     use FieldTrait;
 
     public const OPTION_RENDER_AS_SWITCH = 'renderAsSwitch';
+    public const OPTION_HIDE_WHEN_TRUE = 'hideWhenTrue';
+    public const OPTION_HIDE_WHEN_FALSE = 'hideWhenFalse';
     /** @internal */
     public const OPTION_TOGGLE_URL = 'toggleUrl';
     /** @internal */
@@ -34,12 +36,28 @@ final class BooleanField implements FieldInterface
             ->setFormType(CheckboxType::class)
             ->addCssClass('field-boolean')
             ->addJsFiles(Asset::fromEasyAdminAssetPackage('field-boolean.js')->onlyOnIndex())
-            ->setCustomOption(self::OPTION_RENDER_AS_SWITCH, true);
+            ->setCustomOption(self::OPTION_RENDER_AS_SWITCH, true)
+            ->setCustomOption(self::OPTION_HIDE_WHEN_TRUE, false)
+            ->setCustomOption(self::OPTION_HIDE_WHEN_FALSE, false);
     }
 
     public function renderAsSwitch(bool $isASwitch = true): self
     {
         $this->setCustomOption(self::OPTION_RENDER_AS_SWITCH, $isASwitch);
+
+        return $this;
+    }
+
+    public function hideWhenTrue(bool $hide = true): self
+    {
+        $this->setCustomOption(self::OPTION_HIDE_WHEN_TRUE, $hide);
+
+        return $this;
+    }
+
+    public function hideWhenFalse(bool $hide = true): self
+    {
+        $this->setCustomOption(self::OPTION_HIDE_WHEN_FALSE, $hide);
 
         return $this;
     }

--- a/src/Resources/views/crud/field/boolean.html.twig
+++ b/src/Resources/views/crud/field/boolean.html.twig
@@ -4,9 +4,18 @@
 {% trans_default_domain 'EasyAdminBundle' %}
 
 {% if ea.crud.currentAction == 'detail' or not field.customOptions.get('renderAsSwitch') %}
-    <span class="badge {{ field.value == true ? 'badge-boolean-true' : 'badge-boolean-false' }}">
-        {{ (field.value == true ? 'label.true' : 'label.false')|trans }}
-    </span>
+    {% set badge_is_hidden = ea.crud.currentAction == 'index'
+        and (
+            (field.value == true and field.customOptions.get('hideWhenTrue') == true)
+            or
+            (field.value == false and field.customOptions.get('hideWhenFalse') == true)
+        ) %}
+
+    {% if not badge_is_hidden %}
+        <span class="badge {{ field.value == true ? 'badge-boolean-true' : 'badge-boolean-false' }}">
+            {{ (field.value == true ? 'label.true' : 'label.false')|trans }}
+        </span>
+    {% endif %}
 {% else %}
     <div class="form-check form-switch">
         <input type="checkbox" class="form-check-input" id="{{ field.uniqueId }}" {{ field.value == true ? 'checked' }}


### PR DESCRIPTION
In some backends I have some entities where some field is almost always TRUE or FALSE. In the `index` listing it doesn't look nice to see so many `NO` or `YES`.

In this PR, I propose to add two new options `hideWhenTrue()` and `hideWhenFalse()` for boolean fields so we can hide the repetitive values and highlight the rare values.