### PR TITLE
Trim trailing slash from pretty index route path

### DIFF
--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -152,7 +152,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
 
                 foreach (array_keys($actionsRouteConfig) as $actionName) {
                     $actionRouteConfig = $actionsRouteConfig[$actionName];
-                    $adminRoutePath = sprintf('%s/%s/%s', $dashboardRouteConfig['routePath'], $crudControllerRouteConfig['routePath'], ltrim($actionRouteConfig['routePath'], '/'));
+                    $adminRoutePath = rtrim(sprintf('%s/%s/%s', $dashboardRouteConfig['routePath'], $crudControllerRouteConfig['routePath'], ltrim($actionRouteConfig['routePath'], '/')), '/');
                     $adminRouteName = sprintf('%s_%s_%s', $dashboardRouteConfig['routeName'], $crudControllerRouteConfig['routeName'], $actionRouteConfig['routeName']);
 
                     if (\in_array($adminRouteName, $addedRouteNames, true)) {


### PR DESCRIPTION
Only one generated route path (index) contains trailing slash, let's remove it and unify it with other generated routes.

Before:
```
admin_user_index             GET               ANY    ANY    /admin/user/                <-- HERE
admin_user_new               GET|POST          ANY    ANY    /admin/user/new
admin_user_batch_delete      POST              ANY    ANY    /admin/user/batchDelete
admin_user_autocomplete      GET               ANY    ANY    /admin/user/autocomplete
admin_user_render_filters    GET               ANY    ANY    /admin/user/renderFilters
admin_user_edit              GET|POST|PATCH    ANY    ANY    /admin/user/{entityId}/edit
admin_user_delete            POST              ANY    ANY    /admin/user/{entityId}/delete
admin_user_detail            GET               ANY    ANY    /admin/user/{entityId}
```

After:
```
admin_user_index             GET               ANY    ANY    /admin/user                 <-- HERE
admin_user_new               GET|POST          ANY    ANY    /admin/user/new
admin_user_batch_delete      POST              ANY    ANY    /admin/user/batchDelete
admin_user_autocomplete      GET               ANY    ANY    /admin/user/autocomplete
admin_user_render_filters    GET               ANY    ANY    /admin/user/renderFilters
admin_user_edit              GET|POST|PATCH    ANY    ANY    /admin/user/{entityId}/edit
admin_user_delete            POST              ANY    ANY    /admin/user/{entityId}/delete
admin_user_detail            GET               ANY    ANY    /admin/user/{entityId}
```