### PR TITLE
Fix failing sort test

### DIFF
--- a/tests/Orm/PageSortTest.php
+++ b/tests/Orm/PageSortTest.php
@@ -35,12 +35,14 @@ class PageSortTest extends AbstractCrudTestCase
     {
         // Arrange
         $expectedAmountMapping = [];
+        $websites = [];
 
         /**
          * @var Page $entity
          */
         foreach ($this->repository->findAll() as $entity) {
-            $expectedAmountMapping[$entity->getName()] = $entity->getWebsite()->getName();
+            $expectedAmountMapping[$entity->getName()] = $entity->getWebsite()->getId();
+            $websites[$entity->getWebsite()->getId()] = $entity->getWebsite()->getName();
         }
 
         if (null !== $sortFunction) {
@@ -57,11 +59,13 @@ class PageSortTest extends AbstractCrudTestCase
 
         $index = 1;
 
-        foreach ($expectedAmountMapping as $expectedName => $expectedValue) {
+        foreach ($expectedAmountMapping as $expectedPageName => $websiteId) {
             $expectedRow = $index++;
 
-            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(2)', $expectedName, sprintf('Expected "%s" in row %d', $expectedName, $expectedRow));
-            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(3)', $expectedValue, sprintf('Expected "%s" in row %d', $expectedValue, $expectedRow));
+            $expectedWebsiteName = $websites[$websiteId];
+
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(2)', $expectedPageName, sprintf('Expected "%s" in row %d', $expectedPageName, $expectedRow));
+            $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(3)', $expectedWebsiteName, sprintf('Expected "%s" in row %d', $expectedWebsiteName, $expectedRow));
         }
     }
 


### PR DESCRIPTION
The sorting is based on the website id but I checked the website name, the diff will fix that. This is and was expected behaviour, why the test doesn't fail since the beginning? I don't know. 😄

Related: #6105 