### PR TITLE
Improve the URL Field and add tests

### DIFF
--- a/src/Field/Configurator/UrlConfigurator.php
+++ b/src/Field/Configurator/UrlConfigurator.php
@@ -23,6 +23,7 @@ final class UrlConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $field->setFormTypeOptionIfNotSet('attr.inputmode', 'url');
+        $field->setFormTypeOptionIfNotSet('default_protocol', $field->getCustomOption(UrlField::OPTION_DEFAULT_PROTOCOL));
 
         $prettyUrl = str_replace(['http://www.', 'https://www.', 'http://', 'https://'], '', (string) $field->getValue());
         $prettyUrl = rtrim($prettyUrl, '/');

--- a/src/Field/UrlField.php
+++ b/src/Field/UrlField.php
@@ -13,6 +13,8 @@ final class UrlField implements FieldInterface
 {
     use FieldTrait;
 
+    public const OPTION_DEFAULT_PROTOCOL = 'defaultProtocol';
+
     /**
      * @param TranslatableInterface|string|false|null $label
      */
@@ -24,6 +26,20 @@ final class UrlField implements FieldInterface
             ->setTemplateName('crud/field/url')
             ->setFormType(UrlType::class)
             ->addCssClass('field-url')
-            ->setDefaultColumns('col-md-10 col-xxl-8');
+            ->setDefaultColumns('col-md-10 col-xxl-8')
+            ->setCustomOption(self::OPTION_DEFAULT_PROTOCOL, null);
+    }
+
+    /**
+     * Defines the protocol prepended to the URL if it doesn't include it.
+     * If not set, no protocol is prepended to the URL and the field is rendered
+     * using an <input type="url"> HTML element to enable local browser validation.
+     * See https://symfony.com/doc/current/reference/forms/types/url.html#default-protocol.
+     */
+    public function setDefaultProtocol(string $protocol): self
+    {
+        $this->setCustomOption(self::OPTION_DEFAULT_PROTOCOL, $protocol);
+
+        return $this;
     }
 }

--- a/tests/Field/AbstractFieldTest.php
+++ b/tests/Field/AbstractFieldTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
@@ -30,15 +31,16 @@ abstract class AbstractFieldTest extends KernelTestCase
         return $this->entityDto = $entityDtoMock;
     }
 
-    private function getAdminContext(string $pageName, string $requestLocale): AdminContext
+    private function getAdminContext(string $pageName, string $requestLocale, string $actionName): AdminContext
     {
         self::bootKernel();
 
         $crudMock = $this->getMockBuilder(CrudDto::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getCurrentPage', 'getDatePattern', 'getDateTimePattern', 'getTimePattern'])
+            ->onlyMethods(['getCurrentPage', 'getCurrentAction', 'getDatePattern', 'getDateTimePattern', 'getTimePattern'])
             ->getMock();
         $crudMock->method('getCurrentPage')->willReturn($pageName);
+        $crudMock->method('getCurrentAction')->willReturn($actionName);
         $crudMock->method('getDatePattern')->willReturn(DateTimeField::FORMAT_MEDIUM);
         $crudMock->method('getTimePattern')->willReturn(DateTimeField::FORMAT_MEDIUM);
         $crudMock->method('getDateTimePattern')->willReturn([DateTimeField::FORMAT_MEDIUM, DateTimeField::FORMAT_MEDIUM]);
@@ -80,10 +82,10 @@ abstract class AbstractFieldTest extends KernelTestCase
         return $this->adminContext = $adminContextMock;
     }
 
-    protected function configure(FieldInterface $field, string $pageName = Crud::PAGE_INDEX, string $requestLocale = 'en'): FieldDto
+    protected function configure(FieldInterface $field, string $pageName = Crud::PAGE_INDEX, string $requestLocale = 'en', string $actionName = Action::INDEX): FieldDto
     {
         $fieldDto = $field->getAsDto();
-        $this->configurator->configure($fieldDto, $this->getEntityDto(), $this->getAdminContext($pageName, $requestLocale));
+        $this->configurator->configure($fieldDto, $this->getEntityDto(), $this->getAdminContext($pageName, $requestLocale, $actionName));
 
         return $fieldDto;
     }

--- a/tests/Field/UrlFieldTest.php
+++ b/tests/Field/UrlFieldTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\UrlConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\UrlField;
+
+class UrlFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testDefaultFieldOptions()
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo');
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        self::assertSame('url', $fieldDto->getFormTypeOption('attr.inputmode'));
+        self::assertNull($fieldDto->getCustomOption(UrlField::OPTION_DEFAULT_PROTOCOL));
+    }
+
+    /**
+     * @testWith [""]
+     *           ["http"]
+     *           ["https"]
+     *           ["ftp"]
+     */
+    public function testDefaultProtocolOption(string $defaultProtocol)
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo');
+        $field->setDefaultProtocol($defaultProtocol);
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        self::assertSame($defaultProtocol, $fieldDto->getCustomOption(UrlField::OPTION_DEFAULT_PROTOCOL));
+        self::assertSame($defaultProtocol, $fieldDto->getFormTypeOption('default_protocol'));
+    }
+
+    /**
+     * @testWith ["http://example.com", "example.com"]
+     *           ["https://example.com", "example.com"]
+     *           ["http://www.example.com", "example.com"]
+     *           ["https://www.example.com", "example.com"]
+     *           ["https://01234567890123456789012345678901234567890123456789.com", "0123456789012345678901234567890…"]
+     */
+    public function testFormattedValuesOnIndexAction(string $url, string $expectedRenderedUrl)
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->setValue($url);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($expectedRenderedUrl, $fieldDto->getFormattedValue());
+    }
+
+    private function initializeConfigurator(): void
+    {
+        self::bootKernel();
+        $this->configurator = new UrlConfigurator();
+    }
+}


### PR DESCRIPTION
I saw this deprecation today in a Symfony + EA app that uses `UrlField`:

<img width="962" alt="" src="https://github.com/user-attachments/assets/3f285481-6af7-4a44-b599-b28f6914eae7" />

This PR fixes the deprecation by setting the `null` value by default to this option. It also adds tests for this and other features of the UrlField.