### PR TITLE
Prevent Menu JS logic from failing when structure is changed.

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -61,6 +61,9 @@ class App {
         const menuItemsWithSubmenus = document.querySelectorAll('#main-menu .menu-item.has-submenu');
         menuItemsWithSubmenus.forEach((menuItem) => {
             const menuItemSubmenu = menuItem.querySelector('.submenu');
+            if(menuItemSubmenu === null) {
+                return;
+            }
 
             // needed because the menu accordion is based on the max-height property.
             // visible elements must be initialized with a explicit max-height; otherwise


### PR DESCRIPTION
This prevents failures from when developers change the structure of the `menu.html.twig` 

