### PR TITLE
chore: add test of `active` URL in menu

### DIFF
--- a/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
+++ b/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
@@ -146,6 +146,17 @@ class PrettyUrlsControllerTest extends WebTestCase
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index', $crawler->filter('li.menu-item a:contains("Users")')->attr('href'));
     }
 
+    public function testCustomMainMenuHasActiveClass()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/admin/pretty/urls/category');
+
+        $this->assertStringContainsString('active', $crawler->filter('li.menu-item a:contains("Categories")')->closest('li.menu-item')->attr('class'), 'The “Categories” link must have the active class');
+        $this->assertStringNotContainsString('active', $crawler->filter('li.menu-item a:contains("Blog Posts")')->closest('li.menu-item')->attr('class'), 'The “Blog Posts” link must not have the active class');
+    }
+
     public function testDefaultActionsUsePrettyUrls()
     {
         $client = static::createClient();


### PR DESCRIPTION
Add a test to avoid future regressions after #6541: 

- #6541 

:warning: This requires #6553 to be merged:

- #6553