### PR TITLE
Make NullFilter::CHOICE_VALUE_* consts public

### DIFF
--- a/src/Filter/NullFilter.php
+++ b/src/Filter/NullFilter.php
@@ -18,8 +18,8 @@ final class NullFilter implements FilterInterface
 {
     use FilterTrait;
 
-    private const CHOICE_VALUE_NULL = 'null';
-    private const CHOICE_VALUE_NOT_NULL = 'not_null';
+    public const CHOICE_VALUE_NULL = 'null';
+    public const CHOICE_VALUE_NOT_NULL = 'not_null';
 
     public static function new(string $propertyName, $label = null): self
     {


### PR DESCRIPTION
User may wish to use these constants in their applications to not rely on magic strings.

Closes #5917 (a very simple suggestion that's pending since 2023)
