### PR TITLE
fix: incorrect display of html attributes on detail page

### DIFF
--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -159,7 +159,7 @@
     {% set tab_id_option_name = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Field\\FormField::OPTION_TAB_ID') %}
     {% set tab_is_active_option_name = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Field\\FormField::OPTION_TAB_IS_ACTIVE') %}
 
-    <div id="{{ field.getCustomOption(tab_id_option_name) }}" class="tab-pane {% if field.getCustomOption(tab_is_active_option_name) %}active{% endif %} {{ field.cssClass }}" {% for key, value in field.getFormTypeOption('attr') %}{{ key }}={{ value|e('html_attr') }}{% endfor %}>
+    <div id="{{ field.getCustomOption(tab_id_option_name) }}" class="tab-pane {% if field.getCustomOption(tab_is_active_option_name) %}active{% endif %} {{ field.cssClass }}" {% for key, value in field.getFormTypeOption('attr') %}{{ key }}="{{ value|e('html_attr') }}"{% endfor %}>
         {% if field.help %}
             <div class="content-header-help tab-help">
                 {{ field.help|trans(domain = ea.i18n.translationDomain)|raw }}


### PR DESCRIPTION
The following code :
    `->setHtmlAttributes(['data-foo' => 'bar', 'autofocus' => 'autofocus'])`

Display this in the HTML:
`data-foo="barautofocus=autofocus"`

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
