### PR TITLE
fix: use dashboardRoute when necessary

### DIFF
--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -147,7 +147,7 @@ final class MenuFactory implements MenuFactoryInterface
         }
 
         if (MenuItemDto::TYPE_DASHBOARD === $menuItemType) {
-            return $this->adminUrlGenerator->unsetAll()->generateUrl();
+            return $this->adminUrlGenerator->unsetAll()->generateUrl(MenuItemDto::TYPE_DASHBOARD);
         }
 
         if (MenuItemDto::TYPE_ROUTE === $menuItemType) {

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -9,6 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInte
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistryInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -216,7 +217,7 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this->generateUrl();
     }
 
-    public function generateUrl(): string
+    public function generateUrl(?string $type = null): string
     {
         if (false === $this->isInitialized) {
             $this->initialize();
@@ -277,7 +278,7 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
             return $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType);
         }
 
-        if ($usePrettyUrls) {
+        if ($usePrettyUrls && MenuItemDto::TYPE_DASHBOARD !== $type) {
             $dashboardControllerFqcn = $this->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $context->getRequest()->attributes->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $this->dashboardControllerRegistry->getFirstDashboardFqcn();
             $crudControllerFqcn = $this->get(EA::CRUD_CONTROLLER_FQCN) ?? $context->getRequest()->attributes->get(EA::CRUD_CONTROLLER_FQCN);
             $actionName = $this->get(EA::CRUD_ACTION) ?? $context->getRequest()->attributes->get(EA::CRUD_ACTION);

--- a/src/Router/AdminUrlGeneratorInterface.php
+++ b/src/Router/AdminUrlGeneratorInterface.php
@@ -42,5 +42,5 @@ interface AdminUrlGeneratorInterface
 
     public function getSignature(): string;
 
-    public function generateUrl(): string;
+    public function generateUrl(?string $type = null): string;
 }

--- a/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
+++ b/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
@@ -129,7 +129,7 @@ class PrettyUrlsControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/admin/pretty/urls/blog_post');
 
         $this->assertSame('/admin/pretty/urls', $crawler->filter('#header-logo a.logo')->attr('href'), 'The main Dashboard logo link points to the dashboard entry URL');
-        $this->assertSame('http://localhost/admin/pretty/urls/blog_post', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the first entity of the menu');
+        $this->assertSame('http://localhost/admin/pretty/urls', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the dashboard');
         $this->assertSame('http://localhost/admin/pretty/urls/blog_post', $crawler->filter('li.menu-item a:contains("Blog Posts")')->attr('href'));
         $this->assertSame('http://localhost/admin/pretty/urls/category', $crawler->filter('li.menu-item a:contains("Categories")')->attr('href'));
     }
@@ -142,7 +142,7 @@ class PrettyUrlsControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/second/dashboard/user-editor/custom/path-for-index');
 
         $this->assertSame('/second/dashboard', $crawler->filter('#header-logo a.logo')->attr('href'), 'The main Dashboard logo link points to the dashboard entry URL');
-        $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the first entity of the menu');
+        $this->assertSame('http://localhost/second/dashboard', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the dashboard');
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index', $crawler->filter('li.menu-item a:contains("Users")')->attr('href'));
     }
 

--- a/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
+++ b/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
@@ -160,6 +160,19 @@ class PrettyUrlsControllerTest extends WebTestCase
         $this->assertMatchesRegularExpression('#http://localhost/admin/pretty/urls/blog_post/1/edit\?csrfToken=.*&fieldName=content#', $crawler->filter('td.field-boolean input[type="checkbox"]')->attr('data-toggle-url'));
     }
 
+    /**
+     * @dataProvider categoryActionsDataProvider
+     */
+    public function testDefaultActionsWithPrettyUrls(string $uri)
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $client->request('GET', $uri);
+
+        $this->assertResponseIsSuccessful();
+    }
+
     public function testCustomActionsUsePrettyUrls()
     {
         $client = static::createClient();
@@ -197,5 +210,12 @@ class PrettyUrlsControllerTest extends WebTestCase
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bid%5D=DESC', $crawler->filter('th.searchable a')->eq(0)->attr('href'));
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bname%5D=DESC', $crawler->filter('th.searchable a')->eq(1)->attr('href'));
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bemail%5D=DESC', $crawler->filter('th.searchable a')->eq(2)->attr('href'));
+    }
+
+    public static function categoryActionsDataProvider(): iterable
+    {
+        yield 'Create' => ['/admin/pretty/urls/category/new'];
+        yield 'Read' => ['/admin/pretty/urls/category/1'];
+        yield 'Update' => ['/admin/pretty/urls/category/1/edit'];
     }
 }


### PR DESCRIPTION
This PR changes the behaviour of the dashboard links, in my opinion they should not lead to an entity. Tests have been updated accordingly.

Fixes #6550: 

- #6550

The issue is reproducible on CI:

- #6559

This is a different approach than the one used in #6551:

-  #6551