### PR TITLE
Allow highlight searchable fields with different names

### DIFF
--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -108,7 +108,7 @@
                     {% set ea_sort_asc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::ASC') %}
                     {% set ea_sort_desc = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Config\\Option\\SortOrder::DESC') %}
                     {% for field in entities|filter(e => e.isAccessible)|first.fields ?? [] %}
-                        {% set is_searchable = null == ea.crud.searchFields or field.property in ea.crud.searchFields %}
+                        {% set is_searchable = null == ea.crud.searchFields or field.property in ea.crud.searchFields or field.property in ea.crud.searchFields|keys %}
                         {% set is_sorting_field = ea.search.isSortingField(field.property) %}
                         {% set next_sort_direction = is_sorting_field ? (ea.search.sortDirection(field.property) == ea_sort_desc ? ea_sort_asc : ea_sort_desc) : ea_sort_desc %}
                         {% set column_icon = is_sorting_field ? (next_sort_direction == ea_sort_desc ? 'fa-arrow-up' : 'fa-arrow-down') : 'fa-sort' %}
@@ -146,7 +146,7 @@
                         {% endif %}
 
                         {% for field in entity.fields %}
-                            {% set is_searchable = null == ea.crud.searchFields or field.property in ea.crud.searchFields %}
+                            {% set is_searchable = null == ea.crud.searchFields or field.property in ea.crud.searchFields or field.property in ea.crud.searchFields|keys %}
 
                             <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea.i18n.textDirection }}">
                                 {{ include(field.templatePath, { field: field, entity: entity }, with_context = false) }}


### PR DESCRIPTION
Imagine crud controller with following configuration
```php
//...
    public function configureCrud(Crud $crud): Crud
    {
        return $crud
            ->setSearchFields(['child_collection.subentity.title'])
        ;
    }
//...
    public function configureFields(string $pageName): iterable
    {
        return [
            CollectionField::new('child_collection')
        ];
    }
```
In such case, search works fine by subnested field. 
Search query looks like
```sql
SELECT * FROM entity 
LEFT JOIN child_collection ON entity.id = child_collection.entity_id 
LEFT JOIN subentity ON child_collection.subentity_id = subentity.id 
WHERE (LOWER(subentity.title) LIKE ?)
```
BUT, search terms does not highlighted in index page, because `searchable` css class does not added to `td`

With proposed change it will be possible to do like this and all will be fine
```php
setSearchFields([
  'child_collection' => 'child_collection.subentity.title',
  'some_other_field',
])
```