### PR TITLE
Fix AdminRouteGenerator assuming the Route attribute is used from the Attribute namespace instead of the Annotation's

### DIFF
--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -219,8 +219,14 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         foreach ($this->dashboardControllers as $dashboardController) {
             $reflectionClass = new \ReflectionClass($dashboardController);
             $indexMethod = $reflectionClass->getMethod('index');
-            $routeAttributeFqcn = class_exists(\Symfony\Component\Routing\Attribute\Route::class) ? \Symfony\Component\Routing\Attribute\Route::class : \Symfony\Component\Routing\Annotation\Route::class;
-            $attributes = $indexMethod->getAttributes($routeAttributeFqcn);
+
+            if (class_exists(\Symfony\Component\Routing\Attribute\Route::class)) {
+                $attributes = $indexMethod->getAttributes(\Symfony\Component\Routing\Attribute\Route::class);
+            }
+
+            if (!isset($attributes) || [] === $attributes) {
+                $attributes = $indexMethod->getAttributes(\Symfony\Component\Routing\Annotation\Route::class);
+            }
 
             if ([] === $attributes) {
                 throw new \RuntimeException(sprintf('When using pretty URLs, the "%s" EasyAdmin dashboard controller must define its route configuration (route name and path) using Symfony\'s #[Route] attribute applied to its "index()" method.', $reflectionClass->getName()));

--- a/tests/PrettyUrlsTestApplication/src/Controller/DashboardController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/DashboardController.php
@@ -8,7 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\BlogPost;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 class DashboardController extends AbstractDashboardController
 {


### PR DESCRIPTION
Fixes #6687 