### PR TITLE
Fix enum choices label override

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -55,7 +55,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
                 $allChoicesAreEnums = true;
             }
 
-            if ($allChoicesAreEnums) {
+            if ($allChoicesAreEnums && array_is_list($choices)) {
                 $processedEnumChoices = [];
                 foreach ($choices as $choice) {
                     $processedEnumChoices[$choice->name] = $choice;

--- a/tests/Field/Configurator/ChoiceConfiguratorTest.php
+++ b/tests/Field/Configurator/ChoiceConfiguratorTest.php
@@ -117,4 +117,19 @@ class ChoiceConfiguratorTest extends AbstractFieldTest
             $this->markTestSkipped('PHP 8.1 or higher is required to run this test.');
         }
     }
+
+    public function testBackedEnumChoicesLabeled(): void
+    {
+        $this->checkPhpVersion();
+
+        $choices = [];
+        foreach (StatusBackedEnum::cases() as $case) {
+            $choices[$case->label()] = $case;
+        }
+
+        $field = ChoiceField::new(self::PROPERTY_NAME);
+        $field->setCustomOptions(['choices' => $choices]);
+
+        $this->assertSame($choices, $this->configure($field)->getFormTypeOption('choices'));
+    }
 }

--- a/tests/Field/Fixtures/ChoiceField/StatusBackedEnum.php
+++ b/tests/Field/Fixtures/ChoiceField/StatusBackedEnum.php
@@ -8,5 +8,14 @@ if (\PHP_VERSION_ID >= 80100) {
         case Draft = 'draft';
         case Published = 'published';
         case Deleted = 'deleted';
+
+        public function label(): string
+        {
+            return match ($this) {
+                self::Draft => 'Draft label',
+                self::Published => 'Published label',
+                self::Deleted => 'Deleted label',
+            };
+        }
     }
 }


### PR DESCRIPTION
This fix allows setting custom labels for enum cases on forms.

It's possible to change displayed values on index/show using `$field->formatValue(static fn (EnumClass $status) => $status->getLabel())`.

I'd like to change labels used on forms, too. For now, I have to use workaround: `$field->setFormTypeOption('choices', $choices)`.

With this fix, it'll be easier and more convenient.

Actually, I'd say this is a bug fix and not a feature, because the current `setChoices()` call is ignored.