### PR TITLE
Make filter modal scrollable

### DIFF
--- a/src/Resources/views/crud/includes/_filters_modal.html.twig
+++ b/src/Resources/views/crud/includes/_filters_modal.html.twig
@@ -1,5 +1,5 @@
 <div id="modal-filters" class="modal fade" tabindex="-1">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" data-bs-dismiss="modal" class="btn btn-sm btn-secondary" id="modal-clear-button" formtarget="_self">


### PR DESCRIPTION
In my project, we sometimes have a lot of filters available for a CRUD. 
Making the header sticky saves a lot of scrolling :wink:  
This won't impact cases where there are few filters.

![Screenshot_20240722_090811](https://github.com/user-attachments/assets/fcd965f9-9f98-4786-b6d3-dc8ae9c4354e)

