### PR TITLE
Allow fields containing null-safe property paths

### DIFF
--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -48,7 +48,7 @@ class CrudFormType extends AbstractType
             // 'property_path' option to keep the original field name
             if (str_contains($fieldDto->getProperty(), '.')) {
                 $formFieldOptions['property_path'] = $fieldDto->getProperty();
-                $name = str_replace(['.', '[', ']'], '_', $fieldDto->getProperty());
+                $name = str_replace(['.', '[', ']', '?'], '_', $fieldDto->getProperty());
             } else {
                 $name = $fieldDto->getProperty();
             }


### PR DESCRIPTION
see https://github.com/EasyCorp/EasyAdminBundle/issues/6249

Added additional field name sanitization so that symfony form does not throw an error on fields with null-safe property paths.