### PR TITLE
Fix empty collection first item index

### DIFF
--- a/assets/js/field-collection.js
+++ b/assets/js/field-collection.js
@@ -44,10 +44,10 @@ const EaCollectionProperty = {
             const nameRegexp = new RegExp(formTypeNamePlaceholder, 'g');
 
             let newItemHtml = collection.dataset.prototype
-                .replace(labelRegexp, ++numItems)
+                .replace(labelRegexp, numItems)
                 .replace(nameRegexp, numItems);
 
-            collection.dataset.numItems = numItems;
+            collection.dataset.numItems = ++numItems;
             const newItemInsertionSelector = isArrayCollection ? '.ea-form-collection-items' : '.ea-form-collection-items .accordion > .form-widget-compound [data-empty-collection]';
             const collectionItemsWrapper = collection.querySelector(newItemInsertionSelector);
 

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -137,7 +137,7 @@
         'data-entry-is-complex': form.vars.ea_vars.field and form.vars.ea_vars.field.customOptions.get('entryIsComplex') ? 'true' : 'false',
         'data-allow-add': allow_add ? 'true' : 'false',
         'data-allow-delete': allow_delete ? 'true' : 'false',
-        'data-num-items': form.children is empty ? 0 : max(form.children|keys),
+        'data-num-items': form.children is empty ? 0 : max(form.children|keys) + 1,
         'data-form-type-name-placeholder': prototype is defined ? prototype.vars.name : '',
     }) %}
 


### PR DESCRIPTION
Currently `data-num-items` does not denotes actually items count, and in fact it is 0 for empty collection AND collection with 1 item.
Because of  this first item of empty collection obtain index 1
And if there validation violations on new created collection, indexes are shifted by 1
Because field names looks like `Entity[collection][1][field]` for very first item, but validation violation is like `data.collection[0].field`

PS. This PR does not include compiled assets via `npm run build`