### PR TITLE
Tweak the name of some boolean options

### DIFF
--- a/doc/fields/BooleanField.rst
+++ b/doc/fields/BooleanField.rst
@@ -28,15 +28,15 @@ Basic Information
 Options
 -------
 
-``hideWhenFalse``
-~~~~~~~~~~~~~~~~
+``hideValueWhenFalse``
+~~~~~~~~~~~~~~~~~~~~~~
 
 Use this option to not display anything when the field value is ``false``. This
 is useful to reduce the "visual noise" in listings where most rows have the same
 ``false`` value and you want to ignore those and better highlight the rows with
 the ``true`` value::
 
-    yield BooleanField::new('...')->hideWhenFalse();
+    yield BooleanField::new('...')->hideValueWhenFalse();
 
 Keep in mind that:
 
@@ -45,15 +45,15 @@ Keep in mind that:
 * This option is only applied to the ``index`` page; in the ``detail`` page you
   will always see the field value to avoid any confussion.
 
-``hideWhenTrue``
-~~~~~~~~~~~~~~~~
+``hideValueWhenTrue``
+~~~~~~~~~~~~~~~~~~~~~
 
 Use this option to not display anything when the field value is ``true``. This
 is useful to reduce the "visual noise" in listings where most rows have the same
 ``true`` value and you want to ignore those and better highlight the rows with
 the ``false`` value::
 
-    yield BooleanField::new('...')->hideWhenTrue();
+    yield BooleanField::new('...')->hideValueWhenTrue();
 
 Keep in mind that:
 

--- a/src/Field/BooleanField.php
+++ b/src/Field/BooleanField.php
@@ -16,8 +16,8 @@ final class BooleanField implements FieldInterface
     use FieldTrait;
 
     public const OPTION_RENDER_AS_SWITCH = 'renderAsSwitch';
-    public const OPTION_HIDE_WHEN_TRUE = 'hideWhenTrue';
-    public const OPTION_HIDE_WHEN_FALSE = 'hideWhenFalse';
+    public const OPTION_HIDE_VALUE_WHEN_TRUE = 'hideValueWhenTrue';
+    public const OPTION_HIDE_VALUE_WHEN_FALSE = 'hideValueWhenFalse';
     /** @internal */
     public const OPTION_TOGGLE_URL = 'toggleUrl';
     /** @internal */
@@ -37,8 +37,8 @@ final class BooleanField implements FieldInterface
             ->addCssClass('field-boolean')
             ->addJsFiles(Asset::fromEasyAdminAssetPackage('field-boolean.js')->onlyOnIndex())
             ->setCustomOption(self::OPTION_RENDER_AS_SWITCH, true)
-            ->setCustomOption(self::OPTION_HIDE_WHEN_TRUE, false)
-            ->setCustomOption(self::OPTION_HIDE_WHEN_FALSE, false);
+            ->setCustomOption(self::OPTION_HIDE_VALUE_WHEN_TRUE, false)
+            ->setCustomOption(self::OPTION_HIDE_VALUE_WHEN_FALSE, false);
     }
 
     public function renderAsSwitch(bool $isASwitch = true): self
@@ -48,16 +48,16 @@ final class BooleanField implements FieldInterface
         return $this;
     }
 
-    public function hideWhenTrue(bool $hide = true): self
+    public function hideValueWhenTrue(bool $hide = true): self
     {
-        $this->setCustomOption(self::OPTION_HIDE_WHEN_TRUE, $hide);
+        $this->setCustomOption(self::OPTION_HIDE_VALUE_WHEN_TRUE, $hide);
 
         return $this;
     }
 
-    public function hideWhenFalse(bool $hide = true): self
+    public function hideValueWhenFalse(bool $hide = true): self
     {
-        $this->setCustomOption(self::OPTION_HIDE_WHEN_FALSE, $hide);
+        $this->setCustomOption(self::OPTION_HIDE_VALUE_WHEN_FALSE, $hide);
 
         return $this;
     }

--- a/src/Resources/views/crud/field/boolean.html.twig
+++ b/src/Resources/views/crud/field/boolean.html.twig
@@ -6,9 +6,9 @@
 {% if ea.crud.currentAction == 'detail' or not field.customOptions.get('renderAsSwitch') %}
     {% set badge_is_hidden = ea.crud.currentAction == 'index'
         and (
-            (field.value == true and field.customOptions.get('hideWhenTrue') == true)
+            (field.value == true and field.customOptions.get('hideValueWhenTrue') == true)
             or
-            (field.value == false and field.customOptions.get('hideWhenFalse') == true)
+            (field.value == false and field.customOptions.get('hideValueWhenFalse') == true)
         ) %}
 
     {% if not badge_is_hidden %}


### PR DESCRIPTION
Related to #5892.

I realized that the original option name was confusing because in EA, when we say "hide.." or "show..." we always refer to the entire widget/field.

So, let's rename them to `hideValueWhen*()` to avoid confusion.

These options were introduced a few hours ago, so changing their names won't break anything 🙏 