### PR TITLE
Fix full width datetime input (single widget)

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -41,7 +41,9 @@
 {%- endblock form_widget_simple %}
 
 {% block datetime_widget %}
-    {% set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) %}
+    {%- if widget != 'single_text' -%}
+        {%- set attr = attr|merge({class: (attr.class|default('') ~ ' form-inline')|trim}) -%}
+    {%- endif -%}
     <div class="datetime-widget datetime-widget-datetime">
         {{- parent() -}}
     </div>


### PR DESCRIPTION
The `form-inline` should not be applied on `single_widget` datetime field.

See https://github.com/symfony/symfony/blob/678abb4b128c0bd9f6db83a280bd5355ce234aec/src/Symfony/Bridge/Twig/Resources/views/Form/bootstrap_5_layout.html.twig#L94-L96

This is causing a small UI issue when trying to display the datetime field with 100% width:

Before:

![image](https://github.com/EasyCorp/EasyAdminBundle/assets/915273/a3d6f66a-c55e-457f-abc0-efb7b6559dc6)

After:

![image](https://github.com/EasyCorp/EasyAdminBundle/assets/915273/19b8941e-1633-4918-acc8-6e9ce05df976)

