### PR TITLE
Fix ugly URLs with i18n backends

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -141,9 +141,14 @@
                             {% endif %}
 
                             {% for localeDto in ea.dashboardLocales %}
+                                {% if ea.usePrettyUrls %}
+                                    {% set url = ea_url().set('_locale', localeDto.locale).set('entityId', app.request.attributes.get('entityId')) %}
+                                {% else %}
+                                    {% set url = ea_url().set('_locale', localeDto.locale) %}
+                                {% endif %}
                                 <twig:ea:ActionMenu:ActionList:Item
                                     class="{{ app.request.locale == localeDto.locale ? 'active' }}"
-                                    url="{{ ea_url().set('_locale', localeDto.locale).set('entityId', app.request.attributes.get('entityId')).generateUrl() }}"
+                                    url="{{ url.generateUrl() }}"
                                     icon="{{ localeDto.icon }}" label="{{ localeDto.name }}" />
                             {% endfor %}
 


### PR DESCRIPTION
#6688 fixed language change for pretty URLs but it broke ugly URLs.
Ugly URLs rely on existing query parameters. #6688 always sets the `entityId` from the attributes, but for ugly URLs it will always be missing