### PR TITLE
Use form.children|length to set data-num-items in collection_row block

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -136,7 +136,7 @@
         'data-entry-is-complex': form.vars.ea_vars.field and form.vars.ea_vars.field.customOptions.get('entryIsComplex') ? 'true' : 'false',
         'data-allow-add': allow_add ? 'true' : 'false',
         'data-allow-delete': allow_delete ? 'true' : 'false',
-        'data-num-items': form.children is empty ? 0 : max(form.children|keys),
+        'data-num-items': form.children|length,
         'data-form-type-name-placeholder': prototype is defined ? prototype.vars.name : '',
     }) %}
 


### PR DESCRIPTION
[Relevant code](https://github.com/EasyCorp/EasyAdminBundle/blob/4.x/src/Resources/views/crud/form_theme.html.twig#L139):
```
{% set row_attr = row_attr|merge({
    ...
    'data-allow-add': allow_add ? 'true' : 'false',
    'data-allow-delete': allow_delete ? 'true' : 'false',
    'data-num-items': form.children is empty ? 0 : max(form.children|keys),    <<< THIS LINE
    ...
}) %}
```

Consider `form.children` equals to:
![image](https://github.com/EasyCorp/EasyAdminBundle/assets/30590523/126e2c5d-c563-4f3b-a65c-a8953f5c19ec)

Current implementation sets attribute `data-num-items` to 0, beacuse thats max key, but 1 is correct.