### PR TITLE
Fix nullable detection

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -227,7 +227,9 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
             return false;
         }
 
-        return !$doctrinePropertyMetadata->get('nullable');
+        $nullable = $doctrinePropertyMetadata->get('nullable');
+
+        return false === $nullable || null === $nullable;
     }
 
     private function humanizeString(string $string): string

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -227,7 +227,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
             return false;
         }
 
-        return false === $doctrinePropertyMetadata->get('nullable');
+        return !$doctrinePropertyMetadata->get('nullable');
     }
 
     private function humanizeString(string $string): string


### PR DESCRIPTION
In Symfony production environment, since Doctrine 3.x, **cached** values for 'nullable' property can be either `null`, `false` or `true`. In Doctrine 2.x, it's only `false` or `true`. When Doctrine returns `null` for the nullable property, the required option for the field is set to `false`.

While in fact, Doctrine considers `nullable => null` as `nullable => false`, thus the field should be required.

To reproduce:
- create an entity, with a field that has 'nullable' property set to `false`
- create an admin controller for the entity (make sure to **NOT** set `setRequired(true)` explicitly)
- try to create a new record in the dashboard, you will see that the field is optional

References:
[Doctrine 3.x $nullable](https://github.com/doctrine/orm/blob/f79d166a4e844beb9389f23bdb44abdbf58cec38/src/Mapping/FieldMapping.php#L25)
[How Doctrine determines nullable](https://github.com/doctrine/orm/blob/c3cc0fdd8c9ffb102170c930ca56188626a34719/src/Mapping/ClassMetadata.php#L1030)




<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
