### PR TITLE
Fix menu item matcher when using pretty URLs and submenus

### DIFF
--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -200,9 +200,9 @@ class MenuItemMatcher implements MenuItemMatcherInterface
 
             // compare the ending of the URL instead of a strict equality because link URLs can be absolute URLs
             if (str_ends_with($menuItemUrl, $currentRequestUriWithoutQueryString)
-                || str_ends_with($menuItemUrl, $currentRequestUriWithoutAction)
+                || ('' !== $currentRequestUriWithoutAction && str_ends_with($menuItemUrl, $currentRequestUriWithoutAction))
                 || str_ends_with($menuItemUrlWithoutQueryString, $currentRequestUriWithoutQueryString)
-                || str_ends_with($menuItemUrlWithoutQueryString, $currentRequestUriWithoutAction)) {
+                || ('' !== $currentRequestUriWithoutAction && str_ends_with($menuItemUrlWithoutQueryString, $currentRequestUriWithoutAction))) {
                 $menuItemDto->setSelected(true);
 
                 return $menuItems;


### PR DESCRIPTION
If menu has submenus, then opening any submenu item triggers "selecting" of all other submenus first item besides opened menu item. For example:

- Menu item 1
- Submenu 1
- Submenu item 1-1
- Submenu item 1-2
- Submenu 2
- Submenu item 2-1
- Submenu item 2-2
- Submenu item 2-3
- Submenu 3
- Submenu item 3-1
- Submenu item 3-2

Click on Submenu item 2-2 and these items will be selected: Menu item 1, Submenu item 1-1, Submenu item 2-2, Submenu item 3-1.
Admin url is localhost/, submenu url is localhost/banana, so in MenuItemMatcher method doMarkSelectedPrettyUrlsMenuItem $currentRequestUriWithoutAction will be an empty string:
```
// the edit URL is '/admin/foo/{id}/edit' so we need to remove the two last segments of the URL
if (str_ends_with($currentRequestUriWithoutQueryString, '/edit')) {
    $currentRequestUriWithoutAction = preg_replace('#/[^/]+$#', '', $currentRequestUriWithoutAction);
}
```
Later this condition will be true and item will be selected, because str_ends_with('any-string', '') - returns true.
```
// compare the ending of the URL instead of a strict equality because link URLs can be absolute URLs
if (str_ends_with($menuItemUrl, $currentRequestUriWithoutQueryString)
    || str_ends_with($menuItemUrl, $currentRequestUriWithoutAction)
    || str_ends_with($menuItemUrlWithoutQueryString, $currentRequestUriWithoutQueryString)
    || str_ends_with($menuItemUrlWithoutQueryString, $currentRequestUriWithoutAction)) {
    $menuItemDto->setSelected(true);

```
So, I've added check for an empty string and then menu selecting is correct: only Submenu item 2-2.
