### PR TITLE
Fix user menu styles when user is impersonated

### DIFF
--- a/assets/css/easyadmin-theme/base.css
+++ b/assets/css/easyadmin-theme/base.css
@@ -193,8 +193,8 @@ a.user-menu-wrapper .user-details:hover {
     display: flex;
     -webkit-appearance: none; /* needed for Safari */
 }
-.user-menu-wrapper .user-is-impersonated a.user-details,
-.user-menu-wrapper .user-is-impersonated a.user-details:hover {
+.user-menu-wrapper.user-is-impersonated a.user-details,
+.user-menu-wrapper.user-is-impersonated a.user-details:hover {
     color: var(--user-menu-impersonated-link-color);
     font-weight: 500;
 }


### PR DESCRIPTION
Removes the unnecessary space that appeared after transitioning from SCSS to CSS. After this change, the username in the user menu should have the correct styles when the user is impersonated.