### PR TITLE
Update the logic of the menu item matcher

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,20 @@
 Upgrade between EasyAdmin 4.x versions
 ======================================
 
+EasyAdmin 4.11.0
+----------------
+
+### Updated the `MenuItemMatcherInterface`
+
+The `MenuItemMatcherInterface` has changed as follows:
+
+  * The `isSelected(MenuItemDto $menuItemDto)` method has been removed
+  * The `isExpanded(MenuItemDto $menuItemDto)` method has been removed
+  * A new `markSelectedMenuItem(array<MenuItemDto> $menuItems)` method has been added
+
+Read the comments in the code of the `MenuItemMatcher` class to learn about the
+new menu item matching logic.
+
 EasyAdmin 4.10.0
 ----------------
 

--- a/src/Contracts/Menu/MenuItemMatcherInterface.php
+++ b/src/Contracts/Menu/MenuItemMatcherInterface.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -10,12 +11,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 interface MenuItemMatcherInterface
 {
     /**
-     * @return bool Returns true when this menu item is the selected one
+     * Given the full list of menu items and the current request, this method
+     * must find the currently selected item (if any) and update its status
+     * to mark it as selected.
+     *
+     * @param MenuItemDto[] $menuItems
+     *
+     * @return MenuItemDto[]
      */
-    public function isSelected(MenuItemDto $menuItemDto): bool;
-
-    /**
-     * @return bool Returns true when any of the subitems of the menu item is selected
-     */
-    public function isExpanded(MenuItemDto $menuItemDto): bool;
+    public function markSelectedMenuItem(array $menuItems, Request $request): array;
 }

--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -6,61 +6,241 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 class MenuItemMatcher implements MenuItemMatcherInterface
 {
-    public function __construct(private AdminContextProvider $adminContextProvider)
+    /**
+     * Given the full list of menu items, this method finds which item should be
+     * marked as 'selected' based on the current page being visited by the user.
+     * If the selected item is a submenu item, it also marks the parent menu item
+     * as 'expanded'.
+     *
+     * It returns the full list of menu items, including the updated item(s) marked
+     * as selected/expanded.
+     *
+     * @param MenuItemDto[] $menuItems
+     *
+     * @return MenuItemDto[]
+     */
+    public function markSelectedMenuItem(array $menuItems, Request $request): array
     {
+        $menuItems = $this->doMarkSelectedMenuItem($menuItems, $request);
+        $menuItems = $this->doMarkExpandedMenuItem($menuItems);
+
+        return $menuItems;
     }
 
+    /**
+     * @deprecated because you can't decide which menu item to select by only looking at the menu item itself. You need to check all menu items at the same time to solve edge-cases like multiple menu items linking to the same action of the same entity
+     * @see markSelectedMenuItem()
+     */
     public function isSelected(MenuItemDto $menuItemDto): bool
     {
-        $adminContext = $this->adminContextProvider->getContext();
-        if (null === $adminContext || $menuItemDto->isMenuSection()) {
-            return false;
-        }
+        @trigger_deprecation('easycorp/easyadmin-bundle', '4.11', 'The "%s()" method is deprecated. Use the "%s()" method instead.', __METHOD__, 'markSelectedMenuItem()');
 
-        $currentPageQueryParameters = $adminContext->getRequest()->query->all();
-        $menuItemQueryString = null === $menuItemDto->getLinkUrl() ? null : parse_url($menuItemDto->getLinkUrl(), \PHP_URL_QUERY);
-
-        $menuItemQueryParameters = [];
-        if (\is_string($menuItemQueryString)) {
-            parse_str($menuItemQueryString, $menuItemQueryParameters);
-        }
-
-        if ([] === $menuItemQueryParameters || [] === $currentPageQueryParameters) {
-            return $menuItemDto->getLinkUrl() === $adminContext->getRequest()->getUri();
-        }
-
-        $menuItemLinksToIndexCrudAction = Crud::PAGE_INDEX === ($menuItemQueryParameters[EA::CRUD_ACTION] ?? false);
-        $currentPageLinksToIndexCrudAction = Crud::PAGE_INDEX === ($currentPageQueryParameters[EA::CRUD_ACTION] ?? false);
-        $menuItemQueryParameters = $this->filterIrrelevantQueryParameters($menuItemQueryParameters, $menuItemLinksToIndexCrudAction);
-        $currentPageQueryParameters = $this->filterIrrelevantQueryParameters($currentPageQueryParameters, $currentPageLinksToIndexCrudAction);
-
-        // needed so you can pass route parameters in any order
-        sort($menuItemQueryParameters);
-        sort($currentPageQueryParameters);
-
-        return $menuItemQueryParameters === $currentPageQueryParameters;
+        return false;
     }
 
+    /**
+     * @deprecated because you can't decide which menu item to render expanded by only looking at the menu item itself. You need to check all menu items at the same time.
+     * @see markExpandedMenuItem()
+     */
     public function isExpanded(MenuItemDto $menuItemDto): bool
     {
-        if ([] === $menuSubitems = $menuItemDto->getSubItems()) {
-            return false;
-        }
+        @trigger_deprecation('easycorp/easyadmin-bundle', '4.11', 'The "%s()" method is deprecated. Use the "%s()" method instead.', __METHOD__, 'markExpandedMenuItem()');
 
-        foreach ($menuSubitems as $submenuItem) {
-            if ($submenuItem->isSelected()) {
-                return true;
+        return false;
+    }
+
+    /**
+     * @param MenuItemDto[] $menuItems
+     *
+     * @return MenuItemDto[]
+     */
+    private function doMarkSelectedMenuItem(array $menuItems, Request $request): array
+    {
+        // the menu-item matching is a 2-phase process:
+        // 1) scan all menu items to list which controllers and actions are linked from the menu;
+        //    this is needed because e.g. sometimes we match a menu item that doesn't have the exact
+        //    action but links to the INDEX action of the same controller of the current request
+        // 2) decide which is the most appropriate menu item (if any) to mark as selected based on the current request
+        $controllersAndActionsLinkedInTheMenu = $this->getControllersAndActionsLinkedInTheMenu($menuItems);
+        $currentPageQueryParameters = $request->query->all();
+        $currentRequestUri = $request->getUri();
+
+        foreach ($menuItems as $menuItemDto) {
+            if ($menuItemDto->isMenuSection()) {
+                continue;
+            }
+
+            if ([] !== $subItems = $menuItemDto->getSubItems()) {
+                $menuItemDto->setSubItems($this->doMarkSelectedMenuItem($subItems, $request));
+            }
+
+            $menuItemQueryString = null === $menuItemDto->getLinkUrl() ? null : parse_url($menuItemDto->getLinkUrl(), \PHP_URL_QUERY);
+
+            $menuItemQueryParameters = [];
+            if (\is_string($menuItemQueryString)) {
+                parse_str($menuItemQueryString, $menuItemQueryParameters);
+            }
+
+            if ([] === $menuItemQueryParameters || [] === $currentPageQueryParameters) {
+                if ($menuItemDto->getLinkUrl() === $currentRequestUri) {
+                    $menuItemDto->setSelected(true);
+                }
+
+                break;
+            }
+
+            // if the menu only contains links to the INDEX action of the CRUD controller,
+            // match that menu item for all actions (EDIT, NEW, etc.) of the same controller;
+            // this is not strictly correct, but backend users expect this behavior because it
+            // makes the sidebar menu more predictable and easier to use
+            $menuItemController = $menuItemQueryParameters[EA::CRUD_CONTROLLER_FQCN] ?? null;
+            $currentPageController = $currentPageQueryParameters[EA::CRUD_CONTROLLER_FQCN] ?? null;
+            $actionsLinkedInTheMenuForThisEntity = $controllersAndActionsLinkedInTheMenu[$currentPageController] ?? [];
+            $menuOnlyLinksToIndexActionOfThisEntity = $actionsLinkedInTheMenuForThisEntity === [Crud::PAGE_INDEX];
+            if ($menuItemController === $currentPageController && $menuOnlyLinksToIndexActionOfThisEntity) {
+                $menuItemDto->setSelected(true);
+
+                break;
+            }
+
+            // if the menu contains links to more than one action of the CRUD controller
+            // (e.g. INDEX and NEW), and the action of the current page is not included
+            // in that list, match the menu item with the INDEX action; this is again not
+            // strictly correct, but it's the expected behavior by backend users
+            $menuItemAction = $menuItemQueryParameters[EA::CRUD_ACTION] ?? null;
+            $currentPageAction = $currentPageQueryParameters[EA::CRUD_ACTION] ?? null;
+            $isCurrentPageActionLinkedInTheMenu = \in_array($currentPageAction, $actionsLinkedInTheMenuForThisEntity, true);
+            if ($menuItemController === $currentPageController && Crud::PAGE_INDEX === $menuItemAction && !$isCurrentPageActionLinkedInTheMenu) {
+                $menuItemDto->setSelected(true);
+
+                break;
+            }
+
+            // otherwise, match the query parameters of each menu item with the query
+            // parameters of the current request; before making the match, we remove
+            // some irrelevant query parameters such as filters, sorting, pagination, etc.
+            $menuItemQueryParametersToCompare = $this->filterIrrelevantQueryParameters($menuItemQueryParameters);
+            $currentPageQueryParametersToCompare = $this->filterIrrelevantQueryParameters($currentPageQueryParameters);
+
+            // needed so you can pass route parameters in any order
+            $this->recursiveKsort($menuItemQueryParametersToCompare);
+            $this->recursiveKsort($currentPageQueryParametersToCompare);
+
+            if ($menuItemQueryParametersToCompare === $currentPageQueryParametersToCompare) {
+                $menuItemDto->setSelected(true);
+
+                break;
             }
         }
 
-        return false;
+        return $menuItems;
+    }
+
+    /**
+     * Given the full list of menu items, this method finds which item should be
+     * marked as expanded because any of its items is currently selected and
+     * updates it.
+     *
+     * @param MenuItemDto[] $menuItems
+     *
+     * @return MenuItemDto[]
+     */
+    private function doMarkExpandedMenuItem(array $menuItems): array
+    {
+        foreach ($menuItems as $menuItemDto) {
+            if ([] === $menuSubitems = $menuItemDto->getSubItems()) {
+                continue;
+            }
+
+            foreach ($menuSubitems as $submenuItem) {
+                if ($submenuItem->isSelected()) {
+                    $menuItemDto->setExpanded(true);
+
+                    break;
+                }
+            }
+        }
+
+        return $menuItems;
+    }
+
+    /**
+     * It scans the full list of menu items to find which controllers and actions
+     * are linked from the menu. The output is something like:
+     * [
+     *     'App\Controller\Admin\BlogPostCrudController' => ['index', 'new'],
+     *     'App\Controller\Admin\BlogCategoryCrudController' => ['index'],
+     *     // ...
+     *     'App\Controller\Admin\UserCrudController' => ['index', 'new'],
+     * ].
+     *
+     * @return array<string, array<string>>
+     */
+    private function getControllersAndActionsLinkedInTheMenu(array $menuItems): array
+    {
+        $controllersAndActionsLinkedInTheMenu = [];
+        foreach ($menuItems as $menuItemDto) {
+            if ($menuItemDto->isMenuSection()) {
+                continue;
+            }
+
+            if ([] !== $subItems = $menuItemDto->getSubItems()) {
+                $controllersAndActionsLinkedInTheMenu = array_merge_recursive($controllersAndActionsLinkedInTheMenu, $this->getControllersAndActionsLinkedInTheMenu($subItems));
+
+                continue;
+            }
+
+            $menuItemQueryString = null === $menuItemDto->getLinkUrl() ? null : parse_url($menuItemDto->getLinkUrl(), \PHP_URL_QUERY);
+            if (null === $menuItemQueryString) {
+                continue;
+            }
+
+            $menuItemQueryParameters = [];
+            if (\is_string($menuItemQueryString)) {
+                parse_str($menuItemQueryString, $menuItemQueryParameters);
+            }
+
+            $controllerFqcn = $menuItemQueryParameters[EA::CRUD_CONTROLLER_FQCN] ?? null;
+            $crudAction = $menuItemQueryParameters[EA::CRUD_ACTION] ?? null;
+            if (null === $controllerFqcn || null === $crudAction) {
+                continue;
+            }
+
+            if (isset($controllersAndActionsLinkedInTheMenu[$controllerFqcn])) {
+                $controllersAndActionsLinkedInTheMenu[$controllerFqcn][] = $crudAction;
+            } else {
+                $controllersAndActionsLinkedInTheMenu[$controllerFqcn] = [$crudAction];
+            }
+        }
+
+        return $controllersAndActionsLinkedInTheMenu;
+    }
+
+    /*
+     * Sorts an array recursively by its keys. This is needed because some values
+     * of the array with the query string parameters can be arrays too, and we must
+     * sort those before the comparison.
+     */
+    private function recursiveKsort(&$array): void
+    {
+        if (!\is_array($array)) {
+            return;
+        }
+
+        ksort($array);
+
+        foreach ($array as &$value) {
+            if (\is_array($value)) {
+                $this->recursiveKsort($value);
+            }
+        }
     }
 
     /**
@@ -68,19 +248,9 @@ class MenuItemMatcher implements MenuItemMatcherInterface
      * should be ignored when deciding if some menu item matches the current page
      * (such as the applied filters or sorting, the listing page number, etc.).
      */
-    private function filterIrrelevantQueryParameters(array $queryStringParameters, bool $menuItemLinksToIndexCrudAction): array
+    private function filterIrrelevantQueryParameters(array $queryStringParameters): array
     {
         $paramsToRemove = [EA::REFERRER, EA::PAGE, EA::FILTERS, EA::SORT];
-
-        // if the menu item being inspected links to the 'index' action of some entity,
-        // remove both the CRUD action and the entity ID from the list of parameters;
-        // this way, an 'index' menu item is highlighted for all actions of the same entity;
-        // however, if the menu item points to an action different from 'index' (e.g. 'detail',
-        // 'new', or 'edit'), only highlight it when the current page points to that same action
-        if ($menuItemLinksToIndexCrudAction) {
-            $paramsToRemove[] = EA::CRUD_ACTION;
-            $paramsToRemove[] = EA::ENTITY_ID;
-        }
 
         return array_filter($queryStringParameters, static fn ($k) => !\in_array($k, $paramsToRemove, true), \ARRAY_FILTER_USE_KEY);
     }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -207,7 +207,6 @@ return static function (ContainerConfigurator $container) {
             ->arg(4, service(MenuItemMatcherInterface::class))
 
         ->set(MenuItemMatcher::class)
-            ->arg(0, service(AdminContextProvider::class))
 
         ->alias(MenuItemMatcherInterface::class, MenuItemMatcher::class)
 

--- a/tests/Menu/MenuItemMatcherTest.php
+++ b/tests/Menu/MenuItemMatcherTest.php
@@ -4,13 +4,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Menu;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
-use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Menu\MenuItemMatcher;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,111 +14,250 @@ class MenuItemMatcherTest extends KernelTestCase
 {
     public function testIsSelectedWhenContextIsNull()
     {
-        $menuItemMatcher = $this->getMenuItemMatcher(useNullContext: true);
+        $request = $this->getRequestMock();
+        $menuItemMatcher = new MenuItemMatcher();
+        $menuItemDto = new MenuItemDto();
 
-        $this->assertFalse($menuItemMatcher->isSelected(new MenuItemDto()));
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+
+        $this->assertFalse($menuItemDto->isSelected());
     }
 
     public function testIsSelectedWhenMenuItemIsSection()
     {
-        $menuItemMatcher = $this->getMenuItemMatcher();
-
+        $request = $this->getRequestMock();
+        $menuItemMatcher = new MenuItemMatcher();
         $menuItemDto = new MenuItemDto();
         $menuItemDto->setType(MenuItemDto::TYPE_SECTION);
 
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+
+        $this->assertFalse($menuItemDto->isSelected());
     }
 
     public function testIsSelectedWithCrudControllers()
     {
-        $menuItemMatcher = $this->getMenuItemMatcher(
+        $request = $this->getRequestMock(
             getControllerFqcn: 'App\Controller\Admin\SomeController',
         );
-
+        $menuItemMatcher = new MenuItemMatcher();
         $menuItemDto = $this->getMenuItemDto();
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+
+        $this->assertFalse($menuItemDto->isSelected());
 
         $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'NOT_App\Controller\Admin\SomeController');
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller does not match');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertFalse($menuItemDto->isSelected(), 'The CRUD controller does not match');
 
         $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController');
-        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller matches');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertTrue($menuItemDto->isSelected(), 'The CRUD controller matches');
 
-        $menuItemMatcher = $this->getMenuItemMatcher(
+        $request = $this->getRequestMock(
             getControllerFqcn: 'App\Controller\Admin\SomeController',
             getPrimaryKeyValue: '57',
+            getCurrentAction: 'edit',
         );
 
-        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', entityId: '57');
-        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller and the entity ID match');
+        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', action: 'edit', entityId: '57');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertTrue($menuItemDto->isSelected(), 'The CRUD controller and the entity ID match');
 
-        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', entityId: 'NOT_57');
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The entity ID of the menu item does not match');
+        $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', action: 'edit', entityId: 'NOT_57');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertFalse($menuItemDto->isSelected(), 'The entity ID of the menu item does not match');
 
-        $menuItemMatcher = $this->getMenuItemMatcher(
+        $request = $this->getRequestMock(
             getControllerFqcn: 'App\Controller\Admin\SomeController',
             getPrimaryKeyValue: '57',
             getCurrentAction: 'detail',
         );
 
         $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', action: Crud::PAGE_DETAIL, entityId: '57');
-        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller, entity ID and action match');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertTrue($menuItemDto->isSelected(), 'The CRUD controller, entity ID and action match');
 
         $menuItemDto = $this->getMenuItemDto(crudControllerFqcn: 'App\Controller\Admin\SomeController', action: 'NOT_'.Crud::PAGE_DETAIL, entityId: '57');
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The CRUD controller and entity ID match but the action does not match');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertFalse($menuItemDto->isSelected(), 'The CRUD controller and entity ID match but the action does not match');
     }
 
     public function testIsSelectedWithRoutes()
     {
-        $menuItemMatcher = $this->getMenuItemMatcher(
+        $request = $this->getRequestMock(
             routeName: 'some_route',
         );
-
+        $menuItemMatcher = new MenuItemMatcher();
         $menuItemDto = $this->getMenuItemDto(routeName: 'some_route');
-        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The route name matches');
+
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+
+        $this->assertTrue($menuItemDto->isSelected(), 'The route name matches');
 
         $menuItemDto = $this->getMenuItemDto(routeName: 'some_route', routeParameters: ['foo' => 'bar']);
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertFalse($menuItemDto->isSelected());
 
-        $menuItemMatcher = $this->getMenuItemMatcher(
+        $request = $this->getRequestMock(
             routeName: 'some_route',
             routeParameters: ['foo1' => 'bar1', 'foo2' => 'bar2'],
         );
 
         $menuItemDto = $this->getMenuItemDto(routeName: 'some_route');
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertFalse($menuItemDto->isSelected());
 
         $menuItemDto = $this->getMenuItemDto(routeName: 'some_route', routeParameters: ['foo1' => 'bar1']);
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertFalse($menuItemDto->isSelected());
 
         $menuItemDto = $this->getMenuItemDto(routeName: 'some_route', routeParameters: ['foo1' => 'bar1', 'foo2' => 'bar2']);
-        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto));
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertTrue($menuItemDto->isSelected());
 
         $menuItemDto = $this->getMenuItemDto(routeName: 'some_route', routeParameters: ['foo2' => 'bar2', 'foo1' => 'bar1']);
-        // CHECK THIS - It should be TRUE
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto));
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertTrue($menuItemDto->isSelected(), 'A menu item with the same query parameters but in different order matches too.');
     }
 
     public function testIsSelectedWithUrls()
     {
-        $menuItemMatcher = $this->getMenuItemMatcher(
+        $request = $this->getRequestMock(
             getUri: 'https://example.com/foo?bar=baz',
         );
-
+        $menuItemMatcher = new MenuItemMatcher();
         $menuItemDto = new MenuItemDto();
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The URL does not match');
+
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+
+        $this->assertFalse($menuItemDto->isSelected(), 'The URL does not match');
 
         $menuItemDto = new MenuItemDto();
         $menuItemDto->setLinkUrl('https://example.com');
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The URL does not match');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertFalse($menuItemDto->isSelected(), 'The URL does not match');
 
         $menuItemDto = new MenuItemDto();
         $menuItemDto->setLinkUrl('https://example.com/foo');
-        $this->assertFalse($menuItemMatcher->isSelected($menuItemDto), 'The URL does not match');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertFalse($menuItemDto->isSelected(), 'The URL does not match');
 
         $menuItemDto = new MenuItemDto();
         $menuItemDto->setLinkUrl('https://example.com/foo?bar=baz');
-        $this->assertTrue($menuItemMatcher->isSelected($menuItemDto), 'The URL matches');
+        $menuItemMatcher->markSelectedMenuItem([$menuItemDto], $request);
+        $this->assertTrue($menuItemDto->isSelected(), 'The URL matches');
+    }
+
+    public function testComplexMenu()
+    {
+        $menuItems = $this->getComplexMenuItems();
+        $request = $this->getRequestMock(
+            getControllerFqcn: 'App\Controller\Admin\Controller1',
+        );
+        $menuItemMatcher = new MenuItemMatcher();
+
+        $menuItems = $menuItemMatcher->markSelectedMenuItem($menuItems, $request);
+
+        $this->assertSame('item1', $this->getSelectedMenuItemLabel($menuItems), 'Perfect match: CRUD controller and action');
+        $this->assertNull($this->getExpandedMenuItemLabel($menuItems), 'No menu item is marked as expanded');
+
+        unset($menuItems);
+        $menuItems = $this->getComplexMenuItems();
+        $request = $this->getRequestMock(
+            getControllerFqcn: 'App\Controller\Admin\Controller1',
+            getCurrentAction: 'edit',
+            // the primary key value is missing on purpose in this example
+        );
+        $menuItems = $menuItemMatcher->markSelectedMenuItem($menuItems, $request);
+        $this->assertSame('item2', $this->getSelectedMenuItemLabel($menuItems), 'Perfect match: CRUD controller and action');
+        $this->assertNull($this->getExpandedMenuItemLabel($menuItems), 'No menu item is marked as expanded');
+
+        unset($menuItems);
+        $menuItems = $this->getComplexMenuItems();
+        $request = $this->getRequestMock(
+            getControllerFqcn: 'App\Controller\Admin\Controller1',
+            getCurrentAction: 'new',
+        );
+        $menuItems = $menuItemMatcher->markSelectedMenuItem($menuItems, $request);
+        $this->assertSame('item5', $this->getSelectedMenuItemLabel($menuItems), 'Perfect match: CRUD controller and action');
+        $this->assertSame('item4', $this->getExpandedMenuItemLabel($menuItems), 'A submenu item is matched, so its parent item must be marked as expanded');
+
+        unset($menuItems);
+        $menuItems = $this->getComplexMenuItems();
+        $request = $this->getRequestMock(
+            getControllerFqcn: 'App\Controller\Admin\Controller2',
+            getCurrentAction: 'new',
+        );
+        $menuItems = $menuItemMatcher->markSelectedMenuItem($menuItems, $request);
+        $this->assertSame('item3', $this->getSelectedMenuItemLabel($menuItems), 'Approximate match: controller matches, action doesn\'t match; the item with the INDEX action is selected by default');
+        $this->assertNull($this->getExpandedMenuItemLabel($menuItems), 'No menu item is marked as expanded');
+
+        unset($menuItems);
+        $menuItems = $this->getComplexMenuItems();
+        $request = $this->getRequestMock(
+            getControllerFqcn: 'App\Controller\Admin\Controller2',
+            getCurrentAction: 'edit',
+            getPrimaryKeyValue: 'NOT_57',
+        );
+        $menuItems = $menuItemMatcher->markSelectedMenuItem($menuItems, $request);
+        $this->assertNull($this->getSelectedMenuItemLabel($menuItems), 'No match: controller and action match, but query parameters don\'t');
+        $this->assertNull($this->getExpandedMenuItemLabel($menuItems), 'No menu item is marked as expanded');
+
+        unset($menuItems);
+        $menuItems = $this->getComplexMenuItems();
+        $request = $this->getRequestMock(
+            getControllerFqcn: 'App\Controller\Admin\Controller3',
+            getCurrentAction: 'new',
+        );
+        $menuItems = $menuItemMatcher->markSelectedMenuItem($menuItems, $request);
+        $this->assertSame('item7', $this->getSelectedMenuItemLabel($menuItems), 'Approximate match: only the controller matches; the item with the INDEX action is selected');
+        $this->assertSame('item4', $this->getExpandedMenuItemLabel($menuItems), 'A submenu item is matched, so its parent item must be marked as expanded');
+    }
+
+    private function getComplexMenuItems(): array
+    {
+        return [
+            $this->getMenuItemDto(label: 'item1', crudControllerFqcn: 'App\Controller\Admin\Controller1'),
+            $this->getMenuItemDto(label: 'item2', crudControllerFqcn: 'App\Controller\Admin\Controller1', action: 'edit'),
+            $this->getMenuItemDto(label: 'item3', crudControllerFqcn: 'App\Controller\Admin\Controller2'),
+            $this->getMenuItemDto(label: 'item4', subItems: [
+                $this->getMenuItemDto(label: 'item5', crudControllerFqcn: 'App\Controller\Admin\Controller1', action: 'new'),
+                $this->getMenuItemDto(label: 'item6', crudControllerFqcn: 'App\Controller\Admin\Controller2', action: 'edit', entityId: '57'),
+                $this->getMenuItemDto(label: 'item7', crudControllerFqcn: 'App\Controller\Admin\Controller3'),
+                // 'item8' is a duplicate of 'item1'; this is a mistake but done on purpose to test that the first match is selected
+                $this->getMenuItemDto(label: 'item8', crudControllerFqcn: 'App\Controller\Admin\Controller1'),
+            ]),
+            $this->getMenuItemDto(label: 'item9', crudControllerFqcn: 'App\Controller\Admin\Controller4'),
+        ];
+    }
+
+    private function getSelectedMenuItemLabel(array $menuItems): ?string
+    {
+        foreach ($menuItems as $menuItemDto) {
+            if ($menuItemDto->isSelected()) {
+                return $menuItemDto->getLabel();
+            }
+
+            if (null !== $subItems = $menuItemDto->getSubItems()) {
+                if (null !== $label = $this->getSelectedMenuItemLabel($subItems)) {
+                    return $label;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function getExpandedMenuItemLabel(array $menuItems): ?string
+    {
+        foreach ($menuItems as $menuItemDto) {
+            if ($menuItemDto->isExpanded()) {
+                return $menuItemDto->getLabel();
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -131,10 +265,14 @@ class MenuItemMatcherTest extends KernelTestCase
      * done in MenuFactory. To simplify tests, we just append the needed query parameters
      * to build the final menu item URL.
      */
-    private function getMenuItemDto(?string $crudControllerFqcn = null, ?string $action = null, ?string $entityId = null, ?string $routeName = null, ?array $routeParameters = null): MenuItemDto
+    private function getMenuItemDto(?string $crudControllerFqcn = null, ?string $action = null, ?string $entityId = null, ?string $routeName = null, ?array $routeParameters = null, ?array $subItems = null, ?string $label = null): MenuItemDto
     {
         $menuItemDto = new MenuItemDto();
         $menuItemRouteParameters = [];
+
+        if (null !== $label) {
+            $menuItemDto->setLabel($label);
+        }
 
         if (null !== $crudControllerFqcn) {
             $menuItemRouteParameters[EA::CRUD_CONTROLLER_FQCN] = $crudControllerFqcn;
@@ -142,6 +280,8 @@ class MenuItemMatcherTest extends KernelTestCase
 
         if (null !== $action) {
             $menuItemRouteParameters[EA::CRUD_ACTION] = $action;
+        } elseif (null === $action && null === $routeName) {
+            $menuItemRouteParameters[EA::CRUD_ACTION] = Crud::PAGE_INDEX;
         }
 
         if (null !== $entityId) {
@@ -156,46 +296,29 @@ class MenuItemMatcherTest extends KernelTestCase
             $menuItemRouteParameters[EA::ROUTE_PARAMS] = $routeParameters;
         }
 
+        if (null !== $subItems) {
+            $menuItemDto->setSubItems($subItems);
+        }
+
         $menuItemDto->setRouteParameters($menuItemRouteParameters);
         $menuItemDto->setLinkUrl('/?'.http_build_query($menuItemDto->getRouteParameters()));
 
         return $menuItemDto;
     }
 
-    private function getMenuItemMatcher(bool $useNullContext = false, ?string $getControllerFqcn = null, ?string $getPrimaryKeyValue = null, ?string $getCurrentAction = null, ?string $routeName = null, ?array $routeParameters = null, ?string $getUri = null): MenuItemMatcherInterface
+    private function getRequestMock(?string $getControllerFqcn = null, ?string $getPrimaryKeyValue = null, ?string $getCurrentAction = null, ?string $routeName = null, ?array $routeParameters = null, ?string $getUri = null): Request
     {
         $queryParameters = [];
-        $adminContextProviderMock = $this->getMockBuilder(AdminContextProvider::class)->disableOriginalConstructor()->getMock();
 
-        if ($useNullContext) {
-            $adminContextProviderMock->method('getContext')->willReturn(null);
-
-            return new MenuItemMatcher($adminContextProviderMock);
-        }
-
-        $adminContextMock = $this->getMockBuilder(AdminContext::class)->disableOriginalConstructor()->getMock();
-
-        if (null !== $getControllerFqcn || null !== $getCurrentAction) {
-            $crudDtoMock = $this->getMockBuilder(CrudDto::class)->disableOriginalConstructor()->getMock();
-        }
         if (null !== $getControllerFqcn) {
             $queryParameters[EA::CRUD_CONTROLLER_FQCN] = $getControllerFqcn;
-            $crudDtoMock->method('getControllerFqcn')->willReturn($getControllerFqcn);
-            $adminContextMock->method('getCrud')->willReturn($crudDtoMock);
         }
         if (null !== $getCurrentAction) {
             $queryParameters[EA::CRUD_ACTION] = $getCurrentAction;
-            $crudDtoMock->method('getCurrentAction')->willReturn($getCurrentAction);
-        }
-        if (null !== $getControllerFqcn || null !== $getCurrentAction) {
-            $adminContextMock->method('getCrud')->willReturn($crudDtoMock);
         }
 
         if (null !== $getPrimaryKeyValue) {
             $queryParameters[EA::ENTITY_ID] = $getPrimaryKeyValue;
-            $entityDtoMock = $this->getMockBuilder(EntityDto::class)->disableOriginalConstructor()->getMock();
-            $entityDtoMock->method('getPrimaryKeyValue')->willReturn($getPrimaryKeyValue);
-            $adminContextMock->method('getEntity')->willReturn($entityDtoMock);
         }
 
         if (null !== $routeName) {
@@ -207,15 +330,13 @@ class MenuItemMatcherTest extends KernelTestCase
 
         $request = $this->getMockBuilder(Request::class)->getMock();
         $request->query = new InputBag($queryParameters);
+
         if (null !== $getUri) {
             $request->method('getUri')->willReturn($getUri);
         } else {
             $request->method('getUri')->willReturn('/?'.http_build_query($queryParameters));
         }
-        $adminContextMock->method('getRequest')->willReturn($request);
 
-        $adminContextProviderMock->expects($this->any())->method('getContext')->willReturn($adminContextMock);
-
-        return new MenuItemMatcher($adminContextProviderMock);
+        return $request;
     }
 }


### PR DESCRIPTION
Fixes #6147 and fixes #6366

This PR changes the menu item matcher logic completely. Instead of using methods that look at each menu item individually to decide if it's selected or not ... now we have methods that take all menu items at once and find which one should be selected. This is needed to fix edge-cases.

I'll add more tests and comments/explanations in the code ... but this can be tested already in apps. I tested in my own apps and everything works as before. The new code feels as fast as before, but I also profiled it with Blackfire to double check it.