### PR TITLE
Apply default CSS classes to updated actions

### DIFF
--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -256,6 +256,7 @@ final class ActionDto
     {
         $action = Action::new($this->name, $this->label, $this->icon);
         $action->setCssClass($this->cssClass);
+        $action->addCssClass($this->addedCssClass);
         $action->setHtmlAttributes($this->htmlAttributes);
         $action->setTranslationParameters($this->translationParameters);
 

--- a/tests/Controller/ActionsCrudControllerTest.php
+++ b/tests/Controller/ActionsCrudControllerTest.php
@@ -39,5 +39,7 @@ class ActionsCrudControllerTest extends AbstractCrudTestCase
         static::assertSame('dropdown-item foo', $crawler->filter('a.dropdown-item:contains("Action2")')->attr('class'));
         static::assertSame('dropdown-item action-action3 bar', $crawler->filter('a.dropdown-item:contains("Action3")')->attr('class'));
         static::assertSame('dropdown-item foo bar', $crawler->filter('a.dropdown-item:contains("Action4")')->attr('class'));
+
+        static::assertSame('action-new btn btn-primary', trim($crawler->filter('.global-actions > a')->first()->attr('class')));
     }
 }

--- a/tests/TestApplication/src/Controller/ActionsCrudController.php
+++ b/tests/TestApplication/src/Controller/ActionsCrudController.php
@@ -38,6 +38,9 @@ class ActionsCrudController extends AbstractCrudController
             ->add(Crud::PAGE_INDEX, $action2)
             ->add(Crud::PAGE_INDEX, $action3)
             ->add(Crud::PAGE_INDEX, $action4)
+            ->update(Crud::PAGE_INDEX, Action::NEW, function (Action $action) {
+                return $action->setIcon('fa fa-fw fa-plus')->setLabel(false);
+            })
         ;
     }
 }


### PR DESCRIPTION
Fixes the bug reported in https://github.com/EasyCorp/EasyAdminBundle/pull/5899#issuecomment-1705512916