### PR TITLE
Correctly extract the entityID for the title when using pretty URLs

### DIFF
--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -183,7 +183,14 @@ final class AdminContextFactory
         if (null !== $crudDto) {
             $translationParameters['%entity_name%'] = $entityName = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
             $translationParameters['%entity_as_string%'] = null === $entityDto ? '' : $entityDto->toString();
-            $translationParameters['%entity_id%'] = $entityId = $request->query->get(EA::ENTITY_ID);
+
+            // If pretty URLs are used, extract the entity ID from the route attributes, otherwise from the query parameters
+            if ($this->adminRouteGenerator->usesPrettyUrls()) {
+                $translationParameters['%entity_id%'] = $entityId = $request->attributes->get(EA::ENTITY_ID);
+            } else {
+                $translationParameters['%entity_id%'] = $entityId = $request->query->get(EA::ENTITY_ID);
+            }
+
             $translationParameters['%entity_short_id%'] = null === $entityId ? null : u($entityId)->truncate(7)->toString();
 
             $entityInstance = null === $entityDto ? null : $entityDto->getInstance();


### PR DESCRIPTION
When using pretty URLs the ID in the detail page title is currently wrong/not existing.

This is caused by the creation of the I18nDTO, where the entityID is extracted from the request. As for pretty URLs the entityURL is not available anymore as query parameter but as route attribute, it needs a slightly different method to derive the entityURL.

This PR implements this if pretty URLs are enabled, so that correct info is shown.
