### PR TITLE
Fix upload file to subdir

### DIFF
--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -97,7 +97,7 @@ class StringToFileTransformer implements DataTransformerInterface
         }
 
         if ($value instanceof File) {
-            return $value->getFilename();
+            return str_replace($this->uploadDir, '', $value->getPathname());
         }
 
         throw new TransformationFailedException('Expected an instance of File or null.');

--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -77,7 +77,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         $uploadNew = static function (UploadedFile $file, string $uploadDir, string $fileName) {
-            $file->move($uploadDir.'/'.dirname($filename), $fileName);
+            $file->move($uploadDir.'/'.dirname($fileName), $fileName);
         };
 
         $uploadDelete = static function (File $file) {

--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -77,7 +77,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         $uploadNew = static function (UploadedFile $file, string $uploadDir, string $fileName) {
-            $file->move($uploadDir.'/'.dirname($fileName), $fileName);
+            $file->move($uploadDir.'/'.\dirname($fileName), $fileName);
         };
 
         $uploadDelete = static function (File $file) {

--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -77,7 +77,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         $uploadNew = static function (UploadedFile $file, string $uploadDir, string $fileName) {
-            $file->move($uploadDir, $fileName);
+            $file->move($uploadDir.'/'.dirname($filename), $fileName);
         };
 
         $uploadDelete = static function (File $file) {

--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -77,7 +77,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
     public function configureOptions(OptionsResolver $resolver): void
     {
         $uploadNew = static function (UploadedFile $file, string $uploadDir, string $fileName) {
-            $file->move($uploadDir.'/'.\dirname($fileName), $fileName);
+            $file->move($uploadDir.\dirname($fileName), $fileName);
         };
 
         $uploadDelete = static function (File $file) {


### PR DESCRIPTION
In docs (https://symfony.com/bundles/EasyAdminBundle/current/fields/ImageField.html) and annotation of `setUploadedFileNamePattern` method, noticed that you can combine uploaded file name like `[year]/[month]/[day]/[slug]-[contenthash].[extension]`
But in such case you get that name with subdirs in database field, but not in filesystem. 
`UploadedFile::move` works in such way (get basename of second parameter) because of 
https://github.com/symfony/symfony/blob/d90416ff001b3af6197df477d19eff4f101dac96/src/Symfony/Component/HttpFoundation/File/UploadedFile.php#L185

https://github.com/symfony/symfony/blob/d90416ff001b3af6197df477d19eff4f101dac96/src/Symfony/Component/HttpFoundation/File/File.php#L125
and
https://github.com/symfony/symfony/blob/d90416ff001b3af6197df477d19eff4f101dac96/src/Symfony/Component/HttpFoundation/File/File.php#L133-L139


As workaround you can add form type option `upload_new` for now, like
```php
ImageField::new('image')
    ->setBasePath('uploads')
    ->setUploadDir('public/uploads')
    ->setFormTypeOption('upload_new', static function ($file, string $uploadDir, string $fileName) {
        $file->move($uploadDir.dirname($fileName), $fileName);
    })
    ->setUploadedFileNamePattern('entity/[year]-[month]/[ulid].[extension]')

```