### PR TITLE
feat: allow user to add custom attributes to menu items

### DIFF
--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -33,6 +33,13 @@ final class CrudMenuItem implements MenuItemInterface
         ]);
     }
 
+    public function addAttribute(string $attribute, mixed $value): self
+    {
+        $this->dto->addCustomAttribute($attribute, $value);
+
+        return $this;
+    }
+
     public function setController(string $controllerFqcn): self
     {
         $this->dto->setRouteParameters(array_merge(

--- a/src/Config/Menu/MenuItemTrait.php
+++ b/src/Config/Menu/MenuItemTrait.php
@@ -61,7 +61,7 @@ trait MenuItemTrait
      *                        Otherwise, the passed value is applied "as is" to the `style` attribute of the HTML
      *                        element of the badge
      */
-    public function setBadge(/* \Stringable|string|int|float|bool|null */ $content, string $style = 'secondary'): self
+    public function setBadge(/* \Stringable|string|int|float|bool|null */ $content, string $style = 'secondary', array $attributes = []): self
     {
         if (!\is_string($content)
             && !$content instanceof \Stringable
@@ -80,7 +80,7 @@ trait MenuItemTrait
             );
         }
 
-        $this->dto->setBadge($content, $style);
+        $this->dto->setBadge($content, $style, $attributes);
 
         return $this;
     }

--- a/src/Dto/MenuItemBadgeDto.php
+++ b/src/Dto/MenuItemBadgeDto.php
@@ -12,11 +12,13 @@ final class MenuItemBadgeDto
 
     private mixed $content;
     private string $style;
+    private array $customAttributes;
 
-    public function __construct(mixed $content, string $style)
+    public function __construct(mixed $content, string $style, array $customAttributes = [])
     {
         $this->content = $content;
         $this->style = $style;
+        $this->customAttributes = $customAttributes;
     }
 
     public function getContent(): mixed
@@ -32,5 +34,10 @@ final class MenuItemBadgeDto
     public function getHtmlStyle(): string
     {
         return \in_array($this->style, self::PREDEFINED_STYLES, true) ? '' : $this->style;
+    }
+
+    public function getCustomAttributes(): array
+    {
+        return $this->customAttributes;
     }
 }

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -34,6 +34,7 @@ final class MenuItemDto
     private ?MenuItemBadgeDto $badge = null;
     /** @var MenuItemDto[] */
     private array $subItems = [];
+    private array $customAttributes = [];
 
     public function getType(): string
     {
@@ -213,9 +214,9 @@ final class MenuItemDto
         return $this->badge;
     }
 
-    public function setBadge(mixed $content, string $style): void
+    public function setBadge(mixed $content, string $style, array $attributes = []): void
     {
-        $this->badge = new MenuItemBadgeDto($content, trim($style));
+        $this->badge = new MenuItemBadgeDto($content, trim($style), $attributes);
     }
 
     /**
@@ -242,5 +243,25 @@ final class MenuItemDto
     public function isMenuSection(): bool
     {
         return self::TYPE_SECTION === $this->type;
+    }
+
+    public function getCustomAttributes(): array
+    {
+        return $this->customAttributes;
+    }
+
+    public function setCustomAttributes(array $customAttributes): void
+    {
+        $this->customAttributes = $customAttributes;
+    }
+
+    public function addCustomAttribute(string $attribute, mixed $value): void
+    {
+        $this->customAttributes[$attribute] = $value;
+    }
+
+    public function removeCustomAttribute(string $attribute): void
+    {
+        unset($this->customAttributes[$attribute]);
     }
 }

--- a/src/Resources/views/menu.html.twig
+++ b/src/Resources/views/menu.html.twig
@@ -29,26 +29,32 @@
     {% block main_menu_after %}{% endblock %}
 </nav>
 
+{% macro render_custom_attributes(item) %}
+    {% for attribute, value in item.customAttributes %}
+        {{ attribute }}="{{ value }}"
+    {% endfor %}
+{% endmacro %}
+
 {% macro render_menu_item(item) %}
     {% if item.isMenuSection %}
-        <span class="menu-header-contents">
+        <span class="menu-header-contents" {{ _self.render_custom_attributes(item) }}>
             {% if item.icon is not empty %}<i class="menu-icon fa-fw {{ item.icon }}"></i>{% endif %}
             <span class="menu-item-label position-relative {{ item.cssClass }}">
                 {{ item.label|trans|raw }}
             </span>
             {% if item.badge %}
-                <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" style="{{ item.badge.htmlStyle }}">{{ item.badge.content }}</span>
+                <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" {{ _self.render_custom_attributes(item.badge) }} style="{{ item.badge.htmlStyle }}">{{ item.badge.content }}</span>
             {% endif %}
         </span>
     {% else %}
-        <a href="{{ item.linkUrl }}" class="menu-item-contents {{ item.hasSubItems ? 'submenu-toggle' }} {{ item.cssClass }}" target="{{ item.linkTarget }}" rel="{{ item.linkRel }}" referrerpolicy="origin-when-cross-origin">
+        <a href="{{ item.linkUrl }}" class="menu-item-contents {{ item.hasSubItems ? 'submenu-toggle' }} {{ item.cssClass }}" target="{{ item.linkTarget }}" rel="{{ item.linkRel }}" referrerpolicy="origin-when-cross-origin" {{ _self.render_custom_attributes(item) }}>
             {% if item.icon is not empty %}<i class="menu-icon fa-fw {{ item.icon }}"></i>{% endif %}
             <span class="menu-item-label position-relative">
                 {{ item.label|trans|raw }}
             </span>
             {% if item.hasSubItems %}<i class="fa fa-fw fa-angle-right submenu-toggle-icon"></i>{% endif %}
             {% if item.badge %}
-                <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" style="{{ item.badge.htmlStyle }}">{{ item.badge.content }}</span>
+                <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" {{ _self.render_custom_attributes(item.badge) }} style="{{ item.badge.htmlStyle }}">{{ item.badge.content }}</span>
             {% endif %}
         </a>
     {% endif %}

--- a/tests/Controller/AddCustomAttributeDashboardControllerTest.php
+++ b/tests/Controller/AddCustomAttributeDashboardControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CategoryCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CustomAttributeDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+
+class AddCustomAttributeDashboardControllerTest extends AbstractCrudTestCase
+{
+    protected EntityRepository $categories;
+
+    protected function getControllerFqcn(): string
+    {
+        return CategoryCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return CustomAttributeDashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+
+        $this->categories = $this->entityManager->getRepository(Category::class);
+    }
+
+    public function testSingleCustomAttribute()
+    {
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        static::assertCount(1, $crawler->filter('a[test-attribute="test"]'));
+    }
+
+    public function testMultipleCustomAttribute()
+    {
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        static::assertCount(1, $crawler->filter('a[multi-test-one="test1"]'));
+        static::assertCount(1, $crawler->filter('a[multi-test-two="test2"]'));
+        static::assertCount(1, $crawler->filter('span[badge-attr="badge1"]'));
+    }
+}

--- a/tests/TestApplication/src/Controller/CustomAttributeDashboardController.php
+++ b/tests/TestApplication/src/Controller/CustomAttributeDashboardController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class CustomAttributeDashboardController extends AbstractDashboardController
+{
+    #[Route('/custom_attribute_admin', name: 'custom_attribute_admin')]
+    public function index(): Response
+    {
+        return parent::index();
+    }
+
+    public function configureDashboard(): Dashboard
+    {
+        return Dashboard::new()
+            ->setTitle('EasyAdmin Tests');
+    }
+
+    public function configureMenuItems(): iterable
+    {
+        yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
+        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)->addAttribute(
+            'test-attribute', 'test'
+        );
+        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class)
+            ->addAttribute('multi-test-one', 'test1')
+            ->addAttribute('multi-test-two', 'test2')
+            ->setBadge('0', 'secondary', [
+                'badge-attr' => 'badge1',
+            ])
+        ;
+    }
+}


### PR DESCRIPTION
Fixes #6068 by adding the mentioned function and rendering the attributes to the link/span

Edit: I noticed you probably wanna tag batches as well for my usecase, so I added attributes to those as well