### PR TITLE
Fix CI setup to allow patch versions of Symfony

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,7 +132,7 @@ jobs:
 
             - name: Configure Symfony version for symfony/flex
               if: ${{ matrix.symfony_version }}
-              run: composer config extra.symfony.require "${{ matrix.symfony_version }}"
+              run: composer config extra.symfony.require "${{ matrix.symfony_version }}.*"
 
             - name: Install dependencies
               run: |


### PR DESCRIPTION
Specifying `7.1` as version constraint only allows `7.1.0` as matching version.