### PR TITLE
Allow bigint in search

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -88,7 +88,7 @@ final class EntityRepository implements EntityRepositoryInterface
             $lowercaseQueryTerm = mb_strtolower($queryTerm);
             $isNumericQueryTerm = is_numeric($queryTerm);
             $isSmallIntegerQueryTerm = ctype_digit($queryTerm) && $queryTerm >= -32768 && $queryTerm <= 32767;
-            $isIntegerQueryTerm = ctype_digit($queryTerm) && $queryTerm >= -2147483648 && $queryTerm <= 2147483647;
+            $isIntegerQueryTerm = ctype_digit($queryTerm) && $queryTerm >= -9223372036854775808 && $queryTerm <= 18446744073709551617;
             $isUuidQueryTerm = Uuid::isValid($queryTerm);
             $isUlidQueryTerm = Ulid::isValid($queryTerm);
 


### PR DESCRIPTION
If the query is integer but not between these values the query will end up a where clause without any conditions so doctrine fails:

```
Uncaught PHP Exception Doctrine\ORM\Query\QueryException: "[Syntax Error] line 0, col -1: Error: Expected Literal, got end of string." at QueryException.php line 34
```