### PR TITLE
`ea` twig variable existence check fix

### DIFF
--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -31,6 +31,13 @@ final class AdminContextProvider
         $this->requestStack = $requestStack;
     }
 
+    public function hasContext(): bool
+    {
+        $currentRequest = $this->requestStack->getCurrentRequest();
+
+        return null !== $currentRequest && $currentRequest->attributes->has(EA::CONTEXT_REQUEST_ATTRIBUTE);
+    }
+
     public function getContext(bool $throw = false): ?AdminContext
     {
         $currentRequest = $this->requestStack->getCurrentRequest();

--- a/src/Resources/views/flash_messages.html.twig
+++ b/src/Resources/views/flash_messages.html.twig
@@ -1,8 +1,5 @@
-{# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{# This template checks for 'ea' variable existence because it can
-   be used in a EasyAdmin Dashboard controller, where 'ea' is defined
-   or from any other Symfony controller, where 'ea' is not defined #}
-{% trans_default_domain ea is defined ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
+{# @var ea \EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider #}
+{% trans_default_domain ea.hasContext ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% set flash_messages = app.flashes %}
 

--- a/src/Resources/views/page/login.html.twig
+++ b/src/Resources/views/page/login.html.twig
@@ -1,12 +1,9 @@
-{# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{# This template checks for 'ea' variable existence because it can
-   be used in a EasyAdmin Dashboard controller, where 'ea' is defined
-   or from any other Symfony controller, where 'ea' is not defined #}
-{% extends ea is defined ? ea.templatePath('layout') : '@EasyAdmin/page/login_minimal.html.twig' %}
-{% trans_default_domain ea is defined ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
+{# @var ea \EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider #}
+{% extends ea.hasContext ? ea.templatePath('layout') : '@EasyAdmin/page/login_minimal.html.twig' %}
+{% trans_default_domain ea.hasContext ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% block body_class 'page-login' %}
-{% block page_title %}{{ page_title is defined ? page_title|raw : (ea is defined ? ea.dashboardTitle|raw : '') }}{% endblock %}
+{% block page_title %}{{ page_title is defined ? page_title|raw : (ea.hasContext ? ea.dashboardTitle|raw : '') }}{% endblock %}
 
 {% block head_favicon %}
     {% if favicon_path|default(false) %}
@@ -31,7 +28,7 @@
             <div id="header-logo">
                 {% block header_logo %}
                     {% if page_title %}
-                        {% if ea is defined %}
+                        {% if ea.hasContext %}
                             <a class="logo {{ page_title|length > 14 ? 'logo-long' }}" title="{{ page_title|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
                                 {{ page_title|raw }}
                             </a>
@@ -59,7 +56,7 @@
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrf_token_intention) }}">
                 {% endif %}
 
-                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea is defined ? path(ea.dashboardRouteName) : '/') }}" />
+                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea.hasContext ? path(ea.dashboardRouteName) : '/') }}" />
 
                 <div class="form-group">
                     <label class="form-control-label required" for="username">{{ _username_label }}</label>


### PR DESCRIPTION
Fix for #6473 

Added `hasContext` method to check for AdminContext existence instead of relying on `is defined`.
#6273 made `ea` twig global variable always defined.