### PR TITLE
Fix empty query term conditions

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -120,7 +120,7 @@ final class EntityRepository implements EntityRepositoryInterface
                     $parameterName = sprintf('query_for_ulids_%d', $queryTermIndex);
                     $queryTermConditions->add(sprintf('%s.%s = :%s', $entityName, $propertyConfig['property_name'], $parameterName));
                     $queryBuilder->setParameter($parameterName, $dqlParameters['uuid_query'], 'ulid');
-                } elseif ($propertyConfig['is_text'] || $propertyConfig['is_integer']) {
+                } elseif ($propertyConfig['is_text']) {
                     $parameterName = sprintf('query_for_text_%d', $queryTermIndex);
                     // concatenating an empty string is needed to avoid issues on PostgreSQL databases (https://github.com/EasyCorp/EasyAdminBundle/issues/6290)
                     $queryTermConditions->add(sprintf('LOWER(CONCAT(%s.%s, \'\')) LIKE :%s', $entityName, $propertyConfig['property_name'], $parameterName));
@@ -132,6 +132,12 @@ final class EntityRepository implements EntityRepositoryInterface
                     $queryBuilder->setParameter($parameterName, $dqlParameters['text_query']);
                 }
             }
+
+            // When no fields are queried, the current condition must not yield any results
+            if (0 === $queryTermConditions->count()) {
+                $queryTermConditions->add('0 = 1');
+            }
+
             if (SearchMode::ALL_TERMS === $searchDto->getSearchMode()) {
                 $queryBuilder->andWhere($queryTermConditions);
             } else {

--- a/tests/Controller/Search/IdTermCrudSearchControllerTest.php
+++ b/tests/Controller/Search/IdTermCrudSearchControllerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller\Search;
+
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Search\IdTermCrudSearchController;
+
+class IdTermCrudSearchControllerTest extends AbstractCrudTestCase
+{
+    protected function getControllerFqcn(): string
+    {
+        return IdTermCrudSearchController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+    }
+
+    /**
+     * @dataProvider provideSearchTests
+     */
+    public function testSearch(string $query, int $expectedResultCount)
+    {
+        $this->client->request('GET', $this->generateIndexUrl($query));
+        static::assertResponseIsSuccessful();
+        static::assertIndexFullEntityCount($expectedResultCount);
+    }
+
+    public static function provideSearchTests(): iterable
+    {
+        // the CRUD Controller associated to this test has configured the search
+        // properties used by the search engine. That's why results are not the default ones
+        yield 'search by non numeric query yields no results' => [
+            'blog post',
+            0,
+        ];
+
+        yield 'search by id yield 1 result' => [
+            '15',
+            1,
+        ];
+    }
+}

--- a/tests/TestApplication/src/Controller/Search/IdTermCrudSearchController.php
+++ b/tests/TestApplication/src/Controller/Search/IdTermCrudSearchController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Search;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
+
+class IdTermCrudSearchController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return BlogPost::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setSearchFields(['id']);
+    }
+}


### PR DESCRIPTION
When only numeric fields are searchable, `EntityRepository::addSearchClause` generates a bugged DQL when search contains only non numeric terms.