### PR TITLE
Add some missing deprecations about signed URLs

### DIFF
--- a/src/Config/Option/EA.php
+++ b/src/Config/Option/EA.php
@@ -31,5 +31,6 @@ final class EA
     public const SORT = 'sort';
     /** @deprecated this parameter is no longer used because menu items are now highlighted automatically */
     public const SUBMENU_INDEX = 'submenuIndex';
+    /** @deprecated this parameter is no longer used because URLs no longer include a signed hash */
     public const URL_SIGNATURE = 'signature';
 }

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -109,6 +109,13 @@ final class AdminContext implements AdminContextInterface
 
     public function getSignedUrls(): bool
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.1.0',
+            'EasyAdmin URLs no longer include signatures because they don\'t provide any additional security. The "%s" method will be removed in EasyAdmin 5.0.0, so you should stop using it.',
+            __METHOD__
+        );
+
         return $this->dashboardDto->getSignedUrls();
     }
 

--- a/src/Contracts/Context/AdminContextInterface.php
+++ b/src/Contracts/Context/AdminContextInterface.php
@@ -33,6 +33,9 @@ interface AdminContextInterface
 
     public function getAssets(): AssetsDto;
 
+    /**
+     * @deprecated since 4.1.0, will be removed in 5.0.0. Signed URLs don't provide additional security in backends and have been removed without a replacement.
+     */
     public function getSignedUrls(): bool;
 
     public function getAbsoluteUrls(): bool;

--- a/src/Dto/DashboardDto.php
+++ b/src/Dto/DashboardDto.php
@@ -121,11 +121,25 @@ final class DashboardDto
 
     public function getSignedUrls(): bool
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.1.0',
+            'EasyAdmin URLs no longer include signatures because they don\'t provide any additional security. The "%s" method will be removed in EasyAdmin 5.0.0, so you should stop using it.',
+            __METHOD__
+        );
+
         return $this->signedUrls;
     }
 
     public function setSignedUrls(bool $signedUrls): self
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.1.0',
+            'EasyAdmin URLs no longer include signatures because they don\'t provide any additional security. The "%s" method will be removed in EasyAdmin 5.0.0, so you should stop using it.',
+            __METHOD__
+        );
+
         $this->signedUrls = $signedUrls;
 
         return $this;

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -92,6 +92,13 @@ final class AdminContextProvider implements AdminContextProviderInterface
 
     public function getSignedUrls(): bool
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.1.0',
+            'EasyAdmin URLs no longer include signatures because they don\'t provide any additional security. The "%s" method will be removed in EasyAdmin 5.0.0, so you should stop using it.',
+            __METHOD__
+        );
+
         return $this->getContext(true)->getSignedUrls();
     }
 

--- a/src/Router/AdminUrlGeneratorInterface.php
+++ b/src/Router/AdminUrlGeneratorInterface.php
@@ -47,8 +47,14 @@ interface AdminUrlGeneratorInterface
      */
     public function setReferrer(string $referrer): self;
 
+    /**
+     * @deprecated since 4.1.0, will be removed in 5.0.0. Signed URLs don't provide additional security in backends and have been removed without a replacement.
+     */
     public function addSignature(bool $addSignature = true): self;
 
+    /**
+     * @deprecated since 4.1.0, will be removed in 5.0.0. Signed URLs don't provide additional security in backends and have been removed without a replacement.
+     */
     public function getSignature(): string;
 
     public function generateUrl(): string;


### PR DESCRIPTION
This feature was deprecated a long time ago, but we were missing some deprecation notices.