### PR TITLE
Fix background color of Trix editor link input in dark theme

### DIFF
--- a/assets/css/form-type-text-editor.css
+++ b/assets/css/form-type-text-editor.css
@@ -71,6 +71,10 @@ trix-toolbar .trix-dialog {
     font-size:  12px;
 }
 
+trix-toolbar .trix-dialog .trix-input {
+    background: var(--form-control-bg);
+}
+
 .trix-content pre {
     background-color: var(--form-type-text-editor-content-pre-bg);
     border-radius: var(--border-radius);


### PR DESCRIPTION
Before:
![s1](https://github.com/user-attachments/assets/60276aec-fca9-4086-b2ba-b246e5272b50)
![s2](https://github.com/user-attachments/assets/2c2c957c-2fa5-48a0-a641-d9c2f7b42368)

After:
![s3](https://github.com/user-attachments/assets/b040d201-514f-463a-a0e8-8ba92bf70075)
![s4](https://github.com/user-attachments/assets/1048529b-ddfc-4165-9f9d-f4d7dd2f9292)



