### PR TITLE
Fix country field flags in Safari browsers

### DIFF
--- a/src/Resources/views/crud/field/country.html.twig
+++ b/src/Resources/views/crud/field/country.html.twig
@@ -9,7 +9,8 @@
 {% if show_flag and not show_name %}
     {% for flag_code, country_name in field.formattedValue %}
         {% if flag_code is not null %}
-            <img class="country-flag" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
+            {# the explicit height is needed to avoid issues with SVG images in Safari browser #}
+            <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
         {% endif %}
     {% endfor %}
 {% elseif show_name and not show_flag  %}
@@ -19,7 +20,8 @@
         <span>
             {%- if show_flag -%}
                 {%- if flag_code is not null -%}
-                    <img class="country-flag" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
+                    {# the explicit height is needed to avoid issues with SVG images in Safari browser #}
+                    <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
                 {%- endif -%}
             {%- endif -%}
 


### PR DESCRIPTION
Fixes #6015.

Safari has issues with SVG images that don't define their dimensions. It's enough to set one of the two height/width. In our case, controlling the height is more important, so let's set the height explicitly. This doesn't change anything in the other browsers.