### PR TITLE
Fix Fieldset header styles

### DIFF
--- a/assets/css/easyadmin-theme/forms.css
+++ b/assets/css/easyadmin-theme/forms.css
@@ -447,8 +447,8 @@ label.form-check-label {
     font-weight: bold;
     padding: 0 0 5px;
 }
-.form-fieldset-header .form-fieldset-title .form-fieldset-title-content .not-collapsible { cursor: default; }
-.form-fieldset-header .form-fieldset-title .form-fieldset-title-content .collapsed .form-fieldset-collapse-marker {
+.form-fieldset-header .form-fieldset-title .form-fieldset-title-content.not-collapsible { cursor: default; }
+.form-fieldset-header .form-fieldset-title .form-fieldset-title-content.collapsed .form-fieldset-collapse-marker {
     transform: rotate(0deg);
 }
 .form-fieldset-header .form-fieldset-title .form-fieldset-title-content .collapsible::after {


### PR DESCRIPTION
Removes the unnecessary space that appeared after transitioning from SCSS to CSS. After this change, the `form-fieldset-collapse-marker` should display correctly when fieldset is collapsed.

Before:
![image](https://github.com/EasyCorp/EasyAdminBundle/assets/3919837/d4759241-ca0f-4bb4-b42f-3dd3e9d4d22e)

After:
![image](https://github.com/EasyCorp/EasyAdminBundle/assets/3919837/9f1be78e-a370-48b7-8973-6052c20383a9)