### PR TITLE
Add ability to clone fields

### DIFF
--- a/src/Contracts/Field/FieldInterface.php
+++ b/src/Contracts/Field/FieldInterface.php
@@ -12,4 +12,6 @@ interface FieldInterface
     public static function new(string $propertyName, ?string /* TranslatableInterface|string|false|null */ $label = null);
 
     public function getAsDto(): FieldDto;
+
+    public function __clone(): void;
 }

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -23,6 +23,11 @@ trait FieldTrait
         $this->dto = new FieldDto();
     }
 
+    public function __clone(): void
+    {
+        $this->dto = clone $this->dto;
+    }
+
     public function setFieldFqcn(string $fieldFqcn): self
     {
         $this->dto->setFieldFqcn($fieldFqcn);


### PR DESCRIPTION
`FieldDto` class already has a fully implemented `__clone` method, so this seems like an obvious addition that makes certain things just better :)

Allows to do stuff like this
```
$regularCheckInField = TimeField::new('fieldName')
    ->setLabel(t('Field Label'))
    ->setRequired(true)
    ->setFormat('HH:mm');

return [
    ...,
    (clone $regularCheckInField)->onlyOnIndex(),
    $regularCheckInField
        ->onlyOnForms()
        ->setCssClass('col-md-10 col-xxl-10')
        ->setColumns(2),
    ...,
];
```