### PR TITLE
Update actions.rst (fix batchActionEntityIds)

### DIFF
--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -463,7 +463,7 @@ If you do that, EasyAdmin will inject a DTO with all the batch action data::
 
     As an alternative, instead of injecting the ``BatchActionDto`` variable, you can
     also inject Symfony's ``Request`` object to get all the raw submitted batch data
-    (e.g. ``$request->request->get('batchActionEntityIds')``).
+    (e.g. ``$request->request->all('batchActionEntityIds')``).
 
 .. _actions-integrating-symfony:
 


### PR DESCRIPTION
Will close https://github.com/EasyCorp/EasyAdminBundle/issues/6349

The problem is that Symfony 6.x ? get() does not support array anymore.

Maybe can be improved to.
```
/** @var array<int, int|string> $entityIds */
$entityIds = $request->request->all('batchActionEntityIds');
```