### PR TITLE
Render expanded invalid collection entry

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -178,7 +178,7 @@
     {% set is_array_field = 'EasyCorp\\Bundle\\EasyAdminBundle\\Field\\ArrayField' == form_parent(form).vars.ea_vars.field.fieldFqcn ?? false %}
     {% set is_complex = form_parent(form).vars.ea_vars.field.customOptions.get('entryIsComplex') ?? false %}
     {% set allows_deleting_items = form_parent(form).vars.allow_delete|default(false) %}
-    {% set render_expanded = form_parent(form).vars.ea_vars.field.customOptions.get('renderExpanded') ?? false %}
+    {% set render_expanded = not form.vars.valid or form_parent(form).vars.ea_vars.field.customOptions.get('renderExpanded') ?? false %}
     {% set delete_item_button %}
         <button type="button" class="btn btn-link btn-link-danger field-collection-delete-button"
                 title="{{ 'action.remove_item'|trans({}, 'EasyAdminBundle') }}">


### PR DESCRIPTION
For now you must do `->setEntryIsComplex()`  for collection field just for notice what entry is invalid (otherwise it will not highlighted with red border). 
But even with red border you must do additional click to expand and see actual validation error.