### PR TITLE
Add Interface for `AdminContextProvider` and replaced types in injected classes

### DIFF
--- a/src/ArgumentResolver/AdminContextResolver.php
+++ b/src/ArgumentResolver/AdminContextResolver.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver;
 
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
@@ -17,7 +18,7 @@ if (interface_exists(ValueResolverInterface::class)) {
     {
         private AdminContextProvider $adminContextProvider;
 
-        public function __construct(AdminContextProvider $adminContextProvider)
+        public function __construct(AdminContextProviderInterface $adminContextProvider)
         {
             $this->adminContextProvider = $adminContextProvider;
         }
@@ -36,7 +37,7 @@ if (interface_exists(ValueResolverInterface::class)) {
     {
         private AdminContextProvider $adminContextProvider;
 
-        public function __construct(AdminContextProvider $adminContextProvider)
+        public function __construct(AdminContextProviderInterface $adminContextProvider)
         {
             $this->adminContextProvider = $adminContextProvider;
         }

--- a/src/ArgumentResolver/AdminContextResolver.php
+++ b/src/ArgumentResolver/AdminContextResolver.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver;
 
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
@@ -16,11 +15,9 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 if (interface_exists(ValueResolverInterface::class)) {
     final class AdminContextResolver implements ValueResolverInterface
     {
-        private AdminContextProvider $adminContextProvider;
-
-        public function __construct(AdminContextProviderInterface $adminContextProvider)
-        {
-            $this->adminContextProvider = $adminContextProvider;
+        public function __construct(
+            private AdminContextProviderInterface $adminContextProvider
+        ) {
         }
 
         public function resolve(Request $request, ArgumentMetadata $argument): iterable
@@ -35,11 +32,9 @@ if (interface_exists(ValueResolverInterface::class)) {
 } else {
     final class AdminContextResolver implements ArgumentValueResolverInterface
     {
-        private AdminContextProvider $adminContextProvider;
-
-        public function __construct(AdminContextProviderInterface $adminContextProvider)
-        {
-            $this->adminContextProvider = $adminContextProvider;
+        public function __construct(
+            private AdminContextProviderInterface $adminContextProvider
+        ) {
         }
 
         public function supports(Request $request, ArgumentMetadata $argument): bool

--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -4,7 +4,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\BatchActionDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,13 +17,10 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 if (interface_exists(ValueResolverInterface::class)) {
     final class BatchActionDtoResolver implements ValueResolverInterface
     {
-        private AdminContextProvider $adminContextProvider;
-        private AdminUrlGeneratorInterface $adminUrlGenerator;
-
-        public function __construct(AdminContextProviderInterface $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
-        {
-            $this->adminContextProvider = $adminContextProvider;
-            $this->adminUrlGenerator = $adminUrlGenerator;
+        public function __construct(
+            private AdminContextProviderInterface $adminContextProvider,
+            private AdminUrlGeneratorInterface $adminUrlGenerator
+        ) {
         }
 
         public function resolve(Request $request, ArgumentMetadata $argument): iterable
@@ -54,13 +50,10 @@ if (interface_exists(ValueResolverInterface::class)) {
 } else {
     final class BatchActionDtoResolver implements ArgumentValueResolverInterface
     {
-        private AdminContextProvider $adminContextProvider;
-        private AdminUrlGeneratorInterface $adminUrlGenerator;
-
-        public function __construct(AdminContextProviderInterface $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
-        {
-            $this->adminContextProvider = $adminContextProvider;
-            $this->adminUrlGenerator = $adminUrlGenerator;
+        public function __construct(
+            private AdminContextProviderInterface $adminContextProvider,
+            private AdminUrlGeneratorInterface $adminUrlGenerator
+        ) {
         }
 
         public function supports(Request $request, ArgumentMetadata $argument): bool

--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\BatchActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
@@ -20,7 +21,7 @@ if (interface_exists(ValueResolverInterface::class)) {
         private AdminContextProvider $adminContextProvider;
         private AdminUrlGeneratorInterface $adminUrlGenerator;
 
-        public function __construct(AdminContextProvider $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
+        public function __construct(AdminContextProviderInterface $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
         {
             $this->adminContextProvider = $adminContextProvider;
             $this->adminUrlGenerator = $adminUrlGenerator;
@@ -56,7 +57,7 @@ if (interface_exists(ValueResolverInterface::class)) {
         private AdminContextProvider $adminContextProvider;
         private AdminUrlGeneratorInterface $adminUrlGenerator;
 
-        public function __construct(AdminContextProvider $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
+        public function __construct(AdminContextProviderInterface $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
         {
             $this->adminContextProvider = $adminContextProvider;
             $this->adminUrlGenerator = $adminUrlGenerator;

--- a/src/EventListener/CrudResponseListener.php
+++ b/src/EventListener/CrudResponseListener.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
@@ -17,7 +18,7 @@ final class CrudResponseListener
     private AdminContextProvider $adminContextProvider;
     private Environment $twig;
 
-    public function __construct(AdminContextProvider $adminContextProvider, Environment $twig)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, Environment $twig)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->twig = $twig;

--- a/src/EventListener/CrudResponseListener.php
+++ b/src/EventListener/CrudResponseListener.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,7 +17,8 @@ final class CrudResponseListener
     public function __construct(
         private AdminContextProviderInterface $adminContextProvider,
         private Environment $twig
-    ) {}
+    ) {
+    }
 
     public function onKernelView(ViewEvent $event): void
     {

--- a/src/EventListener/CrudResponseListener.php
+++ b/src/EventListener/CrudResponseListener.php
@@ -15,14 +15,10 @@ use Twig\Environment;
  */
 final class CrudResponseListener
 {
-    private AdminContextProvider $adminContextProvider;
-    private Environment $twig;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider, Environment $twig)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->twig = $twig;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private Environment $twig
+    ) {}
 
     public function onKernelView(ViewEvent $event): void
     {

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\BaseException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\FlattenException;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Twig\Environment;
@@ -25,7 +26,7 @@ final class ExceptionListener
     private AdminContextProvider $adminContextProvider;
     private Environment $twig;
 
-    public function __construct(bool $kernelDebug, AdminContextProvider $adminContextProvider, Environment $twig)
+    public function __construct(bool $kernelDebug, AdminContextProviderInterface $adminContextProvider, Environment $twig)
     {
         $this->kernelDebug = $kernelDebug;
         $this->adminContextProvider = $adminContextProvider;

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -22,16 +22,11 @@ use Twig\Error\RuntimeError;
  */
 final class ExceptionListener
 {
-    private bool $kernelDebug;
-    private AdminContextProvider $adminContextProvider;
-    private Environment $twig;
-
-    public function __construct(bool $kernelDebug, AdminContextProviderInterface $adminContextProvider, Environment $twig)
-    {
-        $this->kernelDebug = $kernelDebug;
-        $this->adminContextProvider = $adminContextProvider;
-        $this->twig = $twig;
-    }
+    public function __construct(
+        private bool $kernelDebug,
+        private AdminContextProviderInterface $adminContextProvider,
+        private Environment $twig
+    ) {}
 
     public function onKernelException(ExceptionEvent $event)
     {

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -4,7 +4,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 
 use EasyCorp\Bundle\EasyAdminBundle\Exception\BaseException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\FlattenException;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
@@ -26,7 +25,8 @@ final class ExceptionListener
         private bool $kernelDebug,
         private AdminContextProviderInterface $adminContextProvider,
         private Environment $twig
-    ) {}
+    ) {
+    }
 
     public function onKernelException(ExceptionEvent $event)
     {

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -10,6 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionConfigDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableMessageBuilder;
@@ -29,7 +30,7 @@ final class ActionFactory
     private AdminUrlGeneratorInterface $adminUrlGenerator;
     private ?CsrfTokenManagerInterface $csrfTokenManager;
 
-    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authChecker, AdminUrlGeneratorInterface $adminUrlGenerator, ?CsrfTokenManagerInterface $csrfTokenManager = null)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, AuthorizationCheckerInterface $authChecker, AdminUrlGeneratorInterface $adminUrlGenerator, ?CsrfTokenManagerInterface $csrfTokenManager = null)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->authChecker = $authChecker;

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -9,7 +9,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionConfigDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
@@ -30,7 +29,8 @@ final class ActionFactory
         private AuthorizationCheckerInterface $authChecker,
         private AdminUrlGeneratorInterface $adminUrlGenerator,
         private ?CsrfTokenManagerInterface $csrfTokenManager = null
-    ) {}
+    ) {
+    }
 
     public function processEntityActions(EntityDto $entityDto, ActionConfigDto $actionsDto): void
     {

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -25,18 +25,12 @@ use Symfony\Contracts\Translation\TranslatableInterface;
  */
 final class ActionFactory
 {
-    private AdminContextProvider $adminContextProvider;
-    private AuthorizationCheckerInterface $authChecker;
-    private AdminUrlGeneratorInterface $adminUrlGenerator;
-    private ?CsrfTokenManagerInterface $csrfTokenManager;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider, AuthorizationCheckerInterface $authChecker, AdminUrlGeneratorInterface $adminUrlGenerator, ?CsrfTokenManagerInterface $csrfTokenManager = null)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->authChecker = $authChecker;
-        $this->adminUrlGenerator = $adminUrlGenerator;
-        $this->csrfTokenManager = $csrfTokenManager;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private AuthorizationCheckerInterface $authChecker,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private ?CsrfTokenManagerInterface $csrfTokenManager = null
+    ) {}
 
     public function processEntityActions(EntityDto $entityDto, ActionConfigDto $actionsDto): void
     {

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -20,6 +20,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EaFormRowType;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -60,7 +61,7 @@ final class FieldFactory
     private iterable $fieldConfigurators;
     private FormLayoutFactory $fieldLayoutFactory;
 
-    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authorizationChecker, iterable $fieldConfigurators, FormLayoutFactory $fieldLayoutFactory)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, AuthorizationCheckerInterface $authorizationChecker, iterable $fieldConfigurators, FormLayoutFactory $fieldLayoutFactory)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->authorizationChecker = $authorizationChecker;

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -19,7 +19,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EaFormRowType;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -61,7 +60,8 @@ final class FieldFactory
         private AuthorizationCheckerInterface $authorizationChecker,
         private iterable $fieldConfigurators,
         private FormLayoutFactory $fieldLayoutFactory
-    ) {}
+    ) {
+    }
 
     public function processFields(EntityDto $entityDto, FieldCollection $fields): void
     {

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -56,18 +56,12 @@ final class FieldFactory
         Types::TIME_IMMUTABLE => TimeField::class,
     ];
 
-    private AdminContextProvider $adminContextProvider;
-    private AuthorizationCheckerInterface $authorizationChecker;
-    private iterable $fieldConfigurators;
-    private FormLayoutFactory $fieldLayoutFactory;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider, AuthorizationCheckerInterface $authorizationChecker, iterable $fieldConfigurators, FormLayoutFactory $fieldLayoutFactory)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->authorizationChecker = $authorizationChecker;
-        $this->fieldConfigurators = $fieldConfigurators;
-        $this->fieldLayoutFactory = $fieldLayoutFactory;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private AuthorizationCheckerInterface $authorizationChecker,
+        private iterable $fieldConfigurators,
+        private FormLayoutFactory $fieldLayoutFactory
+    ) {}
 
     public function processFields(EntityDto $entityDto, FieldCollection $fields): void
     {

--- a/src/Factory/FilterFactory.php
+++ b/src/Factory/FilterFactory.php
@@ -24,8 +24,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
  */
 final class FilterFactory
 {
-    private AdminContextProvider $adminContextProvider;
-    private iterable $filterConfigurators;
     private static array $doctrineTypeToFilterClass = [
         'json_array' => ArrayFilter::class,
         Types::SIMPLE_ARRAY => ArrayFilter::class,
@@ -53,11 +51,10 @@ final class FilterFactory
         Types::TEXT => TextFilter::class,
     ];
 
-    public function __construct(AdminContextProviderInterface $adminContextProvider, iterable $filterConfigurators)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->filterConfigurators = $filterConfigurators;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private iterable $filterConfigurators
+    ) {}
 
     public function create(FilterConfigDto $filterConfig, FieldCollection $fields, EntityDto $entityDto): FilterCollection
     {

--- a/src/Factory/FilterFactory.php
+++ b/src/Factory/FilterFactory.php
@@ -15,7 +15,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\NumericFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 
 /**
@@ -54,7 +53,8 @@ final class FilterFactory
     public function __construct(
         private AdminContextProviderInterface $adminContextProvider,
         private iterable $filterConfigurators
-    ) {}
+    ) {
+    }
 
     public function create(FilterConfigDto $filterConfig, FieldCollection $fields, EntityDto $entityDto): FilterCollection
     {

--- a/src/Factory/FilterFactory.php
+++ b/src/Factory/FilterFactory.php
@@ -16,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\NumericFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -52,7 +53,7 @@ final class FilterFactory
         Types::TEXT => TextFilter::class,
     ];
 
-    public function __construct(AdminContextProvider $adminContextProvider, iterable $filterConfigurators)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, iterable $filterConfigurators)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->filterConfigurators = $filterConfigurators;

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -11,7 +11,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
@@ -31,7 +30,8 @@ final class MenuFactory implements MenuFactoryInterface
         private LogoutUrlGenerator $logoutUrlGenerator,
         private AdminUrlGeneratorInterface $adminUrlGenerator,
         private MenuItemMatcherInterface $menuItemMatcher
-    ) {}
+    ) {
+    }
 
     /**
      * @param MenuItemInterface[] $menuItems

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -25,20 +25,13 @@ use Symfony\Contracts\Translation\TranslatableInterface;
  */
 final class MenuFactory implements MenuFactoryInterface
 {
-    private AdminContextProvider $adminContextProvider;
-    private AuthorizationCheckerInterface $authChecker;
-    private LogoutUrlGenerator $logoutUrlGenerator;
-    private AdminUrlGeneratorInterface $adminUrlGenerator;
-    private MenuItemMatcherInterface $menuItemMatcher;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider, AuthorizationCheckerInterface $authChecker, LogoutUrlGenerator $logoutUrlGenerator, AdminUrlGeneratorInterface $adminUrlGenerator, MenuItemMatcherInterface $menuItemMatcher)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->authChecker = $authChecker;
-        $this->logoutUrlGenerator = $logoutUrlGenerator;
-        $this->adminUrlGenerator = $adminUrlGenerator;
-        $this->menuItemMatcher = $menuItemMatcher;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private AuthorizationCheckerInterface $authChecker,
+        private LogoutUrlGenerator $logoutUrlGenerator,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private MenuItemMatcherInterface $menuItemMatcher
+    ) {}
 
     /**
      * @param MenuItemInterface[] $menuItems

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -12,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -30,7 +31,7 @@ final class MenuFactory implements MenuFactoryInterface
     private AdminUrlGeneratorInterface $adminUrlGenerator;
     private MenuItemMatcherInterface $menuItemMatcher;
 
-    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authChecker, LogoutUrlGenerator $logoutUrlGenerator, AdminUrlGeneratorInterface $adminUrlGenerator, MenuItemMatcherInterface $menuItemMatcher)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, AuthorizationCheckerInterface $authChecker, LogoutUrlGenerator $logoutUrlGenerator, AdminUrlGeneratorInterface $adminUrlGenerator, MenuItemMatcherInterface $menuItemMatcher)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->authChecker = $authChecker;

--- a/src/Factory/PaginatorFactory.php
+++ b/src/Factory/PaginatorFactory.php
@@ -4,7 +4,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityPaginatorInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 
 /**
@@ -15,7 +14,8 @@ final class PaginatorFactory
     public function __construct(
         private AdminContextProviderInterface $adminContextProvider,
         private EntityPaginatorInterface $entityPaginator
-    ) {}
+    ) {
+    }
 
     public function create(QueryBuilder $queryBuilder): EntityPaginatorInterface
     {

--- a/src/Factory/PaginatorFactory.php
+++ b/src/Factory/PaginatorFactory.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityPaginatorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -14,7 +15,7 @@ final class PaginatorFactory
     private AdminContextProvider $adminContextProvider;
     private EntityPaginatorInterface $entityPaginator;
 
-    public function __construct(AdminContextProvider $adminContextProvider, EntityPaginatorInterface $entityPaginator)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, EntityPaginatorInterface $entityPaginator)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->entityPaginator = $entityPaginator;

--- a/src/Factory/PaginatorFactory.php
+++ b/src/Factory/PaginatorFactory.php
@@ -12,14 +12,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
  */
 final class PaginatorFactory
 {
-    private AdminContextProvider $adminContextProvider;
-    private EntityPaginatorInterface $entityPaginator;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider, EntityPaginatorInterface $entityPaginator)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->entityPaginator = $entityPaginator;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private EntityPaginatorInterface $entityPaginator
+    ) {}
 
     public function create(QueryBuilder $queryBuilder): EntityPaginatorInterface
     {

--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -7,7 +7,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use function Symfony\Component\String\u;
 use Twig\Markup;
@@ -20,7 +19,8 @@ final class CommonPostConfigurator implements FieldConfiguratorInterface
     public function __construct(
         private AdminContextProviderInterface $adminContextProvider,
         private string $charset
-    ) {}
+    ) {
+    }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {

--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use function Symfony\Component\String\u;
 use Twig\Markup;
 
@@ -19,7 +20,7 @@ final class CommonPostConfigurator implements FieldConfiguratorInterface
     private AdminContextProvider $adminContextProvider;
     private string $charset;
 
-    public function __construct(AdminContextProvider $adminContextProvider, string $charset)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, string $charset)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->charset = $charset;

--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -17,14 +17,10 @@ use Twig\Markup;
  */
 final class CommonPostConfigurator implements FieldConfiguratorInterface
 {
-    private AdminContextProvider $adminContextProvider;
-    private string $charset;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider, string $charset)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->charset = $charset;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private string $charset
+    ) {}
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {

--- a/src/Form/Extension/EaCrudFormTypeExtension.php
+++ b/src/Form/Extension/EaCrudFormTypeExtension.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\Extension;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FormVarsDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -21,7 +20,8 @@ class EaCrudFormTypeExtension extends AbstractTypeExtension
 {
     public function __construct(
         private AdminContextProviderInterface $adminContextProvider
-    ) {}
+    ) {
+    }
 
     public function configureOptions(OptionsResolver $resolver): void
     {

--- a/src/Form/Extension/EaCrudFormTypeExtension.php
+++ b/src/Form/Extension/EaCrudFormTypeExtension.php
@@ -19,12 +19,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class EaCrudFormTypeExtension extends AbstractTypeExtension
 {
-    private AdminContextProvider $adminContextProvider;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider
+    ) {}
 
     public function configureOptions(OptionsResolver $resolver): void
     {

--- a/src/Form/Extension/EaCrudFormTypeExtension.php
+++ b/src/Form/Extension/EaCrudFormTypeExtension.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Form\Extension;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FormVarsDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
@@ -20,7 +21,7 @@ class EaCrudFormTypeExtension extends AbstractTypeExtension
 {
     private AdminContextProvider $adminContextProvider;
 
-    public function __construct(AdminContextProvider $adminContextProvider)
+    public function __construct(AdminContextProviderInterface $adminContextProvider)
     {
         $this->adminContextProvider = $adminContextProvider;
     }

--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Inspector;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector as BaseDataCollector;
@@ -19,7 +20,7 @@ class DataCollector extends BaseDataCollector
 {
     private AdminContextProvider $adminContextProvider;
 
-    public function __construct(AdminContextProvider $adminContextProvider)
+    public function __construct(AdminContextProviderInterface $adminContextProvider)
     {
         $this->adminContextProvider = $adminContextProvider;
     }

--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -18,12 +18,9 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector as BaseDataCollecto
  */
 class DataCollector extends BaseDataCollector
 {
-    private AdminContextProvider $adminContextProvider;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider
+    ) {}
 
     public function reset(): void
     {

--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -4,7 +4,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Inspector;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +19,8 @@ class DataCollector extends BaseDataCollector
 {
     public function __construct(
         private AdminContextProviderInterface $adminContextProvider
-    ) {}
+    ) {
+    }
 
     public function reset(): void
     {

--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -7,13 +7,14 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 class MenuItemMatcher implements MenuItemMatcherInterface
 {
-    public function __construct(private AdminContextProvider $adminContextProvider)
+    public function __construct(private AdminContextProviderInterface $adminContextProvider)
     {
     }
 

--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -6,7 +6,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 
 /**

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -20,6 +20,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -35,7 +36,7 @@ final class EntityRepository implements EntityRepositoryInterface
     private FormFactory $formFactory;
     private EventDispatcherInterface $eventDispatcher;
 
-    public function __construct(AdminContextProvider $adminContextProvider, ManagerRegistry $doctrine, EntityFactory $entityFactory, FormFactory $formFactory, EventDispatcherInterface $eventDispatcher)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, ManagerRegistry $doctrine, EntityFactory $entityFactory, FormFactory $formFactory, EventDispatcherInterface $eventDispatcher)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->doctrine = $doctrine;

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -30,20 +30,13 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 final class EntityRepository implements EntityRepositoryInterface
 {
-    private AdminContextProvider $adminContextProvider;
-    private ManagerRegistry $doctrine;
-    private EntityFactory $entityFactory;
-    private FormFactory $formFactory;
-    private EventDispatcherInterface $eventDispatcher;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider, ManagerRegistry $doctrine, EntityFactory $entityFactory, FormFactory $formFactory, EventDispatcherInterface $eventDispatcher)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->doctrine = $doctrine;
-        $this->entityFactory = $entityFactory;
-        $this->formFactory = $formFactory;
-        $this->eventDispatcher = $eventDispatcher;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private ManagerRegistry $doctrine,
+        private EntityFactory $entityFactory,
+        private FormFactory $formFactory,
+        private EventDispatcherInterface $eventDispatcher
+    ) {}
 
     public function createQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
     {

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -19,7 +19,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntitySearchEvent;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
@@ -36,7 +35,8 @@ final class EntityRepository implements EntityRepositoryInterface
         private EntityFactory $entityFactory,
         private FormFactory $formFactory,
         private EventDispatcherInterface $eventDispatcher
-    ) {}
+    ) {
+    }
 
     public function createQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder
     {

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -13,7 +13,8 @@ final class AdminContextProvider implements AdminContextProviderInterface
 {
     public function __construct(
         private RequestStack $requestStack
-    ) {}
+    ) {
+    }
 
     public function getContext(): ?AdminContext
     {

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -7,23 +7,16 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Inject this in services that need to get the admin context object.
- *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AdminContextProvider
+final class AdminContextProvider implements AdminContextProviderInterface
 {
-    private RequestStack $requestStack;
-
-    public function __construct(RequestStack $requestStack)
-    {
-        $this->requestStack = $requestStack;
-    }
+    public function __construct(
+        private RequestStack $requestStack
+    ) {}
 
     public function getContext(): ?AdminContext
     {
-        $currentRequest = $this->requestStack->getCurrentRequest();
-
-        return null !== $currentRequest ? $currentRequest->get(EA::CONTEXT_REQUEST_ATTRIBUTE) : null;
+        return $this->requestStack->getCurrentRequest()?->get(EA::CONTEXT_REQUEST_ATTRIBUTE);
     }
 }

--- a/src/Provider/AdminContextProviderInterface.php
+++ b/src/Provider/AdminContextProviderInterface.php
@@ -6,9 +6,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Provider;
 
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 
-/**
- * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- */
 interface AdminContextProviderInterface
 {
     public function getContext(): ?AdminContext;

--- a/src/Provider/AdminContextProviderInterface.php
+++ b/src/Provider/AdminContextProviderInterface.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Provider;
 
-
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 
 /**

--- a/src/Provider/AdminContextProviderInterface.php
+++ b/src/Provider/AdminContextProviderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Provider;
+
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+interface AdminContextProviderInterface
+{
+    public function getContext(): ?AdminContext;
+}

--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -13,7 +13,8 @@ final class FieldProvider
 {
     public function __construct(
         private AdminContextProviderInterface $adminContextProvider
-    ) {}
+    ) {
+    }
 
     public function getDefaultFields(string $pageName): array
     {

--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -13,7 +13,7 @@ final class FieldProvider
 {
     private AdminContextProvider $adminContextProvider;
 
-    public function __construct(AdminContextProvider $adminContextProvider)
+    public function __construct(AdminContextProviderInterface $adminContextProvider)
     {
         $this->adminContextProvider = $adminContextProvider;
     }

--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -11,12 +11,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
  */
 final class FieldProvider
 {
-    private AdminContextProvider $adminContextProvider;
-
-    public function __construct(AdminContextProviderInterface $adminContextProvider)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider
+    ) {}
 
     public function getDefaultFields(string $pageName): array
     {

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -6,7 +6,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -27,7 +26,8 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         private AdminContextProviderInterface $adminContextProvider,
         private UrlGeneratorInterface $urlGenerator,
         private DashboardControllerRegistry $dashboardControllerRegistry
-    ) {}
+    ) {
+    }
 
     /**
      * @return AdminUrlGenerator

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -7,6 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -25,7 +26,7 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
     private ?string $currentPageReferrer = null;
     private ?string $customPageReferrer = null;
 
-    public function __construct(AdminContextProvider $adminContextProvider, UrlGeneratorInterface $urlGenerator, DashboardControllerRegistry $dashboardControllerRegistry)
+    public function __construct(AdminContextProviderInterface $adminContextProvider, UrlGeneratorInterface $urlGenerator, DashboardControllerRegistry $dashboardControllerRegistry)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->urlGenerator = $urlGenerator;

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -17,21 +17,17 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 final class AdminUrlGenerator implements AdminUrlGeneratorInterface
 {
     private bool $isInitialized = false;
-    private AdminContextProvider $adminContextProvider;
-    private UrlGeneratorInterface $urlGenerator;
-    private DashboardControllerRegistry $dashboardControllerRegistry;
     private ?string $dashboardRoute = null;
     private ?bool $includeReferrer = null;
     private array $routeParameters = [];
     private ?string $currentPageReferrer = null;
     private ?string $customPageReferrer = null;
 
-    public function __construct(AdminContextProviderInterface $adminContextProvider, UrlGeneratorInterface $urlGenerator, DashboardControllerRegistry $dashboardControllerRegistry)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->urlGenerator = $urlGenerator;
-        $this->dashboardControllerRegistry = $dashboardControllerRegistry;
-    }
+    public function __construct(
+        private AdminContextProviderInterface $adminContextProvider,
+        private UrlGeneratorInterface $urlGenerator,
+        private DashboardControllerRegistry $dashboardControllerRegistry
+    ) {}
 
     /**
      * @return AdminUrlGenerator

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -18,14 +18,10 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  */
 final class SecurityVoter extends Voter
 {
-    private AuthorizationCheckerInterface $authorizationChecker;
-    private AdminContextProvider $adminContextProvider;
-
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, AdminContextProviderInterface $adminContextProvider)
-    {
-        $this->authorizationChecker = $authorizationChecker;
-        $this->adminContextProvider = $adminContextProvider;
-    }
+    public function __construct(
+        private AuthorizationCheckerInterface $authorizationChecker,
+        private AdminContextProviderInterface $adminContextProvider,
+    ) {}
 
     protected function supports(string $permissionName, mixed $subject): bool
     {

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -20,7 +21,7 @@ final class SecurityVoter extends Voter
     private AuthorizationCheckerInterface $authorizationChecker;
     private AdminContextProvider $adminContextProvider;
 
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, AdminContextProvider $adminContextProvider)
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, AdminContextProviderInterface $adminContextProvider)
     {
         $this->authorizationChecker = $authorizationChecker;
         $this->adminContextProvider = $adminContextProvider;

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -7,7 +7,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -21,7 +20,8 @@ final class SecurityVoter extends Voter
     public function __construct(
         private AuthorizationCheckerInterface $authorizationChecker,
         private AdminContextProviderInterface $adminContextProvider,
-    ) {}
+    ) {
+    }
 
     protected function supports(string $permissionName, mixed $subject): bool
     {

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -27,16 +27,11 @@ use Twig\TwigFunction;
  */
 class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterface
 {
-    private ServiceLocator $serviceLocator;
-    private AdminContextProvider $adminContextProvider;
-    private ?CsrfTokenManagerInterface $csrfTokenManager;
-
-    public function __construct(ServiceLocator $serviceLocator, AdminContextProviderInterface $adminContextProvider, ?CsrfTokenManagerInterface $csrfTokenManager)
-    {
-        $this->serviceLocator = $serviceLocator;
-        $this->adminContextProvider = $adminContextProvider;
-        $this->csrfTokenManager = $csrfTokenManager;
-    }
+    public function __construct(
+        private ServiceLocator $serviceLocator,
+        private AdminContextProviderInterface $adminContextProvider,
+        private ?CsrfTokenManagerInterface $csrfTokenManager
+    ) {}
 
     public function getFunctions(): array
     {

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -6,6 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldLayoutDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -30,7 +31,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
     private AdminContextProvider $adminContextProvider;
     private ?CsrfTokenManagerInterface $csrfTokenManager;
 
-    public function __construct(ServiceLocator $serviceLocator, AdminContextProvider $adminContextProvider, ?CsrfTokenManagerInterface $csrfTokenManager)
+    public function __construct(ServiceLocator $serviceLocator, AdminContextProviderInterface $adminContextProvider, ?CsrfTokenManagerInterface $csrfTokenManager)
     {
         $this->serviceLocator = $serviceLocator;
         $this->adminContextProvider = $adminContextProvider;

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -5,7 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Twig;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldLayoutDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
@@ -31,7 +30,8 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
         private ServiceLocator $serviceLocator,
         private AdminContextProviderInterface $adminContextProvider,
         private ?CsrfTokenManagerInterface $csrfTokenManager
-    ) {}
+    ) {
+    }
 
     public function getFunctions(): array
     {


### PR DESCRIPTION
This adds another Interface for a `final class` without existing Interface.

Works regardless of `service.php` declarations -> the instanceof should always run trough fine. Tests may have to be adapted accordingly.