### PR TITLE
User formattedValue in ColorField template

### DIFF
--- a/src/Resources/views/crud/field/color.html.twig
+++ b/src/Resources/views/crud/field/color.html.twig
@@ -2,7 +2,7 @@
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% if field.customOptions.get('showSample') %}
-    <span class="color-sample" style="background: {{ field.value }}; {{ field.customOptions.get('showValue') ? 'margin-right: 5px;' }}" title="{{ field.formattedValue }}">&nbsp;</span>
+    <span class="color-sample" style="background: {{ field.formattedValue }}; {{ field.customOptions.get('showValue') ? 'margin-right: 5px;' }}" title="{{ field.formattedValue }}">&nbsp;</span>
 {% endif %}
 {% if field.customOptions.get('showValue') %}
     {{ field.formattedValue }}


### PR DESCRIPTION
When you have color in enum, this template fails, becase enum could not be converted to string. I think this is a mistake in template and we should use`formattedValue` instead of `value`.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
