### PR TITLE
Fix action callables

### DIFF
--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -165,7 +165,7 @@ final class ActionFactory
             return;
         }
 
-        if (\is_callable($label)) {
+        if (\is_callable($label) && $label instanceof \Closure) {
             $label = \call_user_func_array($label, array_filter([$entityDto?->getInstance()]));
 
             if (!\is_string($label) && !$label instanceof TranslatableInterface) {

--- a/tests/Controller/ActionsCrudControllerTest.php
+++ b/tests/Controller/ActionsCrudControllerTest.php
@@ -47,8 +47,9 @@ class ActionsCrudControllerTest extends AbstractCrudTestCase
     {
         $crawler = $this->client->request('GET', $this->generateIndexUrl());
 
-        static::assertSame('Action 5: Category 0', $crawler->filter('a.dropdown-item:contains("Action 5")')->text());
-        static::assertSame('Action 6: Category 0', $crawler->filter('a.dropdown-item:contains("Action 6")')->text());
-        static::assertSame('Action 7: Category 0', $crawler->filter('a.dropdown-item:contains("Action 7")')->text());
+        static::assertSame('Action 5: Category 0', $crawler->filter('a.dropdown-item[data-action-name="action5"]')->text());
+        static::assertSame('Action 6: Category 0', $crawler->filter('a.dropdown-item[data-action-name="action6"]')->text());
+        static::assertSame('Action 7: Category 0', $crawler->filter('a.dropdown-item[data-action-name="action7"]')->text());
+        static::assertSame('Reset', $crawler->filter('a.dropdown-item[data-action-name="action8"]')->text());
     }
 }

--- a/tests/TestApplication/src/Controller/ActionsCrudController.php
+++ b/tests/TestApplication/src/Controller/ActionsCrudController.php
@@ -40,6 +40,9 @@ class ActionsCrudController extends AbstractCrudController
 
         $action7 = Action::new('action7')->linkToCrudAction('')->setLabel(fn (Category $category) => t('Action %number%: %name%', ['%number%' => 7, '%name%' => $category->getName()]));
 
+        // this tests that the 'Reset' label is interpreted as a string and not as a callable to the PHP reset() function
+        $action8 = Action::new('action8')->linkToCrudAction('')->setLabel('Reset');
+
         return $actions
             ->add(Crud::PAGE_INDEX, $action1)
             ->add(Crud::PAGE_INDEX, $action2)
@@ -48,6 +51,7 @@ class ActionsCrudController extends AbstractCrudController
             ->add(Crud::PAGE_INDEX, $action5)
             ->add(Crud::PAGE_INDEX, $action6)
             ->add(Crud::PAGE_INDEX, $action7)
+            ->add(Crud::PAGE_INDEX, $action8)
             ->update(Crud::PAGE_INDEX, Action::NEW, function (Action $action) {
                 return $action->setIcon('fa fa-fw fa-plus')->setLabel(false);
             })


### PR DESCRIPTION
This morning, when updating some app to the latest version, I faced an issue in an action with the label `Reset`. Let's fix it.