### PR TITLE
Pass added element in ea.collection.item-added event

### DIFF
--- a/assets/js/field-collection.js
+++ b/assets/js/field-collection.js
@@ -67,7 +67,7 @@ const EaCollectionProperty = {
                 lastElementBody.classList.add('show');
             }
 
-            document.dispatchEvent(new Event('ea.collection.item-added'));
+            document.dispatchEvent(new CustomEvent('ea.collection.item-added', { detail: { newElement: lastElement }));
         });
 
         collection.classList.add('processed');


### PR DESCRIPTION
Sometimes (in my case "always") need to get new inserted element in collection. 
For example to attach events to sub form elements etc.

https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events#adding_custom_data_%E2%80%93_customevent

Currently I use someting like this, which looks not so good
```js
document.addEventListener('ea.collection.item-added', () => {
  const someSelectorInThatCollection = 'select[name*="[inventory]"]'
  const processedCssClass = 'some-class-processed'
  document.querySelectorAll(`${someSelectorInThatCollection}:not(.${processedCssClass})`).forEach((el) => {
    el.classList.add(processedCssClass)
    // do my job here like
    el.addEventListener('change', function () {
      this.parentNode.querySelector('.some-btn').disabled = !this.value
    })
  })
})
```

With proposed changes it can be refactored to
```js
document.addEventListener('ea.collection.item-added', (e) => {
  const someSelectorInThatCollection = 'select[name*="[inventory]"]'
  const el = e.detail.newElement.querySelector(someSelectorInThatCollection)
  // maybe check like if not el then return
  el.addEventListener('change', function () {
    this.parentNode.querySelector('.some-btn').disabled = !this.value
  })
})
```