### PR TITLE
Remove an unneeded comparison in FileUploadType

### DIFF
--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -148,7 +148,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
                 $value = $this->projectDir.'/'.$value;
             }
 
-            if (!$isStreamWrapper && '' !== $value && (!is_dir($value) || !is_writable($value))) {
+            if (!$isStreamWrapper && (!is_dir($value) || !is_writable($value))) {
                 throw new InvalidArgumentException(sprintf('Invalid upload directory "%s" it does not exist or is not writable.', $value));
             }
 


### PR DESCRIPTION
This fixes:

```
Error: Strict comparison using !== between '' and non-falsy-string will always evaluate to true.
 ------ ------------------------------------------------------------------ 
  Line   Form/Type/FileUploadType.php                                      
 ------ ------------------------------------------------------------------ 
  [15](https://github.com/EasyCorp/EasyAdminBundle/actions/runs/9535095150/job/26280406642?pr=6328#step:5:16)1    Strict comparison using !== between '' and non-falsy-string will  
         always evaluate to true.                                          
 ------ ------------------------------------------------------------------
```