### PR TITLE
Remove some unneeded query parameters in the search field

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -274,8 +274,6 @@
 
                                                 <input type="hidden" name="crudAction" value="index">
                                                 <input type="hidden" name="crudControllerFqcn" value="{{ ea.request.query.get('crudControllerFqcn') }}">
-                                                <input type="hidden" name="menuIndex" value="{{ ea.request.query.get('menuIndex') }}">
-                                                <input type="hidden" name="submenuIndex" value="{{ ea.request.query.get('submenuIndex') }}">
                                                 <input type="hidden" name="page" value="1">
 
                                                 <div class="form-group">


### PR DESCRIPTION
This is a leftover of the change we did in #5533. We no longer need or use these two parameters.