### PR TITLE
Bug #5161 Disallow clear in AssociationField when field is required

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -64,6 +64,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
 
         $isRequired = $this->buildRequiredOption($field, $entityDto);
         $field->setFormTypeOption('required', $isRequired);
+        $field->setHtmlAttribute('required', $isRequired);
 
         $isSortable = $this->buildSortableOption($field, $entityDto);
         $field->setSortable($isSortable);


### PR DESCRIPTION
Hi,

This small change closes #5161 and instructs the frontend library to not render the `x` button for unsetting the association completely.

Admittedly, "extending" the trait methods in PHP is always weird and it's not very common, but it allows for the least amount of code repetition. This approach also doesn't require any JS changes. Please let me know if such approach is acceptable. This is my first contribution so there might be some other rules that I'm not aware of.

Thanks! 
