### PR TITLE
Adapt Gitignore to ignore .idea folders as its keep getting commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ vendor/*
 /node_modules/
 npm-debug.log
 yarn-error.log
+
+.idea/


### PR DESCRIPTION
Albeit its an software-specific adaptation, I feel that the idea folder should be ignored on this project; it keeps getting committed to the repository by accident and this simple change would stop that behavior for once.

Eventually, it will be less work for maintainers to remove them, once wrongfully committed.