### PR TITLE
Bugfix/6074 collection collapsing

### DIFF
--- a/assets/js/form.js
+++ b/assets/js/form.js
@@ -1,5 +1,4 @@
 import DirtyForm from 'dirty-form';
-import { Tab } from 'bootstrap';
 
 document.addEventListener('DOMContentLoaded', () => {
     new Form();
@@ -152,6 +151,7 @@ class Form {
             return;
         }
 
+        const Tab = bootstrap.Tab;
         const bootstrapTab = new Tab(tabElement);
         // when showing a tab, Bootstrap hides all the other tabs automatically
         bootstrapTab.show();


### PR DESCRIPTION
Removing the Tab import from form.js resolves the issue in #6074 

Furthermore the file size of form.js is reduced from ~25 KB to 2.6 KB.