### PR TITLE
Allow customizing some bits of the login form page via twig blocks

### DIFF
--- a/templates/page/login.html.twig
+++ b/templates/page/login.html.twig
@@ -49,12 +49,16 @@
                 </div>
             {% endif %}
 
+            {% block login_top %}{% endblock %}
+
             <form method="post" action="{{ action|default('') }}">
                 {% if csrf_token_intention|default(false) %}
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrf_token_intention) }}">
                 {% endif %}
 
                 <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea.hasContext ? path(ea.dashboardRouteName) : '/') }}" />
+
+                {% block login_form_top %}{% endblock %}
 
                 <div class="form-group">
                     <label class="form-control-label required" for="username">{{ _username_label }}</label>
@@ -76,6 +80,8 @@
                     {% endif %}
                 </div>
 
+                {% block login_form_bottom %}{% endblock %}
+
                 {% if remember_me_enabled|default(false) %}
                     <div class="form-group">
                         <input class="form-check-input" type="checkbox" id="remember_me" name="{{ remember_me_parameter|default('_remember_me') }}" {{ remember_me_checked|default(false) ? 'checked' }}>
@@ -89,6 +95,8 @@
             </form>
 
             <script src="{{ asset('login.js', constant('EasyCorp\\Bundle\\EasyAdminBundle\\Asset\\AssetPackage::PACKAGE_NAME')) }}"></script>
+
+            {% block login_bottom %}{% endblock %}
         </section>
     </div>
 {% endblock %}


### PR DESCRIPTION
This allows creating a custom login page with EA's background and adding the logo **inside** the content box, new Form elements (this can be useful when you just need another form field, like a context selection.

Or it can allow adding a bottom text like "Don't have an account? <a href="...">Register</a>" for instance.

Allow people to avoid copy/pasting the template, risking new versions breaks.