### PR TITLE
fix(FileUploadType): check if is stream wrapper

### DIFF
--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -144,7 +144,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
                 $value = $this->projectDir.'/'.$value;
             }
 
-            if ('' !== $value && (!is_dir($value) || !is_writable($value))) {
+            if (!$isStreamWrapper && '' !== $value && (!is_dir($value) || !is_writable($value))) {
                 throw new InvalidArgumentException(sprintf('Invalid upload directory "%s" it does not exist or is not writable.', $value));
             }
 


### PR DESCRIPTION
If you use like s3 and you don't want to use the filesystem (even to save tmpfile), 'upload_dir' stuff not working cause of the missing condition which check if the url (for stream) is writable... no sens.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
