### PR TITLE
handling case when referrer in query string is present but empty

### DIFF
--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -65,7 +65,9 @@ final class AdminContext
 
     public function getReferrer(): ?string
     {
-        return $this->request->query->get(EA::REFERRER);
+        $referrer = $this->request->query->get(EA::REFERRER);
+
+        return '' !== $referrer ? $referrer : null;
     }
 
     public function getI18n(): I18nDto

--- a/tests/Context/AdminContextTest.php
+++ b/tests/Context/AdminContextTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Context;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Factory\MenuFactoryInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetsDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\DashboardDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\TemplateRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\InputBag;
+use Symfony\Component\HttpFoundation\Request;
+
+class AdminContextTest extends TestCase
+{
+    public function testGetReferrerEmptyString()
+    {
+        $request = $this->createMock(Request::class);
+        $request->query = new InputBag();
+        $request->query->set(EA::REFERRER, '');
+
+        $target = new AdminContext(
+            $request,
+            null,
+            new I18nDto('en', 'ltr', 'en', []),
+            new CrudControllerRegistry([], [], [], []),
+            new DashboardDto(),
+            $this->createMock(DashboardControllerInterface::class),
+            new AssetsDto(),
+            null,
+            null,
+            null,
+            $this->createMock(MenuFactoryInterface::class),
+            TemplateRegistry::new(),
+        );
+
+        self::assertNull($target->getReferrer());
+    }
+}


### PR DESCRIPTION
fixes #6154 