### PR TITLE
[findEntityFqcnByCrud] - Allows you to find the Fqcn of an entity fro…

### DIFF
--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -115,7 +115,7 @@ final class AdminContextFactory
         $defaultCrud = $dashboardController->configureCrud();
         $crudDto = $crudController->configureCrud($defaultCrud)->getAsDto();
 
-        $entityFqcn = $crudControllers->findEntityFqcnByCrudFqcn($crudController::class);
+        $entityFqcn = $crudControllers->findEntityFqcnByCrud($crudController);
 
         $crudDto->setControllerFqcn($crudController::class);
         $crudDto->setActionsConfig($actionConfigDto);

--- a/src/Registry/CrudControllerRegistry.php
+++ b/src/Registry/CrudControllerRegistry.php
@@ -2,6 +2,8 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
+
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
@@ -31,9 +33,9 @@ final class CrudControllerRegistry
         return $this->entityFqcnToCrudFqcnMap[$entityFqcn] ?? null;
     }
 
-    public function findEntityFqcnByCrudFqcn(string $controllerFqcn): ?string
+    public function findEntityFqcnByCrud(CrudControllerInterface $controllerFqcn): string
     {
-        return $this->crudFqcnToEntityFqcnMap[$controllerFqcn] ?? null;
+        return $this->crudFqcnToEntityFqcnMap[$controllerFqcn::class] ?? $controllerFqcn::getEntityFqcn();
     }
 
     public function findCrudFqcnByCrudId(string $crudId): ?string


### PR DESCRIPTION
When using easy admin in a bundle, it does not map the crud in `crudFqcnToEntityFqcnMap`.

Since the Crud holds the Fqcn of the linked entity. I propose:

- Rename the method `findEntityFqcnByCrudFqcn` to `findEntityFqcnByCrud` wich take an instance of `CrudControllerInterface`.
- Then if the method does not find the mapping, it will use the `getEntityFqcn` method of the crud passed as a parameter.

ps: Namely the `findEntityFqcnByCrudFqcn` method is only called once in `AdminContextFactory`