### PR TITLE
Boolean-Field: Allow to render null value as null badge instead of false

### DIFF
--- a/assets/css/easyadmin-theme/fields.scss
+++ b/assets/css/easyadmin-theme/fields.scss
@@ -36,6 +36,12 @@
   box-shadow: var(--badge-boolean-true-box-shadow);
   color: var(--badge-boolean-true-color);
 }
+.field-boolean .badge-boolean-null {
+  background: var(--badge-boolean-null-bg);
+  border: 0;
+  box-shadow: var(--badge-boolean-null-box-shadow);
+  color: var(--badge-boolean-null-color);
+}
 
 // CodeEditor field
 .field-code_editor .form-widget {

--- a/assets/css/easyadmin-theme/variables-theme.scss
+++ b/assets/css/easyadmin-theme/variables-theme.scss
@@ -192,6 +192,9 @@
     --badge-boolean-true-bg: var(--color-primary);
     --badge-boolean-true-box-shadow: none;
     --badge-boolean-true-color: var(--white);
+    --badge-boolean-null-bg: var(--white);
+    --badge-boolean-null-box-shadow: inset 0 0 0 1px var(--gray-300);
+    --badge-boolean-null-color: var(--text-color);
     --badge-success-bg: var(--green-100);
     --badge-success-box-shadow: none;
     --badge-success-color: var(--text-green-600);

--- a/src/Field/BooleanField.php
+++ b/src/Field/BooleanField.php
@@ -18,6 +18,7 @@ final class BooleanField implements FieldInterface
     public const OPTION_RENDER_AS_SWITCH = 'renderAsSwitch';
     public const OPTION_HIDE_VALUE_WHEN_TRUE = 'hideValueWhenTrue';
     public const OPTION_HIDE_VALUE_WHEN_FALSE = 'hideValueWhenFalse';
+    public const OPTION_NULLABLE = 'nullable';
     /** @internal */
     public const OPTION_TOGGLE_URL = 'toggleUrl';
     /** @internal */
@@ -38,7 +39,8 @@ final class BooleanField implements FieldInterface
             ->addJsFiles(Asset::fromEasyAdminAssetPackage('field-boolean.js')->onlyOnIndex())
             ->setCustomOption(self::OPTION_RENDER_AS_SWITCH, true)
             ->setCustomOption(self::OPTION_HIDE_VALUE_WHEN_TRUE, false)
-            ->setCustomOption(self::OPTION_HIDE_VALUE_WHEN_FALSE, false);
+            ->setCustomOption(self::OPTION_HIDE_VALUE_WHEN_FALSE, false)
+            ->setCustomOption(self::OPTION_NULLABLE, false);
     }
 
     public function renderAsSwitch(bool $isASwitch = true): self
@@ -58,6 +60,13 @@ final class BooleanField implements FieldInterface
     public function hideValueWhenFalse(bool $hide = true): self
     {
         $this->setCustomOption(self::OPTION_HIDE_VALUE_WHEN_FALSE, $hide);
+
+        return $this;
+    }
+
+    public function nullable(bool $nullable = true): self
+    {
+        $this->setCustomOption(self::OPTION_NULLABLE, $nullable);
 
         return $this;
     }

--- a/src/Resources/views/crud/field/boolean.html.twig
+++ b/src/Resources/views/crud/field/boolean.html.twig
@@ -12,8 +12,8 @@
         ) %}
 
     {% if not badge_is_hidden %}
-        <span class="badge {{ field.value == true ? 'badge-boolean-true' : 'badge-boolean-false' }}">
-            {{ (field.value == true ? 'label.true' : 'label.false')|trans }}
+        <span class="badge {{ field.customOptions.get('nullable') == true and field.value is same as(null) ? 'badge-boolean-null' : field.value == true ? 'badge-boolean-true' : 'badge-boolean-false' }}">
+            {{ (field.customOptions.get('nullable') == true and field.value is same as(null) ? 'label.null' : field.value == true ? 'label.true' : 'label.false')|trans }}
         </span>
     {% endif %}
 {% else %}


### PR DESCRIPTION
Currently, if using the `BooleanField` on a value that can be null will output `label.false` if the value is actually `null`.

With this PR and the following configuration there is the possibility to allow rendering a `null` value as `label.null`.
```php
yield BooleanField::new('column')->nullable();
```

The default is the current behavior that `null` will render as `label.false`.

Added a new style for `null` values, which looks like that (in German):
![image](https://github.com/EasyCorp/EasyAdminBundle/assets/922919/a7a15d0e-42c2-46fe-8ae7-4d80a6c88a3d)
