### PR TITLE
NumericFilter, allow to skip NULL values

### DIFF
--- a/src/Dto/FilterDto.php
+++ b/src/Dto/FilterDto.php
@@ -14,6 +14,7 @@ final class FilterDto
     private ?string $fqcn = null;
     private ?string $formType = null;
     private KeyValueStore $formTypeOptions;
+    private KeyValueStore $customOptions;
     private ?string $propertyName = null;
     private $label;
     private $applyCallable;
@@ -21,6 +22,7 @@ final class FilterDto
     public function __construct()
     {
         $this->formTypeOptions = KeyValueStore::new();
+        $this->customOptions = KeyValueStore::new();
     }
 
     public function getFqcn(): ?string
@@ -63,6 +65,27 @@ final class FilterDto
         $this->formTypeOptions->setIfNotSet($optionName, $optionValue);
     }
 
+    public function getCustomOptions(): KeyValueStore
+    {
+        return $this->customOptions;
+    }
+
+    public function getCustomOption(string $optionName): mixed
+    {
+        return $this->customOptions->get($optionName);
+    }
+
+    public function setCustomOptions(array $customOptions): void
+    {
+        $this->customOptions = KeyValueStore::new($customOptions);
+    }
+
+    public function setCustomOption(string $optionName, mixed $optionValue): void
+    {
+        $this->customOptions->set($optionName, $optionValue);
+    }
+
+    
     public function setFormType(string $formType): void
     {
         $this->formType = $formType;

--- a/src/Filter/FilterTrait.php
+++ b/src/Filter/FilterTrait.php
@@ -70,6 +70,20 @@ trait FilterTrait
         return $this;
     }
 
+        public function setCustomOption(string $optionName, $optionValue): self
+    {
+        $this->dto->setCustomOption($optionName, $optionValue);
+
+        return $this;
+    }
+
+    public function setCustomOptions(array $options): self
+    {
+        $this->dto->setCustomOptions($options);
+
+        return $this;
+    }
+
     public function getAsDto(): FilterDto
     {
         return $this->dto;


### PR DESCRIPTION
Currently, NumericFilter Request displays NULL values.

Addition of a skipNullValues method, default false, to prevent querying null values.

````php
    public function configureFilters(Filters $filters): Filters
    {
        $filters = $filters
           ->add(NumericFilter::new("age","fiche.filter.age")->skipNullValues(true));
        return $filters;
    }
````