### PR TITLE
Fix twig regex for collection field (related to #6364)

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -136,7 +136,7 @@
 
     {% set maxKey = 0 %}
     {% for key in form.children|keys %}
-        {% if key matches '/^\d+$/' %}
+        {% if key matches '/^\\d+$/' %}
             {% set intKey = key|number_format(0, '', '', '') %}
             {% if intKey > maxKey %}
                 {% set maxKey = intKey %}


### PR DESCRIPTION
The twig regex need to have double backslash, without this fix the data-num-items is always set to 1.
Fix #6369