### PR TITLE
fix form_theme.html.twig error

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -134,12 +134,22 @@
         {% set row_attr = row_attr|merge({ 'data-prototype': form_row(prototype) }) %}
     {% endif %}
 
+    {% set maxKey = 0 %}
+    {% for key in form.children|keys %}
+        {% if key matches '/^\d+$/' %}
+            {% set intKey = key|number_format(0, '', '', '') %}
+            {% if intKey > maxKey %}
+                {% set maxKey = intKey %}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
+
     {% set row_attr = row_attr|merge({
         'data-ea-collection-field': 'true',
         'data-entry-is-complex': form.vars.ea_vars.field and form.vars.ea_vars.field.customOptions.get('entryIsComplex') ? 'true' : 'false',
         'data-allow-add': allow_add ? 'true' : 'false',
         'data-allow-delete': allow_delete ? 'true' : 'false',
-        'data-num-items': form.children is empty ? 0 : max(form.children|keys) + 1,
+        'data-num-items': form.children is empty ? 0 : maxKey + 1,
         'data-form-type-name-placeholder': prototype is defined ? prototype.vars.name : '',
     }) %}
 


### PR DESCRIPTION
An exception has been thrown during the rendering of a template ("Unsupported operand types: string + int").

With this fix it should be solved.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
