### PR TITLE
Fix bug with tabs being invisible when an association or similar has …

### DIFF
--- a/src/Factory/FormLayoutFactory.php
+++ b/src/Factory/FormLayoutFactory.php
@@ -180,7 +180,11 @@ final class FormLayoutFactory
 
             if ($fieldDto->isFormTab()) {
                 $isTabActive = 0 === \count($tabs);
-                $tabId = sprintf('tab-%s', $fieldDto->getLabel() ? $slugger->slug(strip_tags($fieldDto->getLabel()))->lower()->toString() : ++$tabsWithoutLabelCounter);
+                $tabId = sprintf('tab-%s-%s', $fieldDto->getLabel()
+                    ? $slugger->slug(strip_tags($fieldDto->getLabel()))->lower()->toString()
+                    : ++$tabsWithoutLabelCounter,
+                    uniqid(),
+                );
                 $fieldDto->setCustomOption(FormField::OPTION_TAB_ID, $tabId);
                 $fieldDto->setCustomOption(FormField::OPTION_TAB_IS_ACTIVE, $isTabActive);
 


### PR DESCRIPTION
…property with same label.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

Situation:

Class A has property B 
Class C has also property B
Class A has also reference to Class C

Class A Crud Controller displays Association to C, and also another Association to B. 

Now, when this happens the Crud Edit Interface will no longer display the Association of a tab. This is because of the tabId generation that takes into account only the label, which means that for many more situations (not just the one above), Tabs cannot be utilized correctly. 

This bugfix causes this issue by adding a uniqid to an invisible-to-the-user ID, that must be unique anyway.