### PR TITLE
Replace `sr-only` class with `visually-hidden`

### DIFF
--- a/templates/crud/index.html.twig
+++ b/templates/crud/index.html.twig
@@ -128,7 +128,7 @@
                     {% endfor %}
 
                     <th class="{{ ea.crud.showEntityActionsAsDropdown ? 'actions-as-dropdown-table-head' }}" dir="{{ ea.i18n.textDirection }}">
-                        <span class="sr-only">{{ t('action.entity_actions', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}</span>
+                        <span class="visually-hidden">{{ t('action.entity_actions', ea.i18n.translationParameters, 'EasyAdminBundle')|trans }}</span>
                     </th>
                 </tr>
             {% endblock table_head %}


### PR DESCRIPTION
Ref https://getbootstrap.com/docs/5.2/getting-started/accessibility/#visually-hidden-content

I've noticed since version 4.16.0 that fields with `sr-only` class have become visible. This seems to be because the `sr-only` class is no longer available in Bootstrap, but was still present in the recently removed font-awesome assets. E.g. the actions `<th>`:

![image](https://github.com/user-attachments/assets/0ca21e0c-0817-4d7c-aa6c-a8561eb56261)

