### PR TITLE
Fixed invalid DQL

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -120,7 +120,7 @@ final class EntityRepository implements EntityRepositoryInterface
                     $parameterName = sprintf('query_for_ulids_%d', $queryTermIndex);
                     $queryTermConditions->add(sprintf('%s.%s = :%s', $entityName, $propertyConfig['property_name'], $parameterName));
                     $queryBuilder->setParameter($parameterName, $dqlParameters['uuid_query'], 'ulid');
-                } elseif ($propertyConfig['is_text']) {
+                } elseif ($propertyConfig['is_text'] || $propertyConfig['is_integer']) {
                     $parameterName = sprintf('query_for_text_%d', $queryTermIndex);
                     $queryTermConditions->add(sprintf('LOWER(%s.%s) LIKE :%s', $entityName, $propertyConfig['property_name'], $parameterName));
                     $queryBuilder->setParameter($parameterName, $dqlParameters['text_query']);


### PR DESCRIPTION
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/6223

When searching text having only integer fields, an invalid DQL like `SELECT entity FROM App\Entity\Product entity WHERE ` is generated because there are no any `$queryTermConditions`.  This PR should fix the issue.
