### PR TITLE
Remove the deprecated NumberFormatter::TYPE_CURRENCY constant

### DIFF
--- a/src/Intl/IntlFormatter.php
+++ b/src/Intl/IntlFormatter.php
@@ -24,7 +24,6 @@ final class IntlFormatter
         'int32' => \NumberFormatter::TYPE_INT32,
         'int64' => \NumberFormatter::TYPE_INT64,
         'double' => \NumberFormatter::TYPE_DOUBLE,
-        'currency' => \NumberFormatter::TYPE_CURRENCY,
     ];
     private const NUMBER_STYLES = [
         'decimal' => \NumberFormatter::DECIMAL,


### PR DESCRIPTION
Fixes #6071.

I saw this from Twig project --> https://github.com/twigphp/Twig/pull/3894

Given that they just removed it because it's unused and given that we copied this code from that project, let's just remove it too.