### PR TITLE
Fix Route attribute namespace in dashboard template

### DIFF
--- a/src/Resources/skeleton/dashboard.tpl
+++ b/src/Resources/skeleton/dashboard.tpl
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class <?= $class_name; ?> extends AbstractDashboardController
 {


### PR DESCRIPTION
Fix Route PHP attribute namespace in the dashboard template, the annotation one was used.