### PR TITLE
Allow setting sort field for *-to-one associations

### DIFF
--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -35,6 +35,10 @@ final class AssociationField implements FieldInterface
 
     public const OPTION_EMBEDDED_CRUD_FORM_NEW_PAGE_NAME = 'crudNewPageName';
     public const OPTION_EMBEDDED_CRUD_FORM_EDIT_PAGE_NAME = 'crudEditPageName';
+    /**
+     * Which property to use in the associated entity to sort the results. (For *-To-One associations).
+     */
+    public const OPTION_SORT_PROPERTY = 'sortProperty';
 
     /**
      * @param TranslatableInterface|string|false|null $label
@@ -93,6 +97,13 @@ final class AssociationField implements FieldInterface
         $this->setCustomOption(self::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER, $crudControllerFqcn);
         $this->setCustomOption(self::OPTION_EMBEDDED_CRUD_FORM_NEW_PAGE_NAME, $crudNewPageName);
         $this->setCustomOption(self::OPTION_EMBEDDED_CRUD_FORM_EDIT_PAGE_NAME, $crudEditPageName);
+
+        return $this;
+    }
+
+    public function setSortProperty(string $orderProperty): self
+    {
+        $this->setCustomOption(self::OPTION_SORT_PROPERTY, $orderProperty);
 
         return $this;
     }

--- a/tests/Orm/PageSortTest.php
+++ b/tests/Orm/PageSortTest.php
@@ -35,14 +35,12 @@ class PageSortTest extends AbstractCrudTestCase
     {
         // Arrange
         $expectedAmountMapping = [];
-        $websites = [];
 
         /**
          * @var Page $entity
          */
         foreach ($this->repository->findAll() as $entity) {
-            $expectedAmountMapping[$entity->getName()] = $entity->getWebsite()->getId();
-            $websites[$entity->getWebsite()->getId()] = $entity->getWebsite()->getName();
+            $expectedAmountMapping[$entity->getName()] = $entity->getWebsite()->getName();
         }
 
         if (null !== $sortFunction) {
@@ -59,10 +57,8 @@ class PageSortTest extends AbstractCrudTestCase
 
         $index = 1;
 
-        foreach ($expectedAmountMapping as $expectedPageName => $websiteId) {
+        foreach ($expectedAmountMapping as $expectedPageName => $expectedWebsiteName) {
             $expectedRow = $index++;
-
-            $expectedWebsiteName = $websites[$websiteId];
 
             $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(2)', $expectedPageName, sprintf('Expected "%s" in row %d', $expectedPageName, $expectedRow));
             $this->assertSelectorTextSame('tbody tr:nth-child('.$expectedRow.') td:nth-child(3)', $expectedWebsiteName, sprintf('Expected "%s" in row %d', $expectedWebsiteName, $expectedRow));

--- a/tests/TestApplication/src/Controller/Sort/PageCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/PageCrudController.php
@@ -19,7 +19,8 @@ class PageCrudController extends AbstractCrudController
     {
         return [
             TextField::new('name'),
-            AssociationField::new('website'),
+            AssociationField::new('website')
+                ->setSortProperty('name'),
         ];
     }
 


### PR DESCRIPTION
Hey @javiereguiluz I noticed in #6110 that it would be nice to set the property it should sort for (Which might also be displayed instead of the id). Also found an older issue which will be fixed by this feature. 😄 

Follow-Up for: #6110 
Replaces: #4315
Fixes: #4307