### PR TITLE
Fix depreciations configureOptions() and buildView()

### DIFF
--- a/src/Form/Type/Layout/EaFormColumnGroupCloseType.php
+++ b/src/Form/Type/Layout/EaFormColumnGroupCloseType.php
@@ -16,14 +16,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class EaFormColumnGroupCloseType extends AbstractType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->define('ea_is_inside_tab')->default(false)->allowedTypes('boolean')
         ;
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['ea_is_inside_tab'] = $options['ea_is_inside_tab'];
     }

--- a/src/Form/Type/Layout/EaFormColumnGroupOpenType.php
+++ b/src/Form/Type/Layout/EaFormColumnGroupOpenType.php
@@ -16,14 +16,14 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class EaFormColumnGroupOpenType extends AbstractType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->define('ea_is_inside_tab')->default(false)->allowedTypes('boolean')
         ;
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['ea_is_inside_tab'] = $options['ea_is_inside_tab'];
     }

--- a/src/Form/Type/Layout/EaFormFieldsetOpenType.php
+++ b/src/Form/Type/Layout/EaFormFieldsetOpenType.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatableInterface;
  */
 class EaFormFieldsetOpenType extends AbstractType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->define('ea_css_class')->default(null)->allowedTypes('string', 'null')
@@ -28,7 +28,7 @@ class EaFormFieldsetOpenType extends AbstractType
         ;
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['ea_css_class'] = $options['ea_css_class'];
         $view->vars['ea_icon'] = $options['ea_icon'];

--- a/src/Form/Type/Layout/EaFormTabListType.php
+++ b/src/Form/Type/Layout/EaFormTabListType.php
@@ -14,7 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class EaFormTabListType extends AbstractType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->define('tabs')->required()->default([])->allowedTypes('array')

--- a/src/Form/Type/Layout/EaFormTabPaneOpenType.php
+++ b/src/Form/Type/Layout/EaFormTabPaneOpenType.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatableInterface;
  */
 class EaFormTabPaneOpenType extends AbstractType
 {
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver
             ->define('ea_tab_id')->allowedTypes('string')
@@ -27,7 +27,7 @@ class EaFormTabPaneOpenType extends AbstractType
         ;
     }
 
-    public function buildView(FormView $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['ea_tab_id'] = $options['ea_tab_id'];
         $view->vars['ea_css_class'] = $options['ea_css_class'];


### PR DESCRIPTION
This is a small fix for some depreciations with 4.8.0 and latest version of symfony : 

<img width="1400" alt="Capture d’écran 2023-10-22 à 20 59 16" src="https://github.com/EasyCorp/EasyAdminBundle/assets/25297943/447f4eac-7107-4ffa-987a-3b33c362cb4a">
