### PR TITLE
Provide $previous exception context for EntityRemoveException

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -372,7 +372,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         try {
             $this->deleteEntity($this->container->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
         } catch (ForeignKeyConstraintViolationException $e) {
-            throw new EntityRemoveException(['entity_name' => $context->getEntity()->getName(), 'message' => $e->getMessage()]);
+            throw new EntityRemoveException(['entity_name' => $context->getEntity()->getName(), 'message' => $e->getMessage()], $e);
         }
 
         $this->container->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));
@@ -433,7 +433,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             try {
                 $this->deleteEntity($entityManager, $entityInstance);
             } catch (ForeignKeyConstraintViolationException $e) {
-                throw new EntityRemoveException(['entity_name' => $entityDto->toString(), 'message' => $e->getMessage()]);
+                throw new EntityRemoveException(['entity_name' => $entityDto->toString(), 'message' => $e->getMessage()], $e);
             }
 
             $this->container->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));

--- a/src/Exception/BaseException.php
+++ b/src/Exception/BaseException.php
@@ -12,10 +12,10 @@ class BaseException extends HttpException
 {
     private ExceptionContext $context;
 
-    public function __construct(ExceptionContext $context)
+    public function __construct(ExceptionContext $context, ?\Throwable $previous = null)
     {
         $this->context = $context;
-        parent::__construct($this->context->getStatusCode(), $this->context->getDebugMessage());
+        parent::__construct($this->context->getStatusCode(), $this->context->getDebugMessage(), $previous);
     }
 
     public function getContext(): ExceptionContext

--- a/src/Exception/EntityRemoveException.php
+++ b/src/Exception/EntityRemoveException.php
@@ -9,7 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\ExceptionContext;
  */
 final class EntityRemoveException extends BaseException
 {
-    public function __construct(array $parameters = [])
+    public function __construct(array $parameters = [], ?\Throwable $previous = null)
     {
         $exceptionContext = new ExceptionContext(
             'exception.entity_remove',
@@ -18,6 +18,6 @@ final class EntityRemoveException extends BaseException
             409
         );
 
-        parent::__construct($exceptionContext);
+        parent::__construct($exceptionContext, $previous);
     }
 }


### PR DESCRIPTION
Closes #6615

I checked the other exceptions defined by EasyAdmin but it seems none other can utilize `$previous`.
