### PR TITLE
Fix untranslateable Help texts in crud view.

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -100,7 +100,7 @@
                 {% if has_input_groups %}</div>{% endif %}
 
                 {% if field.help ?? false %}
-                    <small class="form-help">{{ field.help|raw }}</small>
+                    <small class="form-help">{{ field.help|raw|trans(label_translation_parameters, translation_domain) }}</small>
                 {% elseif form.vars.help ?? false %}
                     <small class="form-help">{{ form.vars.help|trans(form.vars.help_translation_parameters, form.vars.translation_domain)|raw }}</small>
                 {% endif %}


### PR DESCRIPTION
This configuration in a CrudController (1) leads to this result (2). The expected output however is a translated/translatable help line (3).

This PR will allow Help texts to be translated properly with the given parameters in a Crud overview.

1. Code Configuration in Crud:
![grafik](https://github.com/EasyCorp/EasyAdminBundle/assets/6654389/54bdb670-b6b9-46b2-afcd-79011d1ce124)

2. Result: 
![grafik](https://github.com/EasyCorp/EasyAdminBundle/assets/6654389/2d9fc097-4c09-4209-98e5-20c127d0f633)

3. Expectation (the Help is translated)
![grafik](https://github.com/EasyCorp/EasyAdminBundle/assets/6654389/452cb3e3-1c9e-4154-b428-f55b2d4243fd)

Bug is reproducible in 4.8.0 tag. 

This PR allows for both usage of `t()` method and plain inputs to be translated by the Symfony translator automatically.