### PR TITLE
fix: before entity deleted event cannot be stopped in batch delete

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -425,6 +425,9 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
             $event = new BeforeEntityDeletedEvent($entityInstance);
             $this->container->get('event_dispatcher')->dispatch($event);
+            if ($event->isPropagationStopped()) {
+                return $event->getResponse();
+            }
             $entityInstance = $event->getEntityInstance();
 
             try {


### PR DESCRIPTION
Fix to handle `BeforeEntityDeletedEvent`stop propagation on batch delete