### PR TITLE
chore: remove unnecessary `true` comparison on  `is_string()`

### DIFF
--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -28,7 +28,7 @@ class MenuItemMatcher implements MenuItemMatcherInterface
         $menuItemQueryString = null === $menuItemDto->getLinkUrl() ? null : parse_url($menuItemDto->getLinkUrl(), \PHP_URL_QUERY);
 
         $menuItemQueryParameters = [];
-        if (true === \is_string($menuItemQueryString)) {
+        if (\is_string($menuItemQueryString)) {
             parse_str($menuItemQueryString, $menuItemQueryParameters);
         }
 


### PR DESCRIPTION
Follow-up of #6087

- #6087

[`is_string()`](https://www.php.net/manual/en/function.is-string.php) only return `true` or `false` so `true ===` is redundant.