### PR TITLE
Fix next page url

### DIFF
--- a/src/Orm/EntityPaginator.php
+++ b/src/Orm/EntityPaginator.php
@@ -228,7 +228,7 @@ final class EntityPaginator implements EntityPaginatorInterface
             $nextPageUrl->setController($crudControllerFqcn)->setAction($currentRequest->attributes->get(EA::CRUD_ACTION));
         }
 
-        $jsonResult['next_page'] = $nextPageUrl->generateUrl();
+        $jsonResult['next_page'] = $nextPageUrl?->generateUrl();
 
         return json_encode($jsonResult, \JSON_THROW_ON_ERROR);
     }


### PR DESCRIPTION
When using `AssociationField` and there are no more pages for a result the `generateUrl()` method will be called on `null`.

This PR adds a check when calling `$nextPageUrl->generateUrl()`.

