### PR TITLE
Drop spaceless filter in Twig templates to fix deprecation

### DIFF
--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -34,12 +34,10 @@
 {% endblock %}
 
 {% block content_title %}
-    {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters, ea.i18n.translationDomain) %}
-        {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
-            : custom_page_title|trans|raw }}
-    {%- endapply -%}
+    {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters, ea.i18n.translationDomain) %}
+    {{ custom_page_title is null
+        ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
+        : custom_page_title|trans|raw }}
 {% endblock %}
 
 {% block page_actions %}

--- a/src/Resources/views/crud/edit.html.twig
+++ b/src/Resources/views/crud/edit.html.twig
@@ -42,12 +42,10 @@
 {% endblock %}
 
 {% block content_title %}
-    {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters, ea.i18n.translationDomain) %}
-        {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
-            : custom_page_title|trans|raw }}
-    {%- endapply -%}
+    {% set custom_page_title = ea.crud.customPageTitle(pageName, entity ? entity.instance : null, ea.i18n.translationParameters, ea.i18n.translationDomain) %}
+    {{ custom_page_title is null
+        ? ea.crud.defaultPageTitle(null, null, ea.i18n.translationParameters)|trans|raw
+        : custom_page_title|trans|raw }}
 {% endblock %}
 
 {% block page_actions %}

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -36,12 +36,10 @@
 {% endblock %}
 
 {% block content_title %}
-    {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle('index', null, ea.i18n.translationParameters, ea.i18n.translationDomain) %}
-        {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle('index', null, ea.i18n.translationParameters)|trans|raw
-            : custom_page_title|trans|raw }}
-    {%- endapply -%}
+    {% set custom_page_title = ea.crud.customPageTitle('index', null, ea.i18n.translationParameters, ea.i18n.translationDomain) %}
+    {{ custom_page_title is null
+        ? ea.crud.defaultPageTitle('index', null, ea.i18n.translationParameters)|trans|raw
+        : custom_page_title|trans|raw }}
 {% endblock %}
 
 {% set has_batch_actions = batch_actions|length > 0 %}

--- a/src/Resources/views/crud/new.html.twig
+++ b/src/Resources/views/crud/new.html.twig
@@ -42,12 +42,10 @@
 {% endblock %}
 
 {% block content_title %}
-    {%- apply spaceless -%}
-        {% set custom_page_title = ea.crud.customPageTitle('new', null, ea.i18n.translationParameters, ea.i18n.translationDomain) %}
-        {{ custom_page_title is null
-            ? ea.crud.defaultPageTitle('new', null, ea.i18n.translationParameters)|trans|raw
-            : custom_page_title|trans|raw }}
-    {%- endapply -%}
+    {% set custom_page_title = ea.crud.customPageTitle('new', null, ea.i18n.translationParameters, ea.i18n.translationDomain) %}
+    {{ custom_page_title is null
+        ? ea.crud.defaultPageTitle('new', null, ea.i18n.translationParameters)|trans|raw
+        : custom_page_title|trans|raw }}
 {% endblock %}
 
 {% block page_actions %}


### PR DESCRIPTION
Hi, this pull request fixes a deprecation introduced in Twig 3.12 that deprecates the spaceless filter.