### PR TITLE
Force auto-generated CSRF token id

### DIFF
--- a/src/Factory/FormFactory.php
+++ b/src/Factory/FormFactory.php
@@ -35,6 +35,7 @@ final class FormFactory
         $formOptions->set('attr.class', trim(($formOptions->get('attr.class') ?? '').' '.$cssClass));
         $formOptions->set('attr.id', sprintf('edit-%s-form', $entityDto->getName()));
         $formOptions->set('entityDto', $entityDto);
+        $formOptions->set('csrf_token_id', '');
         $formOptions->setIfNotSet('translation_domain', $context->getI18n()->getTranslationDomain());
 
         return $this->symfonyFormFactory->createNamedBuilder($entityDto->getName(), CrudFormType::class, $entityDto->getInstance(), $formOptions->all());
@@ -51,6 +52,7 @@ final class FormFactory
         $formOptions->set('attr.class', trim(($formOptions->get('attr.class') ?? '').' '.$cssClass));
         $formOptions->set('attr.id', sprintf('new-%s-form', $entityDto->getName()));
         $formOptions->set('entityDto', $entityDto);
+        $formOptions->set('csrf_token_id', '');
         $formOptions->setIfNotSet('translation_domain', $context->getI18n()->getTranslationDomain());
 
         return $this->symfonyFormFactory->createNamedBuilder($entityDto->getName(), CrudFormType::class, $entityDto->getInstance(), $formOptions->all());


### PR DESCRIPTION
EA is currently sensitive to the form.csrf_token_id config option. When using the new recipe for CSRF shipped with 7.2, this config option is set to "submit", which leads to using the stateless CSRF protection. But because EA doesn't load the JS snippet that goes with this protection, the admin area is broken for such apps: CSRF validation fails.

This change decouples EA from the config option and forces Symfony to auto-generate the CSRF token id, which leads to using the statefull CSRF protection. Using the session in the admin area is normal, so that's totally fine.

An alternative would be to load the app's importmap in EA pages.
This could be nice as it would make easier to add custom JS to admin pages, but it would be a bit more involving, and a bit unrelated.