### PR TITLE
Update minimum Twig requirement to 3.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "symfony/twig-bundle": "^5.4|^6.0|^7.0",
         "symfony/uid": "^5.4|^6.0|^7.0",
         "symfony/ux-twig-component": "^2.21",
-        "symfony/validator": "^5.4|^6.0|^7.0"
+        "symfony/validator": "^5.4|^6.0|^7.0",
+        "twig/twig": "^3.15"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "^3.4|3.5.x-dev",


### PR DESCRIPTION
The recent 3.15 version is the best Twig version in years and adds a ton of features that will help us a lot (like the `guard` tag and the inline comments). See https://github.com/twigphp/Twig/blob/v3.15.0/CHANGELOG