### PR TITLE
Fix XSS when using  setFormatValue($callable)

### DIFF
--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\FieldTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use function Symfony\Component\String\u;
 use Twig\Markup;
@@ -58,7 +58,7 @@ final class CommonPostConfigurator implements FieldConfiguratorInterface
         // in the code just because some people need to have HTML/JS
         // so that if you want know what you're doing you have to explicitly
         // disable this.
-        if ($field->getCustomOptions(TextField::OPTION_STRIP_TAGS)) {
+        if ($field->getCustomOption(FieldTrait::OPTION_STRIP_TAGS) ?? true) {
             return $formatted;
         }
 

--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -7,6 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use function Symfony\Component\String\u;
 use Twig\Markup;
@@ -52,6 +53,14 @@ final class CommonPostConfigurator implements FieldConfiguratorInterface
         }
 
         $formatted = $callable($field->getValue(), $entityDto->getInstance());
+
+        // we don't want to unintentionally allow people to add XSS vulnerabilities
+        // in the code just because some people need to have HTML/JS
+        // so that if you want know what you're doing you have to explicitly
+        // disable this.
+        if ($field->getCustomOptions(TextField::OPTION_STRIP_TAGS)) {
+            return $formatted;
+        }
 
         // if the callable returns a string, wrap it in a Twig Markup to render the
         // HTML and CSS/JS elements that it might contain

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -16,6 +16,8 @@ use Symfony\Contracts\Translation\TranslatableInterface;
  */
 trait FieldTrait
 {
+    public const OPTION_STRIP_TAGS = 'stripTags';
+
     private FieldDto $dto;
 
     private function __construct()
@@ -334,6 +336,13 @@ trait FieldTrait
     public function setCustomOptions(array $options): self
     {
         $this->dto->setCustomOptions($options);
+
+        return $this;
+    }
+    
+    public function stripTags(bool $stripTags = true): self
+    {
+        $this->setCustomOption(self::OPTION_STRIP_TAGS, $stripTags);
 
         return $this;
     }

--- a/src/Field/TextField.php
+++ b/src/Field/TextField.php
@@ -15,7 +15,6 @@ final class TextField implements FieldInterface
 
     public const OPTION_MAX_LENGTH = 'maxLength';
     public const OPTION_RENDER_AS_HTML = 'renderAsHtml';
-    public const OPTION_STRIP_TAGS = 'stripTags';
 
     /**
      * @param TranslatableInterface|string|false|null $label
@@ -52,13 +51,6 @@ final class TextField implements FieldInterface
     public function renderAsHtml(bool $asHtml = true): self
     {
         $this->setCustomOption(self::OPTION_RENDER_AS_HTML, $asHtml);
-
-        return $this;
-    }
-
-    public function stripTags(bool $stripTags = true): self
-    {
-        $this->setCustomOption(self::OPTION_STRIP_TAGS, $stripTags);
 
         return $this;
     }

--- a/src/Field/TextareaField.php
+++ b/src/Field/TextareaField.php
@@ -17,8 +17,6 @@ final class TextareaField implements FieldInterface
     public const OPTION_MAX_LENGTH = TextField::OPTION_MAX_LENGTH;
     public const OPTION_NUM_OF_ROWS = 'numOfRows';
     public const OPTION_RENDER_AS_HTML = TextField::OPTION_RENDER_AS_HTML;
-    public const OPTION_STRIP_TAGS = TextField::OPTION_STRIP_TAGS;
-
     /**
      * @param TranslatableInterface|string|false|null $label
      */
@@ -67,13 +65,6 @@ final class TextareaField implements FieldInterface
     public function renderAsHtml(bool $asHtml = true): self
     {
         $this->setCustomOption(self::OPTION_RENDER_AS_HTML, $asHtml);
-
-        return $this;
-    }
-
-    public function stripTags(bool $stripTags = true): self
-    {
-        $this->setCustomOption(self::OPTION_STRIP_TAGS, $stripTags);
 
         return $this;
     }


### PR DESCRIPTION
instead if people do need it we force them do to

->setStripTag(true) before

Example to reproduce create two entities  Comment and Author in the Comment crud controller do the following

```
        yield AssociationField::new('author', 'Author of the comment')
            ->formatValue(function ($value, Author $author) {
                 return $author->getName();
            });

```


if the author's name contains `<script>alert("coucou")</script>`  it will inject a XSS in the admin 

instead with this PR you will be required to do 

```
        yield AssociationField::new('author', 'Author of the comment')
           ->stripTag(false)
            ->formatValue(function ($value, Author $author) {
                 return $author->getName();
            });

```

if you want to intentionnaly disable it 

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
