### PR TITLE
Include layer after only if panel is collapsible fix #6035

### DIFF
--- a/assets/css/easyadmin-theme/forms.scss
+++ b/assets/css/easyadmin-theme/forms.scss
@@ -456,13 +456,15 @@ label.form-check-label {
                 }
             }
 
-            &::after {
-                content: '';
-                position: absolute;
-                width: 100%;
-                height: 100%;
-                top: 0;
-                left: 0;
+            &.collapsible {
+                &::after {
+                    content: '';
+                    position: absolute;
+                    width: 100%;
+                    height: 100%;
+                    top: 0;
+                    left: 0;
+                }
             }
         }
 


### PR DESCRIPTION
Fix #6035 

I include `after` layer only when the panel is collapsible, and now if the `help` attribute has a link it can be clicked

| Before | After
:-------------------------:|:-------------------------:
![PR](https://github.com/EasyCorp/EasyAdminBundle/assets/1416870/841e7f8a-1581-485a-a0ba-72d0abdc6654) | ![imagen](https://github.com/EasyCorp/EasyAdminBundle/assets/1416870/9e584929-2ad8-4c5f-838f-9b083eef0820)

**Note. Help element is not clickable to collapse the panel


