### PR TITLE
Set default route name and path for custom actions, based on method name

### DIFF
--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -309,6 +309,11 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
                 throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminAction] attribute applied to the "%s()" action includes some unsupported keys. You can only define these keys: "routePath", "routeName", and "methods".', $crudControllerFqcn, $action));
             }
 
+            $customActionsConfig[$action] = [
+                'routeName' => $action,
+                'routePath' => '{entityId}/'.$action,
+            ];
+
             if (null !== $attributeInstance->routePath) {
                 if (\in_array($action, ['edit', 'detail', 'delete'], true) && !str_contains($attributeInstance->routePath, '{entityId}')) {
                     throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminAction] attribute applied to the "%s()" action is missing the "{entityId}" placeholder in its route path.', $crudControllerFqcn, $action));


### PR DESCRIPTION
With this patch you can use `AdminAction` attribute without parameters