### PR TITLE
fix: flash messages do not always appear directly

### DIFF
--- a/src/Resources/views/flash_messages.html.twig
+++ b/src/Resources/views/flash_messages.html.twig
@@ -3,19 +3,18 @@
    be used in a EasyAdmin Dashboard controller, where 'ea' is defined
    or from any other Symfony controller, where 'ea' is not defined #}
 {% trans_default_domain ea is defined ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
-{% if app.session is not null and app.session.started %}
-    {% set flash_messages = app.session.flashbag.all %}
 
-    {% if flash_messages|length > 0 %}
-        <div id="flash-messages">
-            {% for label, messages in flash_messages %}
-                {% for message in messages %}
-                    <div class="alert alert-{{ label }} alert-dismissible fade show" role="alert">
-                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                        {{ message|trans|raw }}
-                    </div>
-                {% endfor %}
+{% set flash_messages = app.flashes %}
+
+{% if flash_messages|length > 0 %}
+    <div id="flash-messages">
+        {% for label, messages in flash_messages %}
+            {% for message in messages %}
+                <div class="alert alert-{{ label }} alert-dismissible fade show" role="alert">
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                    {{ message|trans|raw }}
+                </div>
             {% endfor %}
-        </div>
-    {% endif %}
+        {% endfor %}
+    </div>
 {% endif %}


### PR DESCRIPTION
Update flash_messages.html.twig

The Flash messages added in the controller with `$this->addFlash()` did not always appear directly. 

While read the Symfony documentation, I noticed EasyAdmin used the previous way from Symfony to fetch and display the flash messages. Update it to latest version in documentation did fix the issue for us in our project.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
