### PR TITLE
Added block for meta tags in login minimal template

### DIFF
--- a/src/Resources/views/page/login_minimal.html.twig
+++ b/src/Resources/views/page/login_minimal.html.twig
@@ -4,11 +4,13 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noodp, noimageindex, notranslate, nocache" />
-        <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
-        <meta name="generator" content="EasyAdmin" />
+        {% block head_metas %}
+            <meta charset="utf-8">
+            <meta http-equiv="X-UA-Compatible" content="IE=edge">
+            <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noodp, noimageindex, notranslate, nocache" />
+            <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+            <meta name="generator" content="EasyAdmin" />
+        {% endblock head_metas %}
 
         {% block head_favicon %}
             <link rel="shortcut icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⬛</text></svg>">


### PR DESCRIPTION
Added block for meta tags in `login_minimal.html.twig`. Without this there is no way to add extra meta tags when using this layout.

It is also now consistent with other layouts that do have this block.