### PR TITLE
added missing label to arrayfield entry items

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -187,6 +187,7 @@
 
     <div class="field-collection-item {{ is_complex ? 'field-collection-item-complex' }} {{ not form.vars.valid ? 'is-invalid' }}">
         {% if is_array_field|default(false) %}
+            {{ form_label(form) }}
             {{ form_widget(form) }}
             {% if allows_deleting_items and not disabled %}
                 {{ delete_item_button }}


### PR DESCRIPTION
When using an ArrayField, the entry items can also have separate labels in symfony forms. This feature is configurable via `$field->setFormTypeOptionIfNotSet('entry_options.label', false);` what is also already done in ArrayConfigurator.

However, the actual label rendering is never called currently, even if activated because the form template only renders the form_widget, but not the label.
