### PR TITLE
Fix for issue #6519 (Pretty URLs in tests)

### DIFF
--- a/.ddev/example/Controller/Admin/DashboardController.php
+++ b/.ddev/example/Controller/Admin/DashboardController.php
@@ -7,9 +7,8 @@ use App\Entity\Category;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Attribute\Route;
 
 class DashboardController extends AbstractDashboardController
 {

--- a/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
+++ b/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
@@ -2,6 +2,10 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Controller\PrettyUrls;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller\BlogPostCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller\DashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Kernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -254,6 +258,24 @@ class PrettyUrlsControllerTest extends WebTestCase
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bid%5D=DESC', $crawler->filter('th.searchable a')->eq(0)->attr('href'));
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bname%5D=DESC', $crawler->filter('th.searchable a')->eq(1)->attr('href'));
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index?page=1&sort%5Bemail%5D=DESC', $crawler->filter('th.searchable a')->eq(2)->attr('href'));
+    }
+
+    public function testAdminUrlGeneratorUsePrettyUrls()
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $adminUrlGenerator = $container->get(AdminUrlGenerator::class);
+
+        $this->assertInstanceOf(AdminUrlGenerator::class, $adminUrlGenerator);
+
+        $blogPostIndexUrl = $adminUrlGenerator
+            ->setDashboard(DashboardController::class)
+            ->setController(BlogPostCrudController::class)
+            ->setAction(Action::INDEX)
+            ->generateUrl()
+        ;
+
+        $this->assertSame('http://localhost/admin/pretty/urls/blog-post', $blogPostIndexUrl);
     }
 
     public static function provideActiveMenuUrls(): iterable


### PR DESCRIPTION
When using pretty URLs in tests, the AdminUrlGenerator fails to provide the pretty URLs because it checks the use of pretty URLs through the context, which is null when doing requests from tests. This fixes this behaviour by checking the use of pretty URLs directly from the UrlGenerator (Router), which is what is done by the context anyway.

Tests have been adapted to use pretty URLs.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
