### PR TITLE
Add an option to hide null values

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -324,6 +324,23 @@ Templates and Form Options
         ;
     }
 
+Other Options
+~~~~~~~~~~~~~
+
+::
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            // by default, when the value of some field is `null`, EasyAdmin displays
+            // a label with the `null` text. You can change that by overriding
+            // the `label/null` template. However, if you have lots of `null` values
+            // and want to reduce the "visual noise" in your backend, you can use
+            // the following option to not display anything when some value is `null`
+            // (this option is applied both in the `index` and `detail` pages)
+            ->hideNullValues()
+    }
+
 Custom Redirect After Creating or Editing Entities
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -385,6 +385,13 @@ class Crud
         return $this;
     }
 
+    public function hideNullValues(bool $hide = true): self
+    {
+        $this->dto->hideNullValues($hide);
+
+        return $this;
+    }
+
     public function getAsDto(): CrudDto
     {
         $this->dto->setPaginator(new PaginatorDto($this->paginatorPageSize, $this->paginatorRangeSize, 1, $this->paginatorFetchJoinCollection, $this->paginatorUseOutputWalkers));

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -59,6 +59,7 @@ final class CrudDto
     private ?string $entityPermission = null;
     private ?string $contentWidth = null;
     private ?string $sidebarWidth = null;
+    private bool $hideNullValues = false;
 
     public function __construct()
     {
@@ -460,5 +461,15 @@ final class CrudDto
     public function setSidebarWidth(string $sidebarWidth): void
     {
         $this->sidebarWidth = $sidebarWidth;
+    }
+
+    public function areNullValuesHidden(): bool
+    {
+        return $this->hideNullValues;
+    }
+
+    public function hideNullValues(bool $hide): void
+    {
+        $this->hideNullValues = $hide;
     }
 }

--- a/src/Resources/views/label/null.html.twig
+++ b/src/Resources/views/label/null.html.twig
@@ -1,1 +1,3 @@
-<span class="badge badge-secondary">{{ 'label.null'|trans(domain = 'EasyAdminBundle') }}</span>
+{% if not (ea.crud.areNullValuesHidden ?? false) %}
+    <span class="badge badge-secondary">{{ 'label.null'|trans(domain = 'EasyAdminBundle') }}</span>
+{% endif %}


### PR DESCRIPTION
Similar to #5892, in some backends I have lots of `null` values and that adds some "visual noise".

This new option `hideNullValues()` allows you to display nothing when some value is `null`.