### PR TITLE
Fix Fieldset collapse with new suffix.

### DIFF
--- a/templates/crud/detail.html.twig
+++ b/templates/crud/detail.html.twig
@@ -234,9 +234,9 @@
                         {% endset %}
 
                         {% if is_collapsible %}
-                            <a href="#content-{{ field.property }}" data-bs-toggle="collapse"
+                            <a href="#content-{{ field.propertyNameWithSuffix }}" data-bs-toggle="collapse"
                                class="form-fieldset-title-content form-fieldset-collapse {{ is_collapsed ? 'collapsed' }}"
-                               aria-expanded="{{ is_collapsed ? 'false' : 'true' }}" aria-controls="content-{{ field.property }}">
+                               aria-expanded="{{ is_collapsed ? 'false' : 'true' }}" aria-controls="content-{{ field.propertyNameWithSuffix }}">
                                 {{ fieldset_title_contents|raw }}
                             </a>
                         {% else %}
@@ -252,7 +252,7 @@
                 </div>
             {% endif %}
 
-            <div id="content-{{ field.property }}" class="form-fieldset-body {{ not fieldset_has_header ? 'without-header' }} {{ is_collapsible ? 'collapse' }} {{ not is_collapsed ? 'show'}}">
+            <div id="content-{{ field.propertyNameWithSuffix }}" class="form-fieldset-body {{ not fieldset_has_header ? 'without-header' }} {{ is_collapsible ? 'collapse' }} {{ not is_collapsed ? 'show'}}">
                 <div class="row">
 {% endmacro %}
 


### PR DESCRIPTION
Fix fieldset collapsing that do not use the right property to create the `id` HTML attribute.

https://github.com/EasyCorp/EasyAdminBundle/pull/6555#issuecomment-2541426243