### PR TITLE
Passing EntityDto to AssociationField::OPTION_QUERY_BUILDER_CALLABLE

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -157,12 +157,13 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl);
         } else {
-            $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($field) {
+            // Passing the entityDto to the callback - Sometimes it can be usefull to filter data depending on the entity data
+            $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($field, $entityDto) {
                 // TODO: should this use `createIndexQueryBuilder` instead, so we get the default ordering etc.?
                 // it would then be identical to the one used in autocomplete action, but it is a bit complex getting it in here
                 $queryBuilder = $repository->createQueryBuilder('entity');
                 if (null !== $queryBuilderCallable = $field->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE)) {
-                    $queryBuilderCallable($queryBuilder);
+                    $queryBuilderCallable($queryBuilder, $entityDto);
                 }
 
                 return $queryBuilder;


### PR DESCRIPTION
If I want to do something like that, I can't :
```php
return [
            TextField::new('candidate', new TranslatableMessage('admin.candidate.label'))
                ->setDisabled(),
            TextField::new('referential', new TranslatableMessage('admin.referential.label'))
                ->setDisabled(),
            DateTimeField::new('createdAt', new TranslatableMessage('admin.experience_recognition.created_at'))
                ->onlyOnIndex(),
            EnumField::new('status', new TranslatableMessage('admin.experience_recognition.status'))
                ->setBadgeRender(new ERStatusBadgeRender('enum.er_status'))
                ->onlyOnIndex(),
            TextField::new('establishment', new TranslatableMessage('admin.establishment.label'))
                ->setDisabled(),
            AssociationField::new('accompanist', new TranslatableMessage('admin.candidate.accompanist'))
                ->onlyOnForms()
                ->setQueryBuilder(
                    fn(QueryBuilder $qb) => $this->userRepository->userWithRoleOfTheEstablishmentQuery(
                        User::ROLE_ACCOMPANIST,
                        $establishment
                    )
                ),
        ];
```
I would like to filter data depending on the linked establishment, with my PR we will be able to do that : 
```php
            AssociationField::new('accompanist', new TranslatableMessage('admin.candidate.accompanist'))
                ->onlyOnForms()
                ->setQueryBuilder(
                    fn(QueryBuilder $qb, EntityDto $entityDto) => $this->userRepository->userWithRoleOfTheEstablishmentQuery(
                        User::ROLE_ACCOMPANIST,
                        $entityDto->getInstance()->getEstablishment(),
                    )
                )
```