### PR TITLE
Temporary ignore errors in Symfony 7.2 branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,7 @@ jobs:
                   composer show
 
             - name: Run tests
-              continue-on-error: ${{ matrix.stability == 'dev' }}
+              continue-on-error: ${{ matrix.stability == 'dev' || matrix.symfony_version == '7.2' }}
               env:
                   SYMFONY_DEPRECATIONS_HELPER: "max[total]=999999&ignoreFile=./tests/baseline-ignore.txt"
               run: |
@@ -153,7 +153,7 @@ jobs:
             - name: Run Pretty URLs tests
                 # Symfony 5.4 version doesn't include the #[Route] attribute needed to run these tests (it only includes the @Route annotation)
               if: ${{ matrix.symfony_version != '5.4' && matrix.composer_args != '--prefer-lowest' }}
-              continue-on-error: ${{ matrix.stability == 'dev' }}
+              continue-on-error: ${{ matrix.stability == 'dev' || matrix.symfony_version == '7.2' }}
               env:
                   USE_PRETTY_URLS: "1"
                   SYMFONY_DEPRECATIONS_HELPER: "max[total]=999999&ignoreFile=./tests/baseline-ignore.txt"


### PR DESCRIPTION
EasyAdmin won't work with Symfony 7.2 until this bug fix: https://github.com/symfony/symfony/pull/59059 is not released in Symfony 7.2.1.

So, ignore errors (temporarily) in Symfony 7.2.