### PR TITLE
Fix a deprecation related to Symfony 7.1

### DIFF
--- a/src/DependencyInjection/EasyAdminExtension.php
+++ b/src/DependencyInjection/EasyAdminExtension.php
@@ -8,8 +8,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>


### PR DESCRIPTION
Spotted while updating some app to Symfony 7.1.

It's safe to replace this class because it's supported in all Symfony versions supported by this bundle, starting from 5.4: https://github.com/symfony/symfony/blob/5.4/src/Symfony/Component/DependencyInjection/Extension/Extension.php