### PR TITLE
Replace `ea` variable with a Twig function `ea_context`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,22 @@
 Upgrade between EasyAdmin 4.x versions
 ======================================
 
+EasyAdmin 4.10.0
+----------------
+
+### Twig variables in `ea` in templates
+
+If you use the `ea` variable in your custom templates, you should update it to
+use the new `ea_context` function that is now available in all templates. This new
+function returns the current context of the EasyAdmin application, which is the
+same as the `ea` variable in previous versions.
+
+    // Before
+    {{ ea.i18n.translationDomain }}
+
+    // After
+    {{ ea_context().i18n.translationDomain }}
+
 EasyAdmin 4.8.0
 ---------------
 

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -1,11 +1,11 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% extends ea_context(app.request).templatePath('layout') %}
+{% extends ea_context().templatePath('layout') %}
 
 {% block body_id 'ea-detail-' ~ entity.name ~ '-' ~ entity.primaryKeyValue %}
 {% block body_class 'ea-detail ea-detail-' ~ entity.name %}
 
-{% set ea_field_assets = ea_context(app.request).crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_DETAIL')) %}
+{% set ea_field_assets = ea_context().crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_DETAIL')) %}
 
 {% block configured_head_contents %}
     {{ parent() }}
@@ -35,9 +35,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea_context(app.request).crud.customPageTitle(pageName, entity ? entity.instance : null, ea_context(app.request).i18n.translationParameters) %}
+        {% set custom_page_title = ea_context().crud.customPageTitle(pageName, entity ? entity.instance : null, ea_context().i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea_context(app.request).crud.defaultPageTitle(null, null, ea_context(app.request).i18n.translationParameters)|trans|raw
+            ? ea_context().crud.defaultPageTitle(null, null, ea_context().i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}
@@ -130,7 +130,7 @@
                         {%- if tab.getCustomOption('icon')|default(false) -%}
                             <i class="tab-nav-item-icon fa-fw {{ tab.getCustomOption('icon') }}"></i>
                         {%- endif -%}
-                        {{ tab.label|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
+                        {{ tab.label|trans(domain = ea_context().i18n.translationDomain)|raw }}
 
                         {% set tab_error_count = tab.getCustomOption(tab_error_count_option_name)  %}
                         {%- if tab_error_count > 0 -%}
@@ -162,7 +162,7 @@
     <div id="{{ field.getCustomOption(tab_id_option_name) }}" class="tab-pane {% if field.getCustomOption(tab_is_active_option_name) %}active{% endif %} {{ field.cssClass }}" {% for key, value in field.getFormTypeOption('attr') %}{{ key }}="{{ value|e('html_attr') }}"{% endfor %}>
         {% if field.help %}
             <div class="content-header-help tab-help">
-                {{ field.help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
+                {{ field.help|trans(domain = ea_context().i18n.translationDomain)|raw }}
             </div>
         {% endif %}
 
@@ -197,11 +197,11 @@
             <div class="form-column-title">
                 <div class="form-column-title-content">
                     {% if field_icon %}<i class="form-column-icon fa fa-fw fa-{{ field_icon }}"></i>{% endif %}
-                    {% if field.label %}{{ field.label|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}{% endif %}
+                    {% if field.label %}{{ field.label|trans(domain = ea_context().i18n.translationDomain)|raw }}{% endif %}
                 </div>
 
                 {% if field.help %}
-                    <div class="form-column-help">{{ field.help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}</div>
+                    <div class="form-column-help">{{ field.help|trans(domain = ea_context().i18n.translationDomain)|raw }}</div>
                 {% endif %}
             </div>
         {% endif %}
@@ -278,7 +278,7 @@
                             {%- if tab.customOption('icon') -%}
                                 <i class="fa-fw {{ tab.customOption('icon') }}"></i>
                             {%- endif -%}
-                            {{ tab.label|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
+                            {{ tab.label|trans(domain = ea_context().i18n.translationDomain)|raw }}
                         </a>
                     </li>
                 {% endfor %}
@@ -288,7 +288,7 @@
                     <div id="tab-pane-{{ tab.uniqueId }}" class="tab-pane {% if loop.first %}active{% endif %} {{ tab.cssClass|default('') }}">
                         {% if tab.help|default(false) %}
                             <div class="content-header-help tab-help">
-                                {{ tab.help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
+                                {{ tab.help|trans(domain = ea_context().i18n.translationDomain)|raw }}
                             </div>
                         {% endif %}
                         <div class="row">

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -1,11 +1,11 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% extends ea.templatePath('layout') %}
+{% extends ea_context(app.request).templatePath('layout') %}
 
 {% block body_id 'ea-detail-' ~ entity.name ~ '-' ~ entity.primaryKeyValue %}
 {% block body_class 'ea-detail ea-detail-' ~ entity.name %}
 
-{% set ea_field_assets = ea.crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_DETAIL')) %}
+{% set ea_field_assets = ea_context(app.request).crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_DETAIL')) %}
 
 {% block configured_head_contents %}
     {{ parent() }}
@@ -35,9 +35,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters) %}
+        {% set custom_page_title = ea_context(app.request).crud.customPageTitle(pageName, entity ? entity.instance : null, ea_context(app.request).i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
+            ? ea_context(app.request).crud.defaultPageTitle(null, null, ea_context(app.request).i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}
@@ -130,7 +130,7 @@
                         {%- if tab.getCustomOption('icon')|default(false) -%}
                             <i class="tab-nav-item-icon fa-fw {{ tab.getCustomOption('icon') }}"></i>
                         {%- endif -%}
-                        {{ tab.label|trans(domain = ea.i18n.translationDomain)|raw }}
+                        {{ tab.label|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
 
                         {% set tab_error_count = tab.getCustomOption(tab_error_count_option_name)  %}
                         {%- if tab_error_count > 0 -%}
@@ -162,7 +162,7 @@
     <div id="{{ field.getCustomOption(tab_id_option_name) }}" class="tab-pane {% if field.getCustomOption(tab_is_active_option_name) %}active{% endif %} {{ field.cssClass }}" {% for key, value in field.getFormTypeOption('attr') %}{{ key }}="{{ value|e('html_attr') }}"{% endfor %}>
         {% if field.help %}
             <div class="content-header-help tab-help">
-                {{ field.help|trans(domain = ea.i18n.translationDomain)|raw }}
+                {{ field.help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
             </div>
         {% endif %}
 
@@ -197,11 +197,11 @@
             <div class="form-column-title">
                 <div class="form-column-title-content">
                     {% if field_icon %}<i class="form-column-icon fa fa-fw fa-{{ field_icon }}"></i>{% endif %}
-                    {% if field.label %}{{ field.label|trans(domain = ea.i18n.translationDomain)|raw }}{% endif %}
+                    {% if field.label %}{{ field.label|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}{% endif %}
                 </div>
 
                 {% if field.help %}
-                    <div class="form-column-help">{{ field.help|trans(domain = ea.i18n.translationDomain)|raw }}</div>
+                    <div class="form-column-help">{{ field.help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}</div>
                 {% endif %}
             </div>
         {% endif %}
@@ -278,7 +278,7 @@
                             {%- if tab.customOption('icon') -%}
                                 <i class="fa-fw {{ tab.customOption('icon') }}"></i>
                             {%- endif -%}
-                            {{ tab.label|trans(domain = ea.i18n.translationDomain)|raw }}
+                            {{ tab.label|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
                         </a>
                     </li>
                 {% endfor %}
@@ -288,7 +288,7 @@
                     <div id="tab-pane-{{ tab.uniqueId }}" class="tab-pane {% if loop.first %}active{% endif %} {{ tab.cssClass|default('') }}">
                         {% if tab.help|default(false) %}
                             <div class="content-header-help tab-help">
-                                {{ tab.help|trans(domain = ea.i18n.translationDomain)|raw }}
+                                {{ tab.help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
                             </div>
                         {% endif %}
                         <div class="row">

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -1,18 +1,18 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% extends ea_context(app.request).templatePath('layout') %}
-{% form_theme edit_form with ea_context(app.request).crud.formThemes only %}
+{% extends ea_context().templatePath('layout') %}
+{% form_theme edit_form with ea_context().crud.formThemes only %}
 
-{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
+{% trans_default_domain ea_context().i18n.translationDomain %}
 
 {% block body_id 'ea-edit-' ~ entity.name ~ '-' ~ entity.primaryKeyValue %}
 {% block body_class 'ea-edit ea-edit-' ~ entity.name %}
 
-{% set ea_field_assets = ea_context(app.request).crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_EDIT')) %}
+{% set ea_field_assets = ea_context().crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_EDIT')) %}
 
 {% block head_javascript %}
     {{ parent() }}
-    <script src="{{ asset('form.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
+    <script src="{{ asset('form.js', ea_context().assets.defaultAssetPackageName) }}"></script>
 {% endblock head_javascript %}
 
 {% block configured_head_contents %}
@@ -43,9 +43,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea_context(app.request).crud.customPageTitle(pageName, entity ? entity.instance : null, ea_context(app.request).i18n.translationParameters) %}
+        {% set custom_page_title = ea_context().crud.customPageTitle(pageName, entity ? entity.instance : null, ea_context().i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea_context(app.request).crud.defaultPageTitle(null, null, ea_context(app.request).i18n.translationParameters)|trans|raw
+            ? ea_context().crud.defaultPageTitle(null, null, ea_context().i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -1,18 +1,18 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% extends ea.templatePath('layout') %}
-{% form_theme edit_form with ea.crud.formThemes only %}
+{% extends ea_context(app.request).templatePath('layout') %}
+{% form_theme edit_form with ea_context(app.request).crud.formThemes only %}
 
-{% trans_default_domain ea.i18n.translationDomain %}
+{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
 
 {% block body_id 'ea-edit-' ~ entity.name ~ '-' ~ entity.primaryKeyValue %}
 {% block body_class 'ea-edit ea-edit-' ~ entity.name %}
 
-{% set ea_field_assets = ea.crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_EDIT')) %}
+{% set ea_field_assets = ea_context(app.request).crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_EDIT')) %}
 
 {% block head_javascript %}
     {{ parent() }}
-    <script src="{{ asset('form.js', ea.assets.defaultAssetPackageName) }}"></script>
+    <script src="{{ asset('form.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
 {% endblock head_javascript %}
 
 {% block configured_head_contents %}
@@ -43,9 +43,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters) %}
+        {% set custom_page_title = ea_context(app.request).crud.customPageTitle(pageName, entity ? entity.instance : null, ea_context(app.request).i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
+            ? ea_context(app.request).crud.defaultPageTitle(null, null, ea_context(app.request).i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}

--- a/src/Resources/views/crud/field/array.html.twig
+++ b/src/Resources/views/crud/field/array.html.twig
@@ -1,7 +1,7 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% if ea.crud.currentAction == 'detail' %}
+{% if ea_context(app.request).crud.currentAction == 'detail' %}
     <ul>
         {% for item in field.value %}
             <li>{{ item }}</li>

--- a/src/Resources/views/crud/field/array.html.twig
+++ b/src/Resources/views/crud/field/array.html.twig
@@ -1,7 +1,7 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% if ea_context(app.request).crud.currentAction == 'detail' %}
+{% if ea_context().crud.currentAction == 'detail' %}
     <ul>
         {% for item in field.value %}
             <li>{{ item }}</li>

--- a/src/Resources/views/crud/field/boolean.html.twig
+++ b/src/Resources/views/crud/field/boolean.html.twig
@@ -3,8 +3,8 @@
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% trans_default_domain 'EasyAdminBundle' %}
 
-{% if ea.crud.currentAction == 'detail' or not field.customOptions.get('renderAsSwitch') %}
-    {% set badge_is_hidden = ea.crud.currentAction == 'index'
+{% if ea_context(app.request).crud.currentAction == 'detail' or not field.customOptions.get('renderAsSwitch') %}
+    {% set badge_is_hidden = ea_context(app.request).crud.currentAction == 'index'
         and (
             (field.value == true and field.customOptions.get('hideValueWhenTrue') == true)
             or

--- a/src/Resources/views/crud/field/boolean.html.twig
+++ b/src/Resources/views/crud/field/boolean.html.twig
@@ -3,8 +3,8 @@
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% trans_default_domain 'EasyAdminBundle' %}
 
-{% if ea_context(app.request).crud.currentAction == 'detail' or not field.customOptions.get('renderAsSwitch') %}
-    {% set badge_is_hidden = ea_context(app.request).crud.currentAction == 'index'
+{% if ea_context().crud.currentAction == 'detail' or not field.customOptions.get('renderAsSwitch') %}
+    {% set badge_is_hidden = ea_context().crud.currentAction == 'index'
         and (
             (field.value == true and field.customOptions.get('hideValueWhenTrue') == true)
             or

--- a/src/Resources/views/crud/field/code_editor.html.twig
+++ b/src/Resources/views/crud/field/code_editor.html.twig
@@ -1,7 +1,7 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% if ea_context(app.request).crud.currentAction == 'detail' %}
+{% if ea_context().crud.currentAction == 'detail' %}
     {{ _self.render_code_editor(field) }}
 {% else %}
     {% set html_id = 'ea-code-editor-' ~ field.uniqueId %}

--- a/src/Resources/views/crud/field/code_editor.html.twig
+++ b/src/Resources/views/crud/field/code_editor.html.twig
@@ -1,7 +1,7 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% if ea.crud.currentAction == 'detail' %}
+{% if ea_context(app.request).crud.currentAction == 'detail' %}
     {{ _self.render_code_editor(field) }}
 {% else %}
     {% set html_id = 'ea-code-editor-' ~ field.uniqueId %}

--- a/src/Resources/views/crud/field/country.html.twig
+++ b/src/Resources/views/crud/field/country.html.twig
@@ -10,7 +10,7 @@
     {% for flag_code, country_name in field.formattedValue %}
         {% if flag_code is not null %}
             {# the explicit height is needed to avoid issues with SVG images in Safari browser #}
-            <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
+            <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea_context(app.request).assets.defaultAssetPackageName) }}">
         {% endif %}
     {% endfor %}
 {% elseif show_name and not show_flag  %}
@@ -21,7 +21,7 @@
             {%- if show_flag -%}
                 {%- if flag_code is not null -%}
                     {# the explicit height is needed to avoid issues with SVG images in Safari browser #}
-                    <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea.assets.defaultAssetPackageName) }}">
+                    <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea_context(app.request).assets.defaultAssetPackageName) }}">
                 {%- endif -%}
             {%- endif -%}
 

--- a/src/Resources/views/crud/field/country.html.twig
+++ b/src/Resources/views/crud/field/country.html.twig
@@ -10,7 +10,7 @@
     {% for flag_code, country_name in field.formattedValue %}
         {% if flag_code is not null %}
             {# the explicit height is needed to avoid issues with SVG images in Safari browser #}
-            <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea_context(app.request).assets.defaultAssetPackageName) }}">
+            <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea_context().assets.defaultAssetPackageName) }}">
         {% endif %}
     {% endfor %}
 {% elseif show_name and not show_flag  %}
@@ -21,7 +21,7 @@
             {%- if show_flag -%}
                 {%- if flag_code is not null -%}
                     {# the explicit height is needed to avoid issues with SVG images in Safari browser #}
-                    <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea_context(app.request).assets.defaultAssetPackageName) }}">
+                    <img class="country-flag" height="17" alt="{{ country_name }}" title="{{ country_name }}" src="{{ asset('images/flags/' ~ flag_code ~ '.svg', ea_context().assets.defaultAssetPackageName) }}">
                 {%- endif -%}
             {%- endif -%}
 

--- a/src/Resources/views/crud/field/text.html.twig
+++ b/src/Resources/views/crud/field/text.html.twig
@@ -1,7 +1,7 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% if ea_context(app.request).crud.currentAction == 'detail' %}
+{% if ea_context().crud.currentAction == 'detail' %}
     <span title="{{ field.value }}">{{ field.formattedValue|raw|nl2br }}</span>
 {% else %}
     <span title="{{ field.value }}">{{ field.formattedValue|raw }}</span>

--- a/src/Resources/views/crud/field/text.html.twig
+++ b/src/Resources/views/crud/field/text.html.twig
@@ -1,7 +1,7 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% if ea.crud.currentAction == 'detail' %}
+{% if ea_context(app.request).crud.currentAction == 'detail' %}
     <span title="{{ field.value }}">{{ field.formattedValue|raw|nl2br }}</span>
 {% else %}
     <span title="{{ field.value }}">{{ field.formattedValue|raw }}</span>

--- a/src/Resources/views/crud/field/text_editor.html.twig
+++ b/src/Resources/views/crud/field/text_editor.html.twig
@@ -1,7 +1,7 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% if ea.crud.currentAction == 'detail' %}
+{% if ea_context(app.request).crud.currentAction == 'detail' %}
     {{ field.formattedValue|nl2br }}
 {% else %}
     {% set html_id = 'ea-text-editor-' ~ field.uniqueId %}

--- a/src/Resources/views/crud/field/text_editor.html.twig
+++ b/src/Resources/views/crud/field/text_editor.html.twig
@@ -1,7 +1,7 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% if ea_context(app.request).crud.currentAction == 'detail' %}
+{% if ea_context().crud.currentAction == 'detail' %}
     {{ field.formattedValue|nl2br }}
 {% else %}
     {% set html_id = 'ea-text-editor-' ~ field.uniqueId %}

--- a/src/Resources/views/crud/field/textarea.html.twig
+++ b/src/Resources/views/crud/field/textarea.html.twig
@@ -2,7 +2,7 @@
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% set render_as_html = field.customOptions.get('renderAsHtml') %}
-{% if ea_context(app.request).crud.currentAction == 'detail' %}
+{% if ea_context().crud.currentAction == 'detail' %}
     <span title="{{ field.value }}">
         {{ render_as_html ? field.formattedValue|raw|nl2br : field.formattedValue|nl2br }}
     </span>

--- a/src/Resources/views/crud/field/textarea.html.twig
+++ b/src/Resources/views/crud/field/textarea.html.twig
@@ -2,7 +2,7 @@
 {# @var field \EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {% set render_as_html = field.customOptions.get('renderAsHtml') %}
-{% if ea.crud.currentAction == 'detail' %}
+{% if ea_context(app.request).crud.currentAction == 'detail' %}
     <span title="{{ field.value }}">
         {{ render_as_html ? field.formattedValue|raw|nl2br : field.formattedValue|nl2br }}
     </span>

--- a/src/Resources/views/crud/field/url.html.twig
+++ b/src/Resources/views/crud/field/url.html.twig
@@ -3,7 +3,7 @@
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {# NOTE: the rel="noopener" attr is needed to avoid performance and security issues
   (see https://web.dev/external-anchors-use-rel-noopener/) #}
-{% if ea_context(app.request).crud.currentAction == 'detail' %}
+{% if ea_context().crud.currentAction == 'detail' %}
     <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.value }}</a>
 {% else %}
     <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.formattedValue }}</a>

--- a/src/Resources/views/crud/field/url.html.twig
+++ b/src/Resources/views/crud/field/url.html.twig
@@ -3,7 +3,7 @@
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {# NOTE: the rel="noopener" attr is needed to avoid performance and security issues
   (see https://web.dev/external-anchors-use-rel-noopener/) #}
-{% if ea.crud.currentAction == 'detail' %}
+{% if ea_context(app.request).crud.currentAction == 'detail' %}
     <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.value }}</a>
 {% else %}
     <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.formattedValue }}</a>

--- a/src/Resources/views/crud/filters.html.twig
+++ b/src/Resources/views/crud/filters.html.twig
@@ -1,6 +1,6 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var filters_form \EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType #}
-{% form_theme filters_form with ea_context(app.request).crud.formThemes only %}
+{% form_theme filters_form with ea_context().crud.formThemes only %}
 
 {{ form_start(filters_form, { attr: {
     id: filters_form.vars.id,

--- a/src/Resources/views/crud/filters.html.twig
+++ b/src/Resources/views/crud/filters.html.twig
@@ -1,6 +1,6 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var filters_form \EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType #}
-{% form_theme filters_form with ea.crud.formThemes only %}
+{% form_theme filters_form with ea_context(app.request).crud.formThemes only %}
 
 {{ form_start(filters_form, { attr: {
     id: filters_form.vars.id,

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -7,8 +7,8 @@
     {% endif %}
 
     {{ parent() }}
-    {% if ea_context(app.request).request.query.get('referrer')  %}
-        <input type="hidden" name="referrer" value="{{ ea_context(app.request).request.query.get('referrer') }}">
+    {% if ea_context().request.query.get('referrer')  %}
+        <input type="hidden" name="referrer" value="{{ ea_context().request.query.get('referrer') }}">
     {% endif %}
 {% endblock form_start %}
 
@@ -236,7 +236,7 @@
 {% endblock form_widget_compound %}
 
 {% block button_row -%}
-    <div class="form-group field-{{ block_prefixes|slice(-2)|first }} {{ ea_context(app.request).field.css_class|default('') }}">
+    <div class="form-group field-{{ block_prefixes|slice(-2)|first }} {{ ea_context().field.css_class|default('') }}">
         {{- form_widget(form) -}}
     </div>
 {%- endblock button_row %}
@@ -292,7 +292,7 @@
 
 {% block empty_collection %}
     <div class="empty collection-empty">
-        {{ include(ea_context(app.request).templatePath('label/empty')) }}
+        {{ include(ea_context().templatePath('label/empty')) }}
     </div>
 {% endblock empty_collection %}
 
@@ -553,11 +553,11 @@
             <div class="form-column-title">
                 <div class="form-column-title-content">
                     {% if field_icon %}<i class="form-column-icon fa fa-fw fa-{{ field_icon }}"></i>{% endif %}
-                    {% if field.label %}{{ field.label|default('')|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}{% endif %}
+                    {% if field.label %}{{ field.label|default('')|trans(domain = ea_context().i18n.translationDomain)|raw }}{% endif %}
                 </div>
 
                 {% if field.help %}
-                    <div class="form-column-help">{{ field.help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}</div>
+                    <div class="form-column-help">{{ field.help|trans(domain = ea_context().i18n.translationDomain)|raw }}</div>
                 {% endif %}
             </div>
         {% endif %}
@@ -631,7 +631,7 @@
                         {%- if tab.getCustomOption('icon')|default(false) -%}
                             <i class="tab-nav-item-icon fa-fw {{ tab.getCustomOption('icon') }}"></i>
                         {%- endif -%}
-                        {{ tab.label|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
+                        {{ tab.label|trans(domain = ea_context().i18n.translationDomain)|raw }}
 
                         {% set tab_error_count = tab.getCustomOption(tab_error_count_option_name)  %}
                         {%- if tab_error_count > 0 -%}
@@ -663,7 +663,7 @@
     <div id="{{ ea_tab_id }}" class="tab-pane {% if field.getCustomOption(tab_is_active_option_name) %}active{% endif %} {{ ea_css_class }}" {% for key, value in form.vars.attr %}{{ key }}={{ value|e('html_attr') }}{% endfor %}>
         {% if ea_help %}
             <div class="content-header-help tab-help">
-                {{ ea_help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
+                {{ ea_help|trans(domain = ea_context().i18n.translationDomain)|raw }}
             </div>
         {% endif %}
 
@@ -677,7 +677,7 @@
 
 {# EasyAdminFilters form type #}
 {% block ea_filters_widget %}
-    {% set applied_filters = ea_context(app.request).request.query.all()['filters']|default([])|keys %}
+    {% set applied_filters = ea_context().request.query.all()['filters']|default([])|keys %}
 
     {% for field in form %}
         <div class="col-12">
@@ -686,7 +686,7 @@
                     <input type="checkbox" class="filter-checkbox" {% if field.vars.name in applied_filters %}checked{% endif %}>
                     <a data-bs-toggle="collapse" href="#filter-content-{{ loop.index }}" aria-expanded="{{ field.vars.name in applied_filters ? 'true' : 'false' }}" aria-controls="filter-content-{{ loop.index }}"
                         {% for name, value in field.vars.label_attr|default([]) %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
-                        {{ field.vars.label|default(field.vars.name|humanize)|trans(domain = ea_context(app.request).i18n.translationDomain) }}
+                        {{ field.vars.label|default(field.vars.name|humanize)|trans(domain = ea_context().i18n.translationDomain) }}
                     </a>
                 </div>
                 <div id="filter-content-{{ loop.index }}" class="filter-content collapse {% if field.vars.name in applied_filters %}show{% endif %}" aria-labelledby="filter-heading-{{ loop.index }}">

--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -7,8 +7,8 @@
     {% endif %}
 
     {{ parent() }}
-    {% if ea.request.query.get('referrer')  %}
-        <input type="hidden" name="referrer" value="{{ ea.request.query.get('referrer') }}">
+    {% if ea_context(app.request).request.query.get('referrer')  %}
+        <input type="hidden" name="referrer" value="{{ ea_context(app.request).request.query.get('referrer') }}">
     {% endif %}
 {% endblock form_start %}
 
@@ -236,7 +236,7 @@
 {% endblock form_widget_compound %}
 
 {% block button_row -%}
-    <div class="form-group field-{{ block_prefixes|slice(-2)|first }} {{ ea.field.css_class|default('') }}">
+    <div class="form-group field-{{ block_prefixes|slice(-2)|first }} {{ ea_context(app.request).field.css_class|default('') }}">
         {{- form_widget(form) -}}
     </div>
 {%- endblock button_row %}
@@ -292,7 +292,7 @@
 
 {% block empty_collection %}
     <div class="empty collection-empty">
-        {{ include(ea.templatePath('label/empty')) }}
+        {{ include(ea_context(app.request).templatePath('label/empty')) }}
     </div>
 {% endblock empty_collection %}
 
@@ -553,11 +553,11 @@
             <div class="form-column-title">
                 <div class="form-column-title-content">
                     {% if field_icon %}<i class="form-column-icon fa fa-fw fa-{{ field_icon }}"></i>{% endif %}
-                    {% if field.label %}{{ field.label|default('')|trans(domain = ea.i18n.translationDomain)|raw }}{% endif %}
+                    {% if field.label %}{{ field.label|default('')|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}{% endif %}
                 </div>
 
                 {% if field.help %}
-                    <div class="form-column-help">{{ field.help|trans(domain = ea.i18n.translationDomain)|raw }}</div>
+                    <div class="form-column-help">{{ field.help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}</div>
                 {% endif %}
             </div>
         {% endif %}
@@ -631,7 +631,7 @@
                         {%- if tab.getCustomOption('icon')|default(false) -%}
                             <i class="tab-nav-item-icon fa-fw {{ tab.getCustomOption('icon') }}"></i>
                         {%- endif -%}
-                        {{ tab.label|trans(domain = ea.i18n.translationDomain)|raw }}
+                        {{ tab.label|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
 
                         {% set tab_error_count = tab.getCustomOption(tab_error_count_option_name)  %}
                         {%- if tab_error_count > 0 -%}
@@ -663,7 +663,7 @@
     <div id="{{ ea_tab_id }}" class="tab-pane {% if field.getCustomOption(tab_is_active_option_name) %}active{% endif %} {{ ea_css_class }}" {% for key, value in form.vars.attr %}{{ key }}={{ value|e('html_attr') }}{% endfor %}>
         {% if ea_help %}
             <div class="content-header-help tab-help">
-                {{ ea_help|trans(domain = ea.i18n.translationDomain)|raw }}
+                {{ ea_help|trans(domain = ea_context(app.request).i18n.translationDomain)|raw }}
             </div>
         {% endif %}
 
@@ -677,7 +677,7 @@
 
 {# EasyAdminFilters form type #}
 {% block ea_filters_widget %}
-    {% set applied_filters = ea.request.query.all()['filters']|default([])|keys %}
+    {% set applied_filters = ea_context(app.request).request.query.all()['filters']|default([])|keys %}
 
     {% for field in form %}
         <div class="col-12">
@@ -686,7 +686,7 @@
                     <input type="checkbox" class="filter-checkbox" {% if field.vars.name in applied_filters %}checked{% endif %}>
                     <a data-bs-toggle="collapse" href="#filter-content-{{ loop.index }}" aria-expanded="{{ field.vars.name in applied_filters ? 'true' : 'false' }}" aria-controls="filter-content-{{ loop.index }}"
                         {% for name, value in field.vars.label_attr|default([]) %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
-                        {{ field.vars.label|default(field.vars.name|humanize)|trans(domain = ea.i18n.translationDomain) }}
+                        {{ field.vars.label|default(field.vars.name|humanize)|trans(domain = ea_context(app.request).i18n.translationDomain) }}
                     </a>
                 </div>
                 <div id="filter-content-{{ loop.index }}" class="filter-content collapse {% if field.vars.name in applied_filters %}show{% endif %}" aria-labelledby="filter-heading-{{ loop.index }}">

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -1,13 +1,13 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var entities \EasyCorp\Bundle\EasyAdminBundle\Collection\EntityCollection #}
 {# @var paginator \EasyCorp\Bundle\EasyAdminBundle\Orm\EntityPaginator #}
-{% extends ea_context(app.request).templatePath('layout') %}
-{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
+{% extends ea_context().templatePath('layout') %}
+{% trans_default_domain ea_context().i18n.translationDomain %}
 
 {% block body_id entities|length > 0 ? 'ea-index-' ~ entities|first.name : '' %}
 {% block body_class 'ea-index' ~ (entities|length > 0 ? ' ea-index-' ~ entities|first.name : '') %}
 
-{% set ea_field_assets = ea_context(app.request).crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_INDEX')) %}
+{% set ea_field_assets = ea_context().crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_INDEX')) %}
 
 {% block configured_head_contents %}
     {{ parent() }}
@@ -37,9 +37,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea_context(app.request).crud.customPageTitle('index', null, ea_context(app.request).i18n.translationParameters) %}
+        {% set custom_page_title = ea_context().crud.customPageTitle('index', null, ea_context().i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea_context(app.request).crud.defaultPageTitle('index', null, ea_context(app.request).i18n.translationParameters)|trans|raw
+            ? ea_context().crud.defaultPageTitle('index', null, ea_context().i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}
@@ -49,10 +49,10 @@
     {% if filters|length > 0 %}
         <div class="datagrid-filters">
             {% block filters %}
-                {% set applied_filters = ea_context(app.request).request.query.all['filters']|default([])|keys %}
+                {% set applied_filters = ea_context().request.query.all['filters']|default([])|keys %}
                 <div class="btn-group action-filters">
                     <a href="#" data-href="{{ ea_url().setAction('renderFilters') }}" class="btn btn-secondary btn-labeled btn-labeled-right action-filters-button disabled {{ applied_filters ? 'action-filters-applied' }}" data-bs-toggle="modal" data-bs-target="#modal-filters">
-                        <i class="fa fa-filter fa-fw"></i> {{ t('filter.title', ea_context(app.request).i18n.translationParameters, 'EasyAdminBundle')|trans }}{% if applied_filters %} <span class="action-filters-button-count">({{ applied_filters|length }})</span>{% endif %}
+                        <i class="fa fa-filter fa-fw"></i> {{ t('filter.title', ea_context().i18n.translationParameters, 'EasyAdminBundle')|trans }}{% if applied_filters %} <span class="action-filters-button-count">({{ applied_filters|length }})</span>{% endif %}
                     </a>
                     {% if applied_filters %}
                         <a href="{{ ea_url().unset('filters') }}" class="btn btn-secondary action-filters-reset">
@@ -88,7 +88,7 @@
     {% set sort_order = app.request.get('sort')|first %}
     {% set some_results_are_hidden = entities|reduce((some_results_are_hidden, entity) => some_results_are_hidden or not entity.isAccessible, false) %}
     {% set has_footer = entities|length != 0 %}
-    {% set has_search = ea_context(app.request).crud.isSearchEnabled %}
+    {% set has_search = ea_context().crud.isSearchEnabled %}
     {% set has_filters = filters|length > 0 %}
     {% set num_results = entities|length %}
 
@@ -108,12 +108,12 @@
                     {% set ea_sort_asc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::ASC') %}
                     {% set ea_sort_desc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::DESC') %}
                     {% for field in entities|filter(e => e.isAccessible)|first.fields ?? [] %}
-                        {% set is_searchable = null == ea_context(app.request).crud.searchFields or field.property in ea_context(app.request).crud.searchFields %}
-                        {% set is_sorting_field = ea_context(app.request).search.isSortingField(field.property) %}
-                        {% set next_sort_direction = is_sorting_field ? (ea_context(app.request).search.sortDirection(field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
+                        {% set is_searchable = null == ea_context().crud.searchFields or field.property in ea_context().crud.searchFields %}
+                        {% set is_sorting_field = ea_context().search.isSortingField(field.property) %}
+                        {% set next_sort_direction = is_sorting_field ? (ea_context().search.sortDirection(field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
                         {% set column_icon = is_sorting_field ? (next_sort_direction == ea_sort_desc ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
 
-                        <th data-column="{{ field.property }}" class="{{ is_searchable ? 'searchable' }} {{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} header-for-{{ field.cssClass|split(' ')|filter(class => class starts with 'field-')|join('') }} text-{{ field.textAlign }}" dir="{{ ea_context(app.request).i18n.textDirection }}">
+                        <th data-column="{{ field.property }}" class="{{ is_searchable ? 'searchable' }} {{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} header-for-{{ field.cssClass|split(' ')|filter(class => class starts with 'field-')|join('') }} text-{{ field.textAlign }}" dir="{{ ea_context().i18n.textDirection }}">
                             {% if field.isSortable %}
                                 <a href="{{ ea_url({ page: 1, sort: { (field.property): next_sort_direction } }) }}">
                                     {{ field.label|trans|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
@@ -124,8 +124,8 @@
                         </th>
                     {% endfor %}
 
-                    <th class="{{ ea_context(app.request).crud.showEntityActionsAsDropdown ? 'actions-as-dropdown-table-head' }}" dir="{{ ea_context(app.request).i18n.textDirection }}">
-                        <span class="sr-only">{{ t('action.entity_actions', ea_context(app.request).i18n.translationParameters, 'EasyAdminBundle')|trans }}</span>
+                    <th class="{{ ea_context().crud.showEntityActionsAsDropdown ? 'actions-as-dropdown-table-head' }}" dir="{{ ea_context().i18n.textDirection }}">
+                        <span class="sr-only">{{ t('action.entity_actions', ea_context().i18n.translationParameters, 'EasyAdminBundle')|trans }}</span>
                     </th>
                 </tr>
             {% endblock table_head %}
@@ -146,17 +146,17 @@
                         {% endif %}
 
                         {% for field in entity.fields %}
-                            {% set is_searchable = null == ea_context(app.request).crud.searchFields or field.property in ea_context(app.request).crud.searchFields %}
+                            {% set is_searchable = null == ea_context().crud.searchFields or field.property in ea_context().crud.searchFields %}
 
-                            <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea_context(app.request).i18n.textDirection }}">
+                            <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea_context().i18n.textDirection }}">
                                 {{ include(field.templatePath, { field: field, entity: entity }, with_context = false) }}
                             </td>
                         {% endfor %}
 
                         {% block entity_actions %}
-                            <td class="actions {{ ea_context(app.request).crud.showEntityActionsAsDropdown ? 'actions-as-dropdown' }}">
+                            <td class="actions {{ ea_context().crud.showEntityActionsAsDropdown ? 'actions-as-dropdown' }}">
                                 {% if entity.actions.count > 0 %}
-                                    {% if ea_context(app.request).crud.showEntityActionsAsDropdown %}
+                                    {% if ea_context().crud.showEntityActionsAsDropdown %}
                                         <div class="dropdown dropdown-actions">
                                             <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                                 {# don't use FontAwesome 'fa-ellipsis-h' icon here because it doesn't look good #}
@@ -168,13 +168,13 @@
 
                                             <div class="dropdown-menu dropdown-menu-right">
                                                 {% for action in entity.actions %}
-                                                    {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea_context(app.request).crud.showEntityActionsAsDropdown }, with_context = false) }}
+                                                    {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea_context().crud.showEntityActionsAsDropdown }, with_context = false) }}
                                                 {% endfor %}
                                             </div>
                                         </div>
                                     {% else %}
                                         {% for action in entity.actions %}
-                                            {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea_context(app.request).crud.showEntityActionsAsDropdown }, with_context = false) }}
+                                            {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea_context().crud.showEntityActionsAsDropdown }, with_context = false) }}
                                         {% endfor %}
                                     {% endif %}
                                 {% endif %}
@@ -198,7 +198,7 @@
                         {% if 3 == loop.index %}
                             <tr class="no-results">
                                 <td colspan="100">
-                                    {{ t('datagrid.no_results', ea_context(app.request).i18n.translationParameters, 'EasyAdminBundle')|trans }}
+                                    {{ t('datagrid.no_results', ea_context().i18n.translationParameters, 'EasyAdminBundle')|trans }}
                                 </td>
                             </tr>
                         {% endif %}
@@ -225,7 +225,7 @@
     {% if entities|length > 0 %}
         <div class="content-panel-footer without-padding without-border">
             {% block paginator %}
-                {{ include(ea_context(app.request).templatePath('crud/paginator'), { render_detailed_pagination: not some_results_are_hidden }) }}
+                {{ include(ea_context().templatePath('crud/paginator'), { render_detailed_pagination: not some_results_are_hidden }) }}
             {% endblock paginator %}
         </div>
     {% endif %}

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -1,13 +1,13 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var entities \EasyCorp\Bundle\EasyAdminBundle\Collection\EntityCollection #}
 {# @var paginator \EasyCorp\Bundle\EasyAdminBundle\Orm\EntityPaginator #}
-{% extends ea.templatePath('layout') %}
-{% trans_default_domain ea.i18n.translationDomain %}
+{% extends ea_context(app.request).templatePath('layout') %}
+{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
 
 {% block body_id entities|length > 0 ? 'ea-index-' ~ entities|first.name : '' %}
 {% block body_class 'ea-index' ~ (entities|length > 0 ? ' ea-index-' ~ entities|first.name : '') %}
 
-{% set ea_field_assets = ea.crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_INDEX')) %}
+{% set ea_field_assets = ea_context(app.request).crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_INDEX')) %}
 
 {% block configured_head_contents %}
     {{ parent() }}
@@ -37,9 +37,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle('index', null, ea.i18n.translationParameters) %}
+        {% set custom_page_title = ea_context(app.request).crud.customPageTitle('index', null, ea_context(app.request).i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle('index', null, ea.i18n.translationParameters)|trans|raw
+            ? ea_context(app.request).crud.defaultPageTitle('index', null, ea_context(app.request).i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}
@@ -49,10 +49,10 @@
     {% if filters|length > 0 %}
         <div class="datagrid-filters">
             {% block filters %}
-                {% set applied_filters = ea.request.query.all['filters']|default([])|keys %}
+                {% set applied_filters = ea_context(app.request).request.query.all['filters']|default([])|keys %}
                 <div class="btn-group action-filters">
                     <a href="#" data-href="{{ ea_url().setAction('renderFilters') }}" class="btn btn-secondary btn-labeled btn-labeled-right action-filters-button disabled {{ applied_filters ? 'action-filters-applied' }}" data-bs-toggle="modal" data-bs-target="#modal-filters">
-                        <i class="fa fa-filter fa-fw"></i> {{ t('filter.title', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}{% if applied_filters %} <span class="action-filters-button-count">({{ applied_filters|length }})</span>{% endif %}
+                        <i class="fa fa-filter fa-fw"></i> {{ t('filter.title', ea_context(app.request).i18n.translationParameters, 'EasyAdminBundle')|trans }}{% if applied_filters %} <span class="action-filters-button-count">({{ applied_filters|length }})</span>{% endif %}
                     </a>
                     {% if applied_filters %}
                         <a href="{{ ea_url().unset('filters') }}" class="btn btn-secondary action-filters-reset">
@@ -88,7 +88,7 @@
     {% set sort_order = app.request.get('sort')|first %}
     {% set some_results_are_hidden = entities|reduce((some_results_are_hidden, entity) => some_results_are_hidden or not entity.isAccessible, false) %}
     {% set has_footer = entities|length != 0 %}
-    {% set has_search = ea.crud.isSearchEnabled %}
+    {% set has_search = ea_context(app.request).crud.isSearchEnabled %}
     {% set has_filters = filters|length > 0 %}
     {% set num_results = entities|length %}
 
@@ -108,12 +108,12 @@
                     {% set ea_sort_asc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::ASC') %}
                     {% set ea_sort_desc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::DESC') %}
                     {% for field in entities|filter(e => e.isAccessible)|first.fields ?? [] %}
-                        {% set is_searchable = null == ea.crud.searchFields or field.property in ea.crud.searchFields %}
-                        {% set is_sorting_field = ea.search.isSortingField(field.property) %}
-                        {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
+                        {% set is_searchable = null == ea_context(app.request).crud.searchFields or field.property in ea_context(app.request).crud.searchFields %}
+                        {% set is_sorting_field = ea_context(app.request).search.isSortingField(field.property) %}
+                        {% set next_sort_direction = is_sorting_field ? (ea_context(app.request).search.sortDirection(field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
                         {% set column_icon = is_sorting_field ? (next_sort_direction == ea_sort_desc ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
 
-                        <th data-column="{{ field.property }}" class="{{ is_searchable ? 'searchable' }} {{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} header-for-{{ field.cssClass|split(' ')|filter(class => class starts with 'field-')|join('') }} text-{{ field.textAlign }}" dir="{{ ea.i18n.textDirection }}">
+                        <th data-column="{{ field.property }}" class="{{ is_searchable ? 'searchable' }} {{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} header-for-{{ field.cssClass|split(' ')|filter(class => class starts with 'field-')|join('') }} text-{{ field.textAlign }}" dir="{{ ea_context(app.request).i18n.textDirection }}">
                             {% if field.isSortable %}
                                 <a href="{{ ea_url({ page: 1, sort: { (field.property): next_sort_direction } }) }}">
                                     {{ field.label|trans|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
@@ -124,8 +124,8 @@
                         </th>
                     {% endfor %}
 
-                    <th class="{{ ea.crud.showEntityActionsAsDropdown ? 'actions-as-dropdown-table-head' }}" dir="{{ ea.i18n.textDirection }}">
-                        <span class="sr-only">{{ t('action.entity_actions', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}</span>
+                    <th class="{{ ea_context(app.request).crud.showEntityActionsAsDropdown ? 'actions-as-dropdown-table-head' }}" dir="{{ ea_context(app.request).i18n.textDirection }}">
+                        <span class="sr-only">{{ t('action.entity_actions', ea_context(app.request).i18n.translationParameters, 'EasyAdminBundle')|trans }}</span>
                     </th>
                 </tr>
             {% endblock table_head %}
@@ -146,17 +146,17 @@
                         {% endif %}
 
                         {% for field in entity.fields %}
-                            {% set is_searchable = null == ea.crud.searchFields or field.property in ea.crud.searchFields %}
+                            {% set is_searchable = null == ea_context(app.request).crud.searchFields or field.property in ea_context(app.request).crud.searchFields %}
 
-                            <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea.i18n.textDirection }}">
+                            <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea_context(app.request).i18n.textDirection }}">
                                 {{ include(field.templatePath, { field: field, entity: entity }, with_context = false) }}
                             </td>
                         {% endfor %}
 
                         {% block entity_actions %}
-                            <td class="actions {{ ea.crud.showEntityActionsAsDropdown ? 'actions-as-dropdown' }}">
+                            <td class="actions {{ ea_context(app.request).crud.showEntityActionsAsDropdown ? 'actions-as-dropdown' }}">
                                 {% if entity.actions.count > 0 %}
-                                    {% if ea.crud.showEntityActionsAsDropdown %}
+                                    {% if ea_context(app.request).crud.showEntityActionsAsDropdown %}
                                         <div class="dropdown dropdown-actions">
                                             <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                                 {# don't use FontAwesome 'fa-ellipsis-h' icon here because it doesn't look good #}
@@ -168,13 +168,13 @@
 
                                             <div class="dropdown-menu dropdown-menu-right">
                                                 {% for action in entity.actions %}
-                                                    {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea.crud.showEntityActionsAsDropdown }, with_context = false) }}
+                                                    {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea_context(app.request).crud.showEntityActionsAsDropdown }, with_context = false) }}
                                                 {% endfor %}
                                             </div>
                                         </div>
                                     {% else %}
                                         {% for action in entity.actions %}
-                                            {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea.crud.showEntityActionsAsDropdown }, with_context = false) }}
+                                            {{ include(action.templatePath, { action: action, entity: entity, isIncludedInDropdown: ea_context(app.request).crud.showEntityActionsAsDropdown }, with_context = false) }}
                                         {% endfor %}
                                     {% endif %}
                                 {% endif %}
@@ -198,7 +198,7 @@
                         {% if 3 == loop.index %}
                             <tr class="no-results">
                                 <td colspan="100">
-                                    {{ t('datagrid.no_results', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}
+                                    {{ t('datagrid.no_results', ea_context(app.request).i18n.translationParameters, 'EasyAdminBundle')|trans }}
                                 </td>
                             </tr>
                         {% endif %}
@@ -225,7 +225,7 @@
     {% if entities|length > 0 %}
         <div class="content-panel-footer without-padding without-border">
             {% block paginator %}
-                {{ include(ea.templatePath('crud/paginator'), { render_detailed_pagination: not some_results_are_hidden }) }}
+                {{ include(ea_context(app.request).templatePath('crud/paginator'), { render_detailed_pagination: not some_results_are_hidden }) }}
             {% endblock paginator %}
         </div>
     {% endif %}

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -1,18 +1,18 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% extends ea.templatePath('layout') %}
-{% form_theme new_form with ea.crud.formThemes only %}
+{% extends ea_context(app.request).templatePath('layout') %}
+{% form_theme new_form with ea_context(app.request).crud.formThemes only %}
 
-{% trans_default_domain ea.i18n.translationDomain %}
+{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
 
 {% block body_id 'ea-new-' ~ entity.name %}
 {% block body_class 'ea-new ea-new-' ~ entity.name %}
 
-{% set ea_field_assets = ea.crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_NEW')) %}
+{% set ea_field_assets = ea_context(app.request).crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_NEW')) %}
 
 {% block head_javascript %}
     {{ parent() }}
-    <script src="{{ asset('form.js', ea.assets.defaultAssetPackageName) }}"></script>
+    <script src="{{ asset('form.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
 {% endblock head_javascript %}
 
 {% block configured_head_contents %}
@@ -43,9 +43,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle('new', null, ea.i18n.translationParameters) %}
+        {% set custom_page_title = ea_context(app.request).crud.customPageTitle('new', null, ea_context(app.request).i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle('new', null, ea.i18n.translationParameters)|trans|raw
+            ? ea_context(app.request).crud.defaultPageTitle('new', null, ea_context(app.request).i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -1,18 +1,18 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
-{% extends ea_context(app.request).templatePath('layout') %}
-{% form_theme new_form with ea_context(app.request).crud.formThemes only %}
+{% extends ea_context().templatePath('layout') %}
+{% form_theme new_form with ea_context().crud.formThemes only %}
 
-{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
+{% trans_default_domain ea_context().i18n.translationDomain %}
 
 {% block body_id 'ea-new-' ~ entity.name %}
 {% block body_class 'ea-new ea-new-' ~ entity.name %}
 
-{% set ea_field_assets = ea_context(app.request).crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_NEW')) %}
+{% set ea_field_assets = ea_context().crud.fieldAssets(constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Crud::PAGE_NEW')) %}
 
 {% block head_javascript %}
     {{ parent() }}
-    <script src="{{ asset('form.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
+    <script src="{{ asset('form.js', ea_context().assets.defaultAssetPackageName) }}"></script>
 {% endblock head_javascript %}
 
 {% block configured_head_contents %}
@@ -43,9 +43,9 @@
 
 {% block content_title %}
     {%- apply spaceless -%}
-        {% set custom_page_title = ea_context(app.request).crud.customPageTitle('new', null, ea_context(app.request).i18n.translationParameters) %}
+        {% set custom_page_title = ea_context().crud.customPageTitle('new', null, ea_context().i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea_context(app.request).crud.defaultPageTitle('new', null, ea_context(app.request).i18n.translationParameters)|trans|raw
+            ? ea_context().crud.defaultPageTitle('new', null, ea_context().i18n.translationParameters)|trans|raw
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}

--- a/src/Resources/views/flash_messages.html.twig
+++ b/src/Resources/views/flash_messages.html.twig
@@ -2,7 +2,7 @@
 {# This template checks for 'ea' variable existence because it can
    be used in a EasyAdmin Dashboard controller, where 'ea' is defined
    or from any other Symfony controller, where 'ea' is not defined #}
-{% trans_default_domain ea is defined ? ea_context(app.request).i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
+{% trans_default_domain ea is defined ? ea_context().i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% set flash_messages = app.flashes %}
 

--- a/src/Resources/views/flash_messages.html.twig
+++ b/src/Resources/views/flash_messages.html.twig
@@ -2,7 +2,7 @@
 {# This template checks for 'ea' variable existence because it can
    be used in a EasyAdmin Dashboard controller, where 'ea' is defined
    or from any other Symfony controller, where 'ea' is not defined #}
-{% trans_default_domain ea is defined ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
+{% trans_default_domain ea is defined ? ea_context(app.request).i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% set flash_messages = app.flashes %}
 

--- a/src/Resources/views/label/null.html.twig
+++ b/src/Resources/views/label/null.html.twig
@@ -1,3 +1,3 @@
-{% if not (ea_context(app.request).crud.areNullValuesHidden ?? false) %}
+{% if not (ea_context().crud.areNullValuesHidden ?? false) %}
     <span class="badge badge-outline">{{ 'label.null'|trans(domain = 'EasyAdminBundle') }}</span>
 {% endif %}

--- a/src/Resources/views/label/null.html.twig
+++ b/src/Resources/views/label/null.html.twig
@@ -1,3 +1,3 @@
-{% if not (ea.crud.areNullValuesHidden ?? false) %}
+{% if not (ea_context(app.request).crud.areNullValuesHidden ?? false) %}
     <span class="badge badge-outline">{{ 'label.null'|trans(domain = 'EasyAdminBundle') }}</span>
 {% endif %}

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -1,8 +1,8 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{% trans_default_domain ea.i18n.translationDomain %}
+{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
 
 <!DOCTYPE html>
-<html lang="{{ ea.i18n.htmlLocale }}" dir="{{ ea.i18n.textDirection }}" data-turbo="false">
+<html lang="{{ ea_context(app.request).i18n.htmlLocale }}" dir="{{ ea_context(app.request).i18n.textDirection }}" data-turbo="false">
 <head>
     {% block head_metas %}
         <meta charset="utf-8">
@@ -16,37 +16,37 @@
     <title>{{ page_title_block_output|striptags|raw }}</title>
 
     {% block head_stylesheets %}
-        <link rel="stylesheet" href="{{ asset('app.css', ea.assets.defaultAssetPackageName) }}">
+        <link rel="stylesheet" href="{{ asset('app.css', ea_context(app.request).assets.defaultAssetPackageName) }}">
     {% endblock %}
 
     {% block configured_stylesheets %}
-        {{ include('@EasyAdmin/includes/_css_assets.html.twig', { assets: ea.assets.cssAssets ?? [] }, with_context = false) }}
-        {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', { assets: ea.assets.webpackEncoreAssets ?? [] }, with_context = false) }}
+        {{ include('@EasyAdmin/includes/_css_assets.html.twig', { assets: ea_context(app.request).assets.cssAssets ?? [] }, with_context = false) }}
+        {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', { assets: ea_context(app.request).assets.webpackEncoreAssets ?? [] }, with_context = false) }}
     {% endblock %}
 
     {% block head_favicon %}
-        <link rel="shortcut icon" href="{{ asset(ea.dashboardFaviconPath) }}">
+        <link rel="shortcut icon" href="{{ asset(ea_context(app.request).dashboardFaviconPath) }}">
     {% endblock %}
 
     {% block head_javascript %}
-        <script src="{{ asset('app.js', ea.assets.defaultAssetPackageName) }}"></script>
+        <script src="{{ asset('app.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
 
         {% block importmap %}
-            {{ include('@EasyAdmin/includes/_importmap.html.twig', { assets: ea.assets.assetMapperAssets ?? [] }, with_context = false) }}
+            {{ include('@EasyAdmin/includes/_importmap.html.twig', { assets: ea_context(app.request).assets.assetMapperAssets ?? [] }, with_context = false) }}
         {% endblock %}
     {% endblock head_javascript %}
 
     {% block configured_javascripts %}
-        {{ include('@EasyAdmin/includes/_js_assets.html.twig', { assets: ea.assets.jsAssets ?? [] }, with_context = false) }}
-        {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', { assets: ea.assets.webpackEncoreAssets ?? [] }, with_context = false) }}
+        {{ include('@EasyAdmin/includes/_js_assets.html.twig', { assets: ea_context(app.request).assets.jsAssets ?? [] }, with_context = false) }}
+        {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', { assets: ea_context(app.request).assets.webpackEncoreAssets ?? [] }, with_context = false) }}
     {% endblock %}
 
-    {% if 'rtl' == ea.i18n.textDirection %}
-        <link rel="stylesheet" href="{{ asset('app.rtl.css', ea.assets.defaultAssetPackageName) }}">
+    {% if 'rtl' == ea_context(app.request).i18n.textDirection %}
+        <link rel="stylesheet" href="{{ asset('app.rtl.css', ea_context(app.request).assets.defaultAssetPackageName) }}">
     {% endif %}
 
     {% block configured_head_contents %}
-        {% for htmlContent in ea.assets.headContents ?? [] %}
+        {% for htmlContent in ea_context(app.request).assets.headContents ?? [] %}
             {{ htmlContent|raw }}
         {% endfor %}
     {% endblock %}
@@ -56,32 +56,32 @@
     <body {% block body_attr %}{% endblock %}
         id="{% block body_id %}{% endblock %}"
         class="ea {% block body_class %}{% endblock %}"
-        data-ea-content-width="{{ ea.crud.contentWidth ?? ea.dashboardContentWidth ?? 'normal' }}"
-        data-ea-sidebar-width="{{ ea.crud.sidebarWidth ?? ea.dashboardSidebarWidth ?? 'normal' }}"
-        data-ea-dark-scheme-is-enabled="{{ ea.dashboardHasDarkModeEnabled ? 'true' : 'false' }}"
+        data-ea-content-width="{{ ea_context(app.request).crud.contentWidth ?? ea_context(app.request).dashboardContentWidth ?? 'normal' }}"
+        data-ea-sidebar-width="{{ ea_context(app.request).crud.sidebarWidth ?? ea_context(app.request).dashboardSidebarWidth ?? 'normal' }}"
+        data-ea-dark-scheme-is-enabled="{{ ea_context(app.request).dashboardHasDarkModeEnabled ? 'true' : 'false' }}"
     >
     {% block javascript_page_layout %}
-        <script src="{{ asset('page-layout.js', ea.assets.defaultAssetPackageName) }}"></script>
+        <script src="{{ asset('page-layout.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
     {% endblock javascript_page_layout %}
     {% block javascript_page_color_scheme %}
-        <script src="{{ asset('page-color-scheme.js', ea.assets.defaultAssetPackageName) }}"></script>
+        <script src="{{ asset('page-color-scheme.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
     {% endblock javascript_page_color_scheme %}
 
     {% block wrapper_wrapper %}
         {% block flash_messages %}
-            {{ include(ea.templatePath('flash_messages')) }}
+            {{ include(ea_context(app.request).templatePath('flash_messages')) }}
         {% endblock flash_messages %}
 
         {% set user_menu_avatar %}
-            {% if null == ea.userMenu.avatarUrl %}
+            {% if null == ea_context(app.request).userMenu.avatarUrl %}
                 <span class="user-avatar">
                     <span class="fa-stack">
                         <i class="user-avatar-icon-background fas fa-square fa-stack-2x"></i>
-                        <i class="user-avatar-icon-foreground {{ ea.user is not null ? 'fa fa-user' : 'fas fa-user-slash' }} fa-stack-1x fa-inverse"></i>
+                        <i class="user-avatar-icon-foreground {{ ea_context(app.request).user is not null ? 'fa fa-user' : 'fas fa-user-slash' }} fa-stack-1x fa-inverse"></i>
                     </span>
                 </span>
             {% else %}
-                <img class="user-avatar" src="{{ ea.userMenu.avatarUrl }}" />
+                <img class="user-avatar" src="{{ ea_context(app.request).userMenu.avatarUrl }}" />
             {% endif %}
         {% endset %}
 
@@ -93,14 +93,14 @@
                     <div>{{ user_menu_avatar }}</div>
                     <div>
                         <span class="user-label">{{ 'user.logged_in_as'|trans(domain = 'EasyAdminBundle') }}</span>
-                        <span class="user-name">{{ ea.user is null ? 'user.anonymous'|trans(domain = 'EasyAdminBundle') : ea.userMenu.name }}</span>
+                        <span class="user-name">{{ ea_context(app.request).user is null ? 'user.anonymous'|trans(domain = 'EasyAdminBundle') : ea_context(app.request).userMenu.name }}</span>
                     </div>
                 </li>
 
                 {% block user_menu %}
-                    {% if ea.userMenu.items|length > 0 %}
+                    {% if ea_context(app.request).userMenu.items|length > 0 %}
                         <li><hr class="dropdown-divider"></li>
-                        {% for item in ea.userMenu.items %}
+                        {% for item in ea_context(app.request).userMenu.items %}
                             <li>
                                 {% if item.isMenuSection and not loop.first %}
                                     <hr class="dropdown-divider">
@@ -120,19 +120,19 @@
         {% endset %}
 
         {% set settings_dropdown %}
-            {% if ea.dashboardLocales or ea.dashboardHasDarkModeEnabled %}
+            {% if ea_context(app.request).dashboardLocales or ea_context(app.request).dashboardHasDarkModeEnabled %}
                 <div class="dropdown dropdown-settings">
                     <a class="dropdown-settings-button" type="button" data-bs-toggle="dropdown" data-bs-offset="0,5" aria-expanded="false">
                         <i class="fas fa-gear"></i>
                     </a>
 
                     <ul class="dropdown-menu dropdown-menu-end">
-                        {% if ea.dashboardLocales %}
+                        {% if ea_context(app.request).dashboardLocales %}
                             <li class="dropdown-header dropdown-locales-label">
                                 {{ 'settings.locale'|trans(domain = 'EasyAdminBundle') }}
                             </li>
 
-                            {% for localeDto in ea.dashboardLocales %}
+                            {% for localeDto in ea_context(app.request).dashboardLocales %}
                                 <li>
                                     <a href="{{ ea_url().set('_locale', localeDto.locale) }}" class="dropdown-item{% if app.request.locale == localeDto.locale %} active{% endif %}">
                                         {% if localeDto.icon %}
@@ -144,8 +144,8 @@
                             {% endfor %}
                         {% endif %}
 
-                        {% if ea.dashboardHasDarkModeEnabled %}
-                            {% if ea.dashboardLocales %}
+                        {% if ea_context(app.request).dashboardHasDarkModeEnabled %}
+                            {% if ea_context(app.request).dashboardLocales %}
                                 <div class="dropdown-divider"></div>
                             {% endif %}
 
@@ -186,8 +186,8 @@
 
                         <div id="responsive-header-logo" class="text-truncate ms-auto">
                             {% block responsive_header_logo %}
-                                <a class="responsive-logo" title="{{ ea.dashboardTitle|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
-                                    {{ ea.dashboardTitle|raw }}
+                                <a class="responsive-logo" title="{{ ea_context(app.request).dashboardTitle|striptags }}" href="{{ path(ea_context(app.request).dashboardRouteName) }}">
+                                    {{ ea_context(app.request).dashboardTitle|raw }}
                                 </a>
                             {% endblock responsive_header_logo %}
                         </div>
@@ -196,10 +196,10 @@
                             <a class="user-details" type="button" data-bs-toggle="dropdown" data-bs-offset="0,5" aria-expanded="false">
                                 {# to make the site design consistent, always display the user avatar in responsive header
                                    and hide the user name (because there's no space left) regardless of the user config #}
-                                {% if ea.userMenu.avatarDisplayed %}
+                                {% if ea_context(app.request).userMenu.avatarDisplayed %}
                                     {{ user_menu_avatar }}
                                 {% else %}
-                                    <i class="user-avatar fa fa-fw {{ ea.user is not null ? 'fa-user' : 'fa-user-times' }}"></i>
+                                    <i class="user-avatar fa fa-fw {{ ea_context(app.request).user is not null ? 'fa-user' : 'fa-user-times' }}"></i>
                                 {% endif %}
                             </a>
 
@@ -219,8 +219,8 @@
                                     {% block header_navbar %}
                                         <div id="header-logo">
                                             {% block header_logo %}
-                                                <a class="logo" title="{{ ea.dashboardTitle|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
-                                                    <span class="logo-custom">{{ ea.dashboardTitle|raw }}</span>
+                                                <a class="logo" title="{{ ea_context(app.request).dashboardTitle|striptags }}" href="{{ path(ea_context(app.request).dashboardRouteName) }}">
+                                                    <span class="logo-custom">{{ ea_context(app.request).dashboardTitle|raw }}</span>
                                                     <span class="logo-compact"><i class="fas fa-home"></i></span>
                                                 </a>
                                             {% endblock header_logo %}
@@ -231,7 +231,7 @@
                             </header>
 
                             {% block main_menu_wrapper %}
-                                {{ include(ea.templatePath('main_menu')) }}
+                                {{ include(ea_context(app.request).templatePath('main_menu')) }}
                             {% endblock main_menu_wrapper %}
                         {% endblock sidebar %}
 
@@ -240,7 +240,7 @@
                 </div>
 
                 <section class="main-content">
-                    {% set has_search = ea.crud is not null and ea.crud.isSearchEnabled %}
+                    {% set has_search = ea_context(app.request).crud is not null and ea_context(app.request).crud.isSearchEnabled %}
                     <aside class="content-top {{ has_search ? 'ea-search-enabled' : 'ea-search-disabled' }}">
                         {% block content_top_header %}
                             {% block search_wrapper %}
@@ -251,7 +251,7 @@
                                         <form class="form-action-search" method="get">
                                             {% block search_form %}
                                                 {% block search_form_filters %}
-                                                    {% for field, fieldValue in ea.search.appliedFilters %}
+                                                    {% for field, fieldValue in ea_context(app.request).search.appliedFilters %}
                                                         {% if fieldValue is iterable %}
                                                             {% for key, value in fieldValue %}
                                                                 {# This code re-applies your filters on searches, an iterable check is needed in cases we have more than one object for a filter #}
@@ -277,7 +277,7 @@
                                                 {% endblock %}
 
                                                 <input type="hidden" name="crudAction" value="index">
-                                                <input type="hidden" name="crudControllerFqcn" value="{{ ea.request.query.get('crudControllerFqcn') }}">
+                                                <input type="hidden" name="crudControllerFqcn" value="{{ ea_context(app.request).request.query.get('crudControllerFqcn') }}">
                                                 <input type="hidden" name="page" value="1">
 
                                                 <div class="form-group">
@@ -285,7 +285,7 @@
                                                         <i class="fas fa-search content-search-icon"></i>
 
                                                         <label class="content-search-label" data-value="{{ app.request.get('query') }}">
-                                                            <input class="form-control {{ app.request.get('query') is null ? 'is-blank' }}" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ t('action.search', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}" spellcheck="false" autocorrect="off" onInput="this.parentNode.dataset.value=this.value"{% if ea.crud.currentAction == 'index' and ea.crud.autofocusSearch == true %} autofocus="autofocus"{% endif %}>
+                                                            <input class="form-control {{ app.request.get('query') is null ? 'is-blank' }}" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ t('action.search', ea_context(app.request).i18n.translationParameters, 'EasyAdminBundle')|trans }}" spellcheck="false" autocorrect="off" onInput="this.parentNode.dataset.value=this.value"{% if ea_context(app.request).crud.currentAction == 'index' and ea_context(app.request).crud.autofocusSearch == true %} autofocus="autofocus"{% endif %}>
                                                         </label>
 
                                                         {% if app.request.get('query') %}
@@ -308,8 +308,8 @@
                                     <div class="dropdown user-menu-wrapper {{ is_granted(impersonator_permission) ? 'user-is-impersonated' }}">
                                         <a class="user-details" type="button" data-bs-toggle="dropdown" data-bs-offset="0,5" aria-expanded="false">
                                             {{ user_menu_avatar }}
-                                            {% if ea.userMenu.isNameDisplayed %}
-                                                <span class="user-name">{{ ea.userMenu.name }}</span>
+                                            {% if ea_context(app.request).userMenu.isNameDisplayed %}
+                                                <span class="user-name">{{ ea_context(app.request).userMenu.name }}</span>
                                             {% endif %}
                                         </a>
 
@@ -329,7 +329,7 @@
                         {% block content %}
                             <article class="content">
                                 {% block content_header_wrapper %}
-                                    {% set has_help_message = (ea.crud.helpMessage ?? '') is not empty %}
+                                    {% set has_help_message = (ea_context(app.request).crud.helpMessage ?? '') is not empty %}
                                     <section class="content-header">
                                         {% block content_header %}
                                             <div class="content-header-title">
@@ -338,7 +338,7 @@
 
                                                     {% block content_help %}
                                                         {% if has_help_message %}
-                                                            <a tabindex="0" class="content-header-help" data-bs-toggle="popover" data-bs-custom-class="ea-content-help-popover" data-bs-animation="true" data-bs-html="true" data-bs-placement="bottom" data-bs-trigger="focus" data-bs-content="{{ ea.crud.helpMessage|trans|e('html_attr') }}">
+                                                            <a tabindex="0" class="content-header-help" data-bs-toggle="popover" data-bs-custom-class="ea-content-help-popover" data-bs-animation="true" data-bs-html="true" data-bs-placement="bottom" data-bs-trigger="focus" data-bs-content="{{ ea_context(app.request).crud.helpMessage|trans|e('html_attr') }}">
                                                                 <i class="far fa-question-circle"></i>
                                                             </a>
                                                         {% endif %}
@@ -378,7 +378,7 @@
     {% block body_javascript %}{% endblock body_javascript %}
 
     {% block configured_body_contents %}
-        {% for htmlContent in ea.assets.bodyContents ?? [] %}
+        {% for htmlContent in ea_context(app.request).assets.bodyContents ?? [] %}
             {{ htmlContent|raw }}
         {% endfor %}
     {% endblock %}

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -1,8 +1,8 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
+{% trans_default_domain ea_context().i18n.translationDomain %}
 
 <!DOCTYPE html>
-<html lang="{{ ea_context(app.request).i18n.htmlLocale }}" dir="{{ ea_context(app.request).i18n.textDirection }}" data-turbo="false">
+<html lang="{{ ea_context().i18n.htmlLocale }}" dir="{{ ea_context().i18n.textDirection }}" data-turbo="false">
 <head>
     {% block head_metas %}
         <meta charset="utf-8">
@@ -16,37 +16,37 @@
     <title>{{ page_title_block_output|striptags|raw }}</title>
 
     {% block head_stylesheets %}
-        <link rel="stylesheet" href="{{ asset('app.css', ea_context(app.request).assets.defaultAssetPackageName) }}">
+        <link rel="stylesheet" href="{{ asset('app.css', ea_context().assets.defaultAssetPackageName) }}">
     {% endblock %}
 
     {% block configured_stylesheets %}
-        {{ include('@EasyAdmin/includes/_css_assets.html.twig', { assets: ea_context(app.request).assets.cssAssets ?? [] }, with_context = false) }}
-        {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', { assets: ea_context(app.request).assets.webpackEncoreAssets ?? [] }, with_context = false) }}
+        {{ include('@EasyAdmin/includes/_css_assets.html.twig', { assets: ea_context().assets.cssAssets ?? [] }, with_context = false) }}
+        {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', { assets: ea_context().assets.webpackEncoreAssets ?? [] }, with_context = false) }}
     {% endblock %}
 
     {% block head_favicon %}
-        <link rel="shortcut icon" href="{{ asset(ea_context(app.request).dashboardFaviconPath) }}">
+        <link rel="shortcut icon" href="{{ asset(ea_context().dashboardFaviconPath) }}">
     {% endblock %}
 
     {% block head_javascript %}
-        <script src="{{ asset('app.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
+        <script src="{{ asset('app.js', ea_context().assets.defaultAssetPackageName) }}"></script>
 
         {% block importmap %}
-            {{ include('@EasyAdmin/includes/_importmap.html.twig', { assets: ea_context(app.request).assets.assetMapperAssets ?? [] }, with_context = false) }}
+            {{ include('@EasyAdmin/includes/_importmap.html.twig', { assets: ea_context().assets.assetMapperAssets ?? [] }, with_context = false) }}
         {% endblock %}
     {% endblock head_javascript %}
 
     {% block configured_javascripts %}
-        {{ include('@EasyAdmin/includes/_js_assets.html.twig', { assets: ea_context(app.request).assets.jsAssets ?? [] }, with_context = false) }}
-        {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', { assets: ea_context(app.request).assets.webpackEncoreAssets ?? [] }, with_context = false) }}
+        {{ include('@EasyAdmin/includes/_js_assets.html.twig', { assets: ea_context().assets.jsAssets ?? [] }, with_context = false) }}
+        {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', { assets: ea_context().assets.webpackEncoreAssets ?? [] }, with_context = false) }}
     {% endblock %}
 
-    {% if 'rtl' == ea_context(app.request).i18n.textDirection %}
-        <link rel="stylesheet" href="{{ asset('app.rtl.css', ea_context(app.request).assets.defaultAssetPackageName) }}">
+    {% if 'rtl' == ea_context().i18n.textDirection %}
+        <link rel="stylesheet" href="{{ asset('app.rtl.css', ea_context().assets.defaultAssetPackageName) }}">
     {% endif %}
 
     {% block configured_head_contents %}
-        {% for htmlContent in ea_context(app.request).assets.headContents ?? [] %}
+        {% for htmlContent in ea_context().assets.headContents ?? [] %}
             {{ htmlContent|raw }}
         {% endfor %}
     {% endblock %}
@@ -56,32 +56,32 @@
     <body {% block body_attr %}{% endblock %}
         id="{% block body_id %}{% endblock %}"
         class="ea {% block body_class %}{% endblock %}"
-        data-ea-content-width="{{ ea_context(app.request).crud.contentWidth ?? ea_context(app.request).dashboardContentWidth ?? 'normal' }}"
-        data-ea-sidebar-width="{{ ea_context(app.request).crud.sidebarWidth ?? ea_context(app.request).dashboardSidebarWidth ?? 'normal' }}"
-        data-ea-dark-scheme-is-enabled="{{ ea_context(app.request).dashboardHasDarkModeEnabled ? 'true' : 'false' }}"
+        data-ea-content-width="{{ ea_context().crud.contentWidth ?? ea_context().dashboardContentWidth ?? 'normal' }}"
+        data-ea-sidebar-width="{{ ea_context().crud.sidebarWidth ?? ea_context().dashboardSidebarWidth ?? 'normal' }}"
+        data-ea-dark-scheme-is-enabled="{{ ea_context().dashboardHasDarkModeEnabled ? 'true' : 'false' }}"
     >
     {% block javascript_page_layout %}
-        <script src="{{ asset('page-layout.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
+        <script src="{{ asset('page-layout.js', ea_context().assets.defaultAssetPackageName) }}"></script>
     {% endblock javascript_page_layout %}
     {% block javascript_page_color_scheme %}
-        <script src="{{ asset('page-color-scheme.js', ea_context(app.request).assets.defaultAssetPackageName) }}"></script>
+        <script src="{{ asset('page-color-scheme.js', ea_context().assets.defaultAssetPackageName) }}"></script>
     {% endblock javascript_page_color_scheme %}
 
     {% block wrapper_wrapper %}
         {% block flash_messages %}
-            {{ include(ea_context(app.request).templatePath('flash_messages')) }}
+            {{ include(ea_context().templatePath('flash_messages')) }}
         {% endblock flash_messages %}
 
         {% set user_menu_avatar %}
-            {% if null == ea_context(app.request).userMenu.avatarUrl %}
+            {% if null == ea_context().userMenu.avatarUrl %}
                 <span class="user-avatar">
                     <span class="fa-stack">
                         <i class="user-avatar-icon-background fas fa-square fa-stack-2x"></i>
-                        <i class="user-avatar-icon-foreground {{ ea_context(app.request).user is not null ? 'fa fa-user' : 'fas fa-user-slash' }} fa-stack-1x fa-inverse"></i>
+                        <i class="user-avatar-icon-foreground {{ ea_context().user is not null ? 'fa fa-user' : 'fas fa-user-slash' }} fa-stack-1x fa-inverse"></i>
                     </span>
                 </span>
             {% else %}
-                <img class="user-avatar" src="{{ ea_context(app.request).userMenu.avatarUrl }}" />
+                <img class="user-avatar" src="{{ ea_context().userMenu.avatarUrl }}" />
             {% endif %}
         {% endset %}
 
@@ -93,14 +93,14 @@
                     <div>{{ user_menu_avatar }}</div>
                     <div>
                         <span class="user-label">{{ 'user.logged_in_as'|trans(domain = 'EasyAdminBundle') }}</span>
-                        <span class="user-name">{{ ea_context(app.request).user is null ? 'user.anonymous'|trans(domain = 'EasyAdminBundle') : ea_context(app.request).userMenu.name }}</span>
+                        <span class="user-name">{{ ea_context().user is null ? 'user.anonymous'|trans(domain = 'EasyAdminBundle') : ea_context().userMenu.name }}</span>
                     </div>
                 </li>
 
                 {% block user_menu %}
-                    {% if ea_context(app.request).userMenu.items|length > 0 %}
+                    {% if ea_context().userMenu.items|length > 0 %}
                         <li><hr class="dropdown-divider"></li>
-                        {% for item in ea_context(app.request).userMenu.items %}
+                        {% for item in ea_context().userMenu.items %}
                             <li>
                                 {% if item.isMenuSection and not loop.first %}
                                     <hr class="dropdown-divider">
@@ -120,19 +120,19 @@
         {% endset %}
 
         {% set settings_dropdown %}
-            {% if ea_context(app.request).dashboardLocales or ea_context(app.request).dashboardHasDarkModeEnabled %}
+            {% if ea_context().dashboardLocales or ea_context().dashboardHasDarkModeEnabled %}
                 <div class="dropdown dropdown-settings">
                     <a class="dropdown-settings-button" type="button" data-bs-toggle="dropdown" data-bs-offset="0,5" aria-expanded="false">
                         <i class="fas fa-gear"></i>
                     </a>
 
                     <ul class="dropdown-menu dropdown-menu-end">
-                        {% if ea_context(app.request).dashboardLocales %}
+                        {% if ea_context().dashboardLocales %}
                             <li class="dropdown-header dropdown-locales-label">
                                 {{ 'settings.locale'|trans(domain = 'EasyAdminBundle') }}
                             </li>
 
-                            {% for localeDto in ea_context(app.request).dashboardLocales %}
+                            {% for localeDto in ea_context().dashboardLocales %}
                                 <li>
                                     <a href="{{ ea_url().set('_locale', localeDto.locale) }}" class="dropdown-item{% if app.request.locale == localeDto.locale %} active{% endif %}">
                                         {% if localeDto.icon %}
@@ -144,8 +144,8 @@
                             {% endfor %}
                         {% endif %}
 
-                        {% if ea_context(app.request).dashboardHasDarkModeEnabled %}
-                            {% if ea_context(app.request).dashboardLocales %}
+                        {% if ea_context().dashboardHasDarkModeEnabled %}
+                            {% if ea_context().dashboardLocales %}
                                 <div class="dropdown-divider"></div>
                             {% endif %}
 
@@ -186,8 +186,8 @@
 
                         <div id="responsive-header-logo" class="text-truncate ms-auto">
                             {% block responsive_header_logo %}
-                                <a class="responsive-logo" title="{{ ea_context(app.request).dashboardTitle|striptags }}" href="{{ path(ea_context(app.request).dashboardRouteName) }}">
-                                    {{ ea_context(app.request).dashboardTitle|raw }}
+                                <a class="responsive-logo" title="{{ ea_context().dashboardTitle|striptags }}" href="{{ path(ea_context().dashboardRouteName) }}">
+                                    {{ ea_context().dashboardTitle|raw }}
                                 </a>
                             {% endblock responsive_header_logo %}
                         </div>
@@ -196,10 +196,10 @@
                             <a class="user-details" type="button" data-bs-toggle="dropdown" data-bs-offset="0,5" aria-expanded="false">
                                 {# to make the site design consistent, always display the user avatar in responsive header
                                    and hide the user name (because there's no space left) regardless of the user config #}
-                                {% if ea_context(app.request).userMenu.avatarDisplayed %}
+                                {% if ea_context().userMenu.avatarDisplayed %}
                                     {{ user_menu_avatar }}
                                 {% else %}
-                                    <i class="user-avatar fa fa-fw {{ ea_context(app.request).user is not null ? 'fa-user' : 'fa-user-times' }}"></i>
+                                    <i class="user-avatar fa fa-fw {{ ea_context().user is not null ? 'fa-user' : 'fa-user-times' }}"></i>
                                 {% endif %}
                             </a>
 
@@ -219,8 +219,8 @@
                                     {% block header_navbar %}
                                         <div id="header-logo">
                                             {% block header_logo %}
-                                                <a class="logo" title="{{ ea_context(app.request).dashboardTitle|striptags }}" href="{{ path(ea_context(app.request).dashboardRouteName) }}">
-                                                    <span class="logo-custom">{{ ea_context(app.request).dashboardTitle|raw }}</span>
+                                                <a class="logo" title="{{ ea_context().dashboardTitle|striptags }}" href="{{ path(ea_context().dashboardRouteName) }}">
+                                                    <span class="logo-custom">{{ ea_context().dashboardTitle|raw }}</span>
                                                     <span class="logo-compact"><i class="fas fa-home"></i></span>
                                                 </a>
                                             {% endblock header_logo %}
@@ -231,7 +231,7 @@
                             </header>
 
                             {% block main_menu_wrapper %}
-                                {{ include(ea_context(app.request).templatePath('main_menu')) }}
+                                {{ include(ea_context().templatePath('main_menu')) }}
                             {% endblock main_menu_wrapper %}
                         {% endblock sidebar %}
 
@@ -240,7 +240,7 @@
                 </div>
 
                 <section class="main-content">
-                    {% set has_search = ea_context(app.request).crud is not null and ea_context(app.request).crud.isSearchEnabled %}
+                    {% set has_search = ea_context().crud is not null and ea_context().crud.isSearchEnabled %}
                     <aside class="content-top {{ has_search ? 'ea-search-enabled' : 'ea-search-disabled' }}">
                         {% block content_top_header %}
                             {% block search_wrapper %}
@@ -251,7 +251,7 @@
                                         <form class="form-action-search" method="get">
                                             {% block search_form %}
                                                 {% block search_form_filters %}
-                                                    {% for field, fieldValue in ea_context(app.request).search.appliedFilters %}
+                                                    {% for field, fieldValue in ea_context().search.appliedFilters %}
                                                         {% if fieldValue is iterable %}
                                                             {% for key, value in fieldValue %}
                                                                 {# This code re-applies your filters on searches, an iterable check is needed in cases we have more than one object for a filter #}
@@ -277,7 +277,7 @@
                                                 {% endblock %}
 
                                                 <input type="hidden" name="crudAction" value="index">
-                                                <input type="hidden" name="crudControllerFqcn" value="{{ ea_context(app.request).request.query.get('crudControllerFqcn') }}">
+                                                <input type="hidden" name="crudControllerFqcn" value="{{ ea_context().request.query.get('crudControllerFqcn') }}">
                                                 <input type="hidden" name="page" value="1">
 
                                                 <div class="form-group">
@@ -285,7 +285,7 @@
                                                         <i class="fas fa-search content-search-icon"></i>
 
                                                         <label class="content-search-label" data-value="{{ app.request.get('query') }}">
-                                                            <input class="form-control {{ app.request.get('query') is null ? 'is-blank' }}" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ t('action.search', ea_context(app.request).i18n.translationParameters, 'EasyAdminBundle')|trans }}" spellcheck="false" autocorrect="off" onInput="this.parentNode.dataset.value=this.value"{% if ea_context(app.request).crud.currentAction == 'index' and ea_context(app.request).crud.autofocusSearch == true %} autofocus="autofocus"{% endif %}>
+                                                            <input class="form-control {{ app.request.get('query') is null ? 'is-blank' }}" type="search" name="query" value="{{ app.request.get('query') ?? '' }}" placeholder="{{ t('action.search', ea_context().i18n.translationParameters, 'EasyAdminBundle')|trans }}" spellcheck="false" autocorrect="off" onInput="this.parentNode.dataset.value=this.value"{% if ea_context().crud.currentAction == 'index' and ea_context().crud.autofocusSearch == true %} autofocus="autofocus"{% endif %}>
                                                         </label>
 
                                                         {% if app.request.get('query') %}
@@ -308,8 +308,8 @@
                                     <div class="dropdown user-menu-wrapper {{ is_granted(impersonator_permission) ? 'user-is-impersonated' }}">
                                         <a class="user-details" type="button" data-bs-toggle="dropdown" data-bs-offset="0,5" aria-expanded="false">
                                             {{ user_menu_avatar }}
-                                            {% if ea_context(app.request).userMenu.isNameDisplayed %}
-                                                <span class="user-name">{{ ea_context(app.request).userMenu.name }}</span>
+                                            {% if ea_context().userMenu.isNameDisplayed %}
+                                                <span class="user-name">{{ ea_context().userMenu.name }}</span>
                                             {% endif %}
                                         </a>
 
@@ -329,7 +329,7 @@
                         {% block content %}
                             <article class="content">
                                 {% block content_header_wrapper %}
-                                    {% set has_help_message = (ea_context(app.request).crud.helpMessage ?? '') is not empty %}
+                                    {% set has_help_message = (ea_context().crud.helpMessage ?? '') is not empty %}
                                     <section class="content-header">
                                         {% block content_header %}
                                             <div class="content-header-title">
@@ -338,7 +338,7 @@
 
                                                     {% block content_help %}
                                                         {% if has_help_message %}
-                                                            <a tabindex="0" class="content-header-help" data-bs-toggle="popover" data-bs-custom-class="ea-content-help-popover" data-bs-animation="true" data-bs-html="true" data-bs-placement="bottom" data-bs-trigger="focus" data-bs-content="{{ ea_context(app.request).crud.helpMessage|trans|e('html_attr') }}">
+                                                            <a tabindex="0" class="content-header-help" data-bs-toggle="popover" data-bs-custom-class="ea-content-help-popover" data-bs-animation="true" data-bs-html="true" data-bs-placement="bottom" data-bs-trigger="focus" data-bs-content="{{ ea_context().crud.helpMessage|trans|e('html_attr') }}">
                                                                 <i class="far fa-question-circle"></i>
                                                             </a>
                                                         {% endif %}
@@ -378,7 +378,7 @@
     {% block body_javascript %}{% endblock body_javascript %}
 
     {% block configured_body_contents %}
-        {% for htmlContent in ea_context(app.request).assets.bodyContents ?? [] %}
+        {% for htmlContent in ea_context().assets.bodyContents ?? [] %}
             {{ htmlContent|raw }}
         {% endfor %}
     {% endblock %}

--- a/src/Resources/views/menu.html.twig
+++ b/src/Resources/views/menu.html.twig
@@ -4,7 +4,7 @@
 
     <ul class="menu">
         {% block main_menu %}
-            {% for menuItem in ea.mainMenu.items %}
+            {% for menuItem in ea_context(app.request).mainMenu.items %}
                 {% block menu_item %}
                     {% set is_submenu_item_with_no_items = menuItem.type == constant('EasyCorp\\Bundle\\EasyAdminBundle\\Dto\\MenuItemDto::TYPE_SUBMENU') and not menuItem.hasSubItems %}
                     {% if is_submenu_item_with_no_items %}

--- a/src/Resources/views/menu.html.twig
+++ b/src/Resources/views/menu.html.twig
@@ -4,7 +4,7 @@
 
     <ul class="menu">
         {% block main_menu %}
-            {% for menuItem in ea_context(app.request).mainMenu.items %}
+            {% for menuItem in ea_context().mainMenu.items %}
                 {% block menu_item %}
                     {% set is_submenu_item_with_no_items = menuItem.type == constant('EasyCorp\\Bundle\\EasyAdminBundle\\Dto\\MenuItemDto::TYPE_SUBMENU') and not menuItem.hasSubItems %}
                     {% if is_submenu_item_with_no_items %}

--- a/src/Resources/views/page/content.html.twig
+++ b/src/Resources/views/page/content.html.twig
@@ -1,6 +1,6 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{% extends ea.templatePath('layout') %}
-{% trans_default_domain ea.i18n.translationDomain %}
+{% extends ea_context(app.request).templatePath('layout') %}
+{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
 
 {% block body_class 'page-content' %}
 

--- a/src/Resources/views/page/content.html.twig
+++ b/src/Resources/views/page/content.html.twig
@@ -1,6 +1,6 @@
 {# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{% extends ea_context(app.request).templatePath('layout') %}
-{% trans_default_domain ea_context(app.request).i18n.translationDomain %}
+{% extends ea_context().templatePath('layout') %}
+{% trans_default_domain ea_context().i18n.translationDomain %}
 
 {% block body_class 'page-content' %}
 

--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -2,11 +2,11 @@
 {# This template checks for 'ea' variable existence because it can
    be used in a EasyAdmin Dashboard controller, where 'ea' is defined
    or from any other Symfony controller, where 'ea' is not defined #}
-{% extends ea is defined ? ea_context(app.request).templatePath('layout') : '@EasyAdmin/page/login_minimal.html.twig' %}
-{% trans_default_domain ea is defined ? ea_context(app.request).i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
+{% extends ea is defined ? ea_context().templatePath('layout') : '@EasyAdmin/page/login_minimal.html.twig' %}
+{% trans_default_domain ea is defined ? ea_context().i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% block body_class 'page-login' %}
-{% block page_title %}{{ page_title is defined ? page_title|raw : (ea is defined ? ea_context(app.request).dashboardTitle|raw : '') }}{% endblock %}
+{% block page_title %}{{ page_title is defined ? page_title|raw : (ea is defined ? ea_context().dashboardTitle|raw : '') }}{% endblock %}
 
 {% block head_favicon %}
     {% if favicon_path|default(false) %}
@@ -32,7 +32,7 @@
                 {% block header_logo %}
                     {% if page_title %}
                         {% if ea is defined %}
-                            <a class="logo {{ page_title|length > 14 ? 'logo-long' }}" title="{{ page_title|striptags }}" href="{{ path(ea_context(app.request).dashboardRouteName) }}">
+                            <a class="logo {{ page_title|length > 14 ? 'logo-long' }}" title="{{ page_title|striptags }}" href="{{ path(ea_context().dashboardRouteName) }}">
                                 {{ page_title|raw }}
                             </a>
                         {% else %}
@@ -59,7 +59,7 @@
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrf_token_intention) }}">
                 {% endif %}
 
-                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea is defined ? path(ea_context(app.request).dashboardRouteName) : '/') }}" />
+                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea is defined ? path(ea_context().dashboardRouteName) : '/') }}" />
 
                 <div class="form-group">
                     <label class="form-control-label required" for="username">{{ _username_label }}</label>

--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -2,11 +2,11 @@
 {# This template checks for 'ea' variable existence because it can
    be used in a EasyAdmin Dashboard controller, where 'ea' is defined
    or from any other Symfony controller, where 'ea' is not defined #}
-{% extends ea is defined ? ea.templatePath('layout') : '@EasyAdmin/page/login_minimal.html.twig' %}
-{% trans_default_domain ea is defined ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
+{% extends ea is defined ? ea_context(app.request).templatePath('layout') : '@EasyAdmin/page/login_minimal.html.twig' %}
+{% trans_default_domain ea is defined ? ea_context(app.request).i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% block body_class 'page-login' %}
-{% block page_title %}{{ page_title is defined ? page_title|raw : (ea is defined ? ea.dashboardTitle|raw : '') }}{% endblock %}
+{% block page_title %}{{ page_title is defined ? page_title|raw : (ea is defined ? ea_context(app.request).dashboardTitle|raw : '') }}{% endblock %}
 
 {% block head_favicon %}
     {% if favicon_path|default(false) %}
@@ -32,7 +32,7 @@
                 {% block header_logo %}
                     {% if page_title %}
                         {% if ea is defined %}
-                            <a class="logo {{ page_title|length > 14 ? 'logo-long' }}" title="{{ page_title|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
+                            <a class="logo {{ page_title|length > 14 ? 'logo-long' }}" title="{{ page_title|striptags }}" href="{{ path(ea_context(app.request).dashboardRouteName) }}">
                                 {{ page_title|raw }}
                             </a>
                         {% else %}
@@ -59,7 +59,7 @@
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrf_token_intention) }}">
                 {% endif %}
 
-                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea is defined ? path(ea.dashboardRouteName) : '/') }}" />
+                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea is defined ? path(ea_context(app.request).dashboardRouteName) : '/') }}" />
 
                 <div class="form-group">
                     <label class="form-control-label required" for="username">{{ _username_label }}</label>

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -3,6 +3,8 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Twig;
 
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldLayoutDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
@@ -10,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapRenderer;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -48,6 +51,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
     {
         return [
             new TwigFunction('ea_url', [$this, 'getAdminUrlGenerator']),
+            new TwigFunction('ea_context', [$this, 'getContext']),
             new TwigFunction('ea_csrf_token', [$this, 'renderCsrfToken']),
             new TwigFunction('ea_call_function_if_exists', [$this, 'callFunctionIfExists'], ['needs_environment' => true, 'is_safe' => ['html' => true]]),
             new TwigFunction('ea_create_field_layout', [$this, 'createFieldLayout']),
@@ -70,6 +74,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
         $context = $this->adminContextProvider->getContext();
 
         // when there's an admin context, make it available in all templates as a short named variable
+        // @deprecated
         return null === $context ? [] : ['ea' => $context];
     }
 
@@ -189,6 +194,11 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
     public function getAdminUrlGenerator(array $queryParameters = []): AdminUrlGeneratorInterface
     {
         return $this->serviceLocator->get(AdminUrlGenerator::class)->setAll($queryParameters);
+    }
+
+    public function getContext(Request $request = null): ?AdminContext
+    {
+        return null !== $request ? $request->get(EA::CONTEXT_REQUEST_ATTRIBUTE) : null;
     }
 
     /**

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -10,10 +10,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
-use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapRenderer;
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -52,7 +50,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
     {
         return [
             new TwigFunction('ea_url', [$this, 'getAdminUrlGenerator']),
-            new TwigFunction('ea_context', [$this, 'getContext'], ['needs_context' => true]),
+            new TwigFunction('ea_context', [$this, 'getContext']),
             new TwigFunction('ea_csrf_token', [$this, 'renderCsrfToken']),
             new TwigFunction('ea_call_function_if_exists', [$this, 'callFunctionIfExists'], ['needs_environment' => true, 'is_safe' => ['html' => true]]),
             new TwigFunction('ea_create_field_layout', [$this, 'createFieldLayout']),
@@ -197,13 +195,9 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
         return $this->serviceLocator->get(AdminUrlGenerator::class)->setAll($queryParameters);
     }
 
-    public function getContext(array $context): ?AdminContext
+    public function getContext(): ?AdminContext
     {
-        if (!isset($context['app']) || !$context['app'] instanceof AppVariable) {
-            throw new \LogicException('The Twig variable "app" cannot be overwritten before using "ea_context" function.');
-        }
-
-        return null !== ($request = $context['app']->getRequest()) ? $request->get(EA::CONTEXT_REQUEST_ATTRIBUTE) : null;
+        return $this->adminContextProvider->getContext();
     }
 
     /**


### PR DESCRIPTION
Fix #5591 (see https://github.com/EasyCorp/EasyAdminBundle/issues/5591#issuecomment-2003793110)

The Twig environment is instantiated lazily when the first template is rendered, this is why it's possible to set the global variable `ea` conditionally depending on the current HTTP request. But this is fragile if there is anything that renders a template earlier.

In particular, this mechanism does not work with the worker modes of FrankenPHP and RoadRunner: the Twig environment is not reinitialized between HTTP requests.


- Introduces a new function `ea_context` to lazy-load the `AdminContext` from the current HTTP request. The name can be discussed.
- The `ea` global variable is deprecated and replaced in all the templates.

