### PR TITLE
Fix the behavior of the Action::addCssClass() method

### DIFF
--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -121,25 +121,23 @@ final class Action
     }
 
     /**
-     * If you set your own CSS classes, the default CSS classes are not applied.
-     * You may want to also add the 'btn' (and 'btn-primary', etc.) classes to make
-     * your action look like a button.
+     * Use this to override the default CSS classes applied to actions and use instead your own CSS classes.
+     * See also addCssClass() to add your own custom classes without removing the default ones.
      */
     public function setCssClass(string $cssClass): self
     {
-        $this->dto->setCssClass($cssClass);
+        $this->dto->setCssClass(trim($cssClass));
 
         return $this;
     }
 
     /**
-     * If you add a custom CSS class, the default CSS classes are not applied.
-     * You may want to also add the 'btn' (and 'btn-primary', etc.) classes to make
-     * your action look like a button.
+     * This adds the given CSS class(es) to the classes already applied to the actions
+     * (no matter if they are the default ones or some custom CSS classes set with the setCssClass() method).
      */
     public function addCssClass(string $cssClass): self
     {
-        $this->dto->setCssClass(trim($this->dto->getCssClass().' '.$cssClass));
+        $this->dto->setAddedCssClass(trim($cssClass));
 
         return $this;
     }

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -15,6 +15,7 @@ final class ActionDto
     private TranslatableInterface|string|null $label = null;
     private ?string $icon = null;
     private string $cssClass = '';
+    private string $addedCssClass = '';
     private ?string $htmlElement = null;
     private array $htmlAttributes = [];
     private ?string $linkUrl = null;
@@ -84,12 +85,22 @@ final class ActionDto
 
     public function getCssClass(): string
     {
-        return $this->cssClass;
+        return trim($this->cssClass);
     }
 
     public function setCssClass(string $cssClass): void
     {
         $this->cssClass = $cssClass;
+    }
+
+    public function getAddedCssClass(): string
+    {
+        return trim($this->addedCssClass);
+    }
+
+    public function setAddedCssClass(string $cssClass): void
+    {
+        $this->addedCssClass .= ' '.$cssClass;
     }
 
     public function getHtmlElement(): string

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -54,6 +54,7 @@ final class ActionFactory
                 continue;
             }
 
+            // if CSS class hasn't been overridden, apply the default ones
             if ('' === $actionDto->getCssClass()) {
                 $defaultCssClass = 'action-'.$actionDto->getName();
                 if (Crud::PAGE_INDEX !== $currentPage) {
@@ -61,6 +62,12 @@ final class ActionFactory
                 }
 
                 $actionDto->setCssClass($defaultCssClass);
+            }
+
+            // these are the additional custom CSS classes defined via addCssClass()
+            // which are always appended to the CSS classes (default ones or custom ones)
+            if ('' !== $addedCssClass = $actionDto->getAddedCssClass()) {
+                $actionDto->setCssClass($actionDto->getCssClass().' '.$addedCssClass);
             }
 
             $entityActions[] = $this->processAction($currentPage, $actionDto, $entityDto);

--- a/tests/Config/ActionTest.php
+++ b/tests/Config/ActionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Config;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use PHPUnit\Framework\TestCase;
+
+class ActionTest extends TestCase
+{
+    public function testDefaultCssClass()
+    {
+        $actionConfig = Action::new(Action::DELETE)->linkToCrudAction('');
+
+        $this->assertSame('', $actionConfig->getAsDto()->getCssClass());
+        $this->assertSame('', $actionConfig->getAsDto()->getAddedCssClass());
+    }
+
+    public function testSetCssClass()
+    {
+        $actionConfig = Action::new(Action::DELETE)->linkToCrudAction('')
+            ->setCssClass('foo');
+
+        $this->assertSame('foo', $actionConfig->getAsDto()->getCssClass());
+        $this->assertSame('', $actionConfig->getAsDto()->getAddedCssClass());
+    }
+
+    public function testAddCssClass()
+    {
+        $actionConfig = Action::new(Action::DELETE)->linkToCrudAction('')
+            ->addCssClass('foo');
+
+        $this->assertSame('', $actionConfig->getAsDto()->getCssClass());
+        $this->assertSame('foo', $actionConfig->getAsDto()->getAddedCssClass());
+    }
+
+    public function testSetAndAddCssClass()
+    {
+        $actionConfig = Action::new(Action::DELETE)->linkToCrudAction('')
+            ->setCssClass('foo')->addCssClass('bar');
+
+        $this->assertSame('foo', $actionConfig->getAsDto()->getCssClass());
+        $this->assertSame('bar', $actionConfig->getAsDto()->getAddedCssClass());
+    }
+
+    public function testSetAndAddCssClassWithSpaces()
+    {
+        $actionConfig = Action::new(Action::DELETE)->linkToCrudAction('')
+            ->setCssClass('      foo1   foo2  ')->addCssClass('     bar1    bar2   ');
+
+        $this->assertSame('foo1   foo2', $actionConfig->getAsDto()->getCssClass());
+        $this->assertSame('bar1    bar2', $actionConfig->getAsDto()->getAddedCssClass());
+    }
+}

--- a/tests/Controller/ActionsCrudControllerTest.php
+++ b/tests/Controller/ActionsCrudControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\ActionsCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\SecureDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+
+class ActionsCrudControllerTest extends AbstractCrudTestCase
+{
+    protected EntityRepository $categories;
+
+    protected function getControllerFqcn(): string
+    {
+        return ActionsCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return SecureDashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+
+        $this->categories = $this->entityManager->getRepository(Category::class);
+    }
+
+    public function testCssClasses()
+    {
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        static::assertSame('dropdown-item action-action1', $crawler->filter('a.dropdown-item:contains("Action1")')->attr('class'));
+        static::assertSame('dropdown-item foo', $crawler->filter('a.dropdown-item:contains("Action2")')->attr('class'));
+        static::assertSame('dropdown-item action-action3 bar', $crawler->filter('a.dropdown-item:contains("Action3")')->attr('class'));
+        static::assertSame('dropdown-item foo bar', $crawler->filter('a.dropdown-item:contains("Action4")')->attr('class'));
+    }
+}

--- a/tests/TestApplication/src/Controller/ActionsCrudController.php
+++ b/tests/TestApplication/src/Controller/ActionsCrudController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+
+/**
+ * Tests the configureActions() method and the generated actions.
+ */
+class ActionsCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Category::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('name'),
+        ];
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $action1 = Action::new('action1')->linkToCrudAction('');
+        $action2 = Action::new('action2')->linkToCrudAction('')->setCssClass('foo');
+        $action3 = Action::new('action3')->linkToCrudAction('')->addCssClass('bar');
+        $action4 = Action::new('action4')->linkToCrudAction('')->setCssClass('foo')->addCssClass('bar');
+
+        return $actions
+            ->add(Crud::PAGE_INDEX, $action1)
+            ->add(Crud::PAGE_INDEX, $action2)
+            ->add(Crud::PAGE_INDEX, $action3)
+            ->add(Crud::PAGE_INDEX, $action4)
+        ;
+    }
+}


### PR DESCRIPTION
I found this bug while working on a complex backend. The current `addCssClass()` method behaves the same as `setCssClass()`. This doesn't make any sense, so let's make `add` behave like "add to existing" and keep `set` as "don't apply the default ones and use this".