### PR TITLE
Allow customize entity row attributes on index page

### DIFF
--- a/templates/crud/index.html.twig
+++ b/templates/crud/index.html.twig
@@ -139,7 +139,7 @@
         {% block table_body %}
             {% for entity in entities %}
                 {% if entity.isAccessible %}
-                    <tr data-id="{{ entity.primaryKeyValueAsString }}">
+                    <tr data-id="{{ entity.primaryKeyValueAsString }}" {% block entity_row_attributes %}{% endblock %}>
                         {% if has_batch_actions %}
                             <td class="batch-actions-selector">
                                 <div class="form-check">


### PR DESCRIPTION
In my project I need to highlight entity rows with different colors based on entity status.
Currently I need to copy all `table_body` just for add css class to row like `class="status-row status-row-{{ entity.instance.status.name|lower }}"`

With this patch I just need to add this in overrided template
```twig
{% block entity_row_attributes %}
    class="status-row status-row-{{ entity.instance.status.name|lower }}"
{% endblock %}
```

PS. After updating from 4.13, currently I need to update all my custom templates with this logic as `table_body`  was changed.