### PR TITLE
Bump PHP requirements to PHP 8.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,12 +83,12 @@ jobs:
                       stability: "stable"
                     # Lowest deps support
                     - os: ubuntu-latest
-                      php_version: "8.0.2"
+                      php_version: "8.1"
                       composer_args: "--prefer-lowest"
                       stability: "stable"
                     # Lowest PHP version support. Remove when it is dropped
                     - os: ubuntu-latest
-                      php_version: "8.0"
+                      php_version: "8.1"
                       symfony_version: "5.4"
                       stability: "stable"
                     - os: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
         }
     ],
     "require": {
-        "php": ">=8.0.2",
+        "php": ">=8.1",
         "ext-json": "*",
         "doctrine/doctrine-bundle": "^2.5",
-        "doctrine/orm": "^2.10|^3.0",
+        "doctrine/orm": "^2.12|^3.0",
         "symfony/asset": "^5.4|^6.0|^7.0",
         "symfony/cache": "^5.4|^6.0|^7.0",
         "symfony/config": "^5.4|^6.0|^7.0",


### PR DESCRIPTION
We are forced to do this because we want to use Twig Components and those require using PHP 8.1.

This should be fine because only 1% of our users still use PHP 8.0 (and ~10% are still in PHP earlier versions): https://packagist.org/packages/easycorp/easyadmin-bundle/php-stats