### PR TITLE
Fix multiple ImageField constraint

### DIFF
--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -20,6 +20,7 @@ use Symfony\Component\String\Slugger\AsciiSlugger;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\All;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -39,7 +40,7 @@ class FileUploadType extends AbstractType implements DataMapperInterface
         $uploadFilename = $options['upload_filename'];
         $uploadValidate = $options['upload_validate'];
         $allowAdd = $options['allow_add'];
-        $options['constraints'] = $options['file_constraints'];
+        $options['constraints'] = (bool) $options['multiple'] ? new All($options['file_constraints']) : $options['file_constraints'];
         unset($options['upload_dir'], $options['upload_new'], $options['upload_delete'], $options['upload_filename'], $options['upload_validate'], $options['download_path'], $options['allow_add'], $options['allow_delete'], $options['compound'], $options['file_constraints']);
 
         $builder->add('file', FileType::class, $options);


### PR DESCRIPTION
I just realized that `ImageField` supports the `multiple` option.

My [recent PR](https://github.com/EasyCorp/EasyAdminBundle/pull/6258) needs to be adjusted to supports multiple files.