### PR TITLE
Introduced new `ea.form.error` event

### DIFF
--- a/assets/js/form.js
+++ b/assets/js/form.js
@@ -93,6 +93,11 @@ class Form {
                     if (formHasErrors) {
                         clickEvent.preventDefault();
                         clickEvent.stopPropagation();
+
+                        document.dispatchEvent(new CustomEvent('ea.form.error', {
+                            cancelable: true,
+                            detail: { page: pageName, form: form }
+                        }));
                     }
                 });
             });


### PR DESCRIPTION
This new event will make it possible to implement custom logic for handling forms with invalid input fields. A good example would be to focus the first invalid input field.