### PR TITLE
Fix table header when entity permissions are applied

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -107,7 +107,7 @@
 
                     {% set ea_sort_asc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::ASC') %}
                     {% set ea_sort_desc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::DESC') %}
-                    {% for field in entities|first.fields ?? [] %}
+                    {% for field in entities|filter(e => e.isAccessible)|first.fields ?? [] %}
                         {% set is_sorting_field = ea.search.isSortingField(field.property) %}
                         {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
                         {% set column_icon = is_sorting_field ? (next_sort_direction == ea_sort_desc ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}


### PR DESCRIPTION
When applying entity permissions to a CrudController
```php
public function configureCrud(Crud $crud): Crud
{
    return parent::configureCrud($crud)
        ->setEntityPermission('ADMIN_USER_EDIT');
}
```
and using a custom voter to validate this permission it can happen that the default index template renders a wrong header.

This happens because the fields are taken from the first entity in the result even if the first entity is inaccessible which may result in some fields being hidden. 

The result looks as follows:
![image](https://github.com/EasyCorp/EasyAdminBundle/assets/33766870/de9ff251-c5af-477e-8a75-fe454347b0d9)
In this case missing some columns that are filtered because other visibility checks.

Adding a filter to only evaluate the fields of accessible entities in the index template fixes the problem since the other fields are not removed from that EntityDto. It does result in an empty header though if there is no accessible entity.