### PR TITLE
feat: allow slug field to be triggered by select fields also

### DIFF
--- a/assets/js/field-slug.js
+++ b/assets/js/field-slug.js
@@ -140,7 +140,7 @@ class Slugger {
      */
     listenTarget() {
         for (const target of this.targets) {
-            target.addEventListener('keyup', () => {
+            target.addEventListener('input', () => {
                 if ('readonly' === this.field.getAttribute('readonly')) {
                     this.updateValue();
                 }


### PR DESCRIPTION
Currently, when targeting `ChoiceField` for example, the `SlugField` don't update, due to event listener only on `keyup`.