### PR TITLE
Improve the detection of pretty URLs usage

### DIFF
--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -43,8 +43,9 @@ final class AdminContext
     private TemplateRegistry $templateRegistry;
     private ?MainMenuDto $mainMenuDto = null;
     private ?UserMenuDto $userMenuDto = null;
+    private bool $usePrettyUrls;
 
-    public function __construct(Request $request, ?UserInterface $user, I18nDto $i18nDto, CrudControllerRegistry $crudControllers, DashboardDto $dashboardDto, DashboardControllerInterface $dashboardController, AssetsDto $assetDto, ?CrudDto $crudDto, ?EntityDto $entityDto, ?SearchDto $searchDto, MenuFactoryInterface $menuFactory, TemplateRegistry $templateRegistry)
+    public function __construct(Request $request, ?UserInterface $user, I18nDto $i18nDto, CrudControllerRegistry $crudControllers, DashboardDto $dashboardDto, DashboardControllerInterface $dashboardController, AssetsDto $assetDto, ?CrudDto $crudDto, ?EntityDto $entityDto, ?SearchDto $searchDto, MenuFactoryInterface $menuFactory, TemplateRegistry $templateRegistry, bool $usePrettyUrls = false)
     {
         $this->request = $request;
         $this->user = $user;
@@ -58,6 +59,7 @@ final class AdminContext
         $this->searchDto = $searchDto;
         $this->menuFactory = $menuFactory;
         $this->templateRegistry = $templateRegistry;
+        $this->usePrettyUrls = $usePrettyUrls;
     }
 
     public function getRequest(): Request
@@ -109,7 +111,7 @@ final class AdminContext
 
     public function usePrettyUrls(): bool
     {
-        return true === (bool) $this->request->attributes->get(EA::ROUTE_CREATED_BY_EASYADMIN);
+        return $this->usePrettyUrls;
     }
 
     public function getDashboardTitle(): string

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -20,6 +20,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\TemplateRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteGenerator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -37,14 +38,16 @@ final class AdminContextFactory
     private MenuFactoryInterface $menuFactory;
     private CrudControllerRegistry $crudControllers;
     private EntityFactory $entityFactory;
+    private AdminRouteGenerator $adminRouteGenerator;
 
-    public function __construct(string $cacheDir, ?TokenStorageInterface $tokenStorage, MenuFactoryInterface $menuFactory, CrudControllerRegistry $crudControllers, EntityFactory $entityFactory)
+    public function __construct(string $cacheDir, ?TokenStorageInterface $tokenStorage, MenuFactoryInterface $menuFactory, CrudControllerRegistry $crudControllers, EntityFactory $entityFactory, AdminRouteGenerator $adminRouteGenerator)
     {
         $this->cacheDir = $cacheDir;
         $this->tokenStorage = $tokenStorage;
         $this->menuFactory = $menuFactory;
         $this->crudControllers = $crudControllers;
         $this->entityFactory = $entityFactory;
+        $this->adminRouteGenerator = $adminRouteGenerator;
     }
 
     public function create(Request $request, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ?string $actionName = null): AdminContext
@@ -65,7 +68,9 @@ final class AdminContextFactory
         $templateRegistry = $this->getTemplateRegistry($dashboardController, $crudDto);
         $user = $this->getUser($this->tokenStorage);
 
-        return new AdminContext($request, $user, $i18nDto, $this->crudControllers, $dashboardDto, $dashboardController, $assetDto, $crudDto, $entityDto, $searchDto, $this->menuFactory, $templateRegistry);
+        $usePrettyUrls = $this->adminRouteGenerator->usesPrettyUrls();
+
+        return new AdminContext($request, $user, $i18nDto, $this->crudControllers, $dashboardDto, $dashboardController, $assetDto, $crudDto, $entityDto, $searchDto, $this->menuFactory, $templateRegistry, $usePrettyUrls);
     }
 
     private function getDashboardDto(Request $request, DashboardControllerInterface $dashboardControllerInstance): DashboardDto

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -185,6 +185,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, new Reference(MenuFactory::class))
             ->arg(3, new Reference(CrudControllerRegistry::class))
             ->arg(4, new Reference(EntityFactory::class))
+            ->arg(5, service(AdminRouteGenerator::class))
 
         ->set(AdminUrlGenerator::class)
             // I don't know if we truly need the share() method to get a new instance of the
@@ -200,9 +201,14 @@ return static function (ContainerConfigurator $container) {
             ->args([[AdminUrlGenerator::class => service(AdminUrlGenerator::class)]])
             ->tag('container.service_locator')
 
+        ->set('cache.easyadmin')
+            ->parent('cache.system')
+            ->tag('cache.pool')
+
         ->set(AdminRouteGenerator::class)
             ->arg(0, tagged_iterator(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER))
             ->arg(1, tagged_iterator(EasyAdminExtension::TAG_CRUD_CONTROLLER))
+            ->arg(2, service('cache.easyadmin'))
 
         ->set(AdminRouteLoader::class)
             ->arg(0, service(AdminRouteGenerator::class))


### PR DESCRIPTION
Fixes #6499.

-----

The bug: if you enable pretty URLs but visit a page that doesn't use them (e.g. a Symfony route embedded in a EasyAdmin dashboard), then all URLs of the dashboard (menus, actions, etc.) use ugly URLs.

Why: because we detected if pretty URLs should be used based on the current request. This is wrong.

How to solve this:

1) We could create a config option `easyadmin.use_pretty_urls: true` ... but that would require creating a config file (that soon will be useless because EasyAdmin 5 will only use pretty URLs). It goes a bit against DX, so I don't like that solution.

2) A good technical solution would be to detect if our custom route loader is enabled and it generated the admin routes. Ideally in a Compiler Pass. Sadly, this doesn't work. I asked in Symfony Slack and smart folks like @stof confirmed that this can't work.

3) So, I ended up with the following solution:

3.1) The custom route loader now dumps all the generated routes using Symfony's cache component
3.2) We detect if pretty URLs are used by checking if that cached item exists and it's not empty
3.3) Indirectly, this improves a lot the performance of finding the route name for a given tuple of Dashboard + CRUD controller + Action. I was going to do this change in the future, but doing it now will help us solve this issue.

-----

I tested in my apps and everything worked as expected, so I'll try to merge this very soon. Thanks.