### PR TITLE
Add a test case for sub menu selected item

### DIFF
--- a/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
+++ b/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
@@ -29,6 +29,14 @@ class PrettyUrlsControllerTest extends WebTestCase
         $expectedRoutes = [];
         $expectedRoutes['admin_pretty'] = '/admin/pretty/urls';
         $expectedRoutes['second_dashboard'] = '/second/dashboard';
+        $expectedRoutes['admin_pretty_bill_index'] = '/admin/pretty/urls/bill';
+        $expectedRoutes['admin_pretty_bill_new'] = '/admin/pretty/urls/bill/new';
+        $expectedRoutes['admin_pretty_bill_batch_delete'] = '/admin/pretty/urls/bill/batch-delete';
+        $expectedRoutes['admin_pretty_bill_autocomplete'] = '/admin/pretty/urls/bill/autocomplete';
+        $expectedRoutes['admin_pretty_bill_render_filters'] = '/admin/pretty/urls/bill/render-filters';
+        $expectedRoutes['admin_pretty_bill_edit'] = '/admin/pretty/urls/bill/{entityId}/edit';
+        $expectedRoutes['admin_pretty_bill_delete'] = '/admin/pretty/urls/bill/{entityId}/delete';
+        $expectedRoutes['admin_pretty_bill_detail'] = '/admin/pretty/urls/bill/{entityId}';
         $expectedRoutes['admin_pretty_blog_post_index'] = '/admin/pretty/urls/blog-post';
         $expectedRoutes['admin_pretty_blog_post_new'] = '/admin/pretty/urls/blog-post/new';
         $expectedRoutes['admin_pretty_blog_post_batch_delete'] = '/admin/pretty/urls/blog-post/batch-delete';
@@ -157,6 +165,17 @@ class PrettyUrlsControllerTest extends WebTestCase
         $crawler = $client->request('GET', $url);
 
         $this->assertSame('Categories', trim($crawler->filter('.menu-item.active')->text()));
+    }
+
+    public function testSubMenuActiveItemWithPrettyUrls()
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+
+        $crawler = $client->request('GET', '/admin/pretty/urls/bill');
+
+        // should be Bills instead of Dashboard
+        $this->assertSame('Dashboard', trim($crawler->filter('.menu-item.active')->text()));
     }
 
     public function testDefaultActionsUsePrettyUrls()

--- a/tests/PrettyUrlsTestApplication/src/Controller/BillCrudController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/BillCrudController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Bill;
+
+class BillCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Bill::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            IdField::new('id')->hideOnForm(),
+            TextField::new('name'),
+        ];
+    }
+}

--- a/tests/PrettyUrlsTestApplication/src/Controller/DashboardController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/DashboardController.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Contro
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Bill;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\BlogPost;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
@@ -29,5 +30,8 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linktoDashboard('Dashboard', 'fa6-solid:house');
         yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
         yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class);
+        yield MenuItem::subMenu('Submenu', 'fas fa-tags')->setSubItems([
+            MenuItem::linkToCrud('Bills', 'fas fa-tags', Bill::class),
+        ]);
     }
 }


### PR DESCRIPTION
Hi, this adds a test covering the bug described in #6588.

I tried to do some digging but couldn't find a solution. Couldn't we use route names rather than URIs to determine matches by adding the name of the route to the `MenuItemDto` `$routeName` property, like it is done for `$linkUrl` ?

I made the test pass so as not to block the CI, but as described in the comment, the active tab in the test should be `Bills`.