### PR TITLE
Import fields used as example

### DIFF
--- a/src/Resources/skeleton/crud_controller.tpl
+++ b/src/Resources/skeleton/crud_controller.tpl
@@ -4,6 +4,9 @@ namespace <?= $namespace; ?>;
 
 use <?= $entity_fqcn; ?>;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextEditorField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 class <?= $class_name; ?> extends AbstractCrudController
 {


### PR DESCRIPTION
Used to be like this after uncommenting the example: 

![image](https://github.com/EasyCorp/EasyAdminBundle/assets/3840367/c49ef1f2-1901-41a5-b217-c610dd4001a6)
