### PR TITLE
Adds ExtendableDashboard attribute to fix route name duplication when extending a DashboardController

### DIFF
--- a/src/Attribute/ExtendableDashboard.php
+++ b/src/Attribute/ExtendableDashboard.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Attribute;
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ExtendableDashboard
+{
+    /**
+     * Fixes admin route name duplication. Add to any Dashboard Controllers that you want to be able to extend from.
+     *
+     * This might be a bit of a hack.
+     *
+     * @param bool|null $hasExtraRoutes -- Set true on child controllers if there are routes which were not referenced by the parent controller
+     */
+    public function __construct(public ?bool $hasExtraRoutes = false)
+    {
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function hasExtraRoutes(): ?bool
+    {
+        return $this->hasExtraRoutes;
+    }
+}

--- a/src/Attribute/ExtendableDashboard.php
+++ b/src/Attribute/ExtendableDashboard.php
@@ -16,9 +16,6 @@ class ExtendableDashboard
     {
     }
 
-    /**
-     * @return bool|null
-     */
     public function hasExtraRoutes(): ?bool
     {
         return $this->hasExtraRoutes;

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -109,7 +109,6 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         foreach ($this->dashboardControllers as $dashboardController) {
             $dashboardFqcn = $dashboardController::class;
 
-            /** @var ExtendableDashboard|null $instance */
             if (null !== $this->getPhpAttributeInstance($dashboardFqcn, ExtendableDashboard::class)
             ) {
                 $extendableDashboards[$dashboardFqcn] = $dashboardFqcn;

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -3,9 +3,9 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Router;
 
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminAction;
-use EasyCorp\Bundle\EasyAdminBundle\Attribute\ExtendableDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminCrud;
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\ExtendableDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -109,10 +109,8 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         foreach ($this->dashboardControllers as $dashboardController) {
             $dashboardFqcn = $dashboardController::class;
 
-            /** @var ExtendableDashboard $instance */
-            if (null !== $instance = $this->getPhpAttributeInstance(
-                    $dashboardFqcn,
-                    ExtendableDashboard::class)
+            /** @var ExtendableDashboard|null $instance */
+            if (null !== $this->getPhpAttributeInstance($dashboardFqcn, ExtendableDashboard::class)
             ) {
                 $extendableDashboards[$dashboardFqcn] = $dashboardFqcn;
             }
@@ -124,7 +122,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
     // Get dashboard controllers which extend from dashboard controllers with the #[ExtendableDashboard] attribute.
     private function getExtendedDashboards(array $extendableDashboards): array
     {
-        if ($extendableDashboards === []) {
+        if ([] === $extendableDashboards) {
             return [];
         }
 
@@ -135,7 +133,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
 
             foreach ($extendableDashboards as $extendableDashboard) {
                 if (is_subclass_of($dashboardFqcn, $extendableDashboard)) {
-                    /** @var ExtendableDashboard $instance */
+                    /** @var ExtendableDashboard|null $instance */
                     $instance = $this->getPhpAttributeInstance($dashboardFqcn, ExtendableDashboard::class);
                     $extendedDashboards[$dashboardFqcn] = [
                         'fqcn' => $dashboardFqcn,


### PR DESCRIPTION
Attribute `#[ExtendableDashboard]` can be added to any DashboardController. It has one optional argument, `#[ExtendableDashboard(hasExtraRoutes: <bool>)]`.

This attribute aims to fix an issue with route generation when using pretty urls and extended Dashboard Controllers with custom routes. When a controller extends an existing dashboard controller, AdminRouteGenerator tries to duplicate all of the routes, but fails due to duplicate route names. 

If the ExtendableDashboard attribute is added to the base dashboard controller, AdminRouteGenerator will find all controllers which are a subclass of the base controller. Then, if hasExtraRoutes is false (default), the AdminRouteGenerator will skip routing entirely for the controller (because it will be / has already been done). If hasExtraRoutes is true, the AdminRouteGenerator will run on the controller like normal but will simply skip over any duplicate routes instead of throwing an error.

I'm not very familiar with the code base, so I fully expect this to be the wrong way to fix the issue, but at the very least this serves as a proof of concept to fix route generation for Controllers extended from DashboardControllers.

To replicate the issue, make a new Controller that extends a DashboardController and create a new function with a route. Clear cache and you will receive an error "all CRUD controllers must have unique PHP class names to generate unique route names". Add the attribute with `hasExtraRoutes: true` to at least the base dashboard controller, clear cache again, and all routes *should* work fine.