### PR TITLE
Fix XSS in layout h1

### DIFF
--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -37,7 +37,7 @@
     {%- apply spaceless -%}
         {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
+            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -45,7 +45,7 @@
     {%- apply spaceless -%}
         {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
+            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -39,7 +39,7 @@
     {%- apply spaceless -%}
         {% set custom_page_title = ea.crud.customPageTitle('index', null, ea.i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle('index', null, ea.i18n.translationParameters)|trans|raw
+            ? ea.crud.defaultPageTitle('index', null, ea.i18n.translationParameters)|trans
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -45,7 +45,7 @@
     {%- apply spaceless -%}
         {% set custom_page_title = ea.crud.customPageTitle('new', null, ea.i18n.translationParameters) %}
         {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle('new', null, ea.i18n.translationParameters)|trans|raw
+            ? ea.crud.defaultPageTitle('new', null, ea.i18n.translationParameters)|trans
             : custom_page_title|trans|raw }}
     {%- endapply -%}
 {% endblock %}


### PR DESCRIPTION
the default layout does a `| raw` which can be exploited if the entity of your CRUD has a `__string()` method that uses some fields from the database.

example to reproduce. 


create an entity Article with a field 'title' and a method __string() which returns it. 

Then put as title `<script>alert('toto')</script>`  -> an XSS is triggered

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
