### PR TITLE
Admin Url Fix for linking from Edit/Detail to Index pages.

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -284,6 +284,11 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
             $this->unset(EA::DASHBOARD_CONTROLLER_FQCN);
         }
 
+        // if the current action is 'index' and an entity ID is defined, remove the entity ID to prevent exceptions automatically
+        if (Action::INDEX === $this->get(EA::CRUD_ACTION) && null !== $this->get(EA::ENTITY_ID)) {
+            $this->unset(EA::ENTITY_ID);
+        }
+
         // this happens when generating URLs from outside EasyAdmin (AdminContext is null) and
         // no Dashboard FQCN has been defined explicitly
         if (null === $this->dashboardRoute) {


### PR DESCRIPTION
Scenario:
* have two entity CRUD forms
* have some entities in Entity 1
* have a few, or none in Entity 2
* have a association or relation to Entity 2 from Entity 1, but allow it to be null and let it be null (no links existing)
* have a link to the Crud Index for Entity 2 in the Form of Entity 1 (when updating / FK existing)
* click the link

Expected result:
* you get redirected to the Index Page of the desired CRUD

Result:
* Exception, as the FK of Entity 1 does not exist in Entity 2
* and if it would, it would be the wrong one, but thats not a bug / exception 

The main point is that the current setup assumes that there will always be existing links. Since non-referring pages like the Index do not need the entityId parameter, we can unset it when the scenario is matched (URL goes to Index, EntityId is set). 

