### PR TITLE
Allow to add AssetMapper entries in dashboards and CRUDs

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -247,6 +247,14 @@ the :doc:`CRUD controllers </crud>` to add your own CSS and JavaScript files::
         public function configureAssets(Assets $assets): Assets
         {
             return $assets
+                // imports the given entrypoint defined in the importmap.php file of AssetMapper
+                // it's equivalent to adding this inside the <head> element:
+                // {{ importmap('admin') }}
+                ->addAssetMapperEntry('admin')
+                // you can also import multiple entries
+                // it's equivalent to calling {{ importmap(['app', 'admin']) }}
+                ->addAssetMapperEntry('app', 'admin')
+
                 // adds the CSS and JS assets associated to the given Webpack Encore entry
                 // it's equivalent to adding these inside the <head> element:
                 // {{ encore_entry_link_tags('...') }} and {{ encore_entry_script_tags('...') }}
@@ -287,6 +295,10 @@ and ``<script>`` tags, pass an ``Asset`` object to the ``addCssFile()``,
         ->addJsFile(Asset::new('build/admin.js')->htmlAttr('referrerpolicy', 'strict-origin'))
 
         ->addWebpackEncoreEntry(Asset::new('admin-app')->webpackEntrypointName('...'))
+
+        // adding full Asset objects for AssetMapper entries work too, but it's
+        // useless because entries can't define any property, only their name
+        ->addAssetMapperEntry(Asset::new('admin'))
 
         ->addCssFile(Asset::new('build/admin-detail.css')->onlyOnDetail())
         ->addJsFile(Asset::new('build/admin.js')->onlyWhenCreating())

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,5 +12,8 @@ parameters:
         - vendor/bin/.phpunit/phpunit/vendor/autoload.php
     ignoreErrors:
         - '#Cannot use array destructuring on callable.#'
+        - '#Property EasyCorp\\Bundle\\EasyAdminBundle\\Twig\\EasyAdminTwigExtension\:\:\$importMapRenderer has unknown class Symfony\\Component\\AssetMapper\\ImportMap\\ImportMapRenderer as its type\.#'
+        - '#Parameter \$importMapRenderer of method EasyCorp\\Bundle\\EasyAdminBundle\\Twig\\EasyAdminTwigExtension\:\:__construct\(\) has invalid type Symfony\\Component\\AssetMapper\\ImportMap\\ImportMapRenderer\.#'
+        - '#Call to method render\(\) on an unknown class Symfony\\Component\\AssetMapper\\ImportMap\\ImportMapRenderer\.#'
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false

--- a/src/Config/Asset.php
+++ b/src/Config/Asset.php
@@ -4,7 +4,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
 use EasyCorp\Bundle\EasyAdminBundle\Asset\AssetPackage;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto;
-use function Symfony\Component\String\u;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -24,15 +23,15 @@ final class Asset
     }
 
     /**
-     * @param string $value The 'path' when adding CSS or JS files and the 'entryName' when adding Webpack Encore entries
+     * The argument is the 'path' when adding CSS or JS files and the 'entryName' when
+     * adding Webpack Encore or ImportMap entries:
+     *
+     *   Asset::new('build/admin.css')
+     *   Asset::new('some/path/admin.js')
+     *   Asset::new('admin-app') (Webpack Encore or AssetMapper entry)
      */
     public static function new(string $value): self
     {
-        $isWebpackEncoreEntry = !u($value)->endsWith('.css') && !u($value)->endsWith('.js');
-        if ($isWebpackEncoreEntry && !class_exists('Symfony\\WebpackEncoreBundle\\WebpackEncoreBundle')) {
-            throw new \RuntimeException(sprintf('You are trying to add a Webpack Encore entry called "%s" but WebpackEncoreBundle is not installed in your project. Try running "composer require symfony/webpack-encore-bundle"', $value));
-        }
-
         $dto = new AssetDto($value);
 
         return new self($dto);

--- a/src/Config/Assets.php
+++ b/src/Config/Assets.php
@@ -39,6 +39,25 @@ final class Assets
         return $this;
     }
 
+    public function addAssetMapperEntry(Asset|string ...$entryNameOrAsset): self
+    {
+        if (!class_exists('Symfony\\Component\\AssetMapper\\AssetMapper')) {
+            $names = array_map(static fn (Asset|string $nameOrAsset) => \is_string($nameOrAsset) ? '"'.$nameOrAsset.'"' : '"'.$nameOrAsset->getAsDto()->getValue().'"', $entryNameOrAsset);
+
+            throw new \RuntimeException(sprintf('You are trying to add '.(1 === \count($names) ? 'an AssetMapper entry called %s' : ' some AssetMapper entries (%s)').' but the AssetMapper component is not installed in your project. Try running "composer require symfony/asset-mapper"', implode(', ', $names)));
+        }
+
+        foreach ($entryNameOrAsset as $nameOrAsset) {
+            if (\is_string($nameOrAsset)) {
+                $this->dto->addAssetMapperAsset(new AssetDto($nameOrAsset));
+            } else {
+                $this->dto->addAssetMapperAsset($nameOrAsset->getAsDto());
+            }
+        }
+
+        return $this;
+    }
+
     public function addCssFile(Asset|string $pathOrAsset): self
     {
         if (\is_string($pathOrAsset)) {

--- a/src/Dto/AssetsDto.php
+++ b/src/Dto/AssetsDto.php
@@ -12,6 +12,8 @@ final class AssetsDto
     /** @var AssetDto[] */
     private array $webpackEncoreAssets = [];
     /** @var AssetDto[] */
+    private array $assetMapperAssets = [];
+    /** @var AssetDto[] */
     private array $cssAssets = [];
     /** @var AssetDto[] */
     private array $jsAssets = [];
@@ -31,6 +33,15 @@ final class AssetsDto
         }
 
         $this->webpackEncoreAssets[$entryName] = $assetDto;
+    }
+
+    public function addAssetMapperAsset(AssetDto $assetDto): void
+    {
+        if (\array_key_exists($entrypointName = $assetDto->getValue(), $this->assetMapperAssets)) {
+            throw new \InvalidArgumentException(sprintf('The "%s" AssetMapper entry has been added more than once via the addAssetMapperAsset() method, but each entry can only be added once (to not overwrite its configuration).', $entrypointName));
+        }
+
+        $this->assetMapperAssets[$entrypointName] = $assetDto;
     }
 
     public function addCssAsset(AssetDto $assetDto): void
@@ -80,6 +91,14 @@ final class AssetsDto
     public function getWebpackEncoreAssets(): array
     {
         return $this->webpackEncoreAssets;
+    }
+
+    /**
+     * @return AssetDto[]
+     */
+    public function getAssetMapperAssets(): array
+    {
+        return $this->assetMapperAssets;
     }
 
     /**

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -132,6 +132,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, service('service_locator_'.AdminUrlGenerator::class))
             ->arg(1, service(AdminContextProvider::class))
             ->arg(2, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->arg(3, new Reference('asset_mapper.importmap.renderer', ContainerInterface::NULL_ON_INVALID_REFERENCE))
             ->tag('twig.extension')
 
         ->set(EaCrudFormTypeExtension::class)

--- a/src/Resources/views/includes/_importmap.html.twig
+++ b/src/Resources/views/includes/_importmap.html.twig
@@ -1,0 +1,2 @@
+{# @var assets \EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto[] #}
+{{ ea_importmap(assets|map(asset => asset.value)) }}

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -30,6 +30,10 @@
 
     {% block head_javascript %}
         <script src="{{ asset('app.js', ea.assets.defaultAssetPackageName) }}"></script>
+
+        {% block importmap %}
+            {{ include('@EasyAdmin/includes/_importmap.html.twig', { assets: ea.assets.assetMapperAssets ?? [] }, with_context = false) }}
+        {% endblock %}
     {% endblock head_javascript %}
 
     {% block configured_javascripts %}


### PR DESCRIPTION
We allow to add all kinds of assets and Webpack Encore entries in backends ... so we were missing the new AssetMapper entries.

This PR allows to do this:

```php
return $assets
    // imports the given entrypoint defined in the importmap.php file of AssetMapper
    // it's equivalent to adding this inside the <head> element:
    // {{ importmap('admin') }}
    ->addAssetMapperEntry('admin')
    
    // you can also import multiple entries
    ->addAssetMapperEntry('admin', 'app')
;
```

I had to duplicate the `importmap` Twig function from Symfony because I can't make it work otherwise. See https://github.com/twigphp/Twig/issues/3655#issuecomment-1913106152