### PR TITLE
Fix login form bottom padding

### DIFF
--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -90,9 +90,7 @@
                     </div>
                 {% endif %}
 
-                <div class="form-group">
-                    <button type="submit" class="btn btn-primary btn-lg btn-block">{{ _sign_in_label }}</button>
-                </div>
+                <button type="submit" class="btn btn-primary btn-lg btn-block">{{ _sign_in_label }}</button>
             </form>
 
             <script src="{{ asset('login.js', constant('EasyCorp\\Bundle\\EasyAdminBundle\\Asset\\AssetPackage::PACKAGE_NAME')) }}"></script>


### PR DESCRIPTION
Remove the bottom padding on the login form:

Before:

![image](https://github.com/EasyCorp/EasyAdminBundle/assets/915273/5bcbf339-19c8-499a-bf6a-3549b2a709f5)

After:

![image](https://github.com/EasyCorp/EasyAdminBundle/assets/915273/4a5a623e-5bf8-4d40-878e-114032598ebb)

