### PR TITLE
Support re-enabling actions if they have been disabled.

### DIFF
--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -149,6 +149,13 @@ final class Actions
         return $this;
     }
 
+    public function enable(string ...$enabledActionNames): self
+    {
+        $this->dto->enableActions($enabledActionNames);
+
+        return $this;
+    }
+
     public function getAsDto(?string $pageName): ActionConfigDto
     {
         $this->dto->setPageName($pageName);

--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -151,6 +151,13 @@ final class Actions
 
     public function enable(string ...$enabledActionNames): self
     {
+        // if 'delete' or 'batch delete' is enabled, both are enabled automatically.
+        // This is the most common case, but user can re-disable the action if needed manually
+        if (\in_array(Action::DELETE, $enabledActionNames, true) || \in_array(Action::BATCH_DELETE, $enabledActionNames, true)) {
+            $enabledActionNames[] = Action::DELETE;
+            $enabledActionNames[] = Action::BATCH_DELETE;
+        }
+
         $this->dto->enableActions($enabledActionNames);
 
         return $this;

--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -109,6 +109,14 @@ final class ActionConfigDto
     }
 
     /**
+     * @param array<string> $actionNames
+     */
+    public function enableActions(array $actionNames): void
+    {
+        $this->disabledActions = array_values(array_diff($this->disabledActions, $actionNames));
+    }
+
+    /**
      * @return ActionCollection|array<string,array<string,ActionDto|ActionGroupDto>>
      */
     public function getActions(): ActionCollection|array

--- a/tests/Unit/Config/ActionsTest.php
+++ b/tests/Unit/Config/ActionsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Config;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use PHPUnit\Framework\TestCase;
+
+class ActionsTest extends TestCase
+{
+    public function testEnableDeleteAction(): void
+    {
+        $actions = Actions::new();
+        $actions->disable(Action::DELETE);
+
+        $this->assertSame(['delete', 'batchDelete'], $actions->getAsDto(null)->getDisabledActions());
+
+        $actions->enable(Action::DELETE);
+        $this->assertSame([], $actions->getAsDto(null)->getDisabledActions());
+    }
+
+    public function testEnableBatchDeleteAction(): void
+    {
+        $actions = Actions::new();
+        $actions->disable(Action::BATCH_DELETE);
+
+        $this->assertSame(['batchDelete'], $actions->getAsDto(null)->getDisabledActions());
+
+        $actions->enable(Action::BATCH_DELETE);
+        $this->assertSame([], $actions->getAsDto(null)->getDisabledActions());
+    }
+
+    public function testEnableBatchDeleteActionWillEnableDeleteAsWell(): void
+    {
+        $actions = Actions::new();
+        $actions->disable(Action::DELETE, Action::BATCH_DELETE);
+
+        $this->assertSame(['delete', 'batchDelete'], $actions->getAsDto(null)->getDisabledActions());
+
+        $actions->enable(Action::BATCH_DELETE);
+        $this->assertSame([], $actions->getAsDto(null)->getDisabledActions());
+    }
+}

--- a/tests/Unit/Dto/ActionConfigDtoTest.php
+++ b/tests/Unit/Dto/ActionConfigDtoTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Dto;
+
+use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionConfigDto;
+use PHPUnit\Framework\TestCase;
+
+final class ActionConfigDtoTest extends TestCase
+{
+    public static function provideLabels(): \Generator
+    {
+        yield 'nothing to enable' => [[], ['foo', 'bar', 'baz', 'qux']];
+        yield 'enable action not disabled' => [['not-disabled'], ['foo', 'bar', 'baz', 'qux']];
+        yield 'enable 1 action' => [['bar'], ['foo', 'baz', 'qux']];
+        yield 'enable multiple action' => [['foo', 'baz'], ['bar', 'qux']];
+        yield 'enable all' => [['foo', 'bar', 'baz', 'qux'], []];
+    }
+
+    /**
+     * @dataProvider provideLabels
+     */
+    public function testEnableActions(array $actionsToEnable, array $expectedDisabledActions): void
+    {
+        $actionConfigDto = new ActionConfigDto();
+        $actionConfigDto->disableActions(['foo', 'bar', 'baz', 'qux']);
+
+        $this->assertSame(['foo', 'bar', 'baz', 'qux'], $actionConfigDto->getDisabledActions());
+
+        $actionConfigDto->enableActions($actionsToEnable);
+        $this->assertSame($expectedDisabledActions, $actionConfigDto->getDisabledActions());
+    }
+}


### PR DESCRIPTION
If an action has been disabled, there is no way to reenable it.

This is usefull when having a base controller that gets extended to create different views. If an action should by default be disabled (in the base controller) it will not be possible to reenable it in the extending controller.

Also fixes #5128