### PR TITLE
Prevent code from throwing exception when parse_url returns false ins…

### DIFF
--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -25,9 +25,13 @@ class MenuItemMatcher implements MenuItemMatcherInterface
         }
 
         $currentPageQueryParameters = $adminContext->getRequest()->query->all();
-        $menuItemQueryString = null === $menuItemDto->getLinkUrl() ? null : parse_url($menuItemDto->getLinkUrl(), \PHP_URL_QUERY);
+        $menuItemQueryString = null === $menuItemDto->getLinkUrl()
+            ? null
+            : parse_url($menuItemDto->getLinkUrl(), \PHP_URL_QUERY);
+
         $menuItemQueryParameters = [];
-        if (null !== $menuItemQueryString) {
+
+        if (true === \is_string($menuItemQueryString)) {
             parse_str($menuItemQueryString, $menuItemQueryParameters);
         }
 


### PR DESCRIPTION
…tead of string/array as case is unmatched currently

After decorating this method, PHPStan complained about this on the highest level. Reason for the change is:

* `parse_url` *can* return a broad set of types and we do only check for if it is not null (it can be `false`)
* to prevent this, a changed condition is implemented that checks if the given input is in fact a string

