### PR TITLE
feat: allow setting custom attributes on crud

### DIFF
--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -430,4 +430,23 @@ class Crud
     {
         return [self::PAGE_DETAIL, self::PAGE_EDIT, self::PAGE_INDEX, self::PAGE_NEW];
     }
+
+    public function getHtmlAttributes(): array
+    {
+        return $this->dto->getHtmlAttributes();
+    }
+
+    public function setHtmlAttributes(array $htmlAttributes): self
+    {
+        $this->dto->setHtmlAttributes($htmlAttributes);
+
+        return $this;
+    }
+
+    public function setHtmlAttribute(string $attribute, mixed $value): self
+    {
+        $this->dto->setHtmlAttribute($attribute, $value);
+
+        return $this;
+    }
 }

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -65,6 +65,7 @@ final class CrudDto
     private ?string $contentWidth = null;
     private ?string $sidebarWidth = null;
     private bool $hideNullValues = false;
+    private array $htmlAttributes = [];
 
     public function __construct()
     {
@@ -506,5 +507,20 @@ final class CrudDto
     public function hideNullValues(bool $hide): void
     {
         $this->hideNullValues = $hide;
+    }
+
+    public function getHtmlAttributes(): array
+    {
+        return $this->htmlAttributes;
+    }
+
+    public function setHtmlAttributes(array $htmlAttributes): void
+    {
+        $this->htmlAttributes = $htmlAttributes;
+    }
+
+    public function setHtmlAttribute(string $attribute, mixed $value): void
+    {
+        $this->htmlAttributes[$attribute] = $value;
     }
 }

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -52,6 +52,12 @@
     {% endblock %}
 </head>
 
+{% macro render_html_attributes(attributes) %}
+    {% for attribute_name, attribute_value in attributes %}
+        {{ attribute_name }}="{{ attribute_value|e('html_attr') }}"
+    {% endfor %}
+{% endmacro %}
+
 {% block body %}
     <body {% block body_attr %}{% endblock %}
         id="{% block body_id %}{% endblock %}"
@@ -176,7 +182,7 @@
             {% endif %}
         {% endset %}
 
-        <div class="wrapper">
+        <div class="wrapper" {{ _self.render_html_attributes(ea.crud.htmlAttributes) }}>
             {% block wrapper %}
                 <div class="responsive-header">
                     {% block responsive_header %}

--- a/tests/Controller/CustomHtmlAttributeCrudControllerTest.php
+++ b/tests/Controller/CustomHtmlAttributeCrudControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CustomHtmlAttributeCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\SecureDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+
+class CustomHtmlAttributeCrudControllerTest extends AbstractCrudTestCase
+{
+    protected EntityRepository $categories;
+
+    protected function getControllerFqcn(): string
+    {
+        return CustomHtmlAttributeCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return SecureDashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+
+        $this->categories = $this->entityManager->getRepository(Category::class);
+    }
+
+    public function testHasCustomAttributes(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+        static::assertCount(1, $crawler->filter('div[multi-test-one="test1"]'));
+        static::assertCount(1, $crawler->filter('div[multi-test-two="test2"]'));
+    }
+}

--- a/tests/TestApplication/src/Controller/CustomHtmlAttributeCrudController.php
+++ b/tests/TestApplication/src/Controller/CustomHtmlAttributeCrudController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+
+class CustomHtmlAttributeCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Category::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setHtmlAttribute('multi-test-one', 'test1')
+            ->setHtmlAttribute('multi-test-two', 'test2');
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('name'),
+        ];
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $action1 = Action::new('action1')->linkToCrudAction('');
+        $action2 = Action::new('action2')->linkToCrudAction('')->setCssClass('foo');
+        $action3 = Action::new('action3')->linkToCrudAction('')->addCssClass('bar');
+        $action4 = Action::new('action4')->linkToCrudAction('')->setCssClass('foo')->addCssClass('bar');
+
+        return $actions
+            ->add(Crud::PAGE_INDEX, $action1)
+            ->add(Crud::PAGE_INDEX, $action2)
+            ->add(Crud::PAGE_INDEX, $action3)
+            ->add(Crud::PAGE_INDEX, $action4)
+            ->update(Crud::PAGE_INDEX, Action::NEW, function (Action $action) {
+                return $action->setIcon('fa fa-fw fa-plus')->setLabel(false);
+            })
+        ;
+    }
+}


### PR DESCRIPTION
Fixes #6231 by adding custom html attributes to the Crud(Dto).
They're added to the wrapper div currently, if you think the scope should be reduced a bit let me know.