### PR TITLE
feat: allow custom money divisor

### DIFF
--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -42,13 +42,20 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
         $field->setFormTypeOption('scale', $numDecimals);
 
         $isStoredAsCents = true === $field->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS);
-        $field->setFormTypeOption('divisor', $isStoredAsCents ? 100 : 1);
+        $field->setFormTypeOptionIfNotSet('divisor', $isStoredAsCents ? 100 : 1);
+
+        $divisor = $field->getFormTypeOption('divisor');
+        $isCustomDivisor = 1 !== $divisor && 100 !== $divisor;
 
         if (null === $field->getValue()) {
             return;
         }
 
-        $amount = $isStoredAsCents ? $field->getValue() / 100 : $field->getValue();
+        if ($isCustomDivisor) {
+            $amount = $field->getValue() / $divisor;
+        } else {
+            $amount = $isStoredAsCents ? $field->getValue() / 100 : $field->getValue();
+        }
 
         $formattedValue = $this->intlFormatter->formatCurrency($amount, $currencyCode, ['fraction_digit' => $numDecimals]);
         $field->setFormattedValue($formattedValue);

--- a/tests/Field/MoneyFieldTest.php
+++ b/tests/Field/MoneyFieldTest.php
@@ -93,16 +93,29 @@ class MoneyFieldTest extends AbstractFieldTest
         self::assertSame(3, $fieldDto->getFormTypeOption('scale'));
     }
 
-    public function testFieldCents()
+    public function testFieldsDefaultsToCents()
     {
         $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
         $fieldDto = $this->configure($field);
         self::assertSame('1€', $fieldDto->getFormattedValue());
         self::assertSame(100, $fieldDto->getFormTypeOption('divisor'));
+    }
 
+    public function testFieldCents()
+    {
+        $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
         $field->setStoredAsCents(false);
         $fieldDto = $this->configure($field);
         self::assertSame('100€', $fieldDto->getFormattedValue());
         self::assertSame(1, $fieldDto->getFormTypeOption('divisor'));
+    }
+
+    public function testFieldWithCustomDivisor()
+    {
+        $field = MoneyField::new('foo')->setValue(725)->setCurrency('EUR');
+        $field->setFormTypeOption('divisor', 10000);
+        $fieldDto = $this->configure($field);
+        self::assertSame('0.0725€', $fieldDto->getFormattedValue());
+        self::assertSame(10000, $fieldDto->getFormTypeOption('divisor'));
     }
 }


### PR DESCRIPTION
Fixes #6054 by only setting the divisor when it's not already set, and in case of a custom one (not 1 or 100) use it to divide.