### PR TITLE
fix(trix): fix trix editor config loading

### DIFF
--- a/assets/js/field-text-editor.js
+++ b/assets/js/field-text-editor.js
@@ -6,7 +6,9 @@ import Trix from 'trix/dist/trix';
 // Provide Trix variable globally to allow custom backend pages to use it
 window.Trix = Trix;
 
-document.addEventListener('DOMContentLoaded', () => {
+// Listening to the DOMLoadedContent event is too late because the Trix editor is already initialized.
+// To be sure to handle properly the custom configuration, we have to to listen to the trix-before-initialize event.
+document.addEventListener('trix-before-initialize', () => {
     new TextEditorField();
 });
 


### PR DESCRIPTION
Ref https://github.com/EasyCorp/EasyAdminBundle/issues/5725

This PR change the listen event to boot TextEditorField. Before it listen on `DOMLoadedContent`. Now it listen on `trix-before-initialize` to be sure to handle the custom configuration and render properly a `heading1` element with a custom tagName `h2` for example.

If needed, I can add some tests to cover it.