### PR TITLE
use asset-mapper asset package if available

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -396,6 +396,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set(AssetPackage::class)
             ->arg(0, service('request_stack'))
+            ->arg(1, service('asset_mapper.asset_package')->ignoreOnInvalid())
             ->tag('assets.package', ['package' => AssetPackage::PACKAGE_NAME])
 
         ->set(Icon::class)

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -5,6 +5,12 @@ The design of the backend is ready for any kind of application. It's been
 created with `Bootstrap 5`_, and some custom CSS and JavaScript code; all
 managed by `Webpack`_ via Symfony's `Webpack Encore`_.
 
+.. tip::
+
+    If you have both `assets` and `asset_mapper` enabled, all the assets
+    url for this bundle will be automatically handled by asset mapper.
+    You can skip to execute below command.
+
 Like any other Symfony bundle, assets are copied to (or symlinked from) the
 ``public/bundles/`` directory of your application when installing or updating
 the bundle. If this doesn't work for any reason, your backend won't display the

--- a/src/Asset/AssetPackage.php
+++ b/src/Asset/AssetPackage.php
@@ -22,19 +22,27 @@ final class AssetPackage implements PackageInterface
     public const PACKAGE_NAME = 'easyadmin.assets.package';
 
     private PackageInterface $package;
+    private ?PackageInterface $mapperAwareAssetPackage;
 
-    public function __construct(RequestStack $requestStack)
+    public function __construct(RequestStack $requestStack, ?PackageInterface $mapperAwareAssetPackage = null)
     {
         $this->package = new PathPackage(
             '/bundles/easyadmin',
             new JsonManifestVersionStrategy(__DIR__.'/../../public/manifest.json'),
             new RequestStackContext($requestStack)
         );
+        $this->mapperAwareAssetPackage = $mapperAwareAssetPackage;
     }
 
     public function getUrl(string $assetPath): string
     {
-        return $this->package->getUrl($assetPath);
+        $url = $this->package->getUrl($assetPath);
+
+        if (null !== $this->mapperAwareAssetPackage) {
+            return $this->mapperAwareAssetPackage->getUrl(ltrim($url, '/'));
+        }
+
+        return $url;
     }
 
     public function getVersion(string $assetPath): string


### PR DESCRIPTION
by default, asset-mapper has all bundles assets https://symfony.com/doc/current/frontend/asset_mapper.html#third-party-bundles-custom-asset-paths

we can skip `assets:install` command to copy the assets to public dir and reuse what asset-mapper has done