### PR TITLE
Fix ajax editing of fields with invalid permission

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -59,6 +59,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use function Symfony\Component\String\u;
 
@@ -555,6 +556,11 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     protected function ajaxEdit(EntityDto $entityDto, ?string $propertyName, bool $newValue): AfterCrudActionEvent
     {
+        $field = $entityDto->getFields()->getByProperty($propertyName);
+        if (null === $field || true === $field->getFormTypeOption('disabled')) {
+            throw new AccessDeniedException(sprintf('The field "%s" is not allowed to be modified.', $propertyName));
+        }
+
         $this->container->get(EntityUpdater::class)->updateProperty($entityDto, $propertyName, $newValue);
 
         $event = new BeforeEntityUpdatedEvent($entityDto->getInstance());

--- a/tests/TestApplication/src/Controller/CategoryCrudController.php
+++ b/tests/TestApplication/src/Controller/CategoryCrudController.php
@@ -40,6 +40,8 @@ class CategoryCrudController extends AbstractCrudController
             TextField::new('name'),
             TextField::new('slug'),
             BooleanField::new('active'),
+            BooleanField::new('activeWithNoPermission')->setPermission('ROLE_FOO'),
+            BooleanField::new('activeDisabled')->setDisabled(),
         ];
     }
 

--- a/tests/TestApplication/src/Entity/Category.php
+++ b/tests/TestApplication/src/Entity/Category.php
@@ -28,6 +28,9 @@ class Category
     #[ORM\Column(type: 'boolean')]
     private bool $active = false;
 
+    #[ORM\Column(type: 'boolean')]
+    private bool $activeDisabled = false;
+
     public function __construct()
     {
         $this->blogPosts = new ArrayCollection();
@@ -97,6 +100,18 @@ class Category
     public function setActive(bool $active): self
     {
         $this->active = $active;
+
+        return $this;
+    }
+
+    public function isActiveDisabled(): bool
+    {
+        return $this->activeDisabled;
+    }
+
+    public function setActiveDisabled(bool $activeDisabled): self
+    {
+        $this->activeDisabled = $activeDisabled;
 
         return $this;
     }


### PR DESCRIPTION
When editing a boolean field using ajax from index page it is not checked if it's valid.

The field is now checked in the FieldCollection and an `AccessDeniedException` is thrown if field is not found.

I did this PR with help from @psihius 

LE : I also added a check to disallow editing if the field is disabled.