### PR TITLE
Make constructors expect Interfaces for final classes instead of fina…

### DIFF
--- a/src/ArgumentResolver/AdminContextResolver.php
+++ b/src/ArgumentResolver/AdminContextResolver.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\ArgumentResolver;
 
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
@@ -17,7 +18,7 @@ if (interface_exists(ValueResolverInterface::class)) {
     {
         private AdminContextProvider $adminContextProvider;
 
-        public function __construct(AdminContextProvider $adminContextProvider)
+        public function __construct(AdminContextProviderInterface $adminContextProvider)
         {
             $this->adminContextProvider = $adminContextProvider;
         }
@@ -36,7 +37,7 @@ if (interface_exists(ValueResolverInterface::class)) {
     {
         private AdminContextProvider $adminContextProvider;
 
-        public function __construct(AdminContextProvider $adminContextProvider)
+        public function __construct(AdminContextProviderInterface $adminContextProvider)
         {
             $this->adminContextProvider = $adminContextProvider;
         }

--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -7,6 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\BatchActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
@@ -19,13 +20,10 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 if (interface_exists(ValueResolverInterface::class)) {
     final class BatchActionDtoResolver implements ValueResolverInterface
     {
-        private AdminContextProvider $adminContextProvider;
-        private AdminUrlGeneratorInterface $adminUrlGenerator;
-
-        public function __construct(AdminContextProvider $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
-        {
-            $this->adminContextProvider = $adminContextProvider;
-            $this->adminUrlGenerator = $adminUrlGenerator;
+        public function __construct(
+            private readonly AdminContextProviderInterface $adminContextProvider,
+            private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
+        ) {
         }
 
         public function resolve(Request $request, ArgumentMetadata $argument): iterable
@@ -75,7 +73,7 @@ if (interface_exists(ValueResolverInterface::class)) {
         private AdminContextProvider $adminContextProvider;
         private AdminUrlGeneratorInterface $adminUrlGenerator;
 
-        public function __construct(AdminContextProvider $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
+        public function __construct(AdminContextProviderInterface $adminContextProvider, AdminUrlGeneratorInterface $adminUrlGenerator)
         {
             $this->adminContextProvider = $adminContextProvider;
             $this->adminUrlGenerator = $adminUrlGenerator;

--- a/src/Contracts/Field/FieldTraitAwareInterface.php
+++ b/src/Contracts/Field/FieldTraitAwareInterface.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+interface FieldTraitAwareInterface extends FieldInterface
+{
+    public function setFieldFqcn(string $fieldFqcn): self;
+
+    public function setProperty(string $propertyName): self;
+
+    public function setLabel(TranslatableInterface|string|false|null $label): self;
+
+    public function setValue($value): self;
+
+    public function setFormattedValue($value): self;
+
+    public function formatValue(?callable $callable): self;
+
+    public function setVirtual(bool $isVirtual): self;
+
+    public function setDisabled(bool $disabled = true): self;
+
+    public function setRequired(bool $isRequired): self;
+
+    public function setEmptyData($emptyData = null): self;
+
+    public function setFormType(string $formTypeFqcn): self;
+
+    public function setFormTypeOptions(array $options): self;
+
+    /**
+     * @param string $optionName You can use "dot" notation to set nested options (e.g. 'attr.class')
+     */
+    public function setFormTypeOption(
+        string $optionName,
+        $optionValue,
+    ): self;
+
+    /**
+     * @param string $optionName You can use "dot" notation to set nested options (e.g. 'attr.class')
+     */
+    public function setFormTypeOptionIfNotSet(
+        string $optionName,
+        $optionValue,
+    ): self;
+
+    public function setSortable(bool $isSortable): self;
+
+    public function setPermission(string $permission): self;
+
+    /**
+     * @param string $textAlign It can be 'left', 'center' or 'right'
+     */
+    public function setTextAlign(string $textAlign): self;
+
+    public function setHelp(TranslatableInterface|string $help): self;
+
+    public function addCssClass(string $cssClass): self;
+
+    public function setCssClass(string $cssClass): self;
+
+    public function setTranslationParameters(array $parameters): self;
+
+    public function setTemplateName(string $name): self;
+
+    public function setTemplatePath(string $path): self;
+
+    public function addFormTheme(string ...$formThemePaths): self;
+
+    public function addWebpackEncoreEntries(Asset|string ...$entryNamesOrAssets,
+    ): self;
+
+    public function addCssFiles(Asset|string ...$pathsOrAssets): self;
+
+    public function addJsFiles(Asset|string ...$pathsOrAssets): self;
+
+    public function addHtmlContentsToHead(string ...$contents): self;
+
+    public function addHtmlContentsToBody(string ...$contents): self;
+
+    public function setCustomOption(
+        string $optionName,
+        $optionValue,
+    ): self;
+
+    public function setCustomOptions(array $options): self;
+
+    public function hideOnDetail(): self;
+
+    public function hideOnForm(): self;
+
+    public function hideWhenCreating(): self;
+
+    public function hideWhenUpdating(): self;
+
+    public function hideOnIndex(): self;
+
+    public function onlyOnDetail(): self;
+
+    public function onlyOnForms(): self;
+
+    public function onlyOnIndex(): self;
+
+    public function onlyWhenCreating(): self;
+
+    public function onlyWhenUpdating(): self;
+
+    /**
+     * @param int|string $cols An integer with the number of columns that this field takes (e.g. 6),
+     *                         or a string with responsive col CSS classes (e.g. 'col-6 col-sm-4 col-lg-3')
+     */
+    public function setColumns(int|string $cols): self;
+
+    /**
+     * Used to define the columns of fields when users don't define the
+     * columns explicitly using the setColumns() method.
+     * This should only be used if you create a custom EasyAdmin field,
+     * not when configuring fields in your backend.
+     *
+     * @internal
+     */
+    public function setDefaultColumns(int|string $cols): self;
+
+    public function setIcon(?string $iconCssClass, string $invokingMethod = 'FormField::setIcon()'): self;
+}

--- a/src/EventListener/CrudResponseListener.php
+++ b/src/EventListener/CrudResponseListener.php
@@ -3,7 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
@@ -14,19 +14,16 @@ use Twig\Environment;
  */
 final class CrudResponseListener
 {
-    private AdminContextProvider $adminContextProvider;
-    private Environment $twig;
-
-    public function __construct(AdminContextProvider $adminContextProvider, Environment $twig)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private Environment $twig,
+    ) {
     }
 
     public function onKernelView(ViewEvent $event): void
     {
         $responseParameters = $event->getControllerResult();
-        if (null === $responseParameters || !$responseParameters instanceof KeyValueStore) {
+        if (!$responseParameters instanceof KeyValueStore) {
             return;
         }
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -4,7 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\EventListener;
 
 use EasyCorp\Bundle\EasyAdminBundle\Exception\BaseException;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\FlattenException;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Twig\Environment;
@@ -21,18 +21,14 @@ use Twig\Error\RuntimeError;
  */
 final class ExceptionListener
 {
-    private bool $kernelDebug;
-    private AdminContextProvider $adminContextProvider;
-    private Environment $twig;
-
-    public function __construct(bool $kernelDebug, AdminContextProvider $adminContextProvider, Environment $twig)
-    {
-        $this->kernelDebug = $kernelDebug;
-        $this->adminContextProvider = $adminContextProvider;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly bool $kernelDebug,
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly Environment $twig,
+    ) {
     }
 
-    public function onKernelException(ExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event): void
     {
         $exception = $event->getThrowable();
 

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -9,7 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionConfigDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableMessageBuilder;
@@ -24,17 +24,12 @@ use Symfony\Contracts\Translation\TranslatableInterface;
  */
 final class ActionFactory
 {
-    private AdminContextProvider $adminContextProvider;
-    private AuthorizationCheckerInterface $authChecker;
-    private AdminUrlGeneratorInterface $adminUrlGenerator;
-    private ?CsrfTokenManagerInterface $csrfTokenManager;
-
-    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authChecker, AdminUrlGeneratorInterface $adminUrlGenerator, ?CsrfTokenManagerInterface $csrfTokenManager = null)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->authChecker = $authChecker;
-        $this->adminUrlGenerator = $adminUrlGenerator;
-        $this->csrfTokenManager = $csrfTokenManager;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly AuthorizationCheckerInterface $authChecker,
+        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
+        private readonly ?CsrfTokenManagerInterface $csrfTokenManager = null,
+    ) {
     }
 
     public function processEntityActions(EntityDto $entityDto, ActionConfigDto $actionsDto): void

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -19,7 +19,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\EaFormRowType;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -55,17 +55,12 @@ final class FieldFactory
         Types::TIME_IMMUTABLE => TimeField::class,
     ];
 
-    private AdminContextProvider $adminContextProvider;
-    private AuthorizationCheckerInterface $authorizationChecker;
-    private iterable $fieldConfigurators;
-    private FormLayoutFactory $fieldLayoutFactory;
-
-    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authorizationChecker, iterable $fieldConfigurators, FormLayoutFactory $fieldLayoutFactory)
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly iterable $fieldConfigurators,
+        private readonly FormLayoutFactory $fieldLayoutFactory)
     {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->authorizationChecker = $authorizationChecker;
-        $this->fieldConfigurators = $fieldConfigurators;
-        $this->fieldLayoutFactory = $fieldLayoutFactory;
     }
 
     public function processFields(EntityDto $entityDto, FieldCollection $fields): void

--- a/src/Factory/FilterFactory.php
+++ b/src/Factory/FilterFactory.php
@@ -15,7 +15,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\NumericFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -23,8 +23,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
  */
 final class FilterFactory
 {
-    private AdminContextProvider $adminContextProvider;
-    private iterable $filterConfigurators;
     private static array $doctrineTypeToFilterClass = [
         'json_array' => ArrayFilter::class,
         Types::SIMPLE_ARRAY => ArrayFilter::class,
@@ -52,10 +50,10 @@ final class FilterFactory
         Types::TEXT => TextFilter::class,
     ];
 
-    public function __construct(AdminContextProvider $adminContextProvider, iterable $filterConfigurators)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->filterConfigurators = $filterConfigurators;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly iterable $filterConfigurators,
+    ) {
     }
 
     public function create(FilterConfigDto $filterConfig, FieldCollection $fields, EntityDto $entityDto): FilterCollection

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -12,7 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -25,19 +25,13 @@ use Symfony\Contracts\Translation\TranslatableInterface;
  */
 final class MenuFactory implements MenuFactoryInterface
 {
-    private AdminContextProvider $adminContextProvider;
-    private AuthorizationCheckerInterface $authChecker;
-    private LogoutUrlGenerator $logoutUrlGenerator;
-    private AdminUrlGeneratorInterface $adminUrlGenerator;
-    private MenuItemMatcherInterface $menuItemMatcher;
-
-    public function __construct(AdminContextProvider $adminContextProvider, AuthorizationCheckerInterface $authChecker, LogoutUrlGenerator $logoutUrlGenerator, AdminUrlGeneratorInterface $adminUrlGenerator, MenuItemMatcherInterface $menuItemMatcher)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->authChecker = $authChecker;
-        $this->logoutUrlGenerator = $logoutUrlGenerator;
-        $this->adminUrlGenerator = $adminUrlGenerator;
-        $this->menuItemMatcher = $menuItemMatcher;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly AuthorizationCheckerInterface $authChecker,
+        private readonly LogoutUrlGenerator $logoutUrlGenerator,
+        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
+        private readonly MenuItemMatcherInterface $menuItemMatcher,
+    ) {
     }
 
     /**

--- a/src/Factory/PaginatorFactory.php
+++ b/src/Factory/PaginatorFactory.php
@@ -4,20 +4,17 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityPaginatorInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class PaginatorFactory
 {
-    private AdminContextProvider $adminContextProvider;
-    private EntityPaginatorInterface $entityPaginator;
-
-    public function __construct(AdminContextProvider $adminContextProvider, EntityPaginatorInterface $entityPaginator)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->entityPaginator = $entityPaginator;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly EntityPaginatorInterface $entityPaginator,
+    ) {
     }
 
     public function create(QueryBuilder $queryBuilder): EntityPaginatorInterface

--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use function Symfony\Component\String\u;
 use Twig\Markup;
 
@@ -16,13 +16,10 @@ use Twig\Markup;
  */
 final class CommonPostConfigurator implements FieldConfiguratorInterface
 {
-    private AdminContextProvider $adminContextProvider;
-    private string $charset;
-
-    public function __construct(AdminContextProvider $adminContextProvider, string $charset)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->charset = $charset;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly string $charset,
+    ) {
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool

--- a/src/Form/Extension/EaCrudFormTypeExtension.php
+++ b/src/Form/Extension/EaCrudFormTypeExtension.php
@@ -3,7 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Form\Extension;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FormVarsDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormInterface;
@@ -18,11 +18,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class EaCrudFormTypeExtension extends AbstractTypeExtension
 {
-    private AdminContextProvider $adminContextProvider;
-
-    public function __construct(AdminContextProvider $adminContextProvider)
-    {
-        $this->adminContextProvider = $adminContextProvider;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+    ) {
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -4,7 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Inspector;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector as BaseDataCollector;
@@ -17,11 +17,9 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector as BaseDataCollecto
  */
 class DataCollector extends BaseDataCollector
 {
-    private AdminContextProvider $adminContextProvider;
-
-    public function __construct(AdminContextProvider $adminContextProvider)
-    {
-        $this->adminContextProvider = $adminContextProvider;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+    ) {
     }
 
     public function reset(): void

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -20,7 +20,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Uid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -30,19 +30,13 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 final class EntityRepository implements EntityRepositoryInterface
 {
-    private AdminContextProvider $adminContextProvider;
-    private ManagerRegistry $doctrine;
-    private EntityFactory $entityFactory;
-    private FormFactory $formFactory;
-    private EventDispatcherInterface $eventDispatcher;
-
-    public function __construct(AdminContextProvider $adminContextProvider, ManagerRegistry $doctrine, EntityFactory $entityFactory, FormFactory $formFactory, EventDispatcherInterface $eventDispatcher)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->doctrine = $doctrine;
-        $this->entityFactory = $entityFactory;
-        $this->formFactory = $formFactory;
-        $this->eventDispatcher = $eventDispatcher;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly ManagerRegistry $doctrine,
+        private readonly EntityFactory $entityFactory,
+        private readonly FormFactory $formFactory,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
     }
 
     public function createQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -8,7 +8,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetsDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\LocaleDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
@@ -17,12 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/**
- * Inject this in services that need to get the admin context object.
- *
- * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- */
-final class AdminContextProvider
+final class AdminContextProvider implements AdminContextProviderInterface
 {
     private RequestStack $requestStack;
 
@@ -138,9 +132,6 @@ final class AdminContextProvider
         return $this->getContext(true)->getDashboardDefaultColorScheme();
     }
 
-    /**
-     * @return LocaleDto[]
-     */
     public function getDashboardLocales(): array
     {
         return $this->getContext(true)->getDashboardLocales();

--- a/src/Provider/AdminContextProviderInterface.php
+++ b/src/Provider/AdminContextProviderInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Provider;
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetsDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\LocaleDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Inject this in services that need to get the admin context object.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+interface AdminContextProviderInterface
+{
+    public function hasContext(): bool;
+
+    public function getContext(bool $throw = false): ?AdminContext;
+
+    public function getRequest(): Request;
+
+    public function getReferrer(): ?string;
+
+    public function getI18n(): I18nDto;
+
+    public function getCrudControllers(): CrudControllerRegistry;
+
+    public function getEntity(): EntityDto;
+
+    public function getUser(): ?UserInterface;
+
+    public function getAssets(): AssetsDto;
+
+    public function getSignedUrls(): bool;
+
+    public function getAbsoluteUrls(): bool;
+
+    public function getDashboardTitle(): string;
+
+    public function getDashboardFaviconPath(): string;
+
+    public function getDashboardControllerFqcn(): string;
+
+    public function getDashboardRouteName(): string;
+
+    public function getDashboardContentWidth(): string;
+
+    public function getDashboardSidebarWidth(): string;
+
+    public function getDashboardHasDarkModeEnabled(): bool;
+
+    public function getDashboardDefaultColorScheme(): string;
+
+    /**
+     * @return LocaleDto[]
+     */
+    public function getDashboardLocales(): array;
+
+    public function getMainMenu(): MainMenuDto;
+
+    public function getUserMenu(): UserMenuDto;
+
+    public function getCrud(): ?CrudDto;
+
+    public function getSearch(): ?SearchDto;
+
+    public function getTemplatePath(string $templateName): string;
+
+    public function usePrettyUrls(): bool;
+}

--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -11,11 +11,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
  */
 final class FieldProvider
 {
-    private AdminContextProvider $adminContextProvider;
-
-    public function __construct(AdminContextProvider $adminContextProvider)
-    {
-        $this->adminContextProvider = $adminContextProvider;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+    ) {
     }
 
     public function getDefaultFields(string $pageName): array

--- a/src/Registry/DashboardControllerRegistry.php
+++ b/src/Registry/DashboardControllerRegistry.php
@@ -5,13 +5,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 use EasyCorp\Bundle\EasyAdminBundle\Cache\CacheWarmer;
 use function Symfony\Component\String\u;
 
-/**
- * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- */
-final class DashboardControllerRegistry
+final class DashboardControllerRegistry implements DashboardControllerRegistryInterface
 {
-    private array $controllerFqcnToContextIdMap = [];
-    private array $contextIdToControllerFqcnMap;
     private array $controllerFqcnToRouteMap = [];
     private array $routeToControllerFqcnMap;
 
@@ -19,11 +14,11 @@ final class DashboardControllerRegistry
      * @param string[] $controllerFqcnToContextIdMap
      * @param string[] $contextIdToControllerFqcnMap
      */
-    public function __construct(string $cacheDir, array $controllerFqcnToContextIdMap, array $contextIdToControllerFqcnMap)
-    {
-        $this->controllerFqcnToContextIdMap = $controllerFqcnToContextIdMap;
-        $this->contextIdToControllerFqcnMap = $contextIdToControllerFqcnMap;
-
+    public function __construct(
+        string $cacheDir,
+        private readonly array $controllerFqcnToContextIdMap,
+        private readonly array $contextIdToControllerFqcnMap,
+    ) {
         $dashboardRoutesCachePath = $cacheDir.'/'.CacheWarmer::DASHBOARD_ROUTES_CACHE;
         $dashboardControllerRoutes = !file_exists($dashboardRoutesCachePath) ? [] : require $dashboardRoutesCachePath;
         foreach ($dashboardControllerRoutes as $routeName => $controller) {
@@ -68,9 +63,6 @@ final class DashboardControllerRegistry
         return \count($this->controllerFqcnToRouteMap) < 1 ? null : array_key_first($this->controllerFqcnToRouteMap);
     }
 
-    /**
-     * @return array<int, array{controller: string, route: string, context: string}>
-     */
     public function getAll(): array
     {
         $dashboards = [];

--- a/src/Registry/DashboardControllerRegistryInterface.php
+++ b/src/Registry/DashboardControllerRegistryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
+
+interface DashboardControllerRegistryInterface
+{
+    public function getControllerFqcnByContextId(string $contextId): ?string;
+
+    public function getContextIdByControllerFqcn(string $controllerFqcn): ?string;
+
+    public function getControllerFqcnByRoute(string $routeName): ?string;
+
+    public function getRouteByControllerFqcn(string $controllerFqcn): ?string;
+
+    public function getNumberOfDashboards(): int;
+
+    public function getFirstDashboardRoute(): ?string;
+
+    public function getFirstDashboardFqcn(): ?string;
+
+    /**
+     * @return array<int, array{controller: string, route: string, context: string}>
+     */
+    public function getAll(): array;
+}

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -6,21 +6,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminAction;
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminCrud;
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
-/**
- * This class generates all routes for every EasyAdmin dashboard in the application
- * and provides a utility to get the Symfony route name for a given {dashboard, CRUD controller, action} tuple.
- *
- * The generated ROUTES are based on a set of default route names and paths, but
- * that can be overwritten at the dashboard, controller and method/action level
- * using the #[AdminDashboard], #[AdminCrud] and #[AdminCrud] attributes.
- *
- * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- */
 final class AdminRouteGenerator implements AdminRouteGeneratorInterface
 {
     public const CACHE_KEY_ROUTE_TO_FQCN = 'easyadmin.routes.route_to_fqcn';

--- a/src/Router/AdminRouteGeneratorInterface.php
+++ b/src/Router/AdminRouteGeneratorInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Router;
+
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface as BaseAdminRouteGeneratorInterface;
+
+/**
+ * This class generates all routes for every EasyAdmin dashboard in the application
+ * and provides a utility to get the Symfony route name for a given {dashboard, CRUD controller, action} tuple.
+ *
+ * The generated ROUTES are based on a set of default route names and paths, but
+ * that can be overwritten at the dashboard, controller and method/action level
+ * using the #[AdminDashboard], #[AdminCrud] and #[AdminCrud] attributes.
+ */
+interface AdminRouteGeneratorInterface extends BaseAdminRouteGeneratorInterface
+{
+    public function usesPrettyUrls(): bool;
+
+    public function findRouteName(string $dashboardFqcn, string $crudControllerFqcn, string $actionName): ?string;
+}

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -7,8 +7,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
-use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistryInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -17,27 +17,20 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 final class AdminUrlGenerator implements AdminUrlGeneratorInterface
 {
     private bool $isInitialized = false;
-    private AdminContextProvider $adminContextProvider;
-    private UrlGeneratorInterface $urlGenerator;
-    private DashboardControllerRegistry $dashboardControllerRegistry;
-    private AdminRouteGenerator $adminRouteGenerator;
     private ?string $dashboardRoute = null;
     private ?bool $includeReferrer = null;
     private array $routeParameters = [];
     private ?string $currentPageReferrer = null;
     private ?string $customPageReferrer = null;
 
-    public function __construct(AdminContextProvider $adminContextProvider, UrlGeneratorInterface $urlGenerator, DashboardControllerRegistry $dashboardControllerRegistry, AdminRouteGenerator $adminRouteGenerator)
-    {
-        $this->adminContextProvider = $adminContextProvider;
-        $this->urlGenerator = $urlGenerator;
-        $this->dashboardControllerRegistry = $dashboardControllerRegistry;
-        $this->adminRouteGenerator = $adminRouteGenerator;
+    public function __construct(
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly DashboardControllerRegistryInterface $dashboardControllerRegistry,
+        private readonly AdminRouteGeneratorInterface $adminRouteGenerator,
+    ) {
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function setDashboard(string $dashboardControllerFqcn): AdminUrlGeneratorInterface
     {
         $this->setRouteParameter(EA::DASHBOARD_CONTROLLER_FQCN, $dashboardControllerFqcn);
@@ -45,9 +38,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function setController(string $crudControllerFqcn): AdminUrlGeneratorInterface
     {
         $this->setRouteParameter(EA::CRUD_CONTROLLER_FQCN, $crudControllerFqcn);
@@ -57,9 +47,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function setAction(string $action): AdminUrlGeneratorInterface
     {
         $this->setRouteParameter(EA::CRUD_ACTION, $action);
@@ -69,9 +56,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function setRoute(string $routeName, array $routeParameters = []): AdminUrlGeneratorInterface
     {
         $this->unsetAllExcept(EA::DASHBOARD_CONTROLLER_FQCN);
@@ -81,9 +65,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function setEntityId($entityId): AdminUrlGeneratorInterface
     {
         $this->setRouteParameter(EA::ENTITY_ID, $entityId);
@@ -100,9 +81,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this->routeParameters[$paramName] ?? null;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function set(string $paramName, $paramValue): AdminUrlGeneratorInterface
     {
         if (\in_array($paramName, [EA::MENU_INDEX, EA::SUBMENU_INDEX], true)) {
@@ -119,9 +97,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function setAll(array $routeParameters): AdminUrlGeneratorInterface
     {
         foreach ($routeParameters as $paramName => $paramValue) {
@@ -131,9 +106,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function unset(string $paramName): AdminUrlGeneratorInterface
     {
         if (false === $this->isInitialized) {
@@ -145,9 +117,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function unsetAll(): AdminUrlGeneratorInterface
     {
         if (false === $this->isInitialized) {
@@ -159,9 +128,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function unsetAllExcept(string ...$namesOfParamsToKeep): AdminUrlGeneratorInterface
     {
         if (false === $this->isInitialized) {
@@ -173,9 +139,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function includeReferrer(): AdminUrlGeneratorInterface
     {
         trigger_deprecation(
@@ -193,9 +156,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function removeReferrer(): AdminUrlGeneratorInterface
     {
         if (false === $this->isInitialized) {
@@ -207,9 +167,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function setReferrer(string $referrer): AdminUrlGeneratorInterface
     {
         trigger_deprecation(
@@ -228,9 +185,6 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
-    /**
-     * @return AdminUrlGenerator
-     */
     public function addSignature(bool $addSignature = true): AdminUrlGeneratorInterface
     {
         trigger_deprecation(

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -17,13 +17,10 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
  */
 final class SecurityVoter extends Voter
 {
-    private AuthorizationCheckerInterface $authorizationChecker;
-    private AdminContextProvider $adminContextProvider;
-
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, AdminContextProvider $adminContextProvider)
-    {
-        $this->authorizationChecker = $authorizationChecker;
-        $this->adminContextProvider = $adminContextProvider;
+    public function __construct(
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly AdminContextProviderInterface $adminContextProvider,
+    ) {
     }
 
     protected function supports(string $permissionName, mixed $subject): bool

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -5,7 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Twig;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldLayoutDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\AssetMapper\ImportMap\ImportMapRenderer;
@@ -29,19 +29,13 @@ use Twig\TwigFunction;
  */
 class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterface
 {
-    private ServiceLocator $serviceLocator;
-    private AdminContextProvider $adminContextProvider;
-    private ?CsrfTokenManagerInterface $csrfTokenManager;
-    private ?ImportMapRenderer $importMapRenderer;
-    private TranslatorInterface $translator;
-
-    public function __construct(ServiceLocator $serviceLocator, AdminContextProvider $adminContextProvider, ?CsrfTokenManagerInterface $csrfTokenManager, ?ImportMapRenderer $importMapRenderer, TranslatorInterface $translator)
-    {
-        $this->serviceLocator = $serviceLocator;
-        $this->adminContextProvider = $adminContextProvider;
-        $this->csrfTokenManager = $csrfTokenManager;
-        $this->importMapRenderer = $importMapRenderer;
-        $this->translator = $translator;
+    public function __construct(
+        private readonly ServiceLocator $serviceLocator,
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly ?CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly ?ImportMapRenderer $importMapRenderer,
+        private readonly TranslatorInterface $translator,
+    ) {
     }
 
     public function getFunctions(): array


### PR DESCRIPTION
…l classes themselves.


This solves an issue where we cannot Mock (or rebuild) controller classes for PHPUnit tests. Also, if a class is final, it should have an Interface. In an ideal world, all classes are final that must be final with exceptions to abstracts. All finals should at least have one Interface. Naturally, there should be 0 instance of a class that is neither final or abstract, and the only exception to Interfaces with Final Classes are DTOs (= Getter-Only Classes with absolutely 0 logic and a constructor receiving values). 

This PR fixes some developer-experience issues and also makes future refactoring much easier.