### PR TITLE
[ImageField] Support constraint validation

### DIFF
--- a/doc/fields/ImageField.rst
+++ b/doc/fields/ImageField.rst
@@ -45,6 +45,14 @@ change that location. The argument is the directory relative to your project roo
 
     yield ImageField::new('...')->setUploadDir('assets/images/');
 
+setFileConstraints
+~~~~~~~~~~~~~~~~~~
+
+By default, the uploaded file is validated using the `Image`_ constraint.
+Use this option to change constraints applied to the uploaded file::
+
+    yield ImageField::new('...')->setFileConstraints(new Image(maxSize: '100k'));
+
 setUploadedFileNamePattern
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -74,3 +82,5 @@ argument the Symfony's UploadedFile instance::
     yield ImageField::new('...')->setUploadedFileNamePattern(
         fn (UploadedFile $file): string => sprintf('upload_%d_%s.%s', random_int(1, 999), $file->getFilename(), $file->guessExtension()))
     );
+
+.. _`Image`: https://symfony.com/doc/current/reference/constraints/Image.html

--- a/src/Field/Configurator/ImageConfigurator.php
+++ b/src/Field/Configurator/ImageConfigurator.php
@@ -59,6 +59,8 @@ final class ImageConfigurator implements FieldConfiguratorInterface
             $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
         }
         $field->setFormTypeOption('upload_dir', $absoluteUploadDir);
+
+        $field->setFormTypeOption('file_constraints', $field->getCustomOption(ImageField::OPTION_FILE_CONSTRAINTS));
     }
 
     private function getImagesPaths(?array $images, ?string $basePath): array

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -6,6 +6,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Image;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
@@ -18,6 +20,7 @@ final class ImageField implements FieldInterface
     public const OPTION_BASE_PATH = 'basePath';
     public const OPTION_UPLOAD_DIR = 'uploadDir';
     public const OPTION_UPLOADED_FILE_NAME_PATTERN = 'uploadedFileNamePattern';
+    public const OPTION_FILE_CONSTRAINTS = 'fileConstraints';
 
     /**
      * @param TranslatableInterface|string|false|null $label
@@ -35,7 +38,8 @@ final class ImageField implements FieldInterface
             ->setTextAlign(TextAlign::CENTER)
             ->setCustomOption(self::OPTION_BASE_PATH, null)
             ->setCustomOption(self::OPTION_UPLOAD_DIR, null)
-            ->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, '[name].[extension]');
+            ->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, '[name].[extension]')
+            ->setCustomOption(self::OPTION_FILE_CONSTRAINTS, [new Image()]);
     }
 
     public function setBasePath(string $path): self
@@ -73,6 +77,19 @@ final class ImageField implements FieldInterface
     public function setUploadedFileNamePattern($patternOrCallable): self
     {
         $this->setCustomOption(self::OPTION_UPLOADED_FILE_NAME_PATTERN, $patternOrCallable);
+
+        return $this;
+    }
+
+    /**
+     * @param Constraint|array<Constraint> $constraints
+     *
+     * Define constraints to be validated on the FileType.
+     * Image constraint is set by default.
+     */
+    public function setFileConstraints($constraints): self
+    {
+        $this->setCustomOption(self::OPTION_FILE_CONSTRAINTS, $constraints);
 
         return $this;
     }

--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -19,6 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Validator\Constraint;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -38,7 +39,8 @@ class FileUploadType extends AbstractType implements DataMapperInterface
         $uploadFilename = $options['upload_filename'];
         $uploadValidate = $options['upload_validate'];
         $allowAdd = $options['allow_add'];
-        unset($options['upload_dir'], $options['upload_new'], $options['upload_delete'], $options['upload_filename'], $options['upload_validate'], $options['download_path'], $options['allow_add'], $options['allow_delete'], $options['compound']);
+        $options['constraints'] = $options['file_constraints'];
+        unset($options['upload_dir'], $options['upload_new'], $options['upload_delete'], $options['upload_filename'], $options['upload_validate'], $options['download_path'], $options['allow_add'], $options['allow_delete'], $options['compound'], $options['file_constraints']);
 
         $builder->add('file', FileType::class, $options);
         $builder->add('delete', CheckboxType::class, ['required' => false]);
@@ -123,6 +125,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
             'required' => false,
             'error_bubbling' => false,
             'allow_file_upload' => true,
+            'file_constraints' => [],
         ]);
 
         $resolver->setAllowedTypes('upload_dir', 'string');
@@ -133,6 +136,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
         $resolver->setAllowedTypes('download_path', ['null', 'string']);
         $resolver->setAllowedTypes('allow_add', 'bool');
         $resolver->setAllowedTypes('allow_delete', 'bool');
+        $resolver->setAllowedTypes('file_constraints', [Constraint::class, Constraint::class.'[]']);
 
         $resolver->setNormalizer('upload_dir', function (Options $options, string $value): string {
             if (\DIRECTORY_SEPARATOR !== mb_substr($value, -1)) {
@@ -180,6 +184,9 @@ class FileUploadType extends AbstractType implements DataMapperInterface
             }
 
             return (bool) $value;
+        });
+        $resolver->setNormalizer('file_constraints', static function (Options $options, $constraints) {
+            return \is_object($constraints) ? [$constraints] : (array) $constraints;
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/5227 and https://github.com/EasyCorp/EasyAdminBundle/issues/4088

Currently, it is not possible to properly validate images uploaded with the `ImageField` using Symfony constraints.
This is because the `constraints` option is applied to both the parent field (returning a `string`) and the underlying `FileType` field (returning an `UploadedFile`) resulting in unexpected validation errors.

This PR adds a new `setFileConstraints` method to the `ImageField` to apply constraints to the `FileType` field only.
By default, I also applied the [`Image`](https://symfony.com/doc/current/reference/constraints/Image.html) constraint on the `ImageField`.

Usage example:

``` php
use Symfony\Component\Validator\Constraints\Image;

// Validate that file is an image by default
ImageField::new('logo', 'Logo'),

// Set custom validation constraints
ImageField::new('logo', 'Logo')->setFileConstraints(new Image(maxSize: '100k')),
```