### PR TITLE
Split `ea_form_fieldset_open_row` form theme block

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -83,6 +83,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\UrlSigner;
 use EasyCorp\Bundle\EasyAdminBundle\Security\AuthorizationChecker;
 use EasyCorp\Bundle\EasyAdminBundle\Security\SecurityVoter;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\EasyAdminTwigExtension;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\FormExtension;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ServiceLocator;
@@ -134,6 +135,9 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
             ->arg(3, new Reference('asset_mapper.importmap.renderer', ContainerInterface::NULL_ON_INVALID_REFERENCE))
             ->arg(4, service('translator'))
+            ->tag('twig.extension')
+
+        ->set(FormExtension::class)
             ->tag('twig.extension')
 
         ->set(EaCrudFormTypeExtension::class)

--- a/src/Twig/FormExtension.php
+++ b/src/Twig/FormExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @author Benjamin Georgeault <git@wedgesama.fr>
+ */
+class FormExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('ea_form_ealabel', null, ['node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => ['html']]),
+        ];
+    }
+}

--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -581,43 +581,47 @@
     </div>
 {% endblock ea_form_column_close_row %}
 
+{% block ea_form_fieldset_open_ealabel %}
+    {% if ea_is_collapsible %}
+        <i class="fas fw fa-chevron-right form-fieldset-collapse-marker"></i>
+    {% endif %}
+
+    {% if ea_icon %}
+        <i class="form-fieldset-icon {{ ea_icon }}"></i>
+    {% endif %}
+
+    {{ form.vars.label|trans|raw }}
+{% endblock ea_form_fieldset_open_ealabel %}
+
+{% block ea_form_fieldset_open_label %}
+    <div class="form-fieldset-header {{ ea_is_collapsible ? 'collapsible' }} {{ ea_help is not empty ? 'with-help' }}">
+        <div class="form-fieldset-title">
+            {% if ea_is_collapsible %}
+                <a href="#content-{{ form.vars.name }}" data-bs-toggle="collapse"
+                   class="form-fieldset-title-content form-fieldset-collapse {{ ea_is_collapsed ? 'collapsed' }}"
+                   aria-expanded="{{ ea_is_collapsed ? 'false' : 'true' }}" aria-controls="content-{{ form.vars.name }}">
+                    {{ ea_form_ealabel(form) }}
+                </a>
+            {% else %}
+                <span class="not-collapsible form-fieldset-title-content">
+                    {{ ea_form_ealabel(form) }}
+                </span>
+            {% endif %}
+
+            {% if ea_help %}
+                <div class="form-fieldset-help">{{ ea_help|trans|raw }}</div>
+            {% endif %}
+        </div>
+    </div>
+{% endblock ea_form_fieldset_open_label %}
+
 {% block ea_form_fieldset_open_row %}
     {% set fieldset_has_header = form.vars.label or ea_icon or ea_help %}
 
     <div class="form-fieldset {{ not fieldset_has_header ? 'form-fieldset-no-header' }} {{ ea_css_class }}">
         <fieldset>
             {% if fieldset_has_header %}
-                <div class="form-fieldset-header {{ ea_is_collapsible ? 'collapsible' }} {{ ea_help is not empty ? 'with-help' }}">
-                    <div class="form-fieldset-title">
-                        {% set fieldset_title_contents %}
-                            {% if ea_is_collapsible %}
-                                <i class="fas fw fa-chevron-right form-fieldset-collapse-marker"></i>
-                            {% endif %}
-
-                            {% if ea_icon %}
-                                <i class="form-fieldset-icon {{ ea_icon }}"></i>
-                            {% endif %}
-
-                            {{ form.vars.label|trans|raw }}
-                        {% endset %}
-
-                        {% if ea_is_collapsible %}
-                            <a href="#content-{{ form.vars.name }}" data-bs-toggle="collapse"
-                               class="form-fieldset-title-content form-fieldset-collapse {{ ea_is_collapsed ? 'collapsed' }}"
-                               aria-expanded="{{ ea_is_collapsed ? 'false' : 'true' }}" aria-controls="content-{{ form.vars.name }}">
-                                {{ fieldset_title_contents|raw }}
-                            </a>
-                        {% else %}
-                            <span class="not-collapsible form-fieldset-title-content">
-                                {{ fieldset_title_contents|raw }}
-                            </span>
-                        {% endif %}
-
-                        {% if ea_help %}
-                            <div class="form-fieldset-help">{{ ea_help|trans|raw }}</div>
-                        {% endif %}
-                    </div>
-                </div>
+                {{ form_label(form) }}
             {% endif %}
 
             <div id="content-{{ form.vars.name }}" class="form-fieldset-body {{ not fieldset_has_header ? 'without-header' }} {{ ea_is_collapsible ? 'collapse' }} {{ not ea_is_collapsed ? 'show'}}">


### PR DESCRIPTION
Split `ea_form_fieldset_open_row` with its `_label` + create `_ealabel` for inner content.

Add new form template blocks for fieldset to ease template customization. Replace `fieldset_title_contents` by dedicated block that can be overridden.

=================

Its add a new twig function `ea_form_ealabel` to be used like any other form function (`form_row`, `form_widget`, `form_label`, etc...) but for specific EA form part.

In this PR, I only add a split for `ea_form_fieldset_open_row`, if this PR is accepted, I will split more template parts.

=================

Why did I suggest that? IMO, for 3 reasons:
- It use more sf Form component rendering functions.
- It will make `templates/crud/form_theme.html.twig` more readable.
- Make `templates/crud/form_theme.html.twig` override easier and more update proof.

=================
Usage example:

```php
class MyController extends AbstractCrudController
{
    //...
    public function configureFields(string $pageName): iterable
    {
        return [
            FormField::addFieldset('My Title')
                ->setFormTypeOption('block_prefix', 'foobar')
        ];
    }
    //...
}
```

```twig
{% extends '@EasyAdmin/crud/form_theme.html.twig' %}

{% block foobar_ealabel %}
  <span>Add something before native block</span>
  {{ block('ea_form_fieldset_open_ealabel') }}
  <span>Add something after native block</span>
{% endblock foobar_ealabel %}
```


