### PR TITLE
Fix a deprecation in IntlFormatter

### DIFF
--- a/src/Intl/IntlFormatter.php
+++ b/src/Intl/IntlFormatter.php
@@ -117,8 +117,22 @@ final class IntlFormatter
         return $formattedCurrency;
     }
 
+    /**
+     * @param int|float $number
+     */
     public function formatNumber($number, array $attrs = [], string $style = 'decimal', string $type = 'default', ?string $locale = null): string
     {
+        if (null === $number) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.8.5',
+                'Passing null values to "%s()" method is deprecated and will throw an exception in EasyAdmin 5.0.0.',
+                __METHOD__,
+            );
+
+            return '0';
+        }
+
         if (!isset(self::NUMBER_TYPES[$type])) {
             throw new RuntimeError(sprintf('The type "%s" does not exist, known types are: "%s".', $type, implode('", "', array_keys(self::NUMBER_TYPES))));
         }

--- a/tests/Intl/IntlFormatterTest.php
+++ b/tests/Intl/IntlFormatterTest.php
@@ -65,7 +65,24 @@ class IntlFormatterTest extends TestCase
     /**
      * @dataProvider provideFormatNumber
      */
-    public function testFormatNumber(?string $expectedResult, int|float|null $number, array $attrs)
+    public function testFormatNumber(?string $expectedResult, int|float $number, array $attrs)
+    {
+        if (\PHP_VERSION_ID < 80200) {
+            $this->markTestSkipped('PHP 8.2 or higher is required to run this test.');
+        }
+
+        $intlFormatter = new IntlFormatter();
+        $formattedNumber = $intlFormatter->formatNumber($number, $attrs);
+
+        $this->assertSame($expectedResult, $formattedNumber);
+    }
+
+    /**
+     * @dataProvider provideLegacyFormatNumber
+     *
+     * @group legacy
+     */
+    public function testLegacyFormatNumber(?string $expectedResult, int|float|null $number, array $attrs)
     {
         if (\PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('PHP 8.2 or higher is required to run this test.');
@@ -157,7 +174,6 @@ class IntlFormatterTest extends TestCase
 
     public static function provideFormatNumber()
     {
-        yield ['0', null, []];
         yield ['0', 0, []];
         yield ['0', 0.0, []];
 
@@ -170,6 +186,11 @@ class IntlFormatterTest extends TestCase
         yield ['1,234,560', 1234.56, ['fraction_digit' => 3, 'decimal_separator' => ',']];
         yield ['1 234.560', 1234.56, ['fraction_digit' => 3, 'grouping_separator' => ' ']];
         yield ['1 234,560', 1234.56, ['fraction_digit' => 3, 'decimal_separator' => ',', 'grouping_separator' => ' ']];
+    }
+
+    public static function provideLegacyFormatNumber()
+    {
+        yield ['0', null, []];
     }
 
     private function normalizeWhiteSpaces(string $string): string


### PR DESCRIPTION
Fixes this direct deprecation:

```
Remaining self deprecation notices (1)

  1x: NumberFormatter::format(): Passing null to parameter #1 ($num) of type int|float is deprecated
    1x in IntlFormatterTest::testFormatNumber from EasyCorp\Bundle\EasyAdminBundle\Tests\Intl
```