### PR TITLE
Update GitHub CI workflow config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,16 +112,6 @@ jobs:
                   extensions: mbstring, intl, pdo, pdo_sqlite, sqlite3
                   ini-values: date.timezone=UTC
 
-            - name: Get Composer cache directory
-              id: composer-cache
-              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            - name: Mount PHP dependencies cache
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-php-${{ matrix.php_version }}-symfony-${{ matrix.symfony_version }}-${{ matrix.stability }}
-
             - name: symfony/flex is required to install the correct symfony version
               if: ${{ matrix.symfony_version }}
               run: |


### PR DESCRIPTION
Windows builds are failing on GitHub because of this error:

```
Run actions/cache@v4
Error: Input required and not supplied: path
```

I tried to debug this but I couldn't. I looked at other projects in the Symfony ecosystem but they use legacy v3 cache or not cache at all (e.g. https://github.com/doctrine/DoctrineBundle/blob/2.12.x/.github/workflows/continuous-integration.yml). So, let's try removing this cache and let's check if CI becomes much slower or not.