### PR TITLE
[FormField] Add new propertyNameSuffix to + Consistency between open & close

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -27,6 +27,7 @@ final class FieldDto
 {
     private ?string $fieldFqcn = null;
     private ?string $propertyName = null;
+    private ?string $propertyNameSuffix = null;
     private mixed $value = null;
     private mixed $formattedValue = null;
     private $formatValueCallable;
@@ -158,6 +159,26 @@ final class FieldDto
     public function setProperty(string $propertyName): void
     {
         $this->propertyName = $propertyName;
+    }
+
+    public function getPropertyNameSuffix(): ?string
+    {
+        return $this->propertyNameSuffix;
+    }
+
+    public function setPropertyNameSuffix(?string $propertyNameSuffix): void
+    {
+        $this->propertyNameSuffix = $propertyNameSuffix;
+    }
+
+    public function getPropertyNameWithSuffix(): string
+    {
+        return sprintf(
+            '%s%s%s',
+            $this->propertyName,
+            null !== $this->propertyNameSuffix ? '_' : '',
+            $this->propertyNameSuffix ?? '',
+        );
     }
 
     /**

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -9,6 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use Symfony\Component\ExpressionLanguage\Expression;
+use Symfony\Component\Form\FormConfigBuilder;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
@@ -38,6 +39,21 @@ trait FieldTrait
     public function setProperty(string $propertyName): self
     {
         $this->dto->setProperty($propertyName);
+
+        return $this;
+    }
+
+    public function setPropertySuffix(string $propertyNameSuffix): self
+    {
+        if ('' === trim($propertyNameSuffix, " \t\n\r\0\v")) {
+            throw new \InvalidArgumentException('The suffix cannot be empty.');
+        }
+
+        if (!FormConfigBuilder::isValidName($propertyNameSuffix)) {
+            throw new \InvalidArgumentException(sprintf('The suffix "%s" is not valid. You must follow form name conventions.', $propertyNameSuffix));
+        }
+
+        $this->dto->setPropertyNameSuffix($propertyNameSuffix);
 
         return $this;
     }

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -54,7 +54,7 @@ final class FormField implements FieldInterface
      * @param TranslatableInterface|string|false|null $label
      * @param string|null                             $icon  The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function addFieldset($label = false, ?string $icon = null): self
+    public static function addFieldset($label = false, ?string $icon = null, ?string $propertySuffix = null): self
     {
         $field = new self();
         $icon = $field->fixIconFormat($icon, 'FormField::addFieldset()');
@@ -62,7 +62,8 @@ final class FormField implements FieldInterface
         return $field
             ->setFieldFqcn(__CLASS__)
             ->hideOnIndex()
-            ->setProperty('ea_form_fieldset_'.(new Ulid()))
+            ->setProperty('ea_form_fieldset')
+            ->setPropertySuffix($propertySuffix ?? Ulid::generate())
             ->setLabel($label)
             ->setFormType(EaFormFieldsetOpenType::class)
             ->addCssClass('field-form_fieldset')
@@ -77,7 +78,7 @@ final class FormField implements FieldInterface
      * @param string $breakpointName The name of the breakpoint where the new row is inserted
      *                               It must be a valid Bootstrap 5 name ('', 'sm', 'md', 'lg', 'xl', 'xxl')
      */
-    public static function addRow(string $breakpointName = ''): self
+    public static function addRow(string $breakpointName = '', ?string $propertySuffix = null): self
     {
         $field = new self();
 
@@ -89,7 +90,8 @@ final class FormField implements FieldInterface
         return $field
             ->setFieldFqcn(__CLASS__)
             ->hideOnIndex()
-            ->setProperty('ea_form_row_'.(new Ulid()))
+            ->setProperty('ea_form_row')
+            ->setPropertySuffix($propertySuffix ?? Ulid::generate())
             ->setFormType(EaFormRowType::class)
             ->addCssClass('field-form_row')
             ->setFormTypeOptions(['mapped' => false, 'required' => false])
@@ -100,7 +102,7 @@ final class FormField implements FieldInterface
     /**
      * @return static
      */
-    public static function addTab(TranslatableInterface|string|false|null $label = null, ?string $icon = null): self
+    public static function addTab(TranslatableInterface|string|false|null $label = null, ?string $icon = null, ?string $propertySuffix = null): self
     {
         $field = new self();
         $icon = $field->fixIconFormat($icon, 'FormField::addTab()');
@@ -108,7 +110,8 @@ final class FormField implements FieldInterface
         return $field
             ->setFieldFqcn(__CLASS__)
             ->hideOnIndex()
-            ->setProperty('ea_form_tab_'.(new Ulid()))
+            ->setProperty('ea_form_tab')
+            ->setPropertySuffix($propertySuffix ?? Ulid::generate())
             ->setLabel($label)
             ->setFormType(EaFormTabPaneOpenType::class)
             ->addCssClass('field-form_tab')
@@ -124,7 +127,7 @@ final class FormField implements FieldInterface
      *                         (e.g. 'col-6', 'col-sm-3', 'col-md-6 col-xl-4', etc.)
      *                         (integer values are transformed like this: N -> 'col-N')
      */
-    public static function addColumn(int|string $cols = 'col', TranslatableInterface|string|false|null $label = null, ?string $icon = null, ?string $help = null): self
+    public static function addColumn(int|string $cols = 'col', TranslatableInterface|string|false|null $label = null, ?string $icon = null, ?string $help = null, ?string $propertySuffix = null): self
     {
         $field = new self();
         // $icon = $field->fixIconFormat($icon, 'FormField::addTab()');
@@ -132,7 +135,8 @@ final class FormField implements FieldInterface
         return $field
             ->setFieldFqcn(__CLASS__)
             ->hideOnIndex()
-            ->setProperty('ea_form_column_'.(new Ulid()))
+            ->setProperty('ea_form_column')
+            ->setPropertySuffix($propertySuffix ?? Ulid::generate())
             ->setLabel($label)
             ->setFormType(EaFormColumnOpenType::class)
             ->addCssClass(sprintf('field-form_column %s', \is_int($cols) ? 'col-md-'.$cols : $cols))

--- a/src/Form/Type/CrudFormType.php
+++ b/src/Form/Type/CrudFormType.php
@@ -7,6 +7,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\EventListener\FormLayoutSubscriber;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormColumnCloseType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormColumnOpenType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormFieldsetCloseType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormFieldsetOpenType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormTabPaneCloseType;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormTabPaneOpenType;
 use Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -104,6 +110,8 @@ class CrudFormType extends AbstractType
                 $formFieldOptions['ea_form_tab'] = $currentFormTab;
             }
 
+            $name = $this->isTypeFormField($formFieldType) ? $fieldDto->getPropertyNameWithSuffix() : $name;
+
             $formField = $builder->getFormFactory()->createNamedBuilder($name, $formFieldType, null, $formFieldOptions);
             $formField->setAttribute('ea_entity', $entityDto);
             $formField->setAttribute('ea_form_fieldset', $options['ea_form_fieldset'] ?? $currentFormFieldset);
@@ -143,5 +151,25 @@ class CrudFormType extends AbstractType
     public function getBlockPrefix(): string
     {
         return 'ea_crud';
+    }
+
+    private function isTypeFormField(?string $type): bool
+    {
+        if (null === $type) {
+            return false;
+        }
+
+        return \in_array($type, [
+            EaFormFieldsetOpenType::class,
+            EaFormFieldsetCloseType::class,
+
+            EaFormRowType::class,
+
+            EaFormTabPaneOpenType::class,
+            EaFormTabPaneCloseType::class,
+
+            EaFormColumnOpenType::class,
+            EaFormColumnCloseType::class,
+        ], true);
     }
 }

--- a/tests/Dto/FieldDtoTest.php
+++ b/tests/Dto/FieldDtoTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Dto;
+
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use PHPUnit\Framework\TestCase;
+
+class FieldDtoTest extends TestCase
+{
+    /** @dataProvider propertyNameWithSuffixProvider */
+    public function testGetPropertyNameWithSuffix(string $property, ?string $propertySuffix, string $expected): void
+    {
+        $dto = new FieldDto();
+        $dto->setProperty($property);
+        $dto->setPropertyNameSuffix($propertySuffix);
+
+        $this->assertSame($expected, $dto->getPropertyNameWithSuffix());
+    }
+
+    public function propertyNameWithSuffixProvider(): \Generator
+    {
+        yield ['foo', null, 'foo'];
+        yield ['foo', 'bar', 'foo_bar'];
+    }
+}

--- a/tests/Field/FormFieldTest.php
+++ b/tests/Field/FormFieldTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Ulid;
+
+class FormFieldTest extends TestCase
+{
+    /** @dataProvider defaultPropertySuffixProvider */
+    public function testDefaultSetPropertySuffix(FormField $formField)
+    {
+        $this->assertTrue(Ulid::isValid($formField->getAsDto()->getPropertyNameSuffix()));
+    }
+
+    public function defaultPropertySuffixProvider(): \Generator
+    {
+        yield [FormField::addFieldset()];
+        yield [FormField::addColumn()];
+        yield [FormField::addRow()];
+        yield [FormField::addTab()];
+    }
+
+    /** @dataProvider propertySuffixProvider */
+    public function testSetPropertySuffix(FormField $formField, string $expectedPropertyName, string $expectedPropertyNameSuffix)
+    {
+        $dto = $formField->getAsDto();
+        $this->assertSame($expectedPropertyName, $dto->getPropertyNameWithSuffix());
+        $this->assertSame($expectedPropertyNameSuffix, $dto->getPropertyNameSuffix());
+    }
+
+    public function propertySuffixProvider(): \Generator
+    {
+        yield [FormField::addFieldset()->setPropertySuffix('foo'), 'ea_form_fieldset_foo', 'foo'];
+        yield [FormField::addColumn()->setPropertySuffix('foo'), 'ea_form_column_foo', 'foo'];
+        yield [FormField::addRow()->setPropertySuffix('foo'), 'ea_form_row_foo', 'foo'];
+        yield [FormField::addTab()->setPropertySuffix('foo'), 'ea_form_tab_foo', 'foo'];
+    }
+}

--- a/tests/Form/Type/CrudFormTypeFormFormFieldTest.php
+++ b/tests/Form/Type/CrudFormTypeFormFormFieldTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Form\Type;
+
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
+use Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class CrudFormTypeFormFormFieldTest extends TypeTestCase
+{
+    /** @dataProvider formFieldFixedProvider */
+    public function testFormFieldFixed(FormField $field, array $expectedKeys)
+    {
+        $form = $this->factory->create(CrudFormType::class, null, [
+            'entityDto' => $this->getEntityDto([$field]),
+        ]);
+
+        foreach ($expectedKeys as $key) {
+            $this->assertArrayHasKey($key, $form);
+        }
+    }
+
+    public function formFieldFixedProvider(): \Generator
+    {
+        yield [FormField::addFieldset(propertySuffix: 'foobar'), ['ea_form_fieldset_foobar', 'ea_form_fieldset_close_foobar']];
+        yield [FormField::addRow(propertySuffix: 'foobar'), ['ea_form_row_foobar']];
+        yield [FormField::addColumn(propertySuffix: 'foobar'), ['ea_form_column_foobar', 'ea_form_column_close_foobar']];
+        yield [FormField::addTab(propertySuffix: 'foobar'), ['ea_form_tab_foobar']];
+    }
+
+    /** @dataProvider formFieldUlidProvider */
+    public function testFormFieldUlid(FormField $field, array $expectedPrefixKeys, string $expectedSuffix)
+    {
+        $form = $this->factory->create(CrudFormType::class, null, [
+            'entityDto' => $this->getEntityDto([$field]),
+        ]);
+
+        foreach ($expectedPrefixKeys as $prefixKey) {
+            $this->assertArrayHasKey($prefixKey.$expectedSuffix, $form);
+        }
+    }
+
+    public function formFieldUlidProvider(): \Generator
+    {
+        yield [$field = FormField::addFieldset(), ['ea_form_fieldset_', 'ea_form_fieldset_close_'], $field->getAsDto()->getPropertyNameSuffix()];
+        yield [$field = FormField::addRow(), ['ea_form_row_'], $field->getAsDto()->getPropertyNameSuffix()];
+        yield [$field = FormField::addColumn(), ['ea_form_column_', 'ea_form_column_close_'], $field->getAsDto()->getPropertyNameSuffix()];
+        yield [$field = FormField::addTab(), ['ea_form_tab_'], $field->getAsDto()->getPropertyNameSuffix()];
+    }
+
+    protected function getExtensions(): array
+    {
+        $typeGuesser = $this->getMockBuilder(DoctrineOrmTypeGuesser::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $types = [
+            'ea_crud' => new CrudFormType($typeGuesser),
+        ];
+
+        return [
+            new PreloadedExtension($types, []),
+        ];
+    }
+
+    private function getEntityDto(array $fields): EntityDto
+    {
+        $mock = $this->getMockBuilder(EntityDto::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $mock
+            ->method('getFqcn')
+            ->willReturn(_TestEntity::class);
+
+        $mock
+            ->method('getFields')
+            ->willReturn((new FormLayoutFactory())
+                ->createLayout(FieldCollection::new($fields), Crud::PAGE_NEW)
+            );
+
+        return $mock;
+    }
+}
+
+class _TestEntity
+{
+}


### PR DESCRIPTION
Allow to set a specific suffix to all `FormField` (tab, fieldset, row and column) in place of a random Ulid.

Still use Ulid if nothing given.

The suffix allow to easily override template by knowing the form name (instead of random one).

The suffix given is kept between open and closed type.

The suffix must be valid like a SF form name.

Usage example:
```php
    public function configureFields(string $pageName): iterable
    {
        $fieldset = FormField::addFieldset('A super title', propertySuffix: 'foo');
        $fieldset = FormField::addFieldset('A super title')
            ->setPropertySuffix('foo')
        ;
    }
```

```twig
{% block _MyEntity_ea_form_fieldset_foo_row %}
    {# do stuff #}
    {{ block('ea_form_fieldset_open_row') }}
    {# do other stuff #}
{% endblock _MyEntity_ea_form_fieldset_foo_row %}

{% block _MyEntity_ea_form_fieldset_close_foo_row %}
    {# do stuff #}
    {{ block('ea_form_fieldset_close_row') }}
    {# do other stuff #}
{% endblock _MyEntity_ea_form_fieldset_close_foo_row %}
```

