### PR TITLE
Allow to set HTML attributes in fields on index and detail pages, not only on form pages

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -812,8 +812,11 @@ Misc. Options
         ->setFormTypeOptions(['option_name' => 'option_value'])
 
         // a custom HTML attribute added when rendering the field
-        // e.g. setAttribute('data-foo', 'bar') renders a 'data-foo="bar"' attribute in HTML
-        // it's a shortcut for the equivalent setFormTypeOption('attr.data-foo', 'bar')
+        // e.g. setHtmlAttribute('data-foo', 'bar') renders a 'data-foo="bar"' attribute in HTML
+        // On 'index' and 'detail' pages, the attribute is added to the field container:
+        // <td> and div.field-group respectively
+        // On 'new' and 'edit' pages, the attribute is added to the form field;
+        // it's a shortcut for the equivalent setFormTypeOption('attr.data-foo', 'bar)
         ->setHtmlAttribute('attribute_name', 'attribute_value')
 
         // a key-value array of attributes to add to the HTML element

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -54,6 +54,7 @@ final class FieldDto
     /** @internal */
     private $uniqueId;
     private KeyValueStore $displayedOn;
+    private array $htmlAttributes = [];
 
     public function __construct()
     {
@@ -475,5 +476,24 @@ final class FieldDto
     public function isDisplayedOn(string $pageName): bool
     {
         return $this->displayedOn->has($pageName);
+    }
+
+    public function getHtmlAttributes(): array
+    {
+        return $this->htmlAttributes;
+    }
+
+    public function setHtmlAttributes(array $htmlAttributes): self
+    {
+        $this->htmlAttributes = $htmlAttributes;
+
+        return $this;
+    }
+
+    public function setHtmlAttribute(string $attribute, mixed $value): self
+    {
+        $this->htmlAttributes[$attribute] = $value;
+
+        return $this;
     }
 }

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -151,6 +151,7 @@ trait FieldTrait
         }
 
         $this->dto->setFormTypeOption('attr.'.$attributeName, $attributeValue);
+        $this->dto->setHtmlAttribute($attributeName, $attributeValue);
 
         return $this;
     }

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -137,8 +137,9 @@ trait FieldTrait
 
     /**
      * Sets the value of a custom HTML attribute that will be added when rendering the field.
-     * E.g. setAttribute('data-foo', 'bar') will render a 'data-foo="bar"' attribute in HTML.
-     * It's a shortcut for the equivalent setFormTypeOption('attr.data-foo', 'bar').
+     * E.g. setHtmlAttribute('data-foo', 'bar') will render a 'data-foo="bar"' attribute in HTML.
+     * On 'index' and 'detail' pages, the attribute is added to the field container (<td> and div.field-group respectively).
+     * On 'new' and 'edit' pages, the attribute is added to the form field; it's a shortcut for the equivalent setFormTypeOption('attr.data-foo', 'bar).
      */
     public function setHtmlAttribute(string $attributeName, $attributeValue): self
     {
@@ -150,8 +151,8 @@ trait FieldTrait
             throw new \InvalidArgumentException(sprintf('The value of the "%s" attribute must be a scalar value (string, integer, float, boolean); "%s" given.', $attributeName, \gettype($attributeValue)));
         }
 
-        $this->dto->setFormTypeOption('attr.'.$attributeName, $attributeValue);
         $this->dto->setHtmlAttribute($attributeName, $attributeValue);
+        $this->dto->setFormTypeOption('attr.'.$attributeName, $attributeValue);
 
         return $this;
     }

--- a/src/Resources/views/crud/detail.html.twig
+++ b/src/Resources/views/crud/detail.html.twig
@@ -63,7 +63,7 @@
 {% endblock %}
 
 {% macro render_field_contents(entity, field) %}
-    <div class="field-group {{ field.cssClass }}">
+    <div class="field-group {{ field.cssClass }}" {% for name, value in field.htmlAttributes %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
         {% if field.label is same as (false) %}
             {# a FALSE label value means that the field doesn't even display the <label> element;
                use an empty string to not display a label but keep the <label> element to not mess with the layout #}

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -42,12 +42,6 @@
         : custom_page_title|trans|raw -}}
 {% endblock %}
 
-{% macro render_html_attributes(item) %}
-    {% for attribute_name, attribute_value in item.htmlAttributes %}
-        {{ attribute_name }}="{{ attribute_value|e('html_attr') }}"
-    {% endfor %}
-{% endmacro %}
-
 {% set has_batch_actions = batch_actions|length > 0 %}
 {% block page_actions %}
     {% if filters|length > 0 %}
@@ -152,7 +146,7 @@
                         {% for field in entity.fields %}
                             {% set is_searchable = null == ea.crud.searchFields or field.property in ea.crud.searchFields %}
 
-                            <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea.i18n.textDirection }}" {{ _self.render_html_attributes(field) }}>
+                            <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea.i18n.textDirection }}" {% for name, value in field.htmlAttributes %}{{ name }}="{{ value|e('html_attr') }}" {% endfor %}>
                                 {{ include(field.templatePath, { field: field, entity: entity }, with_context = false) }}
                             </td>
                         {% endfor %}

--- a/src/Resources/views/crud/index.html.twig
+++ b/src/Resources/views/crud/index.html.twig
@@ -42,6 +42,12 @@
         : custom_page_title|trans|raw -}}
 {% endblock %}
 
+{% macro render_html_attributes(item) %}
+    {% for attribute_name, attribute_value in item.htmlAttributes %}
+        {{ attribute_name }}="{{ attribute_value|e('html_attr') }}"
+    {% endfor %}
+{% endmacro %}
+
 {% set has_batch_actions = batch_actions|length > 0 %}
 {% block page_actions %}
     {% if filters|length > 0 %}
@@ -146,7 +152,7 @@
                         {% for field in entity.fields %}
                             {% set is_searchable = null == ea.crud.searchFields or field.property in ea.crud.searchFields %}
 
-                            <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea.i18n.textDirection }}">
+                            <td data-column="{{ field.property }}" data-label="{{ field.label|trans|e('html_attr') }}" class="{{ is_searchable ? 'searchable' }} {{ field.property == sort_field_name ? 'sorted' }} text-{{ field.textAlign }} {{ field.cssClass }}" dir="{{ ea.i18n.textDirection }}" {{ _self.render_html_attributes(field) }}>
                                 {{ include(field.templatePath, { field: field, entity: entity }, with_context = false) }}
                             </td>
                         {% endfor %}

--- a/tests/Controller/CustomFieldAttributeControllerTest.php
+++ b/tests/Controller/CustomFieldAttributeControllerTest.php
@@ -6,11 +6,11 @@ use Doctrine\ORM\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CustomFieldAttributeCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\SecureDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
 class CustomFieldAttributeControllerTest extends AbstractCrudTestCase
 {
-    protected EntityRepository $categories;
+    protected EntityRepository $blogPosts;
 
     protected function getControllerFqcn(): string
     {
@@ -28,14 +28,70 @@ class CustomFieldAttributeControllerTest extends AbstractCrudTestCase
         $this->client->followRedirects();
         $this->client->setServerParameters(['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
 
-        $this->categories = $this->entityManager->getRepository(Category::class);
+        $this->blogPosts = $this->entityManager->getRepository(BlogPost::class);
     }
 
-    public function testItAddsAttributesToTd(): void
+    public function testFieldAttributesOnIndexPage(): void
     {
         $crawler = $this->client->request('GET', $this->generateIndexUrl());
 
         static::assertCount(20, $crawler->filter('td[multi-test-one="test1"]'));
         static::assertCount(20, $crawler->filter('td[multi-test-two="test2"]'));
+        static::assertCount(20, $crawler->filter('td[data-some-attribute="some-value"]'));
+        static::assertCount(20, $crawler->filter('td[x-attribute-two="another value"]'));
+        static::assertCount(20, $crawler->filter('td[foo="3"]'));
+        static::assertCount(20, $crawler->filter('td[bar=""]'));
+        static::assertCount(20, $crawler->filter('td[foo-bar="1"]'));
+    }
+
+    public function testFieldAttributesOnDetailPage(): void
+    {
+        $blogPost = $this->blogPosts->findOneBy([]);
+        $crawler = $this->client->request('GET', $this->generateDetailUrl($blogPost->getId()));
+
+        $titleContainerElement = $crawler->filter('div.field-group:contains("Blog Post 0")');
+        static::assertSame('test1', $titleContainerElement->attr('multi-test-one'));
+        static::assertSame('test2', $titleContainerElement->attr('multi-test-two'));
+
+        $publishedAtContainerElement = $crawler->filter('div.field-group:contains("Published At")');
+        static::assertSame('some-value', $publishedAtContainerElement->attr('data-some-attribute'));
+        static::assertSame('another value', $publishedAtContainerElement->attr('x-attribute-two'));
+        static::assertSame('3', $publishedAtContainerElement->attr('foo'));
+        static::assertSame('', $publishedAtContainerElement->attr('bar'));
+        static::assertSame('1', $publishedAtContainerElement->attr('foo-bar'));
+    }
+
+    public function testFieldAttributesOnEditPage(): void
+    {
+        $blogPost = $this->blogPosts->findOneBy([]);
+        $crawler = $this->client->request('GET', $this->generateEditFormUrl($blogPost->getId()));
+
+        $titleElement = $crawler->filter('input[name="BlogPost[title]"]');
+        static::assertSame('test1', $titleElement->attr('multi-test-one'));
+        static::assertSame('test2', $titleElement->attr('multi-test-two'));
+
+        $publishedAtElement = $crawler->filter('input[name="BlogPost[publishedAt]"]');
+        static::assertSame('some-value', $publishedAtElement->attr('data-some-attribute'));
+        static::assertSame('another value', $publishedAtElement->attr('x-attribute-two'));
+        static::assertSame('3', $publishedAtElement->attr('foo'));
+        static::assertNull($publishedAtElement->attr('bar'), 'Boolean attributes with FALSE value (e.g. bar="false") are not rendered in the HTML');
+        static::assertSame('foo-bar', $publishedAtElement->attr('foo-bar'), 'Boolean attributes with TRUE value (e.g. foo-bar="true") are rendered as foo-bar="foo-bar"');
+    }
+
+    public function testFieldAttributesOnNewPage(): void
+    {
+        $blogPost = $this->blogPosts->findOneBy([]);
+        $crawler = $this->client->request('GET', $this->generateNewFormUrl());
+
+        $titleElement = $crawler->filter('input[name="BlogPost[title]"]');
+        static::assertSame('test1', $titleElement->attr('multi-test-one'));
+        static::assertSame('test2', $titleElement->attr('multi-test-two'));
+
+        $publishedAtElement = $crawler->filter('input[name="BlogPost[publishedAt]"]');
+        static::assertSame('some-value', $publishedAtElement->attr('data-some-attribute'));
+        static::assertSame('another value', $publishedAtElement->attr('x-attribute-two'));
+        static::assertSame('3', $publishedAtElement->attr('foo'));
+        static::assertNull($publishedAtElement->attr('bar'), 'Boolean attributes with FALSE value (e.g. bar="false") are not rendered in the HTML');
+        static::assertSame('foo-bar', $publishedAtElement->attr('foo-bar'), 'Boolean attributes with TRUE value (e.g. foo-bar="true") are rendered as foo-bar="foo-bar"');
     }
 }

--- a/tests/Controller/CustomFieldAttributeControllerTest.php
+++ b/tests/Controller/CustomFieldAttributeControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\CustomFieldAttributeCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\SecureDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+
+class CustomFieldAttributeControllerTest extends AbstractCrudTestCase
+{
+    protected EntityRepository $categories;
+
+    protected function getControllerFqcn(): string
+    {
+        return CustomFieldAttributeCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return SecureDashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->client->setServerParameters(['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => '1234']);
+
+        $this->categories = $this->entityManager->getRepository(Category::class);
+    }
+
+    public function testItAddsAttributesToTd(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        static::assertCount(20, $crawler->filter('td[multi-test-one="test1"]'));
+        static::assertCount(20, $crawler->filter('td[multi-test-two="test2"]'));
+    }
+}

--- a/tests/TestApplication/src/Controller/CustomFieldAttributeCrudController.php
+++ b/tests/TestApplication/src/Controller/CustomFieldAttributeCrudController.php
@@ -2,47 +2,31 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
 
-use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
-/**
- * Tests the configureActions() method and the generated actions.
- */
 class CustomFieldAttributeCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string
     {
-        return Category::class;
+        return BlogPost::class;
     }
 
     public function configureFields(string $pageName): iterable
     {
-        return [
-            TextField::new('name')
-                ->setHtmlAttribute('multi-test-one', 'test1')
-                ->setHtmlAttribute('multi-test-two', 'test2'),
-        ];
-    }
+        yield TextField::new('title')
+            ->setHtmlAttribute('multi-test-one', 'test1')
+            ->setHtmlAttribute('multi-test-two', 'test2');
 
-    public function configureActions(Actions $actions): Actions
-    {
-        $action1 = Action::new('action1')->linkToCrudAction('');
-        $action2 = Action::new('action2')->linkToCrudAction('')->setCssClass('foo');
-        $action3 = Action::new('action3')->linkToCrudAction('')->addCssClass('bar');
-        $action4 = Action::new('action4')->linkToCrudAction('')->setCssClass('foo')->addCssClass('bar');
-
-        return $actions
-            ->add(Crud::PAGE_INDEX, $action1)
-            ->add(Crud::PAGE_INDEX, $action2)
-            ->add(Crud::PAGE_INDEX, $action3)
-            ->add(Crud::PAGE_INDEX, $action4)
-            ->update(Crud::PAGE_INDEX, Action::NEW, function (Action $action) {
-                return $action->setIcon('fa fa-fw fa-plus')->setLabel(false);
-            })
-        ;
+        yield DateTimeField::new('publishedAt')
+            ->setHtmlAttributes([
+                'data-some-attribute' => 'some-value',
+                'x-attribute-two' => 'another value',
+                'foo' => 3,
+                'bar' => false,
+                'foo-bar' => true,
+            ]);
     }
 }

--- a/tests/TestApplication/src/Controller/CustomFieldAttributeCrudController.php
+++ b/tests/TestApplication/src/Controller/CustomFieldAttributeCrudController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
+
+/**
+ * Tests the configureActions() method and the generated actions.
+ */
+class CustomFieldAttributeCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Category::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('name')
+                ->setHtmlAttribute('multi-test-one', 'test1')
+                ->setHtmlAttribute('multi-test-two', 'test2'),
+        ];
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $action1 = Action::new('action1')->linkToCrudAction('');
+        $action2 = Action::new('action2')->linkToCrudAction('')->setCssClass('foo');
+        $action3 = Action::new('action3')->linkToCrudAction('')->addCssClass('bar');
+        $action4 = Action::new('action4')->linkToCrudAction('')->setCssClass('foo')->addCssClass('bar');
+
+        return $actions
+            ->add(Crud::PAGE_INDEX, $action1)
+            ->add(Crud::PAGE_INDEX, $action2)
+            ->add(Crud::PAGE_INDEX, $action3)
+            ->add(Crud::PAGE_INDEX, $action4)
+            ->update(Crud::PAGE_INDEX, Action::NEW, function (Action $action) {
+                return $action->setIcon('fa fa-fw fa-plus')->setLabel(false);
+            })
+        ;
+    }
+}


### PR DESCRIPTION
This finishes #6233 and fixes #6230 applying the attributes to the detail page too and adds more tests.