### PR TITLE
[Twig/Icon] Fix typo in user icon name `inernal` => `internal`

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -195,7 +195,7 @@
                                 {% if ea.userMenu.avatarDisplayed %}
                                     {{ user_menu_avatar }}
                                 {% else %}
-                                    <twig:ea:Icon class="user-avatar" name="{{ ea.user is not null ? 'inernal:user' : 'internal:user-xmark' }}" />
+                                    <twig:ea:Icon class="user-avatar" name="{{ ea.user is not null ? 'internal:user' : 'internal:user-xmark' }}" />
                                 {% endif %}
                             </a>
 


### PR DESCRIPTION
All in the title :wink: 