### PR TITLE
Fix nullable column detection

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -197,14 +197,12 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         if ($entityDto->isAssociation($field->getProperty())) {
             $associatedEntityMetadata = $this->entityFactory->getEntityMetadata($doctrinePropertyMetadata->get('targetEntity'));
             foreach ($doctrinePropertyMetadata->get('joinColumns', []) as $joinColumn) {
-                $propertyNameInAssociatedEntity = $joinColumn['referencedColumnName'];
-                $associatedPropertyMetadata = $associatedEntityMetadata->fieldMappings[$propertyNameInAssociatedEntity] ?? [];
-                $isNullable = $associatedPropertyMetadata['nullable'] ?? true;
+                $isNullable = $joinColumn['nullable'] ?? true;
                 if (false === $isNullable) {
                     return true;
                 }
             }
-
+            
             return false;
         }
 


### PR DESCRIPTION
This fixes #5531.

The previous logic was failing because it checked the `nullable` state of the `id` field of join _targets_, which was always `false`. By only checking the `nullable` state of the join _column_, the issue is resolved.

It may introduce regressions, but I can't think of any.

Any review appreciated!
ps: Issue #5531 is currently preventing our organization from updating to any tag above `4.4.4`, so this matters to us 😉 