### PR TITLE
Remove referrer url

### DIFF
--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\BatchActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
@@ -39,7 +40,17 @@ if (interface_exists(ValueResolverInterface::class)) {
             $batchActionUrl = $context->getRequest()->request->get(EA::BATCH_ACTION_URL);
             $batchActionUrlQueryString = parse_url($batchActionUrl, \PHP_URL_QUERY);
             parse_str($batchActionUrlQueryString, $batchActionUrlParts);
-            $referrerUrl = $batchActionUrlParts[EA::REFERRER] ?? $this->adminUrlGenerator->unsetAll()->generateUrl();
+            $batchActionUrlParts = $request->query->all();
+            if ($batchActionUrlParts[EA::CRUD_ACTION] ?? null) {
+                $batchActionUrlParts[EA::CRUD_ACTION] = Action::INDEX;
+            }
+
+            $referrerUrl = $this->adminUrlGenerator
+                ->setAll($batchActionUrlParts)
+                // reset the page number to avoid confusing elements after the page reload
+                // (we're deleting items, so the original listing pages will change)
+                ->unset(EA::PAGE)
+                ->generateUrl();
 
             yield new BatchActionDto(
                 $context->getRequest()->request->get(EA::BATCH_ACTION_NAME),
@@ -76,7 +87,17 @@ if (interface_exists(ValueResolverInterface::class)) {
             $batchActionUrl = $context->getRequest()->request->get(EA::BATCH_ACTION_URL);
             $batchActionUrlQueryString = parse_url($batchActionUrl, \PHP_URL_QUERY);
             parse_str($batchActionUrlQueryString, $batchActionUrlParts);
-            $referrerUrl = $batchActionUrlParts[EA::REFERRER] ?? $this->adminUrlGenerator->unsetAll()->generateUrl();
+            $batchActionUrlParts = $request->query->all();
+            if ($batchActionUrlParts[EA::CRUD_ACTION] ?? null) {
+                $batchActionUrlParts[EA::CRUD_ACTION] = Action::INDEX;
+            }
+
+            $referrerUrl = $this->adminUrlGenerator
+                ->setAll($batchActionUrlParts)
+                // reset the page number to avoid confusing elements after the page reload
+                // (we're deleting items, so the original listing pages will change)
+                ->unset(EA::PAGE)
+                ->generateUrl();
 
             yield new BatchActionDto(
                 $context->getRequest()->request->get(EA::BATCH_ACTION_NAME),

--- a/src/Config/Option/EA.php
+++ b/src/Config/Option/EA.php
@@ -19,13 +19,16 @@ final class EA
     public const ENTITY_FQCN = 'entityFqcn';
     public const ENTITY_ID = 'entityId';
     public const FILTERS = 'filters';
+    /** @deprecated this parameter is no longer used because menu items are now highlighted automatically */
     public const MENU_INDEX = 'menuIndex';
     public const PAGE = 'page';
     public const QUERY = 'query';
+    /** @deprecated this parameter is no longer used because the referrer URL is now generated automatically */
     public const REFERRER = 'referrer';
     public const ROUTE_NAME = 'routeName';
     public const ROUTE_PARAMS = 'routeParams';
     public const SORT = 'sort';
+    /** @deprecated this parameter is no longer used because menu items are now highlighted automatically */
     public const SUBMENU_INDEX = 'submenuIndex';
     public const URL_SIGNATURE = 'signature';
 }

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -623,29 +623,18 @@ abstract class AbstractCrudController extends AbstractController implements Crud
     {
         $submitButtonName = $context->getRequest()->request->all()['ea']['newForm']['btn'];
 
-        if (Action::SAVE_AND_CONTINUE === $submitButtonName) {
-            $url = $this->container->get(AdminUrlGenerator::class)
+        $url = match ($submitButtonName) {
+            Action::SAVE_AND_CONTINUE => $this->container->get(AdminUrlGenerator::class)
                 ->setAction(Action::EDIT)
                 ->setEntityId($context->getEntity()->getPrimaryKeyValue())
-                ->generateUrl();
+                ->generateUrl(),
+            Action::SAVE_AND_RETURN => $context->getReferrer()
+                ?? $this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl(),
+            Action::SAVE_AND_ADD_ANOTHER => $this->container->get(AdminUrlGenerator::class)->setAction(Action::NEW)->generateUrl(),
+            default => $this->generateUrl($context->getDashboardRouteName()),
+        };
 
-            return $this->redirect($url);
-        }
-
-        if (Action::SAVE_AND_RETURN === $submitButtonName) {
-            $url = $context->getReferrer()
-                ?? $this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl();
-
-            return $this->redirect($url);
-        }
-
-        if (Action::SAVE_AND_ADD_ANOTHER === $submitButtonName) {
-            $url = $this->container->get(AdminUrlGenerator::class)->setAction(Action::NEW)->generateUrl();
-
-            return $this->redirect($url);
-        }
-
-        return $this->redirectToRoute($context->getDashboardRouteName());
+        return $this->redirect($url);
     }
 
     protected function getFieldAssets(FieldCollection $fieldDtos): AssetsDto

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -119,7 +119,6 @@ final class ActionFactory
         $adminContext = $this->adminContextProvider->getContext();
         $translationDomain = $adminContext->getI18n()->getTranslationDomain();
         $defaultTranslationParameters = $adminContext->getI18n()->getTranslationParameters();
-        $currentPage = $adminContext->getCrud()->getCurrentPage();
 
         $actionDto->setHtmlAttribute('data-action-name', $actionDto->getName());
 
@@ -140,7 +139,7 @@ final class ActionFactory
         $defaultTemplatePath = $adminContext->getTemplatePath('crud/action');
         $actionDto->setTemplatePath($actionDto->getTemplatePath() ?? $defaultTemplatePath);
 
-        $actionDto->setLinkUrl($this->generateActionUrl($currentPage, $adminContext->getRequest(), $actionDto, $entityDto));
+        $actionDto->setLinkUrl($this->generateActionUrl($adminContext->getRequest(), $actionDto, $entityDto));
 
         if (!$actionDto->isGlobalAction() && \in_array($pageName, [Crud::PAGE_EDIT, Crud::PAGE_NEW], true)) {
             $actionDto->setHtmlAttribute('form', sprintf('%s-%s-form', $pageName, $entityDto->getName()));
@@ -168,7 +167,7 @@ final class ActionFactory
         return $actionDto;
     }
 
-    private function generateActionUrl(string $currentAction, Request $request, ActionDto $actionDto, ?EntityDto $entityDto = null): string
+    private function generateActionUrl(Request $request, ActionDto $actionDto, ?EntityDto $entityDto = null): string
     {
         $entityInstance = $entityDto?->getInstance();
 
@@ -186,13 +185,12 @@ final class ActionFactory
                 $routeParameters = $routeParameters($entityInstance);
             }
 
-            return $this->adminUrlGenerator->unsetAll()->includeReferrer()->setRoute($routeName, $routeParameters)->generateUrl();
+            return $this->adminUrlGenerator->unsetAllExcept(EA::FILTERS, EA::PAGE, EA::QUERY, EA::SORT)->setRoute($routeName, $routeParameters)->generateUrl();
         }
 
         $requestParameters = [
             EA::CRUD_CONTROLLER_FQCN => $request->query->get(EA::CRUD_CONTROLLER_FQCN),
             EA::CRUD_ACTION => $actionDto->getCrudActionName(),
-            EA::REFERRER => $this->generateReferrerUrl($request, $actionDto, $currentAction),
         ];
 
         if (\in_array($actionDto->getName(), [Action::INDEX, Action::NEW, Action::SAVE_AND_ADD_ANOTHER, Action::SAVE_AND_RETURN], true)) {
@@ -201,38 +199,16 @@ final class ActionFactory
             $requestParameters[EA::ENTITY_ID] = $entityDto->getPrimaryKeyValueAsString();
         }
 
-        return $this->adminUrlGenerator->unsetAllExcept(EA::FILTERS, EA::PAGE)->setAll($requestParameters)->generateUrl();
-    }
-
-    private function generateReferrerUrl(Request $request, ActionDto $actionDto, string $currentAction): ?string
-    {
-        $nextAction = $actionDto->getName();
-
-        if (Action::DETAIL === $currentAction) {
-            if (Action::EDIT === $nextAction) {
-                return $this->adminUrlGenerator->removeReferrer()->generateUrl();
-            }
+        $urlParametersToKeep = [EA::FILTERS, EA::QUERY, EA::SORT, EA::BATCH_ACTION_CSRF_TOKEN, EA::BATCH_ACTION_ENTITY_IDS, EA::BATCH_ACTION_NAME, EA::BATCH_ACTION_URL];
+        // when creating a new entity, keeping the selected page number is usually confusing:
+        // 1. the user filters/searches/sorts/paginates the results and then creates a new entity
+        // 2. if we keep the page number, when the backend returns to the listing, it's very probable
+        //    that the user doesn't see the new entity, so they might think that it wasn't created
+        // 3. if we keep the other parameters, it's probable that the new entity is shown (sometimes it won't)
+        if (Action::NEW !== $actionDto->getName()) {
+            $urlParametersToKeep[] = EA::PAGE;
         }
 
-        if (Action::INDEX === $currentAction) {
-            return $this->adminUrlGenerator->removeReferrer()->generateUrl();
-        }
-
-        if (Action::NEW === $currentAction) {
-            return null;
-        }
-
-        $referrer = $request->query->get(EA::REFERRER);
-        $referrerParts = parse_url((string) $referrer);
-        parse_str($referrerParts[EA::QUERY] ?? '', $referrerQueryStringVariables);
-        $referrerCrudAction = $referrerQueryStringVariables[EA::CRUD_ACTION] ?? null;
-
-        if (Action::EDIT === $currentAction) {
-            if (\in_array($referrerCrudAction, [Action::INDEX, Action::DETAIL], true)) {
-                return $referrer;
-            }
-        }
-
-        return $this->adminUrlGenerator->removeReferrer()->generateUrl();
+        return $this->adminUrlGenerator->unsetAllExcept(...$urlParametersToKeep)->setAll($requestParameters)->generateUrl();
     }
 }

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -235,9 +235,10 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             ->setController($crudController)
             ->setAction(Action::DETAIL)
             ->setEntityId($entityDto->getPrimaryKeyValue())
-            ->unset(EA::MENU_INDEX)
-            ->unset(EA::SUBMENU_INDEX)
-            ->includeReferrer()
+            ->unset(EA::FILTERS)
+            ->unset(EA::PAGE)
+            ->unset(EA::QUERY)
+            ->unset(EA::SORT)
             ->generateUrl();
     }
 

--- a/src/Orm/EntityPaginator.php
+++ b/src/Orm/EntityPaginator.php
@@ -75,7 +75,7 @@ final class EntityPaginator implements EntityPaginatorInterface
 
     public function generateUrlForPage(int $page): string
     {
-        return $this->adminUrlGenerator->set(EA::PAGE, $page)->includeReferrer()->generateUrl();
+        return $this->adminUrlGenerator->set(EA::PAGE, $page)->generateUrl();
     }
 
     public function getCurrentPage(): int

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -239,6 +239,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set(FormFactory::class)
             ->arg(0, service('form.factory'))
+            ->arg(1, service(AdminUrlGenerator::class))
 
         ->set(FormLayoutFactory::class)
 

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -51,7 +51,7 @@
             {% block filters %}
                 {% set applied_filters = ea.request.query.all['filters']|default([])|keys %}
                 <div class="btn-group action-filters">
-                    <a href="#" data-href="{{ ea_url().setAction('renderFilters').includeReferrer() }}" class="btn btn-secondary btn-labeled btn-labeled-right action-filters-button disabled {{ applied_filters ? 'action-filters-applied' }}" data-bs-toggle="modal" data-bs-target="#modal-filters">
+                    <a href="#" data-href="{{ ea_url().setAction('renderFilters') }}" class="btn btn-secondary btn-labeled btn-labeled-right action-filters-button disabled {{ applied_filters ? 'action-filters-applied' }}" data-bs-toggle="modal" data-bs-target="#modal-filters">
                         <i class="fa fa-filter fa-fw"></i> {{ t('filter.title', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}{% if applied_filters %} <span class="action-filters-button-count">({{ applied_filters|length }})</span>{% endif %}
                     </a>
                     {% if applied_filters %}
@@ -114,7 +114,7 @@
 
                         <th data-column="{{ field.property }}" class="{{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} header-for-{{ field.cssClass|split(' ')|filter(class => class starts with 'field-')|join('') }} text-{{ field.textAlign }}" dir="{{ ea.i18n.textDirection }}">
                             {% if field.isSortable %}
-                                <a href="{{ ea_url({ page: 1, sort: { (field.property): next_sort_direction } }).includeReferrer() }}">
+                                <a href="{{ ea_url({ page: 1, sort: { (field.property): next_sort_direction } }) }}">
                                     {{ field.label|trans|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
                                 </a>
                             {% else %}

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -175,6 +175,12 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
      */
     public function includeReferrer(): AdminUrlGeneratorInterface
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.9.0',
+            'Adding the referrer argument in the admin URLs via the AdminUrlGenerator::includeReferrer() method is deprecated and it will be removed in 5.0.0. The referrer will now be determined automatically based on the current request.',
+        );
+
         if (false === $this->isInitialized) {
             $this->initialize();
         }
@@ -203,6 +209,12 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
      */
     public function setReferrer(string $referrer): AdminUrlGeneratorInterface
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.9.0',
+            'Adding the referrer argument in the admin URLs via the AdminUrlGenerator::setReferrer() method is deprecated and it will be removed in 5.0.0. The referrer will now be determined automatically based on the current request.',
+        );
+
         if (false === $this->isInitialized) {
             $this->initialize();
         }
@@ -254,10 +266,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
 
         if (true === $this->includeReferrer) {
             $this->setRouteParameter(EA::REFERRER, $this->customPageReferrer ?? $this->currentPageReferrer);
-        }
-
-        if (false === $this->includeReferrer) {
-            $this->unset(EA::REFERRER);
         }
 
         // this avoids forcing users to always be explicit about the action to execute

--- a/src/Test/Trait/CrudTestUrlGeneration.php
+++ b/src/Test/Trait/CrudTestUrlGeneration.php
@@ -64,9 +64,6 @@ trait CrudTestUrlGeneration
 
     protected function generateFilterRenderUrl(?string $dashboardFqcn = null, ?string $controllerFqcn = null): string
     {
-        // Use the index URL as referrer but remove scheme, host and port
-        $referrer = preg_replace('/^.*(\/.*)$/', '$1', $this->generateIndexUrl());
-
-        return $this->getCrudUrl('renderFilters', null, ['referrer' => $referrer], dashboardFqcn: $dashboardFqcn, controllerFqcn: $controllerFqcn);
+        return $this->getCrudUrl('renderFilters', dashboardFqcn: $dashboardFqcn, controllerFqcn: $controllerFqcn);
     }
 }

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -204,6 +204,9 @@ class AdminUrlGeneratorTest extends WebTestCase
         $adminUrlGenerator->set('menuIndex', 1);
     }
 
+    /**
+     * @group legacy
+     */
     public function testIncludeReferrer()
     {
         $adminUrlGenerator = $this->getAdminUrlGenerator();
@@ -212,6 +215,9 @@ class AdminUrlGeneratorTest extends WebTestCase
         $this->assertSame('http://localhost/admin?foo=bar&referrer=/?foo%3Dbar', $adminUrlGenerator->generateUrl());
     }
 
+    /**
+     * @group legacy
+     */
     public function testRemoveReferrer()
     {
         $adminUrlGenerator = $this->getAdminUrlGenerator();
@@ -224,14 +230,16 @@ class AdminUrlGeneratorTest extends WebTestCase
         $this->assertSame('http://localhost/admin?foo=bar', $adminUrlGenerator->generateUrl());
     }
 
-    public function testDefaultReferrer()
+    public function testNoReferrerByDefault()
     {
         $adminUrlGenerator = $this->getAdminUrlGenerator();
 
-        $adminUrlGenerator->includeReferrer();
-        $this->assertSame('http://localhost/admin?foo=bar&referrer=/?foo%3Dbar', $adminUrlGenerator->generateUrl());
+        $this->assertStringNotContainsString('referrer', $adminUrlGenerator->generateUrl());
     }
 
+    /**
+     * @group legacy
+     */
     public function testCustomReferrer()
     {
         $adminUrlGenerator = $this->getAdminUrlGenerator();
@@ -240,6 +248,9 @@ class AdminUrlGeneratorTest extends WebTestCase
         $this->assertSame('http://localhost/admin?foo=bar&referrer=any_custom_value', $adminUrlGenerator->generateUrl());
     }
 
+    /**
+     * @group legacy
+     */
     public function testPersistentCustomReferrer()
     {
         $adminUrlGenerator = $this->getAdminUrlGenerator();

--- a/tests/Test/Trait/CrudTestUrlGenerationTraitTest.php
+++ b/tests/Test/Trait/CrudTestUrlGenerationTraitTest.php
@@ -215,20 +215,11 @@ final class CrudTestUrlGenerationTraitTest extends KernelTestCase
             }
         };
 
-        $indexUrl = $this->adminUrlGenerator
-            ->setDashboard(self::TEST_DASHBOARD)
-            ->setController(self::TEST_CONTROLLER)
-            ->setAction(Action::INDEX)
-            ->generateUrl()
-        ;
-        $referrer = preg_replace('/^.*(\/.*)$/', '$1', $indexUrl);
-
         $expectedUrl = $this->adminUrlGenerator
             ->setDashboard(self::TEST_DASHBOARD)
             ->setController(self::TEST_CONTROLLER)
             // No defined const in EasyCorp\Bundle\EasyAdminBundle\Config\Action so need to write it by hand
             ->setAction('renderFilters')
-            ->setReferrer($referrer)
             ->generateUrl()
         ;
 
@@ -249,20 +240,11 @@ final class CrudTestUrlGenerationTraitTest extends KernelTestCase
             }
         };
 
-        $indexUrl = $this->adminUrlGenerator
-            ->setDashboard(self::TEST_DASHBOARD)
-            ->setController(self::TEST_CONTROLLER)
-            ->setAction(Action::INDEX)
-            ->generateUrl()
-        ;
-        $referrer = preg_replace('/^.*(\/.*)$/', '$1', $indexUrl);
-
         $expectedUrl = $this->adminUrlGenerator
             ->setDashboard($dashboardFqcn ?? self::TEST_DASHBOARD)
             ->setController($controllerFqcn ?? self::TEST_CONTROLLER)
             // No defined const in EasyCorp\Bundle\EasyAdminBundle\Config\Action so need to write it by hand
             ->setAction('renderFilters')
-            ->setReferrer($referrer)
             ->generateUrl()
         ;
 


### PR DESCRIPTION
This removes the `referrer` query parameter. Nothing should change for end users, except that admin URLs are now much shorter.

In almost all cases, we can guess the best referrer URL possible from the current URL parameters. In some edge cases, the URL you return to after doing something can vary slightly from before ... but that's worth to shorten the URLs a lot and to simplify code.