### PR TITLE
Update NumericFilter.php for fix STORED_AS_CENTS if not stored as cents

### DIFF
--- a/src/Filter/NumericFilter.php
+++ b/src/Filter/NumericFilter.php
@@ -40,7 +40,7 @@ final class NumericFilter implements FilterInterface
         $value = $filterDataDto->getValue();
         $value2 = $filterDataDto->getValue2();
 
-        if (null !== $fieldDto && null !== $fieldDto->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS)) {
+        if (null !== $fieldDto && true === $fieldDto->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS)) {
             $divisor = $fieldDto->getFormTypeOption('divisor') ?? MoneyConfigurator::DEFAULT_DIVISOR;
             $value *= $divisor;
             $value2 *= $divisor;


### PR DESCRIPTION
No need to multiply MoneyField if OPTION_STORED_AS_CENTS  is false. Previous comparsion was just checking if it exists, but multiplied $value even if money is in decimal, but not in coins

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
