### PR TITLE
Fix `AdminDashboard` attribute routes type

### DIFF
--- a/src/Attribute/AdminDashboard.php
+++ b/src/Attribute/AdminDashboard.php
@@ -9,7 +9,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Attribute;
 class AdminDashboard
 {
     public function __construct(
-        /** @var array<string, array{routeName: string, routePath: string}>|null */
+        /** @var array<string, array{routeName?: string, routePath?: string}>|null */
         public ?array $routes = null,
         /** @var class-string[]|null $allowedControllers If defined, only these CRUD controllers will have a route defined for them */
         public ?array $allowedControllers = null,


### PR DESCRIPTION
The following configuration, which seems valid according to [the doc](https://symfony.com/bundles/EasyAdminBundle/4.x/crud.html#crud-routes), does not pass type validation (`Array does not have offset 'routeName'`):

```PHP
#[AdminDashboard([
    'new' => ['routePath' => 'creer'],
    'edit' => ['routePath' => '{entityId}/modifier'],
    'delete' => ['routePath' => '{entityId}/supprimer'],
])]
class DashboardController extends AbstractDashboardController
```

