### PR TITLE
[FEATURE] Support use of Symfony Expressions for permissions

### DIFF
--- a/.ddev/example/Controller/Admin/DashboardController.php
+++ b/.ddev/example/Controller/Admin/DashboardController.php
@@ -7,6 +7,7 @@ use App\Entity\Category;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -30,6 +31,6 @@ class DashboardController extends AbstractDashboardController
 
         yield MenuItem::section('Entities');
         yield MenuItem::linkToCrud('Articles', 'fas fa-list', BlogArticle::class);
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tag', Category::class);
+        yield MenuItem::linkToCrud('Categories', 'fas fa-tag', Category::class)->setPermission(new Expression('true'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "symfony/css-selector": "^5.4|^6.0|^7.0",
         "symfony/debug-bundle": "^5.4|^6.0|^7.0",
         "symfony/dom-crawler": "^5.4|^6.0|^7.0",
+        "symfony/expression-language": "^5.4|^6.0|^7.0",
         "symfony/phpunit-bridge": "^5.4|^6.0|^7.0"
     },
     "config": {

--- a/doc/security.rst
+++ b/doc/security.rst
@@ -176,6 +176,39 @@ permissions to see some items:
 .. image:: images/easyadmin-list-hidden-results.png
    :alt: Index page with some results hidden because user does not have enough permissions
 
+.. _security-expressions:
+
+Using expressions
+-----------------
+
+EasyAdmin supports for all permissions the usage of Symfony Expressions.
+To use them you need to require the expression language component to your project, using Composer:
+
+.. code-block:: terminal
+
+    $ composer require symfony/expression-language
+
+Now, when defining permissions, instead of a role name string (like ``ROLE_ADMIN``) only,
+you can pass an Symfony Expression object, like this:
+
+.. code-block:: php
+
+    use Symfony\Component\ExpressionLanguage\Expression;
+
+    MenuItem::linkToCrud('Restricted menu-item', null, Example::class)
+        ->setPermission(new Expression('"ROLE_DEVELOPER" in role_names and "ROLE_EXTERNAL" not in role_names'));
+
+This allows you to define much more detailed permissions, based on several role names, user attributes or the given subject.
+
+Available variables in expression are:
+
+* ``user`` - the current user object
+* ``role_names`` - all roles of current user as array
+* ``subject`` or ``object`` - the current subject being checked
+* ``token`` - authentication token
+* ``trust_resolver`` - authentication trust resolver
+* ``auth_checker`` - instance of auth_checker
+
 Custom Security Voters
 ----------------------
 

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionConfigDto;
+use Symfony\Component\ExpressionLanguage\Expression;
 use function Symfony\Component\Translation\t;
 
 /**
@@ -100,7 +101,7 @@ final class Actions
         return $this;
     }
 
-    public function setPermission(string $actionName, string $permission): self
+    public function setPermission(string $actionName, string|Expression $permission): self
     {
         $this->dto->setActionPermission($actionName, $permission);
 

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterConfigDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\PaginatorDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
@@ -390,7 +391,7 @@ class Crud
         return $this;
     }
 
-    public function setEntityPermission(string $permission): self
+    public function setEntityPermission(string|Expression $permission): self
     {
         $this->dto->setEntityPermission($permission);
 

--- a/src/Config/Menu/MenuItemTrait.php
+++ b/src/Config/Menu/MenuItemTrait.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -25,7 +26,7 @@ trait MenuItemTrait
         return $this;
     }
 
-    public function setPermission(string $permission): self
+    public function setPermission(string|Expression $permission): self
     {
         $this->dto->setPermission($permission);
 

--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
 use EasyCorp\Bundle\EasyAdminBundle\Collection\ActionCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -22,7 +23,7 @@ final class ActionConfigDto
     ];
     /** @var string[] */
     private array $disabledActions = [];
-    /** @var string[] */
+    /** @var string[]|Expression[] */
     private array $actionPermissions = [];
 
     public function __construct()
@@ -43,7 +44,7 @@ final class ActionConfigDto
         $this->pageName = $pageName;
     }
 
-    public function setActionPermission(string $actionName, string $permission): void
+    public function setActionPermission(string $actionName, string|Expression $permission): void
     {
         $this->actionPermissions[$actionName] = $permission;
     }

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -7,6 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SearchMode;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableMessageBuilder;
+use Symfony\Component\ExpressionLanguage\Expression;
 use function Symfony\Component\Translation\t;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
@@ -60,7 +61,7 @@ final class CrudDto
     private array $formThemes = ['@EasyAdmin/crud/form_theme.html.twig'];
     private KeyValueStore $newFormOptions;
     private KeyValueStore $editFormOptions;
-    private ?string $entityPermission = null;
+    private string|Expression|null $entityPermission = null;
     private ?string $contentWidth = null;
     private ?string $sidebarWidth = null;
     private bool $hideNullValues = false;
@@ -437,12 +438,12 @@ final class CrudDto
         $this->editFormOptions = $formOptions;
     }
 
-    public function getEntityPermission(): ?string
+    public function getEntityPermission(): string|Expression|null
     {
         return $this->entityPermission;
     }
 
-    public function setEntityPermission(string $entityPermission): void
+    public function setEntityPermission(string|Expression $entityPermission): void
     {
         $this->entityPermission = $entityPermission;
     }

--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -7,6 +7,7 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\ActionCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -21,14 +22,14 @@ final class EntityDto
     private $instance;
     private $primaryKeyName;
     private mixed $primaryKeyValue = null;
-    private ?string $permission;
+    private string|Expression|null $permission;
     private ?FieldCollection $fields = null;
     private ?ActionCollection $actions = null;
 
     /**
      * @param ClassMetadata&ClassMetadataInfo $entityMetadata
      */
-    public function __construct(string $entityFqcn, ClassMetadata $entityMetadata, ?string $entityPermission = null, /* ?object */ $entityInstance = null)
+    public function __construct(string $entityFqcn, ClassMetadata $entityMetadata, string|Expression|null $entityPermission = null, /* ?object */ $entityInstance = null)
     {
         if (!\is_object($entityInstance)
             && null !== $entityInstance) {
@@ -112,7 +113,7 @@ final class EntityDto
         return (string) $this->getPrimaryKeyValue();
     }
 
-    public function getPermission(): ?string
+    public function getPermission(): string|Expression|null
     {
         return $this->permission;
     }

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -16,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormTabPaneCloseType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormTabPaneGroupCloseType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormTabPaneGroupOpenType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormTabPaneOpenType;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
@@ -34,7 +35,7 @@ final class FieldDto
     private KeyValueStore $formTypeOptions;
     private ?bool $sortable = null;
     private ?bool $virtual = null;
-    private ?string $permission = null;
+    private string|Expression|null $permission = null;
     private ?string $textAlign = null;
     private $help;
     private string $cssClass = '';
@@ -296,12 +297,12 @@ final class FieldDto
         $this->textAlign = $textAlign;
     }
 
-    public function getPermission(): ?string
+    public function getPermission(): string|Expression|null
     {
         return $this->permission;
     }
 
-    public function setPermission(string $permission): void
+    public function setPermission(string|Expression $permission): void
     {
         $this->permission = $permission;
     }

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
@@ -24,7 +25,7 @@ final class MenuItemDto
     private TranslatableInterface|string|null $label = null;
     private ?string $icon = null;
     private string $cssClass = '';
-    private ?string $permission = null;
+    private string|Expression|null $permission = null;
     private ?string $routeName = null;
     private ?array $routeParameters = null;
     private ?string $linkUrl = null;
@@ -159,12 +160,12 @@ final class MenuItemDto
         $this->routeParameters = $routeParameters;
     }
 
-    public function getPermission(): ?string
+    public function getPermission(): string|Expression|null
     {
         return $this->permission;
     }
 
-    public function setPermission(?string $permission): void
+    public function setPermission(string|Expression|null $permission): void
     {
         $this->permission = $permission;
     }

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -16,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntityBuiltEvent;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\EntityNotFoundException;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -66,7 +67,7 @@ final class EntityFactory
         return $this->actionFactory->processGlobalActions($actionConfigDto);
     }
 
-    public function create(string $entityFqcn, $entityId = null, ?string $entityPermission = null): EntityDto
+    public function create(string $entityFqcn, $entityId = null, string|Expression|null $entityPermission = null): EntityDto
     {
         return $this->doCreate($entityFqcn, $entityId, $entityPermission);
     }
@@ -109,7 +110,7 @@ final class EntityFactory
         return $entityMetadata;
     }
 
-    private function doCreate(?string $entityFqcn = null, $entityId = null, ?string $entityPermission = null, $entityInstance = null): EntityDto
+    private function doCreate(?string $entityFqcn = null, $entityId = null, string|Expression|null $entityPermission = null, $entityInstance = null): EntityDto
     {
         if (null === $entityInstance && null !== $entityFqcn) {
             $entityInstance = null === $entityId ? null : $this->getEntityInstance($entityFqcn, $entityId);

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
@@ -165,7 +166,7 @@ trait FieldTrait
         return $this;
     }
 
-    public function setPermission(string $permission): self
+    public function setPermission(string|Expression $permission): self
     {
         $this->dto->setPermission($permission);
 


### PR DESCRIPTION
Relates: #4864

To check if it works, you can add a simple expression like that:

```
->setPermission(new Expression('true'))
```
Without this patch this will deny access to defined resource (because the string "true" is no valid role name).

I've also added a new chapter in security.rst, with more details about possible usage.
