### PR TITLE
Replace unsafe guessClientExtension() method with guessExtension()

### DIFF
--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -159,7 +159,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
                 return strtr($fileNamePatternOrCallable, [
                     '[contenthash]' => sha1_file($file->getRealPath()),
                     '[day]' => date('d'),
-                    '[extension]' => $file->guessClientExtension(),
+                    '[extension]' => $file->guessExtension(),
                     '[month]' => date('m'),
                     '[name]' => pathinfo($file->getClientOriginalName(), \PATHINFO_FILENAME),
                     '[randomhash]' => bin2hex(random_bytes(20)),


### PR DESCRIPTION
`guessClientExtension()` method can not be trusted because it depends on request data. In addition, it will be easier to write tests because the extension of the uploaded file no longer depends on the MIME type passed in the request.
