### PR TITLE
Add support for pretty URLs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,11 +136,22 @@ jobs:
 
             - name: Install dependencies
               run: |
-                  composer update ${{ matrix.composer_args }}
+                  composer update ${{ matrix.composer_args }};
                   vendor/bin/simple-phpunit install
 
             - name: Run tests
               continue-on-error: ${{ matrix.stability == 'dev' }}
               env:
-                  SYMFONY_DEPRECATIONS_HELPER: "weak"
-              run: vendor/bin/simple-phpunit
+                  SYMFONY_DEPRECATIONS_HELPER: "max[total]=999999&ignoreFile=./tests/baseline-ignore.txt"
+              run: |
+                  ./vendor/bin/simple-phpunit --exclude-group pretty_urls
+
+            - name: Run Pretty URLs tests
+                # Symfony 5.4 version doesn't include the #[Route] attribute needed to run these tests (it only includes the @Route annotation)
+              if: ${{ matrix.symfony_version != '5.4' && matrix.composer_args != '--prefer-lowest' }}
+              continue-on-error: ${{ matrix.stability == 'dev' }}
+              env:
+                  USE_PRETTY_URLS: "1"
+                  SYMFONY_DEPRECATIONS_HELPER: "max[total]=999999&ignoreFile=./tests/baseline-ignore.txt"
+              run: |
+                  ./vendor/bin/simple-phpunit tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ help: ## Show help
 ## —— Tests ———————————————————————————————————
 tests: ## Run tests
 	rm -rf $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/test/cache/*
-	php vendor/bin/simple-phpunit -v
+	SYMFONY_DEPRECATIONS_HELPER='ignoreFile=./tests/baseline-ignore.txt' php vendor/bin/simple-phpunit -v
+	rm -rf $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/pretty_urls/test/cache/*
+	USE_PRETTY_URLS=1 php vendor/bin/simple-phpunit tests/Controller/PrettyUrls/PrettyUrlsController.php
 tests-coverage: ## Generate test coverage
 	rm -rf $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/test/cache/*
 	XDEBUG_MODE=coverage php vendor/bin/simple-phpunit --coverage-html $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/test/coverage/

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,22 @@
 Upgrade between EasyAdmin 4.x versions
 ======================================
 
+EasyAdmin 4.14.0
+----------------
+
+### Added Pretty URLs Support
+
+Starting from 4.14.0 version, EasyAdmin includes a custom route loader that
+can generate pretty URLs in your backend. Enable this feature by creating the
+following routing file in your application:
+
+```yaml
+# config/routes/easyadmin.yaml
+easyadmin:
+    resource: .
+    type: easyadmin.routes
+```
+
 EasyAdmin 4.11.0
 ----------------
 

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "symfony/debug-bundle": "^5.4|^6.0|^7.0",
         "symfony/dom-crawler": "^5.4|^6.0|^7.0",
         "symfony/expression-language": "^5.4|^6.0|^7.0",
-        "symfony/phpunit-bridge": "^5.4|^6.0|^7.0"
+        "symfony/phpunit-bridge": "^6.1|^7.0"
     },
     "config": {
         "sort-packages": true,
@@ -67,6 +67,7 @@
     "autoload-dev": {
         "psr-4": {
             "EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\TestApplication\\": "tests/TestApplication/src/",
+            "EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\PrettyUrlsTestApplication\\": "tests/PrettyUrlsTestApplication/src/",
             "EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\": "tests/"
         }
     },

--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -369,6 +369,19 @@ The following example shows all kinds of actions in practice::
         }
     }
 
+Custom actions can define the ``#[AdminAction]`` attribute to
+:ref:`customize their route name, path and methods <crud_routes>`::
+
+    use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminAction;
+    // ...
+
+
+    #[AdminAction(routePath: '/invoice', routeName: 'view_invoice', methods: ['GET', 'POST'])]
+    public function renderInvoice(AdminContext $context)
+    {
+        // ...
+    }
+
 .. _global-actions:
 
 Global Actions

--- a/doc/security.rst
+++ b/doc/security.rst
@@ -49,6 +49,45 @@ Another option is to use the `#[IsGranted] attribute`_ in the dashboard controll
         // ...
     }
 
+.. _security-controllers:
+
+Restrict Access to Some CRUD Controllers
+----------------------------------------
+
+When using more than one :doc:`Dashboard </dashboards>` you might need to restrict
+which :doc:`CRUD controllers </crud>` are accessible for each of them.
+
+Consider that in your application you have two dashboards (``DashboardController``
+used by your employees and ``GuestDashboardController`` used by external collaborators).
+In the guest dashboard you only want to allow certain actions related to your blog.
+
+However, when using :ref:`pretty admin URLs <pretty-admin-urls>`, EasyAdmin will
+generate the routes for all CRUD controllers in all dashboards. This means that
+there will be undesired routes like ``admin_guest_invoice``, ``admin_guest_user_detail``, etc.
+The best way to restrict which CRUD controllers are accessible via each dashboard
+is to use the ``#[AdminDashboard]`` attribute::
+
+    // app/Controller/Admin/DashboardController.php
+    use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+    use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+
+    #[AdminDashboard(allowedControllers: [BlogPostCrudController::class, BlogCategoryCrudController::class])]
+    class DashboardController extends AbstractDashboardController
+    {
+        // ...
+    }
+
+The ``allowedControllers`` option defines the only CRUD controllers that will be
+available in the dashboard via Symfony routes. In practice, the above configuration
+will make EasyAdmin to only generate the routes ``admin_guest_blog_post_*`` and
+``admin_guest_blog_category_*``, skipping all the other routes that would have
+allowed to access the other controllers.
+
+.. tip::
+
+    You can also define the opposite option (``deniedControllers``) to allow all
+    controllers except the ones included in that list.
+
 .. _security-menu:
 
 Restrict Access to Menu Items

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,6 +22,7 @@
     <testsuites>
         <testsuite name="EasyAdmin Test Suite">
             <directory>tests/</directory>
+            <exclude>tests/Controller/PrettyUrls/</exclude>
             <exclude>tests/DataCollector/</exclude>
             <exclude>tests/EventListener/</exclude>
             <exclude>tests/Form/</exclude>
@@ -34,3 +35,4 @@
         </include>
     </coverage>
 </phpunit>
+

--- a/src/Attribute/AdminAction.php
+++ b/src/Attribute/AdminAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Attribute;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class AdminAction
+{
+    public function __construct(
+        public ?string $routePath = null,
+        public ?string $routeName = null,
+        public array $methods = ['GET'],
+    ) {
+    }
+}

--- a/src/Attribute/AdminCrud.php
+++ b/src/Attribute/AdminCrud.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Attribute;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AdminCrud
+{
+    public function __construct(
+        public ?string $routePath = null,
+        public ?string $routeName = null,
+    ) {
+    }
+}

--- a/src/Attribute/AdminDashboard.php
+++ b/src/Attribute/AdminDashboard.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Attribute;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AdminDashboard
+{
+    public function __construct(
+        /** @var array<string, array{routeName: string, routePath: string}>|null */
+        public ?array $routes = null,
+        /** @var class-string[]|null $allowedControllers If defined, only these CRUD controllers will have a route defined for them */
+        public ?array $allowedControllers = null,
+        /** @var class-string[]|null $deniedControllers If defined, all CRUD controllers will have a route defined for them except these ones */
+        public ?array $deniedControllers = null,
+    ) {
+    }
+}

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -20,6 +20,7 @@ class Crud
     public const PAGE_EDIT = 'edit';
     public const PAGE_INDEX = 'index';
     public const PAGE_NEW = 'new';
+    public const ACTION_NAMES = ['index', 'detail', 'edit', 'new', 'delete', 'batchDelete', 'autocomplete'];
     public const LAYOUT_CONTENT_DEFAULT = 'normal';
     public const LAYOUT_CONTENT_FULL = 'full';
     public const LAYOUT_SIDEBAR_DEFAULT = 'normal';

--- a/src/Config/Option/EA.php
+++ b/src/Config/Option/EA.php
@@ -27,6 +27,7 @@ final class EA
     public const REFERRER = 'referrer';
     public const ROUTE_NAME = 'routeName';
     public const ROUTE_PARAMS = 'routeParams';
+    public const ROUTE_CREATED_BY_EASYADMIN = 'routeCreatedByEasyAdmin';
     public const SORT = 'sort';
     /** @deprecated this parameter is no longer used because menu items are now highlighted automatically */
     public const SUBMENU_INDEX = 'submenuIndex';

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -107,6 +107,11 @@ final class AdminContext
         return $this->dashboardDto->getAbsoluteUrls();
     }
 
+    public function usePrettyUrls(): bool
+    {
+        return true === (bool) $this->request->attributes->get(EA::ROUTE_CREATED_BY_EASYADMIN);
+    }
+
     public function getDashboardTitle(): string
     {
         return $this->dashboardDto->getTitle();

--- a/src/Contracts/Router/AdminRouteGeneratorInterface.php
+++ b/src/Contracts/Router/AdminRouteGeneratorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Router;
+
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+interface AdminRouteGeneratorInterface
+{
+    /**
+     * This method is called by the custom route loader and must generate all
+     * the routes for all the actions of all CRUD controllers and for all dashboards.
+     */
+    public function generateAll(): RouteCollection;
+}

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -391,7 +391,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $this->redirect($referrer);
         }
 
-        return $this->redirect($this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->unset(EA::ENTITY_ID)->generateUrl());
+        return $this->redirect($this->container->get(AdminUrlGenerator::class)->setController($context->getCrud()->getControllerFqcn())->setAction(Action::INDEX)->unset(EA::ENTITY_ID)->generateUrl());
     }
 
     public function batchDelete(AdminContext $context, BatchActionDto $batchActionDto): Response

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -151,7 +151,7 @@ final class ActionFactory
 
         if (Action::DELETE === $actionDto->getName()) {
             $actionDto->addHtmlAttributes([
-                'formaction' => $this->adminUrlGenerator->setAction(Action::DELETE)->setEntityId($entityDto->getPrimaryKeyValue())->removeReferrer()->generateUrl(),
+                'formaction' => $this->adminUrlGenerator->setController($adminContext->getCrud()->getControllerFqcn())->setAction(Action::DELETE)->setEntityId($entityDto->getPrimaryKeyValue())->removeReferrer()->generateUrl(),
                 'data-bs-toggle' => 'modal',
                 'data-bs-target' => '#modal-delete',
             ]);
@@ -193,11 +193,12 @@ final class ActionFactory
         }
 
         $requestParameters = [
-            EA::CRUD_CONTROLLER_FQCN => $request->query->get(EA::CRUD_CONTROLLER_FQCN),
+            // when using pretty URLs, the data is in the request attributes instead of the query string
+            EA::CRUD_CONTROLLER_FQCN => $request->attributes->get(EA::CRUD_CONTROLLER_FQCN) ?? $request->query->get(EA::CRUD_CONTROLLER_FQCN),
             EA::CRUD_ACTION => $actionDto->getCrudActionName(),
         ];
 
-        if (\in_array($actionDto->getName(), [Action::INDEX, Action::NEW, Action::SAVE_AND_ADD_ANOTHER, Action::SAVE_AND_RETURN], true)) {
+        if (\in_array($actionDto->getName(), [Action::INDEX, Action::NEW, Action::SAVE_AND_ADD_ANOTHER], true)) {
             $requestParameters[EA::ENTITY_ID] = null;
         } elseif (null !== $entityDto) {
             $requestParameters[EA::ENTITY_ID] = $entityDto->getPrimaryKeyValueAsString();

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -47,9 +47,9 @@ final class AdminContextFactory
         $this->entityFactory = $entityFactory;
     }
 
-    public function create(Request $request, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController): AdminContext
+    public function create(Request $request, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ?string $actionName = null): AdminContext
     {
-        $crudAction = $request->query->get(EA::CRUD_ACTION);
+        $crudAction = $actionName ?? $request->query->get(EA::CRUD_ACTION);
         $validPageNames = [Crud::PAGE_INDEX, Crud::PAGE_DETAIL, Crud::PAGE_EDIT, Crud::PAGE_NEW];
         $pageName = \in_array($crudAction, $validPageNames, true) ? $crudAction : null;
 
@@ -240,6 +240,10 @@ final class AdminContextFactory
             return null;
         }
 
-        return $this->entityFactory->create($crudDto->getEntityFqcn(), $request->query->get(EA::ENTITY_ID), $crudDto->getEntityPermission());
+        // when using pretty URLs, the entity ID is passed as a request attribute (it's part of the route path);
+        // in legacy URLs, the entity ID is passed as a regular query parameter
+        $entityId = $request->attributes->get(EA::ENTITY_ID) ?? $request->query->get(EA::ENTITY_ID);
+
+        return $this->entityFactory->create($crudDto->getEntityFqcn(), $entityId, $crudDto->getEntityPermission());
     }
 }

--- a/src/Field/Configurator/BooleanConfigurator.php
+++ b/src/Field/Configurator/BooleanConfigurator.php
@@ -39,6 +39,7 @@ final class BooleanConfigurator implements FieldConfiguratorInterface
 
             if (null !== $crudDto && Action::NEW !== $crudDto->getCurrentAction()) {
                 $toggleUrl = $this->adminUrlGenerator
+                    ->setController($crudDto->getControllerFqcn())
                     ->setAction(Action::EDIT)
                     ->setEntityId($entityDto->getPrimaryKeyValue())
                     ->set('fieldName', $field->getProperty())

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -170,4 +170,9 @@ final class AdminContextProvider
     {
         return $this->getContext(true)->getTemplatePath($templateName);
     }
+
+    public function usePrettyUrls(): bool
+    {
+        return $this->getContext(true)->usePrettyUrls();
+    }
 }

--- a/src/Registry/CrudControllerRegistry.php
+++ b/src/Registry/CrudControllerRegistry.php
@@ -45,4 +45,12 @@ final class CrudControllerRegistry
     {
         return $this->crudFqcnToCrudIdMap[$controllerFqcn] ?? null;
     }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getAll(): array
+    {
+        return array_values($this->entityFqcnToCrudFqcnMap);
+    }
 }

--- a/src/Registry/DashboardControllerRegistry.php
+++ b/src/Registry/DashboardControllerRegistry.php
@@ -62,4 +62,26 @@ final class DashboardControllerRegistry
     {
         return \count($this->controllerFqcnToRouteMap) < 1 ? null : $this->controllerFqcnToRouteMap[array_key_first($this->controllerFqcnToRouteMap)];
     }
+
+    public function getFirstDashboardFqcn(): ?string
+    {
+        return \count($this->controllerFqcnToRouteMap) < 1 ? null : array_key_first($this->controllerFqcnToRouteMap);
+    }
+
+    /**
+     * @return array<int, array{controller: string, route: string, context: string}>
+     */
+    public function getAll(): array
+    {
+        $dashboards = [];
+        foreach ($this->controllerFqcnToContextIdMap as $controllerFqcn => $contextId) {
+            $dashboards[] = [
+                'controller' => $controllerFqcn,
+                'route' => $this->controllerFqcnToRouteMap[$controllerFqcn] ?? null,
+                'context' => $contextId,
+            ];
+        }
+
+        return $dashboards;
+    }
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -78,6 +78,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\FieldProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteLoader;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\UrlSigner;
 use EasyCorp\Bundle\EasyAdminBundle\Security\AuthorizationChecker;
@@ -166,6 +168,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, service('controller_resolver'))
             ->arg(3, service('router'))
             ->arg(4, service('router'))
+            ->arg(5, service('router'))
             ->tag('kernel.event_subscriber')
 
         ->set(ControllerFactory::class)
@@ -191,10 +194,19 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, service(AdminContextProvider::class))
             ->arg(1, service('router'))
             ->arg(2, service(DashboardControllerRegistry::class))
+            ->arg(3, service(AdminRouteGenerator::class))
 
         ->set('service_locator_'.AdminUrlGenerator::class, ServiceLocator::class)
             ->args([[AdminUrlGenerator::class => service(AdminUrlGenerator::class)]])
             ->tag('container.service_locator')
+
+        ->set(AdminRouteGenerator::class)
+        ->arg(0, tagged_iterator(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER))
+        ->arg(1, tagged_iterator(EasyAdminExtension::TAG_CRUD_CONTROLLER))
+
+        ->set(AdminRouteLoader::class)
+            ->arg(0, service(AdminRouteGenerator::class))
+            ->tag('routing.loader', ['type' => AdminRouteLoader::ROUTE_LOADER_TYPE])
 
         ->set(UrlSigner::class)
             ->arg(0, '%kernel.secret%')
@@ -227,6 +239,7 @@ return static function (ContainerConfigurator $container) {
         ->set(EntityPaginator::class)
             ->arg(0, service(AdminUrlGenerator::class))
             ->arg(1, service(EntityFactory::class))
+            ->arg(2, service('request_stack'))
 
         ->alias(EntityPaginatorInterface::class, EntityPaginator::class)
 

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -113,7 +113,12 @@
 
                         <th data-column="{{ field.property }}" class="{{ is_searchable ? 'searchable' }} {{ is_sorting_field ? 'sorted' }} {{ field.isVirtual ? 'field-virtual' }} header-for-{{ field.cssClass|split(' ')|filter(class => class starts with 'field-')|join('') }} text-{{ field.textAlign }}" dir="{{ ea.i18n.textDirection }}">
                             {% if field.isSortable %}
-                                <a href="{{ ea_url({ page: 1, sort: { (field.property): next_sort_direction } }) }}">
+                                {% set sortable_url = ea_url().set('page', 1).set('sort', { (field.property): next_sort_direction }) %}
+                                {% if ea.usePrettyUrls %}
+                                    {% set sortable_url = sortable_url.setController(ea.request.attributes.get('crudControllerFqcn')).setAction('index') %}
+                                {% endif %}
+
+                                <a href="{{ sortable_url }}">
                                     {{ field.label|trans|raw }} <i class="fa fa-fw {{ column_icon }}"></i>
                                 </a>
                             {% else %}

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -248,8 +248,11 @@
                             <div class="content-search">
                                 {% if has_search %}
                                     {% block search %}
-
-                                        <form class="form-action-search" method="get">
+                                        {% set formActionUrl = null %}
+                                        {% if ea.usePrettyUrls %}
+                                            {% set formActionUrl = ea_url().setController(ea.request.attributes.get('crudControllerFqcn')).setAction('index').set('page', 1) %}
+                                        {% endif %}
+                                        <form class="form-action-search" method="get" {% if formActionUrl %}action="{{ formActionUrl }}"{% endif %}>
                                             {% block search_form %}
                                                 {% block search_form_filters %}
                                                     {% for field, fieldValue in ea.search.appliedFilters %}
@@ -277,9 +280,11 @@
                                                     {% endfor %}
                                                 {% endblock %}
 
-                                                <input type="hidden" name="crudAction" value="index">
-                                                <input type="hidden" name="crudControllerFqcn" value="{{ ea.request.query.get('crudControllerFqcn') }}">
-                                                <input type="hidden" name="page" value="1">
+                                                {% if not ea.usePrettyUrls %}
+                                                    <input type="hidden" name="crudAction" value="index">
+                                                    <input type="hidden" name="crudControllerFqcn" value="{{ ea.request.query.get('crudControllerFqcn') }}">
+                                                    <input type="hidden" name="page" value="1">
+                                                {% endif %}
 
                                                 <div class="form-group">
                                                     <div class="form-widget">
@@ -290,7 +295,11 @@
                                                         </label>
 
                                                         {% if app.request.get('query') %}
-                                                            <a href="{{ ea_url().unset('query') }}" class="content-search-reset">
+                                                            {% set search_reset_url = ea_url().unset('query') %}
+                                                            {% if ea.usePrettyUrls %}
+                                                                {% set search_reset_url = ea_url().unset('query').setController(ea.request.attributes.get('crudControllerFqcn')).setAction('index').set('page', 1) %}
+                                                            {% endif %}
+                                                            <a href="{{ search_reset_url }}" class="content-search-reset">
                                                                 <i class="fas fa-fw fa-times"></i>
                                                             </a>
                                                         {% endif %}

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -1,0 +1,325 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Router;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminAction;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminCrud;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * This class generates all routes for every EasyAdmin dashboard in the application
+ * and provides a utility to get the Symfony route name for a given {dashboard, CRUD controller, action} tuple.
+ *
+ * The generated ROUTES are based on a set of default route names and paths, but
+ * that can be overwritten at the dashboard, controller and method/action level
+ * using the #[AdminDashboard], #[AdminCrud] and #[AdminCrud] attributes.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class AdminRouteGenerator implements AdminRouteGeneratorInterface
+{
+    // the order in which routes are defined here is important because routes
+    // are added to the application in the same order and e.g. the path of the
+    // 'detail' route collides with the 'new' route and must be defined after it
+    private const DEFAULT_ROUTES_CONFIG = [
+        'index' => [
+            'routePath' => '/',
+            'routeName' => 'index',
+            'methods' => ['GET'],
+        ],
+        'new' => [
+            'routePath' => '/new',
+            'routeName' => 'new',
+            'methods' => ['GET', 'POST'],
+        ],
+        'batchDelete' => [
+            'routePath' => '/batchDelete',
+            'routeName' => 'batchDelete',
+            'methods' => ['POST'],
+        ],
+        'autocomplete' => [
+            'routePath' => '/autocomplete',
+            'routeName' => 'autocomplete',
+            'methods' => ['GET'],
+        ],
+        'edit' => [
+            'routePath' => '/{entityId}/edit',
+            'routeName' => 'edit',
+            'methods' => ['GET', 'POST', 'PATCH'],
+        ],
+        'delete' => [
+            'routePath' => '/{entityId}/delete',
+            'routeName' => 'delete',
+            'methods' => ['POST'],
+        ],
+        'detail' => [
+            'routePath' => '/{entityId}',
+            'routeName' => 'detail',
+            'methods' => ['GET'],
+        ],
+    ];
+
+    public function __construct(
+        private iterable $dashboardControllers,
+        private iterable $crudControllers,
+    ) {
+    }
+
+    public function generateAll(): RouteCollection
+    {
+        $collection = new RouteCollection();
+        $addedRouteNames = [];
+        foreach ($this->dashboardControllers as $dashboardController) {
+            $dashboardFqcn = $dashboardController::class;
+            [$allowedCrudControllers, $deniedCrudControllers] = $this->getAllowedAndDeniedControllers($dashboardFqcn);
+            $defaultRoutesConfig = $this->getDefaultRoutesConfig($dashboardFqcn);
+            $dashboardRouteConfig = $this->getDashboardsRouteConfig()[$dashboardFqcn];
+
+            foreach ($this->crudControllers as $crudController) {
+                $crudControllerFqcn = $crudController::class;
+
+                if (null !== $allowedCrudControllers && !\in_array($crudControllerFqcn, $allowedCrudControllers, true)) {
+                    continue;
+                }
+
+                if (null !== $deniedCrudControllers && \in_array($crudControllerFqcn, $deniedCrudControllers, true)) {
+                    continue;
+                }
+
+                $crudControllerRouteConfig = $this->getCrudControllerRouteConfig($crudControllerFqcn);
+                $actionsRouteConfig = array_replace_recursive($defaultRoutesConfig, $this->getCustomActionsConfig($crudControllerFqcn));
+
+                foreach (array_keys($actionsRouteConfig) as $actionName) {
+                    $actionRouteConfig = $actionsRouteConfig[$actionName];
+                    $crudActionPath = sprintf('%s/%s/%s', $dashboardRouteConfig['routePath'], $crudControllerRouteConfig['routePath'], ltrim($actionRouteConfig['routePath'], '/'));
+                    $crudActionRouteName = sprintf('%s_%s_%s', $dashboardRouteConfig['routeName'], $crudControllerRouteConfig['routeName'], $actionRouteConfig['routeName']);
+
+                    $defaults = [
+                        '_controller' => $crudControllerFqcn.'::'.$actionName,
+                    ];
+                    $options = [
+                        EA::ROUTE_CREATED_BY_EASYADMIN => true,
+                        EA::DASHBOARD_CONTROLLER_FQCN => $dashboardFqcn,
+                        EA::CRUD_CONTROLLER_FQCN => $crudControllerFqcn,
+                        EA::CRUD_ACTION => $actionName,
+                    ];
+
+                    $route = new Route($crudActionPath, defaults: $defaults, options: $options, methods: $actionRouteConfig['methods']);
+
+                    if (\in_array($crudActionRouteName, $addedRouteNames, true)) {
+                        throw new \RuntimeException(sprintf('When using pretty URLs, all CRUD controllers must have unique PHP class names to generate unique route names. However, your application has at least two controllers with the FQCN "%s", generating the route "%s". Even if both CRUD controllers are in different namespaces, they cannot have the same class name. Rename one of these controllers to resolve the issue.', $crudControllerFqcn, $crudActionRouteName));
+                    }
+
+                    $collection->add($crudActionRouteName, $route);
+                    $addedRouteNames[] = $crudActionRouteName;
+                }
+            }
+        }
+
+        return $collection;
+    }
+
+    public function findRouteName(string $dashboardFqcn, string $crudControllerFqcn, string $actionName): ?string
+    {
+        $defaultRoutesConfig = $this->getDefaultRoutesConfig($dashboardFqcn);
+        $actionsRouteConfig = array_replace_recursive($defaultRoutesConfig, $this->getCustomActionsConfig($crudControllerFqcn));
+        if (!isset($actionsRouteConfig[$actionName])) {
+            return null;
+        }
+
+        $dashboardRouteConfig = $this->getDashboardsRouteConfig()[$dashboardFqcn];
+        $crudControllerRouteConfig = $this->getCrudControllerRouteConfig($crudControllerFqcn);
+        $actionRouteConfig = $actionsRouteConfig[$actionName];
+
+        return sprintf('%s_%s_%s', $dashboardRouteConfig['routeName'], $crudControllerRouteConfig['routeName'], $actionRouteConfig['routeName']);
+    }
+
+    /**
+     * @return array{0: class-string[]|null, 1: class-string[]|null}
+     */
+    private function getAllowedAndDeniedControllers(string $dashboardFqcn): array
+    {
+        if (null === $attribute = $this->getPhpAttributeInstance($dashboardFqcn, AdminDashboard::class)) {
+            return [null, null];
+        }
+
+        if (null !== $attribute->allowedControllers && null !== $attribute->deniedControllers) {
+            throw new \RuntimeException(sprintf('In the #[AdminDashboard] attribute of the "%s" dashboard controller, you cannot define both "allowedControllers" and "deniedControllers" at the same time because they are the exact opposite. Use only one of them.', $dashboardFqcn));
+        }
+
+        return [$attribute->allowedControllers, $attribute->deniedControllers];
+    }
+
+    private function getDefaultRoutesConfig(string $dashboardFqcn): array
+    {
+        if (null === $dashboardAttribute = $this->getPhpAttributeInstance($dashboardFqcn, AdminDashboard::class)) {
+            return self::DEFAULT_ROUTES_CONFIG;
+        }
+
+        if (null === $customRoutesConfig = $dashboardAttribute->routes) {
+            return self::DEFAULT_ROUTES_CONFIG;
+        }
+
+        foreach ($customRoutesConfig as $action => $customRouteConfig) {
+            if (\count(array_diff(array_keys($customRouteConfig), ['routePath', 'routeName'])) > 0) {
+                throw new \RuntimeException(sprintf('In the #[AdminDashboard] attribute of the "%s" dashboard controller, the route configuration for the "%s" action defines some unsupported keys. You can only define these keys: "routePath" and "routeName".', $dashboardFqcn, $action));
+            }
+
+            if (isset($customRouteConfig['routeName']) && !preg_match('/^[a-zA-Z0-9_-]+$/', $customRouteConfig['routeName'])) {
+                throw new \RuntimeException(sprintf('In the #[AdminDashboard] attribute of the "%s" dashboard controller, the route name "%s" for the "%s" action is not valid. It can only contain letter, numbers, dashes, and underscores.', $dashboardFqcn, $customRouteConfig['routeName'], $action));
+            }
+
+            if (isset($customRouteConfig['routePath']) && \in_array($action, ['edit', 'detail', 'delete'], true) && !str_contains($customRouteConfig['routePath'], '{entityId}')) {
+                throw new \RuntimeException(sprintf('In the #[AdminDashboard] attribute of the "%s" dashboard controller, the path for the "%s" action must contain the "{entityId}" placeholder.', $action, $dashboardFqcn));
+            }
+        }
+
+        return array_replace_recursive(self::DEFAULT_ROUTES_CONFIG, $customRoutesConfig);
+    }
+
+    private function getDashboardsRouteConfig(): array
+    {
+        $config = [];
+
+        foreach ($this->dashboardControllers as $dashboardController) {
+            $reflectionClass = new \ReflectionClass($dashboardController);
+            $indexMethod = $reflectionClass->getMethod('index');
+            $routeAttributeFqcn = class_exists(\Symfony\Component\Routing\Attribute\Route::class) ? \Symfony\Component\Routing\Attribute\Route::class : \Symfony\Component\Routing\Annotation\Route::class;
+            $attributes = $indexMethod->getAttributes($routeAttributeFqcn);
+
+            if ([] === $attributes) {
+                throw new \RuntimeException(sprintf('When using pretty URLs, the "%s" EasyAdmin dashboard controller must define its route configuration (route name and path) using Symfony\'s #[Route] attribute applied to its "index()" method.', $reflectionClass->getName()));
+            }
+
+            if (\count($attributes) > 1) {
+                throw new \RuntimeException(sprintf('When using pretty URLs, the "%s" EasyAdmin dashboard controller must define only one #[Route] attribute applied on its "index()" method.', $reflectionClass->getName()));
+            }
+
+            $routeAttribute = $attributes[0]->newInstance();
+            $config[$reflectionClass->getName()] = [
+                'routeName' => $routeAttribute->getName(),
+                'routePath' => rtrim($routeAttribute->getPath(), '/'),
+            ];
+        }
+
+        return $config;
+    }
+
+    private function getCrudControllerRouteConfig(string $crudControllerFqcn): array
+    {
+        $crudControllerConfig = [];
+
+        $reflectionClass = new \ReflectionClass($crudControllerFqcn);
+        $attributes = $reflectionClass->getAttributes(AdminCrud::class);
+        $attribute = $attributes[0] ?? null;
+
+        // first, check if the CRUD controller defines a custom route config in the #[AdminCrud] attribute
+        if (null !== $attribute) {
+            if (\count(array_diff(array_keys($attribute->getArguments()), ['routePath', 'routeName'])) > 0) {
+                throw new \RuntimeException(sprintf('In the #[AdminCrud] attribute of the "%s" CRUD controller, the route configuration defines some unsupported keys. You can only define these keys: "routePath" and "routeName".', $crudControllerFqcn));
+            }
+
+            if (\array_key_exists('routePath', $attribute->getArguments())) {
+                $crudControllerConfig['routePath'] = trim($attribute->getArguments()['routePath'], '/');
+            }
+
+            if (\array_key_exists('routeName', $attribute->getArguments())) {
+                if (!preg_match('/^[a-zA-Z0-9_-]+$/', $attribute->getArguments()['routeName'])) {
+                    throw new \RuntimeException(sprintf('In the #[AdminCrud] attribute of the "%s" CRUD controller, the route name "%s" is not valid. It can only contain letter, numbers, dashes, and underscores.', $crudControllerFqcn, $attribute->getArguments()['routeName']));
+                }
+
+                $crudControllerConfig['routeName'] = trim($attribute->getArguments()['routeName'], '_');
+            }
+        }
+
+        // if the CRUD controller doesn't define any or all of the route configuration,
+        // use the default values based on the controller's class name
+        if (!\array_key_exists('routePath', $crudControllerConfig)) {
+            $crudControllerConfig['routePath'] = trim($this->transformCrudControllerNameToSnakeCase($crudControllerFqcn), '/');
+        }
+        if (!\array_key_exists('routeName', $crudControllerConfig)) {
+            $crudControllerConfig['routeName'] = trim($this->transformCrudControllerNameToSnakeCase($crudControllerFqcn), '_');
+        }
+
+        return $crudControllerConfig;
+    }
+
+    private function getCustomActionsConfig(string $crudControllerFqcn): array
+    {
+        $customActionsConfig = [];
+        $reflectionClass = new \ReflectionClass($crudControllerFqcn);
+        $methods = $reflectionClass->getMethods();
+
+        foreach ($methods as $method) {
+            $attributes = $method->getAttributes(AdminAction::class);
+            if ([] === $attributes) {
+                continue;
+            }
+
+            $attribute = $attributes[0];
+            /** @var AdminAction $attributeInstance */
+            $attributeInstance = $attribute->newInstance();
+            $action = $method->getName();
+
+            if (\count(array_diff(array_keys($attribute->getArguments()), ['routePath', 'routeName', 'methods'])) > 0) {
+                throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminAction] attribute applied to the "%s()" action includes some unsupported keys. You can only define these keys: "routePath", "routeName", and "methods".', $crudControllerFqcn, $action));
+            }
+
+            if (null !== $attributeInstance->routePath) {
+                if (\in_array($action, ['edit', 'detail', 'delete'], true) && !str_contains($attributeInstance->routePath, '{entityId}')) {
+                    throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminAction] attribute applied to the "%s()" action is missing the "{entityId}" placeholder in its route path.', $crudControllerFqcn, $action));
+                }
+
+                $customActionsConfig[$action]['routePath'] = trim($attributeInstance->routePath, '/');
+            }
+
+            if (null !== $attributeInstance->routeName) {
+                if (!preg_match('/^[a-zA-Z0-9_-]+$/', $attributeInstance->routeName)) {
+                    throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminAction] attribute applied to the "%s()" action defines an invalid route name: "%s". Valid route names can only contain letters, numbers, dashes, and underscores.', $crudControllerFqcn, $action, $attributeInstance->routeName));
+                }
+
+                $customActionsConfig[$action]['routeName'] = trim($attributeInstance->routeName, '_');
+            }
+
+            if (\array_key_exists('methods', $attribute->getArguments()) && null !== $attribute->getArguments()['methods'] && \in_array($action, ['index', 'new', 'edit', 'detail', 'delete'], true)) {
+                throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminAction] attribute applied to the "%s()" action cannot define the "methods" argument because these are built-in EasyAdmin actions and have fixed HTTP methods.', $crudControllerFqcn, $action));
+            }
+
+            if (null !== $attributeInstance->methods) {
+                $allowedMethods = ['GET', 'POST', 'PATCH', 'PUT'];
+                foreach ($attributeInstance->methods as $httpMethod) {
+                    if (!\in_array(strtoupper($httpMethod), $allowedMethods, true)) {
+                        throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminAction] attribute applied to the "%s()" action includes "%s" as part of its HTTP methods. However, the only allowed HTTP methods are: %s', $crudControllerFqcn, $action, $httpMethod, implode(', ', $allowedMethods)));
+                    }
+                }
+
+                $customActionsConfig[$action]['methods'] = $attributeInstance->methods;
+            }
+        }
+
+        return $customActionsConfig;
+    }
+
+    private function getPhpAttributeInstance(string $classFqcn, string $attributeFqcn): ?object
+    {
+        $reflectionClass = new \ReflectionClass($classFqcn);
+        if ([] === $attributes = $reflectionClass->getAttributes($attributeFqcn)) {
+            return null;
+        }
+
+        return $attributes[0]->newInstance();
+    }
+
+    // transforms 'App\Controller\Admin\FooBarBazCrudController' into 'foo_bar_baz'
+    private function transformCrudControllerNameToSnakeCase(string $crudControllerFqcn): string
+    {
+        $shortName = str_replace(['CrudController', 'Controller'], '', (new \ReflectionClass($crudControllerFqcn))->getShortName());
+        $shortName = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $shortName));
+
+        return $shortName;
+    }
+}

--- a/src/Router/AdminRouteLoader.php
+++ b/src/Router/AdminRouteLoader.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Router;
+
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class AdminRouteLoader extends Loader
+{
+    public const ROUTE_LOADER_TYPE = 'easyadmin.routes';
+
+    public function __construct(
+        private AdminRouteGeneratorInterface $adminRouteGenerator,
+    ) {
+        parent::__construct(null);
+    }
+
+    public function supports($resource, ?string $type = null): bool
+    {
+        return self::ROUTE_LOADER_TYPE === $type;
+    }
+
+    public function load($resource, ?string $type = null): RouteCollection
+    {
+        return $this->adminRouteGenerator->generateAll();
+    }
+}

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Router;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
@@ -19,17 +20,19 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
     private AdminContextProvider $adminContextProvider;
     private UrlGeneratorInterface $urlGenerator;
     private DashboardControllerRegistry $dashboardControllerRegistry;
+    private AdminRouteGenerator $adminRouteGenerator;
     private ?string $dashboardRoute = null;
     private ?bool $includeReferrer = null;
     private array $routeParameters = [];
     private ?string $currentPageReferrer = null;
     private ?string $customPageReferrer = null;
 
-    public function __construct(AdminContextProvider $adminContextProvider, UrlGeneratorInterface $urlGenerator, DashboardControllerRegistry $dashboardControllerRegistry)
+    public function __construct(AdminContextProvider $adminContextProvider, UrlGeneratorInterface $urlGenerator, DashboardControllerRegistry $dashboardControllerRegistry, AdminRouteGenerator $adminRouteGenerator)
     {
         $this->adminContextProvider = $adminContextProvider;
         $this->urlGenerator = $urlGenerator;
         $this->dashboardControllerRegistry = $dashboardControllerRegistry;
+        $this->adminRouteGenerator = $adminRouteGenerator;
     }
 
     /**
@@ -296,6 +299,7 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
                 throw new \RuntimeException('When generating admin URLs from outside EasyAdmin or without a related HTTP request (e.g. in tests, console commands, etc.), if your application has more than one Dashboard, you must associate the URL to a specific Dashboard using the "setDashboard()" method.');
             }
 
+            $this->setDashboard($this->dashboardControllerRegistry->getFirstDashboardFqcn());
             $this->dashboardRoute = $this->dashboardControllerRegistry->getFirstDashboardRoute();
         }
 
@@ -311,11 +315,44 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         ksort($routeParameters, \SORT_STRING);
 
         $context = $this->adminContextProvider->getContext();
+        $usePrettyUrls = null !== $context && $context->usePrettyUrls();
         $urlType = null !== $context && false === $context->getAbsoluteUrls() ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_URL;
-        $url = $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType);
+
+        if (null !== $this->get(EA::ROUTE_NAME)) {
+            return $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType);
+        }
+
+        if ($usePrettyUrls) {
+            $dashboardControllerFqcn = $this->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $context->getRequest()->attributes->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $this->dashboardControllerRegistry->getFirstDashboardFqcn();
+            $crudControllerFqcn = $this->get(EA::CRUD_CONTROLLER_FQCN) ?? $context->getRequest()->attributes->get(EA::CRUD_CONTROLLER_FQCN);
+            $actionName = $this->get(EA::CRUD_ACTION) ?? $context->getRequest()->attributes->get(EA::CRUD_ACTION);
+
+            $routeName = $this->adminRouteGenerator->findRouteName($dashboardControllerFqcn, $crudControllerFqcn, $actionName);
+            if (null === $routeName) {
+                $routeName = $this->dashboardRoute;
+            } else {
+                // remove these parameters so they don't appear in the query string when using pretty URLs
+                unset($routeParameters[EA::DASHBOARD_CONTROLLER_FQCN]);
+                unset($routeParameters[EA::CRUD_CONTROLLER_FQCN]);
+                unset($routeParameters[EA::CRUD_ACTION]);
+                unset($routeParameters[EA::ENTITY_FQCN]);
+            }
+        } else {
+            $routeName = $this->dashboardRoute;
+        }
+
+        if (!$usePrettyUrls && \in_array($routeParameters[EA::CRUD_ACTION] ?? Action::INDEX, Crud::ACTION_NAMES, true)) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.13.0',
+                'Not using pretty admin URLs is deprecated because they will become the only available URLs starting from EasyAdmin 5.0.0. Read the docs to learn how to enable pretty URLs in your application.',
+            );
+        }
+
+        $url = $this->urlGenerator->generate($routeName, $routeParameters, $urlType);
         $url = '' === $url ? '?' : $url;
 
-        // this is important to start the generation a each URL from the same initial state
+        // this is important to start the generation of each URL from the same initial state
         // otherwise, some parameters used when generating some URL could leak to other URLs
         $this->isInitialized = false;
 

--- a/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
+++ b/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller\PrettyUrls;
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Kernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * @group pretty_urls
+ */
+class PrettyUrlsControllerTest extends WebTestCase
+{
+    public static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    public function testGeneratedRoutes()
+    {
+        $expectedRoutes = [];
+        // the default routes of DashboardController (which doesn't customize anything about them)
+        $expectedRoutes['admin_pretty'] = '/admin/pretty/urls';
+        $expectedRoutes['admin_pretty_blog_post_index'] = '/admin/pretty/urls/blog_post/';
+        $expectedRoutes['admin_pretty_blog_post_detail'] = '/admin/pretty/urls/blog_post/{entityId}';
+        $expectedRoutes['admin_pretty_blog_post_new'] = '/admin/pretty/urls/blog_post/new';
+        $expectedRoutes['admin_pretty_blog_post_edit'] = '/admin/pretty/urls/blog_post/{entityId}/edit';
+        $expectedRoutes['admin_pretty_blog_post_delete'] = '/admin/pretty/urls/blog_post/{entityId}/delete';
+        $expectedRoutes['admin_pretty_blog_post_batchDelete'] = '/admin/pretty/urls/blog_post/batchDelete';
+        $expectedRoutes['admin_pretty_blog_post_autocomplete'] = '/admin/pretty/urls/blog_post/autocomplete';
+        $expectedRoutes['admin_pretty_category_index'] = '/admin/pretty/urls/category/';
+        $expectedRoutes['admin_pretty_category_detail'] = '/admin/pretty/urls/category/{entityId}';
+        $expectedRoutes['admin_pretty_category_new'] = '/admin/pretty/urls/category/new';
+        $expectedRoutes['admin_pretty_category_edit'] = '/admin/pretty/urls/category/{entityId}/edit';
+        $expectedRoutes['admin_pretty_category_delete'] = '/admin/pretty/urls/category/{entityId}/delete';
+        $expectedRoutes['admin_pretty_category_batchDelete'] = '/admin/pretty/urls/category/batchDelete';
+        $expectedRoutes['admin_pretty_category_autocomplete'] = '/admin/pretty/urls/category/autocomplete';
+        // these are the routes related to the User entity; this is not used by DashboardController, but they are created
+        // anyways because EasyAdmin creates routes for all dashboards + CRUD controllers by default (this can be avoided
+        // by setting the 'allowedControllers' option in the #[AdminDashboard] attribute)
+        $expectedRoutes['admin_pretty_external_user_editor_custom_route_for_index'] = '/admin/pretty/urls/user-editor/custom/path-for-index';
+        $expectedRoutes['admin_pretty_external_user_editor_custom_route_for_new'] = '/admin/pretty/urls/user-editor/new';
+        $expectedRoutes['admin_pretty_external_user_editor_batchDelete'] = '/admin/pretty/urls/user-editor/batchDelete';
+        $expectedRoutes['admin_pretty_external_user_editor_autocomplete'] = '/admin/pretty/urls/user-editor/autocomplete';
+        $expectedRoutes['admin_pretty_external_user_editor_edit'] = '/admin/pretty/urls/user-editor/{entityId}/edit';
+        $expectedRoutes['admin_pretty_external_user_editor_delete'] = '/admin/pretty/urls/user-editor/{entityId}/delete';
+        $expectedRoutes['admin_pretty_external_user_editor_detail'] = '/admin/pretty/urls/user-editor/custom/path-for-detail/{entityId}';
+        // the fully-customized routes of the SecondDashboardController; EasyAdmin only generates routes for the User
+        // entity because it's the only one allowed by the 'allowedControllers' option in the #[AdminDashboard] attribute
+        $expectedRoutes['second_dashboard'] = '/second/dashboard';
+        $expectedRoutes['second_dashboard_external_user_editor_custom_route_for_index'] = '/second/dashboard/user-editor/custom/path-for-index';
+        $expectedRoutes['second_dashboard_external_user_editor_custom_route_for_new'] = '/second/dashboard/user-editor/add-new';
+        $expectedRoutes['second_dashboard_external_user_editor_batchDelete'] = '/second/dashboard/user-editor/batchDelete';
+        $expectedRoutes['second_dashboard_external_user_editor_autocomplete'] = '/second/dashboard/user-editor/autocomplete';
+        $expectedRoutes['second_dashboard_external_user_editor_change'] = '/second/dashboard/user-editor/edit/---{entityId}---';
+        $expectedRoutes['second_dashboard_external_user_editor_delete_this_now'] = '/second/dashboard/user-editor/{entityId}/delete';
+        $expectedRoutes['second_dashboard_external_user_editor_detail'] = '/second/dashboard/user-editor/custom/path-for-detail/{entityId}';
+        $expectedRoutes['admin_pretty_external_user_editor_foobar'] = '/admin/pretty/urls/user-editor/bar/foo';
+        $expectedRoutes['second_dashboard_external_user_editor_foobar'] = '/second/dashboard/user-editor/bar/foo';
+
+        self::bootKernel();
+        $container = static::getContainer();
+        $router = $container->get('router');
+        $generatedRoutes = [];
+        foreach ($router->getRouteCollection() as $name => $route) {
+            $generatedRoutes[$name] = $route->getPath();
+        }
+
+        ksort($generatedRoutes);
+        ksort($expectedRoutes);
+
+        $this->assertEquals($expectedRoutes, $generatedRoutes);
+    }
+
+    public function testDefaultWelcomePage()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $client->request('GET', '/admin/pretty/urls');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Welcome to EasyAdmin 4');
+    }
+
+    public function testCusomizedWelcomePage()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $client->request('GET', '/second/dashboard');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1', 'Welcome to EasyAdmin 4');
+    }
+
+    public function testDefaultCrudController()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $client->request('GET', '/admin/pretty/urls/blog_post');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1.title', 'BlogPost');
+    }
+
+    public function testCustomizedCrudController()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $client->request('GET', '/second/dashboard/user-editor/custom/path-for-index');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('h1.title', 'User');
+    }
+
+    public function testDefaultMainMenuUsesPrettyUrls()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/admin/pretty/urls/blog_post');
+
+        $this->assertSame('/admin/pretty/urls', $crawler->filter('#header-logo a.logo')->attr('href'), 'The main Dashboard logo link points to the dashboard entry URL');
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the first entity of the menu');
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/', $crawler->filter('li.menu-item a:contains("Blog Posts")')->attr('href'));
+        $this->assertSame('http://localhost/admin/pretty/urls/category/', $crawler->filter('li.menu-item a:contains("Categories")')->attr('href'));
+    }
+
+    public function testCustomMainMenuUsesPrettyUrls()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/second/dashboard/user-editor/custom/path-for-index');
+
+        $this->assertSame('/second/dashboard', $crawler->filter('#header-logo a.logo')->attr('href'), 'The main Dashboard logo link points to the dashboard entry URL');
+        $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the first entity of the menu');
+        $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index', $crawler->filter('li.menu-item a:contains("Users")')->attr('href'));
+    }
+
+    public function testDefaultActionsUsePrettyUrls()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/admin/pretty/urls/blog_post');
+
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/?page=1', $crawler->filter('form.form-action-search')->attr('action'));
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/new', $crawler->filter('.global-actions a.action-new')->attr('href'));
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/1/edit', $crawler->filter('td a.action-edit')->attr('href'));
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/1/delete', $crawler->filter('td a.action-delete')->attr('href'));
+        $this->assertMatchesRegularExpression('#http://localhost/admin/pretty/urls/blog_post/1/edit\?csrfToken=.*&fieldName=content#', $crawler->filter('td.field-boolean input[type="checkbox"]')->attr('data-toggle-url'));
+    }
+
+    public function testCustomActionsUsePrettyUrls()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/second/dashboard/user-editor/custom/path-for-index');
+
+        $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1', $crawler->filter('form.form-action-search')->attr('action'));
+        $this->assertSame('http://localhost/second/dashboard/user-editor/add-new', $crawler->filter('.global-actions a.action-new')->attr('href'));
+        $this->assertSame('http://localhost/second/dashboard/user-editor/edit/---1---', $crawler->filter('td a.action-edit')->attr('href'));
+        $this->assertSame('http://localhost/second/dashboard/user-editor/1/delete', $crawler->filter('td a.action-delete')->attr('href'));
+    }
+
+    public function testDefaultSortLinksUsePrettyUrls()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/admin/pretty/urls/blog_post');
+
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/?page=1&sort%5Bid%5D=DESC', $crawler->filter('th.searchable a')->eq(0)->attr('href'));
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/?page=1&sort%5Btitle%5D=DESC', $crawler->filter('th.searchable a')->eq(1)->attr('href'));
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/?page=1&sort%5Bslug%5D=DESC', $crawler->filter('th.searchable a')->eq(2)->attr('href'));
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/?page=1&sort%5Bcontent%5D=DESC', $crawler->filter('th.searchable a')->eq(3)->attr('href'));
+        $this->assertSame('http://localhost/admin/pretty/urls/blog_post/?page=1&sort%5Bauthor%5D=DESC', $crawler->filter('th.searchable a')->eq(4)->attr('href'));
+    }
+
+    public function testCustomSortLinksUsePrettyUrls()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/second/dashboard/user-editor/custom/path-for-index');
+
+        $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bid%5D=DESC', $crawler->filter('th.searchable a')->eq(0)->attr('href'));
+        $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bname%5D=DESC', $crawler->filter('th.searchable a')->eq(1)->attr('href'));
+        $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bemail%5D=DESC', $crawler->filter('th.searchable a')->eq(2)->attr('href'));
+    }
+}

--- a/tests/Menu/MenuItemMatcherTest.php
+++ b/tests/Menu/MenuItemMatcherTest.php
@@ -351,6 +351,7 @@ class MenuItemMatcherTest extends KernelTestCase
 
         $request = $this->getMockBuilder(Request::class)->getMock();
         $request->query = new InputBag($queryParameters);
+        $request->attributes = new InputBag($queryParameters);
 
         if (null !== $getUri) {
             $request->method('getUri')->willReturn($getUri);

--- a/tests/PrettyUrlsTestApplication/config/packages/doctrine.php
+++ b/tests/PrettyUrlsTestApplication/config/packages/doctrine.php
@@ -1,0 +1,23 @@
+<?php
+
+$container->loadFromExtension('doctrine', [
+    'dbal' => [
+        'driver' => 'pdo_sqlite',
+        'path' => '%kernel.cache_dir%/test_database.sqlite',
+    ],
+
+    'orm' => [
+        'auto_generate_proxy_classes' => true,
+        'naming_strategy' => 'doctrine.orm.naming_strategy.underscore_number_aware',
+        'auto_mapping' => true,
+        'mappings' => [
+            'TestEntities' => [
+                'is_bundle' => false,
+                'type' => 'attribute',
+                'dir' => '%kernel.project_dir%/src/Entity',
+                'prefix' => 'EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity',
+                'alias' => 'app',
+            ],
+        ],
+    ],
+]);

--- a/tests/PrettyUrlsTestApplication/config/packages/framework.php
+++ b/tests/PrettyUrlsTestApplication/config/packages/framework.php
@@ -1,0 +1,14 @@
+<?php
+
+$configuration = [
+    'secret' => 'F00',
+    'csrf_protection' => true,
+    'http_method_override' => true,
+    'session' => [
+        'handler_id' => null,
+        'storage_factory_id' => 'session.storage.factory.mock_file',
+    ],
+    'test' => true,
+];
+
+$container->loadFromExtension('framework', $configuration);

--- a/tests/PrettyUrlsTestApplication/config/packages/routing.php
+++ b/tests/PrettyUrlsTestApplication/config/packages/routing.php
@@ -1,0 +1,7 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'router' => [
+        'utf8' => true,
+    ],
+]);

--- a/tests/PrettyUrlsTestApplication/config/packages/security.php
+++ b/tests/PrettyUrlsTestApplication/config/packages/security.php
@@ -1,0 +1,52 @@
+<?php
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Kernel;
+use Symfony\Component\Security\Core\User\InMemoryUser;
+
+$configuration = [
+    'enable_authenticator_manager' => true,
+
+    'password_hashers' => [
+        InMemoryUser::class => 'plaintext',
+    ],
+
+    'providers' => [
+        'test_users' => [
+            'memory' => [
+                'users' => [
+                    'user' => [
+                        'password' => '1234',
+                        'roles' => ['ROLE_USER'],
+                    ],
+                    'admin' => [
+                        'password' => '1234',
+                        'roles' => ['ROLE_ADMIN'],
+                    ],
+                ],
+            ],
+        ],
+    ],
+
+    'firewalls' => [
+        'secure_admin' => [
+            'pattern' => '^/secure_admin',
+            'provider' => 'test_users',
+            'http_basic' => null,
+            'logout' => null,
+        ],
+    ],
+
+    'role_hierarchy' => [
+        'ROLE_ADMIN' => ['ROLE_USER'],
+    ],
+
+    'access_control' => [
+        ['path' => '^/secure_admin', 'roles' => ['ROLE_USER']],
+    ],
+];
+
+if (Kernel::MAJOR_VERSION >= 7) {
+    unset($configuration['enable_authenticator_manager']);
+}
+
+$container->loadFromExtension('security', $configuration);

--- a/tests/PrettyUrlsTestApplication/config/packages/twig.php
+++ b/tests/PrettyUrlsTestApplication/config/packages/twig.php
@@ -1,0 +1,5 @@
+<?php
+
+$container->loadFromExtension('twig', [
+    'default_path' => '%kernel.project_dir%/templates',
+]);

--- a/tests/PrettyUrlsTestApplication/config/routes.php
+++ b/tests/PrettyUrlsTestApplication/config/routes.php
@@ -1,0 +1,9 @@
+<?php
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return function (RoutingConfigurator $routes) {
+    $routes->import('../src/Controller/', Kernel::MAJOR_VERSION >= 7 ? 'attribute' : 'annotation');
+    $routes->import('.', 'easyadmin.routes');
+};

--- a/tests/PrettyUrlsTestApplication/config/services.php
+++ b/tests/PrettyUrlsTestApplication/config/services.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\DataFixtures\AppFixtures;
+
+return static function (ContainerConfigurator $container) {
+    $container->parameters()->set('locale', 'en');
+
+    $services = $container->services()
+        ->defaults()
+            ->autowire()
+            ->autoconfigure()
+    ;
+
+    $services->load('EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\PrettyUrlsTestApplication\\', '../src/*')
+        ->exclude('../{Entity,Tests,Kernel.php}');
+
+    $services->load('EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\PrettyUrlsTestApplication\\Controller\\', '../src/Controller/')
+        ->tag('controller.service_arguments');
+
+    $services->set(AppFixtures::class)->tag('doctrine.fixture.orm');
+};

--- a/tests/PrettyUrlsTestApplication/src/Config/Action.php
+++ b/tests/PrettyUrlsTestApplication/src/Config/Action.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Config;
+
+class Action
+{
+    public const CUSTOM_ACTION = 'customAction';
+}

--- a/tests/PrettyUrlsTestApplication/src/Controller/BlogPostCrudController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/BlogPostCrudController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\BlogPost;
+
+class BlogPostCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return BlogPost::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            IdField::new('id')->hideOnForm(),
+            TextField::new('title'),
+            TextField::new('slug'),
+            BooleanField::new('content'),
+            BooleanField::new('author'),
+        ];
+    }
+
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add('title')
+            ->add('author');
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Controller/CategoryCrudController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/CategoryCrudController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Config\Action as AppAction;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Category;
+use Symfony\Component\HttpFoundation\Response;
+
+class CategoryCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Category::class;
+    }
+
+    public function configureAssets(Assets $assets): Assets
+    {
+        return parent::configureAssets($assets)
+            ->addHtmlContentToHead('<link data-added-from-controller rel="me" href="https://example.com">')
+            ->addHtmlContentToBody('<span data-added-from-controller><!-- foo --></span>')
+        ;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            IdField::new('id')->hideOnForm(),
+            TextField::new('name'),
+            TextField::new('slug'),
+            BooleanField::new('active'),
+            BooleanField::new('activeWithNoPermission')->setPermission('ROLE_FOO'),
+            BooleanField::new('activeDisabled')->setDisabled(),
+        ];
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $customPageAction = Action::new(AppAction::CUSTOM_ACTION)
+            ->createAsGlobalAction()
+            ->linkToCrudAction('customPage');
+
+        return $actions->add(Crud::PAGE_INDEX, $customPageAction)
+            ->setPermission(AppAction::CUSTOM_ACTION, 'ROLE_ADMIN');
+    }
+
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add('name')
+            ->add('active');
+    }
+
+    public function customAction(AdminContext $context): Response
+    {
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => AppAction::CUSTOM_ACTION, 'entity' => $context->getEntity()])) {
+            throw new ForbiddenActionException($context);
+        }
+
+        return new Response();
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Controller/DashboardController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/DashboardController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\BlogPost;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Category;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class DashboardController extends AbstractDashboardController
+{
+    #[Route('/admin/pretty/urls', name: 'admin_pretty')]
+    public function index(): Response
+    {
+        return parent::index();
+    }
+
+    public function configureDashboard(): Dashboard
+    {
+        return Dashboard::new()
+            ->setTitle('EasyAdmin Tests');
+    }
+
+    public function configureMenuItems(): iterable
+    {
+        yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
+        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class);
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Controller/SecondDashboardController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/SecondDashboardController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\User;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AdminDashboard(
+    routes: [
+        'new' => ['routePath' => '/add-new', 'routeName' => 'add'],
+        'edit' => ['routePath' => '/edit/---{entityId}---', 'routeName' => 'change'],
+        'detail' => ['routePath' => '/show-{entityId}'],
+        'delete' => ['routeName' => 'delete_this_now'],
+    ],
+    allowedControllers: [UserCrudController::class]
+)]
+class SecondDashboardController extends AbstractDashboardController
+{
+    #[Route('/second/dashboard', name: 'second_dashboard')]
+    public function index(): Response
+    {
+        return parent::index();
+    }
+
+    public function configureDashboard(): Dashboard
+    {
+        return Dashboard::new()
+            ->setTitle('EasyAdmin Tests');
+    }
+
+    public function configureMenuItems(): iterable
+    {
+        yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
+        yield MenuItem::linkToCrud('Users', 'fas fa-users', User::class);
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Controller/UserCrudController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/UserCrudController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminAction;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminCrud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\User;
+use Symfony\Component\HttpFoundation\Response;
+
+#[AdminCrud(routePath: '/user-editor', routeName: 'external_user_editor')]
+class UserCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return User::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            IdField::new('id')->hideOnForm(),
+            TextField::new('name'),
+            EmailField::new('email'),
+        ];
+    }
+
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add('name')
+            ->add('email');
+    }
+
+    #[AdminAction(routePath: '/custom/path-for-index', routeName: 'custom_route_for_index')]
+    public function index(AdminContext $context)
+    {
+        return parent::index($context);
+    }
+
+    #[AdminAction(routePath: '/custom/path-for-detail/{entityId}')]
+    public function detail(AdminContext $context)
+    {
+        return parent::detail($context);
+    }
+
+    #[AdminAction(routeName: 'custom_route_for_new')]
+    public function new(AdminContext $context)
+    {
+        return parent::new($context);
+    }
+
+    // this action doesn't use the #[AdminAction] attribute on purpose to test default behavior
+    public function edit(AdminContext $context)
+    {
+        return parent::edit($context);
+    }
+
+    #[AdminAction(routeName: 'foobar', routePath: '/bar/foo')]
+    public function someCustomAction(): Response
+    {
+        return new Response('This is a custom action');
+    }
+
+    // this custom action doesn't use the #[AdminAction] attribute on purpose to test default behavior
+    public function anotherCustomAction(): Response
+    {
+        return new Response('This is another custom action');
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/DataFixtures/AppFixtures.php
+++ b/tests/PrettyUrlsTestApplication/src/DataFixtures/AppFixtures.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Bill;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\BlogPost;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Customer;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Page;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\User;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Website;
+
+class AppFixtures extends Fixture
+{
+    public function load(ObjectManager $manager)
+    {
+        for ($i = 0; $i < 30; ++$i) {
+            $category = (new Category())
+                ->setName('Category '.$i)
+                ->setSlug('category-'.$i);
+
+            $this->addReference('category'.$i, $category);
+            $manager->persist($category);
+        }
+
+        for ($i = 0; $i < 5; ++$i) {
+            $user = (new User())
+                ->setName('User '.$i)
+                ->setEmail('user'.$i.'@example.com');
+
+            $this->addReference('user'.$i, $user);
+            $manager->persist($user);
+        }
+
+        for ($i = 0; $i < 20; ++$i) {
+            $blogPost = (new BlogPost())
+                ->setTitle('Blog Post '.$i)
+                ->setSlug('blog-post-'.$i)
+                ->setContent('Lorem Ipsum Dolor Sit Amet.')
+                ->setCreatedAt(new \DateTimeImmutable('2020-11-'.($i + 1).' 09:00:00'))
+                ->setPublishedAt(new \DateTimeImmutable('2020-11-'.($i + 1).' 11:00:00'))
+                ->addCategory($this->getReference('category'.($i % 10), Category::class))
+                ->setAuthor($this->getReference('user'.($i % 5), User::class));
+
+            if ($i < 10) {
+                $blogPost->setPublisher(
+                    $this->getReference('user'.(($i + 1) % 5), User::class)
+                );
+            }
+
+            $manager->persist($blogPost);
+        }
+
+        $this->addAssociationFixtures($manager);
+
+        $manager->flush();
+    }
+
+    private function addAssociationFixtures(ObjectManager $manager)
+    {
+        // Customer <-Many-To-Many-> Bill
+
+        // Add 10 Bills
+        for ($i = 0; $i < 10; ++$i) {
+            $bill = (new Bill())
+                ->setName('Bill '.$i);
+
+            $this->addReference('bill'.$i, $bill);
+            $manager->persist($bill);
+        }
+
+        // Pregenerated random amount of elements for each Bill
+        $manyToManyAmount = [3, 0, 0, 1, 4, 0, 2, 2, 1, 1];
+
+        // Amount of elements is the sum of the manyToManyAmount array (Generation was implemented in a way that does not include duplicates)
+        $manyToManyMapping = [6, 5, 6, 3, 1, 7, 2, 9, 4, 6, 2, 6, 1, 4, 0, 2, 4, 1, 6, 0, 9, 6, 7, 9, 8, 5, 2, 4, 9, 4, 0, 8, 7, 1, 3, 2, 1, 8, 4, 9, 7, 5, 3, 0, 6];
+        $manyToManyIndex = 0;
+
+        // Add 10 Customer
+        for ($i = 0; $i < 10; ++$i) {
+            $customer = (new Customer())
+                ->setName('Customer '.$i);
+
+            $amount = $manyToManyAmount[$i];
+
+            if ($amount > 0) {
+                for ($j = 0; $j < $amount; ++$j) {
+                    $customer->addBill(
+                        $this->getReference('bill'.$manyToManyMapping[$manyToManyIndex++], Bill::class)
+                    );
+                }
+            }
+
+            $this->addReference('customer'.$i, $customer);
+            $manager->persist($customer);
+        }
+
+        // Page <-Many-To-One-> Website
+
+        // Add 10 Page
+        for ($i = 0; $i < 10; ++$i) {
+            $page = (new Page())
+                ->setName('Page '.$i);
+
+            $this->addReference('page'.$i, $page);
+            $manager->persist($page);
+        }
+
+        // Pregenerated random amount of elements for each Website
+        $oneToManyAmount = [4, 1, 2, 5, 4, 4, 0, 4, 4, 3];
+
+        // Amount of elements is the sum of the oneToManyAmount array (Generation was implemented in a way that does not include duplicates)
+        $oneToManyMapping = [3, 8, 0, 7, 4, 0, 5, 2, 0, 1, 0, 8, 2, 4, 3, 3, 2, 5, 4, 7, 9, 2, 0, 1, 9, 6, 8, 5, 2, 9, 5, 0, 6, 1, 3, 8, 6, 9, 2, 0, 4, 8, 3, 7, 1];
+        $oneToManyIndex = 0;
+
+        // Add 10 Website
+        for ($i = 0; $i < 10; ++$i) {
+            $website = (new Website())
+                ->setName('Website '.$i);
+
+            $amount = $oneToManyAmount[$i];
+
+            if ($amount > 0) {
+                for ($j = 0; $j < $amount; ++$j) {
+                    $website->addPage(
+                        $this->getReference('page'.$oneToManyMapping[$oneToManyIndex++], Page::class)
+                    );
+                }
+            }
+
+            $this->addReference('website'.$i, $website);
+            $manager->persist($website);
+        }
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Entity/Bill.php
+++ b/tests/PrettyUrlsTestApplication/src/Entity/Bill.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`bill`')]
+class Bill
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\ManyToMany(targetEntity: Customer::class, inversedBy: 'bills')]
+    private $customers;
+
+    public function __construct()
+    {
+        $this->customers = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Customer[]
+     */
+    public function getCustomers(): Collection
+    {
+        return $this->customers;
+    }
+
+    public function addCustomer(Customer $customer): self
+    {
+        if (!$this->customers->contains($customer)) {
+            $this->customers[] = $customer;
+        }
+
+        return $this;
+    }
+
+    public function removeCustomer(Customer $customer): self
+    {
+        $this->customers->removeElement($customer);
+
+        return $this;
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Entity/BlogPost.php
+++ b/tests/PrettyUrlsTestApplication/src/Entity/BlogPost.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class BlogPost
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $title;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $slug;
+
+    #[ORM\Column(type: 'text')]
+    private $content;
+
+    #[ORM\ManyToMany(targetEntity: Category::class, inversedBy: 'blogPosts')]
+    private $categories;
+
+    #[ORM\Column(type: 'datetime_immutable')]
+    private $createdAt;
+
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    private $publishedAt;
+
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'blogPosts')]
+    #[ORM\JoinColumn(nullable: false)]
+    private $author;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    private $publisher;
+
+    public function __construct()
+    {
+        $this->categories = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): self
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    public function getContent(): ?string
+    {
+        return $this->content;
+    }
+
+    public function setContent(string $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Category[]
+     */
+    public function getCategories(): Collection
+    {
+        return $this->categories;
+    }
+
+    public function addCategory(Category $category): self
+    {
+        if (!$this->categories->contains($category)) {
+            $this->categories[] = $category;
+        }
+
+        return $this;
+    }
+
+    public function removeCategory(Category $category): self
+    {
+        $this->categories->removeElement($category);
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getPublishedAt(): ?\DateTimeImmutable
+    {
+        return $this->publishedAt;
+    }
+
+    public function setPublishedAt(?\DateTimeImmutable $publishedAt): self
+    {
+        $this->publishedAt = $publishedAt;
+
+        return $this;
+    }
+
+    public function getAuthor(): ?User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(?User $author): self
+    {
+        $this->author = $author;
+
+        return $this;
+    }
+
+    public function getPublisher()
+    {
+        return $this->publisher;
+    }
+
+    public function setPublisher(?User $publisher): void
+    {
+        $this->publisher = $publisher;
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Entity/Category.php
+++ b/tests/PrettyUrlsTestApplication/src/Entity/Category.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ORM\Entity]
+class Category
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[Assert\NotBlank]
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $slug;
+
+    #[ORM\ManyToMany(targetEntity: BlogPost::class, mappedBy: 'categories')]
+    private $blogPosts;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $active = false;
+
+    #[ORM\Column(type: 'boolean')]
+    private bool $activeDisabled = false;
+
+    public function __construct()
+    {
+        $this->blogPosts = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getSlug(): ?string
+    {
+        return $this->slug;
+    }
+
+    public function setSlug(string $slug): self
+    {
+        $this->slug = $slug;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|BlogPost[]
+     */
+    public function getBlogPosts(): Collection
+    {
+        return $this->blogPosts;
+    }
+
+    public function addBlogPost(BlogPost $blogPost): self
+    {
+        if (!$this->blogPosts->contains($blogPost)) {
+            $this->blogPosts[] = $blogPost;
+            $blogPost->addCategory($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBlogPost(BlogPost $blogPost): self
+    {
+        if ($this->blogPosts->removeElement($blogPost)) {
+            $blogPost->removeCategory($this);
+        }
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->active;
+    }
+
+    public function setActive(bool $active): self
+    {
+        $this->active = $active;
+
+        return $this;
+    }
+
+    public function isActiveDisabled(): bool
+    {
+        return $this->activeDisabled;
+    }
+
+    public function setActiveDisabled(bool $activeDisabled): self
+    {
+        $this->activeDisabled = $activeDisabled;
+
+        return $this;
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Entity/Customer.php
+++ b/tests/PrettyUrlsTestApplication/src/Entity/Customer.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`customer`')]
+class Customer
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\ManyToMany(targetEntity: Bill::class, mappedBy: 'customers')]
+    private $bills;
+
+    public function __construct()
+    {
+        $this->bills = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Bill[]
+     */
+    public function getBills(): Collection
+    {
+        return $this->bills;
+    }
+
+    public function addBill(Bill $bill): self
+    {
+        if (!$this->bills->contains($bill)) {
+            $this->bills[] = $bill;
+            $bill->addCustomer($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBill(Bill $bill): self
+    {
+        if ($this->bills->removeElement($bill)) {
+            $bill->addCustomer($this);
+        }
+
+        return $this;
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Entity/Page.php
+++ b/tests/PrettyUrlsTestApplication/src/Entity/Page.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`page`')]
+class Page
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\ManyToOne(targetEntity: Website::class, inversedBy: 'pages')]
+    #[ORM\JoinColumn(nullable: false)]
+    private $website;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getWebsite()
+    {
+        return $this->website;
+    }
+
+    public function setWebsite(?Website $website)
+    {
+        $this->website = $website;
+
+        return $this;
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Entity/User.php
+++ b/tests/PrettyUrlsTestApplication/src/Entity/User.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`user`')]
+class User
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $email;
+
+    #[ORM\OneToMany(targetEntity: BlogPost::class, mappedBy: 'author', orphanRemoval: true)]
+    private $blogPosts;
+
+    public function __construct()
+    {
+        $this->blogPosts = new ArrayCollection();
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|BlogPost[]
+     */
+    public function getBlogPosts(): Collection
+    {
+        return $this->blogPosts;
+    }
+
+    public function addBlogPost(BlogPost $blogPost): self
+    {
+        if (!$this->blogPosts->contains($blogPost)) {
+            $this->blogPosts[] = $blogPost;
+            $blogPost->setAuthor($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBlogPost(BlogPost $blogPost): self
+    {
+        if ($this->blogPosts->removeElement($blogPost)) {
+            // set the owning side to null (unless already changed)
+            if ($blogPost->getAuthor() === $this) {
+                $blogPost->setAuthor(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Entity/Website.php
+++ b/tests/PrettyUrlsTestApplication/src/Entity/Website.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: '`website`')]
+class Website implements \Stringable
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private $id;
+
+    #[ORM\Column(type: 'string', length: 255)]
+    private $name;
+
+    #[ORM\OneToMany(targetEntity: Page::class, mappedBy: 'website', orphanRemoval: true)]
+    private $pages;
+
+    public function __construct()
+    {
+        $this->pages = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName($name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Page[]
+     */
+    public function getPages(): Collection
+    {
+        return $this->pages;
+    }
+
+    public function addPage(Page $page): self
+    {
+        if (!$this->pages->contains($page)) {
+            $this->pages[] = $page;
+            $page->setWebsite($this);
+        }
+
+        return $this;
+    }
+
+    public function removePage(Page $page): self
+    {
+        if ($this->pages->removeElement($page)) {
+            // set the owning side to null (unless already changed)
+            if ($page->getWebsite() === $this) {
+                $page->setWebsite(null);
+            }
+        }
+
+        return $this;
+    }
+
+    public function __toString()
+    {
+        return $this->name;
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Kernel.php
+++ b/tests/PrettyUrlsTestApplication/src/Kernel.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle;
+use EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle;
+use Symfony\Bundle\DebugBundle\DebugBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel as SymfonyKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+final class Kernel extends SymfonyKernel
+{
+    use MicroKernelTrait;
+
+    public function __construct()
+    {
+        parent::__construct('test', false);
+    }
+
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+            new TwigBundle(),
+            new DoctrineBundle(),
+            new DoctrineFixturesBundle(),
+            new SecurityBundle(),
+            new DebugBundle(),
+            new EasyAdminBundle(),
+        ];
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir().'/com.github.easycorp.easyadmin/tests/var/pretty_urls/'.$this->environment.'/cache';
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir().'/com.github.easycorp.easyadmin/tests/var/pretty_urls/'.$this->environment.'/log';
+    }
+
+    public function getProjectDir(): string
+    {
+        return \dirname(__DIR__);
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->import($this->getProjectDir().'/config/routes.php');
+    }
+
+    protected function configureContainer(ContainerBuilder $containerBuilder, LoaderInterface $loader): void
+    {
+        $loader->load($this->getProjectDir().'/config/{packages}/*.php', 'glob');
+        $loader->load($this->getProjectDir().'/config/{packages}/'.$this->environment.'/*.php', 'glob');
+        $loader->load($this->getProjectDir().'/config/{services}.php', 'glob');
+        $loader->load($this->getProjectDir().'/config/{services}_'.$this->environment.'.php', 'glob');
+    }
+}

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -7,6 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
@@ -306,6 +307,8 @@ class AdminUrlGeneratorTest extends WebTestCase
         $container = Kernel::MAJOR_VERSION >= 6 ? static::getContainer() : self::$container;
         $router = $container->get('router');
 
-        return new AdminUrlGenerator($adminContextProvider, $router, $dashboardControllerRegistry);
+        $adminRouteGenerator = $this->getMockBuilder(AdminRouteGenerator::class)->disableOriginalConstructor()->getMock();
+
+        return new AdminUrlGenerator($adminContextProvider, $router, $dashboardControllerRegistry, $adminRouteGenerator);
     }
 }

--- a/tests/baseline-ignore.txt
+++ b/tests/baseline-ignore.txt
@@ -1,0 +1,1 @@
+%Since easycorp/easyadmin-bundle 4.13.0: Not using pretty admin URLs is deprecated because they will become the only available URLs starting from EasyAdmin 5.0.0. Read the docs to learn how to enable pretty URLs in your application.%

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Kernel as PrettyUrlsKernel;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -37,7 +38,11 @@ if (!file_exists($file)) {
 }
 $autoload = require $file;
 
-$kernel = new Kernel();
+if ('1' === getenv('USE_PRETTY_URLS')) {
+    $kernel = new PrettyUrlsKernel();
+} else {
+    $kernel = new Kernel();
+}
 
 // delete the existing cache directory to avoid issues
 (new Symfony\Component\Filesystem\Filesystem())->remove($kernel->getCacheDir());


### PR DESCRIPTION
Fixes #915 Fixes #4144 Fixes #5010 Fixes #5603 Fixes #6322

A quick example is worth a thousand words:

```
// Before
https://example.com/admin?crudAction=edit&crudControllerFqcn=App%5CController%5CAdmin%5CPostCrudController&entityId=3874

// After
https://example.com/admin/post/3874/edit
```

* Read the updated docs in the PR to learn more about this feature.
* This PR still needs some minor changes (e.g. I'll add an interface for the new `AdminRouteGenerator` class, etc.) but it's ready for test it.