### PR TITLE
feat : add capability to have an entity sent to Voter when at least an entityDto is present 

### DIFF
--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -78,7 +78,9 @@ final class SecurityVoter extends Voter
         $actionPermission = $crudDto->getActionsConfig()->getActionPermissions()[$actionName] ?? null;
         $disabledActionNames = $crudDto->getActionsConfig()->getDisabledActions();
 
-        $subject = null === $entityDto ? null : $entityDto->getInstance();
+        // if the entityDto is null, try to get a default instance of the entity from the context
+        $entityClassName = $this->adminContextProvider->getContext()?->getEntity()?->getFqcn() ?? null;
+        $subject = null === $entityDto ? (null === $entityClassName ? null : new $entityClassName()) : $entityDto->getInstance();
 
         return $this->authorizationChecker->isGranted($actionPermission, $subject) && !\in_array($actionName, $disabledActionNames, true);
     }

--- a/tests/Controller/CrudControllerSpecificEntityPermissionForNew.php
+++ b/tests/Controller/CrudControllerSpecificEntityPermissionForNew.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\BlogPostCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\DashboardController;
+
+class CrudControllerSpecificEntityPermissionForNew extends AbstractCrudTestCase
+{
+    public function testNewActionIsForbiddenForNonLoggedUsers(): void
+    {
+        $this->client->request('GET', $this->generateNewFormUrl());
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testNewActionIsForbiddenForNonAdminUsers(): void
+    {
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'user', 'PHP_AUTH_PW' => '1234']);
+        $this->client->request('GET', $this->generateNewFormUrl());
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testNewActionNotVisibleForNonAdminUsers(): void
+    {
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'user', 'PHP_AUTH_PW' => '1234']);
+        $this->client->request('GET', $this->generateIndexUrl());
+
+        self::assertGlobalActionNotExists(Action::NEW);
+    }
+
+    public function testNewActionVisibleForAdminUsers(): void
+    {
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $this->client->request('GET', $this->generateIndexUrl());
+
+        self::assertGlobalActionExists(Action::NEW);
+    }
+
+    public function testNewActionIsAllowedForAdminUsers(): void
+    {
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+        $this->client->request('GET', $this->generateNewFormUrl());
+
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testNewActionOnEntityWithoutPermissionIsNotForbiddenForNonAdminUsers(): void
+    {
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'user', 'PHP_AUTH_PW' => '1234']);
+        $this->client->request('GET', $this->generateNewFormUrl(controllerFqcn: BlogPostCrudController::class));
+
+        self::assertResponseIsSuccessful();
+    }
+
+    protected function getControllerFqcn(): string
+    {
+        return CategoryCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+}

--- a/tests/Test/Trait/CrudTestActionsTraitTest.php
+++ b/tests/Test/Trait/CrudTestActionsTraitTest.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Test\Trait\CrudTestActions;
 use EasyCorp\Bundle\EasyAdminBundle\Test\Trait\CrudTestUrlGeneration;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CategoryCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\BlogPostCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\DashboardController;
 use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -38,7 +38,7 @@ final class CrudTestActionsTraitTest extends WebTestCase
      */
     protected function getControllerFqcn(): string
     {
-        return CategoryCrudController::class;
+        return BlogPostCrudController::class;
     }
 
     /**

--- a/tests/TestApplication/src/Controller/CategoryCrudController.php
+++ b/tests/TestApplication/src/Controller/CategoryCrudController.php
@@ -16,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config\Action as AppAction;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Security\CustomVoterForNewCategory;
 use Symfony\Component\HttpFoundation\Response;
 
 class CategoryCrudController extends AbstractCrudController
@@ -50,7 +51,9 @@ class CategoryCrudController extends AbstractCrudController
             ->linkToCrudAction('customPage');
 
         return $actions->add(Crud::PAGE_INDEX, $customPageAction)
-            ->setPermission(AppAction::CUSTOM_ACTION, 'ROLE_ADMIN');
+            ->setPermission(AppAction::CUSTOM_ACTION, 'ROLE_ADMIN')
+            ->setPermission(Action::NEW, CustomVoterForNewCategory::NEW_CATEGORY)
+        ;
     }
 
     public function configureFilters(Filters $filters): Filters

--- a/tests/TestApplication/src/Security/CustomVoterForNewCategory.php
+++ b/tests/TestApplication/src/Security/CustomVoterForNewCategory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Security;
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class CustomVoterForNewCategory extends Voter
+{
+    public const NEW_CATEGORY = 'specific_new_category';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return self::NEW_CATEGORY === $attribute && $subject instanceof Category;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (null === $user) {
+            return false;
+        }
+
+        return \in_array('ROLE_ADMIN', $user->getRoles(), true);
+    }
+}


### PR DESCRIPTION
This PR is linked to the issue #5133.  

Not modifying the callers but in the SecurityVoter, allowing to get a default instance when no entityDto provided to be sent to the voter if existing 

Fix #5133 