### PR TITLE
Performance optimization in FieldCollection

### DIFF
--- a/src/Collection/FieldCollection.php
+++ b/src/Collection/FieldCollection.php
@@ -86,12 +86,13 @@ final class FieldCollection implements CollectionInterface
     public function insertBefore(FieldDto $newField, FieldDto $existingField): void
     {
         $newFields = [];
-        foreach ($this->fields as $field) {
-            if ($existingField->getUniqueId() === $field->getUniqueId()) {
+        $existingFieldUniqueId = $existingField->getUniqueId();
+        foreach ($this->fields as $fieldUniqueId => $field) {
+            if ($existingFieldUniqueId === $fieldUniqueId) {
                 $newFields[$newField->getUniqueId()] = $newField;
             }
 
-            $newFields[$field->getUniqueId()] = $field;
+            $newFields[$fieldUniqueId] = $field;
         }
 
         $this->fields = $newFields;


### PR DESCRIPTION
EasyAdmin is pretty fast, but from time to time I profile some apps to check possible performance improvements using the amazing [Blackfire profiler](https://blackfire.io/).

While checking the `detail` page of some entity I saw this:

<img width="418" alt="performance-issue" src="https://github.com/EasyCorp/EasyAdminBundle/assets/73419/aa9ee069-a2b5-4709-acaa-168ee6e65d4c">

5,000 calls to `FieldDto::getUniqueId()` and another 5,000 calls to Symfony's `Ulid::__toString()` 😱 

If you check the changes of this PR, it's easy to understand why. The field collection is already indexed by the field's uniqueID, so let's reuse it instead of recomputing it.

This is the before/after comparison:
<img width="654" alt="optimization-result" src="https://github.com/EasyCorp/EasyAdminBundle/assets/73419/119495b6-3bea-4cce-a0fe-06b33062ac04">

