### PR TITLE
Fix the highlighter so that it doesn't crash on REGEX symbols anymore

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -181,7 +181,11 @@ class App {
         };
 
         const searchQueryTerms = tokenizeString(searchElement.value);
-        const searchQueryTermsHighlightRegexp = new RegExp(searchQueryTerms.join('|'), 'i');
+        const searchQueryTermsHighlightSafe = searchQueryTerms
+            .join('|')
+            .replace(/[|\\{}()[\]^$+*?.]/g, '\\$&')
+            .replace(/-/g, '\\x2d');
+        const searchQueryTermsHighlightRegexp = new RegExp(searchQueryTermsHighlightSafe, 'i');
 
         const elementsToHighlight = document.querySelectorAll('table tbody td.searchable');
         const highlighter = new Mark(elementsToHighlight);


### PR DESCRIPTION
Added a character replace to the highlight function, so that special regex characters no longer break the functionality.

Fixes: #6493