### PR TITLE
Don't translate form values that are already translated

### DIFF
--- a/src/Field/Configurator/CurrencyConfigurator.php
+++ b/src/Field/Configurator/CurrencyConfigurator.php
@@ -23,6 +23,8 @@ final class CurrencyConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $field->setFormTypeOptionIfNotSet('attr.data-ea-widget', 'ea-autocomplete');
+        // currency names passed to the form are already translated, so don't translate them again in the template
+        $field->setFormTypeOptionIfNotSet('choice_translation_domain', false);
 
         if (null === $currencyCode = $field->getValue()) {
             return;

--- a/src/Field/Configurator/LanguageConfigurator.php
+++ b/src/Field/Configurator/LanguageConfigurator.php
@@ -35,6 +35,8 @@ final class LanguageConfigurator implements FieldConfiguratorInterface
                 $field->getCustomOption(LanguageField::OPTION_LANGUAGE_CODES_TO_REMOVE))
             );
             $field->setFormTypeOption('choice_loader', null);
+            // language names passed to the form are already translated, so don't translate them again in the template
+            $field->setFormTypeOptionIfNotSet('choice_translation_domain', false);
         }
 
         if (null === $languageCode = $field->getValue()) {

--- a/src/Field/Configurator/LocaleConfigurator.php
+++ b/src/Field/Configurator/LocaleConfigurator.php
@@ -28,6 +28,8 @@ final class LocaleConfigurator implements FieldConfiguratorInterface
         if (\in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_EDIT, Crud::PAGE_NEW], true)) {
             $field->setFormTypeOption('choices', $this->generateFormTypeChoices($field->getCustomOption(LocaleField::OPTION_LOCALE_CODES_TO_KEEP), $field->getCustomOption(LocaleField::OPTION_LOCALE_CODES_TO_REMOVE)));
             $field->setFormTypeOption('choice_loader', null);
+            // locale names passed to the form are already translated, so don't translate them again in the template
+            $field->setFormTypeOptionIfNotSet('choice_translation_domain', false);
         }
 
         if (null === $localeCode = $field->getValue()) {

--- a/src/Field/Configurator/TimezoneConfigurator.php
+++ b/src/Field/Configurator/TimezoneConfigurator.php
@@ -22,5 +22,7 @@ final class TimezoneConfigurator implements FieldConfiguratorInterface
     {
         $field->setFormTypeOptionIfNotSet('attr.data-ea-widget', 'ea-autocomplete');
         $field->setFormTypeOptionIfNotSet('intl', true);
+        // timezone names passed to the form are already translated, so don't translate them again in the template
+        $field->setFormTypeOptionIfNotSet('choice_translation_domain', false);
     }
 }


### PR DESCRIPTION
In #6121 we fixed this problem for countries ... but other form types also pass their values translated to the template, so let's not translate any of them.