### PR TITLE
Deprecate the AdminContext:getReferrer() method

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -117,6 +117,24 @@ that page title:
         }
     }
 
+EasyAdmin 4.8.11
+----------------
+
+EasyAdmin URLs no longer include the `referrer` query parameter, and the
+`AdminContext:getReferrer()` method is deprecated.
+
+This change is part of the long-term project to simplify URLs, with the goal of
+using pretty URLs in the future. If you still need to access the referrer, you
+can retrieve it from the HTTP headers provided by browsers:
+
+```php
+// Before
+return $this->redirect($context->getReferrer());
+
+// After
+return $this->redirect($context->getRequest()->headers->get('referer'));
+```
+
 EasyAdmin 4.8.0
 ---------------
 

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -70,6 +70,13 @@ final class AdminContext implements AdminContextInterface
 
     public function getReferrer(): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.8.11',
+            'EasyAdmin URLs no longer include the referrer URL. If you still need it, you can get the referrer provided by browsers via $context->getRequest()->headers->get(\'referer\').',
+            __METHOD__,
+        );
+
         $referrer = $this->request->query->get(EA::REFERRER);
 
         return '' !== $referrer ? $referrer : null;


### PR DESCRIPTION
Fixes #6115.

This was deprecated in practice a long time ago, when we removed the `referrer` parameter from URLs in #6105. But, we didn't formally deprecate the associated method in `AdminContext:getReferrer()`. Let's do that now.