### PR TITLE
Fix modal header layout issue due to Bootstrap 5.3.3 changes

### DIFF
--- a/src/Resources/views/crud/includes/_filters_modal.html.twig
+++ b/src/Resources/views/crud/includes/_filters_modal.html.twig
@@ -1,7 +1,7 @@
 <div id="modal-filters" class="modal fade" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">
-            <div class="modal-header">
+            <div class="modal-header justify-content-between">
                 <button type="button" data-bs-dismiss="modal" class="btn btn-sm btn-secondary" id="modal-clear-button" formtarget="_self">
                     <i class="fa fa-close"></i> {{ 'filter.button.clear'|trans(domain = 'EasyAdminBundle') }}
                 </button>


### PR DESCRIPTION
Since Bootstrap 5.3.3, the justify-content: space-between property has been removed from the modal-header class ([#39373](https://github.com/twbs/bootstrap/pull/39373/files)).

This change causes the modal header layout to break, as seen below:

![modal-filters-issue](https://github.com/user-attachments/assets/35f8e1e8-2b4a-411e-9025-79d1ec04675b)



