### PR TITLE
Add null values on NOT IN mutiple ChoiceFilter 

### DIFF
--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -64,7 +64,7 @@ final class ChoiceFilter implements FilterInterface
         } else {
             $orX = new Orx();
             $orX->add(sprintf('%s.%s %s (:%s)', $alias, $property, $comparison, $parameterName));
-            if (ComparisonType::NEQ === $comparison) {
+            if (ComparisonType::NEQ === $comparison || 'NOT IN' === $comparison) {
                 $orX->add(sprintf('%s.%s IS NULL', $alias, $property));
             }
             $queryBuilder->andWhere($orX)


### PR DESCRIPTION
There is a small default on the choicefilter in multiple mode.
If you choose "is" with multiple values, there is no problem. 
By choosing "is not" with several values, it doesn't reflect null values, because instead of the SQL query being `SELECT * from entity where entity.field not like '%a%' or not like '%b%'`, it is `SELECT * from entity where entity.field not IN(a,b)`.