### PR TITLE
Keep URL absolute type for dashboards URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ tests: ## Run tests
 	rm -rf $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/test/cache/*
 	SYMFONY_DEPRECATIONS_HELPER='ignoreFile=./tests/baseline-ignore.txt' php vendor/bin/simple-phpunit -v
 	rm -rf $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/pretty_urls/test/cache/*
-	USE_PRETTY_URLS=1 php vendor/bin/simple-phpunit tests/Controller/PrettyUrls/PrettyUrlsController.php
+	USE_PRETTY_URLS=1 php vendor/bin/simple-phpunit tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
 tests-coverage: ## Generate test coverage
 	rm -rf $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/test/cache/*
 	XDEBUG_MODE=coverage php vendor/bin/simple-phpunit --coverage-html $(shell php -r "echo sys_get_temp_dir();")/com.github.easycorp.easyadmin/tests/var/test/coverage/

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -279,14 +279,14 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         );
         ksort($routeParameters, \SORT_STRING);
 
+        $context = $this->adminContextProvider->getContext();
+        $urlType = null !== $context && false === $context->getAbsoluteUrls() ? UrlGeneratorInterface::ABSOLUTE_PATH : UrlGeneratorInterface::ABSOLUTE_URL;
+
         // if no route parameters are passed, the route doesn't point to any CRUD controller
         // action or to any custom action/route; consider it a link to the current dashboard
         if ([] === $routeParameters) {
-            return $this->urlGenerator->generate($this->dashboardRoute);
+            return $this->urlGenerator->generate($this->dashboardRoute, [], $urlType);
         }
-
-        $context = $this->adminContextProvider->getContext();
-        $urlType = null !== $context && false === $context->getAbsoluteUrls() ? UrlGeneratorInterface::ABSOLUTE_PATH : UrlGeneratorInterface::ABSOLUTE_URL;
 
         if (null !== $this->get(EA::ROUTE_NAME)) {
             return $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType);

--- a/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
+++ b/tests/Controller/PrettyUrls/PrettyUrlsControllerTest.php
@@ -117,7 +117,7 @@ class PrettyUrlsControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/admin/pretty/urls/category');
 
         // assert the Dashboard link points to the right URL
-        $this->assertSame('/admin/pretty/urls', $crawler->filter('.menu-item a:contains("Dashboard")')->attr('href'));
+        $this->assertSame('http://localhost/admin/pretty/urls', $crawler->filter('.menu-item a:contains("Dashboard")')->attr('href'));
         // assert the main menu contains the right items pointing to the right URLs
         $this->assertSelectorExists('.menu-item a:contains("Dashboard")');
         $this->assertSelectorExists('.menu-item.active a:contains("Categories")');
@@ -129,7 +129,7 @@ class PrettyUrlsControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/second/dashboard/user-editor/custom/path-for-index');
 
         // assert the Dashboard link points to the right URL
-        $this->assertSame('/second/dashboard', $crawler->filter('.menu-item a:contains("Dashboard")')->attr('href'));
+        $this->assertSame('http://localhost/second/dashboard', $crawler->filter('.menu-item a:contains("Dashboard")')->attr('href'));
         // assert the main menu contains the right items pointing to the right URLs
         $this->assertSelectorExists('.menu-item a:contains("Dashboard")');
         $this->assertSelectorNotExists('.menu-item.active a:contains("Categories")');
@@ -168,7 +168,7 @@ class PrettyUrlsControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/admin/pretty/urls/blog-post');
 
         $this->assertSame('/admin/pretty/urls', $crawler->filter('#header-logo a.logo')->attr('href'), 'The main Dashboard logo link points to the dashboard entry URL');
-        $this->assertSame('/admin/pretty/urls', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the dashboard entry URL (even if it later redirects to some other entity)');
+        $this->assertSame('http://localhost/admin/pretty/urls', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the dashboard entry URL (even if it later redirects to some other entity)');
         $this->assertSame('http://localhost/admin/pretty/urls/blog-post', $crawler->filter('li.menu-item a:contains("Blog Posts")')->attr('href'));
         $this->assertSame('http://localhost/admin/pretty/urls/category', $crawler->filter('li.menu-item a:contains("Categories")')->attr('href'));
     }
@@ -181,7 +181,7 @@ class PrettyUrlsControllerTest extends WebTestCase
         $crawler = $client->request('GET', '/second/dashboard/user-editor/custom/path-for-index');
 
         $this->assertSame('/second/dashboard', $crawler->filter('#header-logo a.logo')->attr('href'), 'The main Dashboard logo link points to the dashboard entry URL');
-        $this->assertSame('/second/dashboard', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the dashboard entry URL (even if it later redirects to some other entity)');
+        $this->assertSame('http://localhost/second/dashboard', $crawler->filter('li.menu-item a:contains("Dashboard")')->attr('href'), 'The Dashboard link inside the menu points to the dashboard entry URL (even if it later redirects to some other entity)');
         $this->assertSame('http://localhost/second/dashboard/user-editor/custom/path-for-index', $crawler->filter('li.menu-item a:contains("Users")')->attr('href'));
     }
 

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -69,7 +69,7 @@ class AdminUrlGeneratorTest extends WebTestCase
 
         $adminUrlGenerator->set('foo1', 'bar1');
         $adminUrlGenerator->unsetAll();
-        $this->assertSame('/admin', $adminUrlGenerator->generateUrl());
+        $this->assertSame('http://localhost/admin', $adminUrlGenerator->generateUrl());
     }
 
     public function testUnsetAllExcept()


### PR DESCRIPTION
#6567 Fixed an edgecase, but it lost the case for `absolute URL`.
This PR keeds the edgecase fix, but keeps the `absolute URL` if needed.