### PR TITLE
Lint code with php-cs-fixer 3.64.0

### DIFF
--- a/src/Dto/LocaleDto.php
+++ b/src/Dto/LocaleDto.php
@@ -10,7 +10,7 @@ final class LocaleDto
     public function __construct(
         private string $locale,
         private string $name,
-        private ?string $icon = null
+        private ?string $icon = null,
     ) {
     }
 

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -137,7 +137,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
                 // We check if $allChoicesAreEnums is true for enum's and choices array is generated using ->name as index
                 $selectedValue instanceof \BackedEnum => $allChoicesAreEnums && $choicesSupportTranslatableInterface ? $selectedValue->name : $selectedValue->value,
                 $selectedValue instanceof \UnitEnum => $selectedValue->name,
-                default => $selectedValue
+                default => $selectedValue,
             };
             if (null !== $selectedLabel = $flippedChoices[$selectedValue] ?? null) {
                 if ($selectedLabel instanceof TranslatableInterface) {

--- a/src/Router/AdminUrlGeneratorInterface.php
+++ b/src/Router/AdminUrlGeneratorInterface.php
@@ -17,7 +17,7 @@ interface AdminUrlGeneratorInterface
 
     public function setRoute(
         string $routeName,
-        array $routeParameters = []
+        array $routeParameters = [],
     ): self;
 
     public function setEntityId($entityId): self;

--- a/src/Test/Trait/CrudTestSelectors.php
+++ b/src/Test/Trait/CrudTestSelectors.php
@@ -39,7 +39,7 @@ trait CrudTestSelectors
         $columnSelector = match ($type) {
             'header' => 'th',
             'data' => 'td',
-            default => 'th'
+            default => 'th',
         };
 
         return sprintf('%s[data-column="%s"]', $columnSelector, $columnName);

--- a/src/Translation/TranslatableChoiceMessage.php
+++ b/src/Translation/TranslatableChoiceMessage.php
@@ -18,7 +18,7 @@ final class TranslatableChoiceMessage implements TranslatableInterface
      */
     public function __construct(
         private TranslatableInterface $message,
-        private ?string $cssClass
+        private ?string $cssClass,
     ) {
     }
 

--- a/src/Translation/TranslatableChoiceMessageCollection.php
+++ b/src/Translation/TranslatableChoiceMessageCollection.php
@@ -15,7 +15,7 @@ final class TranslatableChoiceMessageCollection implements TranslatableInterface
     public function __construct(
         /** @var TranslatableChoiceMessage[] */
         private array $choices,
-        private bool $isRenderedAsBadge
+        private bool $isRenderedAsBadge,
     ) {
     }
 

--- a/tests/Test/Trait/CrudTestUrlGenerationTraitTest.php
+++ b/tests/Test/Trait/CrudTestUrlGenerationTraitTest.php
@@ -49,7 +49,7 @@ final class CrudTestUrlGenerationTraitTest extends KernelTestCase
      */
     public function testGenericUrlIndexGenerationWithSpecificDashboardAndController(
         ?string $dashboardFqcn,
-        ?string $controllerFqcn
+        ?string $controllerFqcn,
     ) {
         $testClass = new class($this->adminUrlGenerator) extends CrudTestUrlGenerationTraitTestClass {
             public function test(?string $dashboardFqcn, ?string $controllerFqcn): string
@@ -94,7 +94,7 @@ final class CrudTestUrlGenerationTraitTest extends KernelTestCase
      */
     public function testUrlDetailGenerationWithSpecificDashboardAndControllerFqcn(
         ?string $dashboardFqcn,
-        ?string $controllerFqcn
+        ?string $controllerFqcn,
     ) {
         $testClass = new class($this->adminUrlGenerator) extends CrudTestUrlGenerationTraitTestClass {
             public function test(string|int $id, ?string $dashboardFqcn, ?string $controllerFqcn): string
@@ -139,7 +139,7 @@ final class CrudTestUrlGenerationTraitTest extends KernelTestCase
      */
     public function testUrlNewFormGenerationWithSpecificDashboardAndControllerFqcn(
         ?string $dashboardFqcn,
-        ?string $controllerFqcn
+        ?string $controllerFqcn,
     ) {
         $testClass = new class($this->adminUrlGenerator) extends CrudTestUrlGenerationTraitTestClass {
             public function test(?string $dashboardFqcn, ?string $controllerFqcn): string
@@ -185,7 +185,7 @@ final class CrudTestUrlGenerationTraitTest extends KernelTestCase
      */
     public function testUrlEditGenerationWithSpecificDashboardAndControllerFqcn(
         ?string $dashboardFqcn,
-        ?string $controllerFqcn
+        ?string $controllerFqcn,
     ) {
         $testClass = new class($this->adminUrlGenerator) extends CrudTestUrlGenerationTraitTestClass {
             public function test(string|int $id, ?string $dashboardFqcn, ?string $controllerFqcn): string
@@ -231,7 +231,7 @@ final class CrudTestUrlGenerationTraitTest extends KernelTestCase
      */
     public function testUrlRenderFiltersGenerationWithSpecificDashboardAndControllerFqcn(
         ?string $dashboardFqcn,
-        ?string $controllerFqcn
+        ?string $controllerFqcn,
     ) {
         $testClass = new class($this->adminUrlGenerator) extends CrudTestUrlGenerationTraitTestClass {
             public function test(?string $dashboardFqcn, ?string $controllerFqcn): string


### PR DESCRIPTION
The latest PHP-CS-Fixer contains new lint rules that breaks the CI of some PRs (#6431). I reformat it with the latest `php-cs-fixer`.