### PR TITLE
Allow `AdminCrud` and `AdminAction` attributes to be used without parameter names

### DIFF
--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -219,20 +219,23 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
 
         // first, check if the CRUD controller defines a custom route config in the #[AdminCrud] attribute
         if (null !== $attribute) {
-            if (\count(array_diff(array_keys($attribute->getArguments()), ['routePath', 'routeName'])) > 0) {
+            /** @var AdminCrud $attributeInstance */
+            $attributeInstance = $attribute->newInstance();
+
+            if (\count(array_diff(array_keys($attribute->getArguments()), ['routePath', 'routeName', 0, 1])) > 0) {
                 throw new \RuntimeException(sprintf('In the #[AdminCrud] attribute of the "%s" CRUD controller, the route configuration defines some unsupported keys. You can only define these keys: "routePath" and "routeName".', $crudControllerFqcn));
             }
 
-            if (\array_key_exists('routePath', $attribute->getArguments())) {
-                $crudControllerConfig['routePath'] = trim($attribute->getArguments()['routePath'], '/');
+            if (null !== $attributeInstance->routePath) {
+                $crudControllerConfig['routePath'] = trim($attributeInstance->routePath, '/');
             }
 
-            if (\array_key_exists('routeName', $attribute->getArguments())) {
-                if (!preg_match('/^[a-zA-Z0-9_-]+$/', $attribute->getArguments()['routeName'])) {
-                    throw new \RuntimeException(sprintf('In the #[AdminCrud] attribute of the "%s" CRUD controller, the route name "%s" is not valid. It can only contain letter, numbers, dashes, and underscores.', $crudControllerFqcn, $attribute->getArguments()['routeName']));
+            if (null !== $attributeInstance->routeName) {
+                if (!preg_match('/^[a-zA-Z0-9_-]+$/', $attributeInstance->routeName)) {
+                    throw new \RuntimeException(sprintf('In the #[AdminCrud] attribute of the "%s" CRUD controller, the route name "%s" is not valid. It can only contain letter, numbers, dashes, and underscores.', $crudControllerFqcn, $attributeInstance->routeName));
                 }
 
-                $crudControllerConfig['routeName'] = trim($attribute->getArguments()['routeName'], '_');
+                $crudControllerConfig['routeName'] = trim($attributeInstance->routeName, '_');
             }
         }
 
@@ -265,7 +268,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
             $attributeInstance = $attribute->newInstance();
             $action = $method->getName();
 
-            if (\count(array_diff(array_keys($attribute->getArguments()), ['routePath', 'routeName', 'methods'])) > 0) {
+            if (\count(array_diff(array_keys($attribute->getArguments()), ['routePath', 'routeName', 'methods', 0, 1, 2])) > 0) {
                 throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminAction] attribute applied to the "%s()" action includes some unsupported keys. You can only define these keys: "routePath", "routeName", and "methods".', $crudControllerFqcn, $action));
             }
 

--- a/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
+++ b/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
@@ -56,6 +56,8 @@ class PrettyUrlsControllerTest extends WebTestCase
         $expectedRoutes['second_dashboard_external_user_editor_detail'] = '/second/dashboard/user-editor/custom/path-for-detail/{entityId}';
         $expectedRoutes['admin_pretty_external_user_editor_foobar'] = '/admin/pretty/urls/user-editor/bar/foo';
         $expectedRoutes['second_dashboard_external_user_editor_foobar'] = '/second/dashboard/user-editor/bar/foo';
+        $expectedRoutes['admin_pretty_external_user_editor_foofoo'] = '/admin/pretty/urls/user-editor/bar/bar';
+        $expectedRoutes['second_dashboard_external_user_editor_foofoo'] = '/second/dashboard/user-editor/bar/bar';
 
         self::bootKernel();
         $container = static::getContainer();

--- a/tests/PrettyUrlsTestApplication/src/Controller/UserCrudController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/UserCrudController.php
@@ -13,7 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\User;
 use Symfony\Component\HttpFoundation\Response;
 
-#[AdminCrud(routePath: '/user-editor', routeName: 'external_user_editor')]
+#[AdminCrud('/user-editor', 'external_user_editor')]
 class UserCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string
@@ -65,6 +65,12 @@ class UserCrudController extends AbstractCrudController
     public function someCustomAction(): Response
     {
         return new Response('This is a custom action');
+    }
+
+    #[AdminAction('/bar/bar', 'foofoo')]
+    public function anotherCustomActionWithoutPropertyNames(): Response
+    {
+        return new Response('This is custom action with short attribute syntax');
     }
 
     // this custom action doesn't use the #[AdminAction] attribute on purpose to test default behavior


### PR DESCRIPTION
This PR allows using both `AdminCrud` and `AdminAction` attributes in their short form, like:

```
#[AdminCrud('/user-editor', 'external_user_editor')]
#[AdminAction('/bar/bar', 'foofoo')]
```

Right now they are only functional with parameters, like:
```
#[AdminAction(routeName: 'foobar', routePath: '/bar/foo')]
```

This closes #6501 