### PR TITLE
Minor performance improvement in Twig extension

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -182,7 +182,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
                 return sprintf('%s #%s', $value::class, $value->getId());
             }
 
-            return sprintf('%s #%s', $value::class, substr(md5(spl_object_hash($value)), 0, 7));
+            return sprintf('%s #%s', $value::class, hash('xxh32', (string) spl_object_id($value)));
         }
 
         return '';


### PR DESCRIPTION
`spl_object_id()` is slightly faster than `spl_object_hash()` (see https://github.com/symfony/symfony/pull/59355) and `xxhash` algorithms are much faster than `md5`