### PR TITLE
refactor(search): Nested properties

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -262,13 +262,13 @@ final class EntityRepository implements EntityRepositoryInterface
                 $associatedEntityAlias = $associatedPropertyName = '';
                 for ($i = 0; $i < $numAssociatedProperties - 1; ++$i) {
                     $associatedEntityName = $associatedProperties[$i];
-                    $associatedEntityAlias = Escaper::escapeDqlAlias($associatedEntityName).(0 === $i ? '' : $i);
+                    $associatedEntityAlias = $entitiesAlreadyJoined[$associatedEntityName] ?? Escaper::escapeDqlAlias($associatedEntityName).(0 === $i ? '' : $i);
                     $associatedPropertyName = $associatedProperties[$i + 1];
 
                     if (!\in_array($associatedEntityAlias, $entitiesAlreadyJoined, true)) {
-                        $parentEntityName = 0 === $i ? 'entity' : $associatedProperties[$i - 1];
+                        $parentEntityName = 0 === $i ? 'entity' : $entitiesAlreadyJoined[$associatedProperties[$i - 1]];
                         $queryBuilder->leftJoin(Escaper::escapeDqlAlias($parentEntityName).'.'.$associatedEntityName, $associatedEntityAlias);
-                        $entitiesAlreadyJoined[] = $associatedEntityAlias;
+                        $entitiesAlreadyJoined[$associatedEntityName] = $associatedEntityAlias;
                     }
 
                     if ($i < $numAssociatedProperties - 2) {

--- a/tests/TestApplication/src/Controller/Search/AnyTermsCrudSearchController.php
+++ b/tests/TestApplication/src/Controller/Search/AnyTermsCrudSearchController.php
@@ -17,7 +17,7 @@ class AnyTermsCrudSearchController extends AbstractCrudController
     public function configureCrud(Crud $crud): Crud
     {
         return parent::configureCrud($crud)
-            ->setSearchFields(['id', 'author.email', 'publisher.email'])
+            ->setSearchFields(['id', 'author.email', 'publisher.email', 'author.blogPosts.publisher.email'])
             ->setSearchMode(SearchMode::ANY_TERMS);
     }
 }


### PR DESCRIPTION
Update the query builder logic to correctly apply aliases for all levels of nested joins. 

Before (incorrect):
```sql
SELECT o 
FROM App\Entity\Order o 
LEFT JOIN o.orderItem oi 
LEFT JOIN oi.reservation r1 
LEFT JOIN r.product p2 
LEFT JOIN p.manufacturer m3 
LEFT JOIN m.orders o4 
WHERE LOWER(CONCAT(o4.reference, '')) LIKE :query_for_text_1 
ORDER BY o.createdAt DESC
```

After
```sql
SELECT o 
FROM App\Entity\Order o 
LEFT JOIN o.orderItem oi 
LEFT JOIN oi.reservation r1 
LEFT JOIN r1.product p2 
LEFT JOIN p2.manufacturer m3 
LEFT JOIN m3.orders o4 
WHERE LOWER(CONCAT(o4.reference, '')) LIKE :query_for_text_1 
ORDER BY o.createdAt DESC
```

related #6409