### PR TITLE
ControllerResolver::getController return value check

### DIFF
--- a/src/Factory/ControllerFactory.php
+++ b/src/Factory/ControllerFactory.php
@@ -51,7 +51,11 @@ final class ControllerFactory
         }
 
         $newRequest = $request->duplicate(null, null, ['_controller' => [$controllerFqcn, $controllerAction]]);
-        $controllerCallable = $this->controllerResolver->getController($newRequest);
+        try {
+            $controllerCallable = $this->controllerResolver->getController($newRequest);
+        } catch (\InvalidArgumentException $e) {
+            $controllerCallable = false;
+        }
 
         if (false === $controllerCallable) {
             throw new NotFoundHttpException(sprintf('Unable to find the controller "%s::%s".', $controllerFqcn, $controllerAction));


### PR DESCRIPTION
ControllerResolver::getController throws InvalidArgumentException resulting in 500 error, when the `crudControllerFqcn` or `crudAction` query param is changed by hand (non-existent CrudController).
