### PR TITLE
Allow Symfony 7.1 tests to fail

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,6 +132,7 @@ jobs:
                   vendor/bin/simple-phpunit install
 
             - name: Run tests
+              continue-on-error: ${{ matrix.stability == 'dev' }}
               env:
                   SYMFONY_DEPRECATIONS_HELPER: "weak"
               run: vendor/bin/simple-phpunit


### PR DESCRIPTION
Symfony 7.1 is still too unstable, so let allow those tests to fail for now.