### PR TITLE
Add default locale to all pretty routes

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -216,6 +216,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, service('cache.easyadmin'))
             ->arg(3, service('filesystem'))
             ->arg(4, '%kernel.build_dir%')
+            ->arg(5, '%kernel.default_locale%')
 
         ->set(AdminRouteLoader::class)
             ->arg(0, service(AdminRouteGenerator::class))

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -68,6 +68,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         private CacheItemPoolInterface $cache,
         private Filesystem $filesystem,
         private string $buildDir,
+        private string $defaultLocale,
     ) {
     }
 
@@ -158,6 +159,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
                     }
 
                     $defaults = [
+                        '_locale' => $this->defaultLocale,
                         '_controller' => $crudControllerFqcn.'::'.$actionName,
                         EA::ROUTE_CREATED_BY_EASYADMIN => true,
                         EA::DASHBOARD_CONTROLLER_FQCN => $dashboardFqcn,

--- a/tests/Router/AdminRouteGeneratorTest.php
+++ b/tests/Router/AdminRouteGeneratorTest.php
@@ -63,6 +63,7 @@ class AdminRouteGeneratorTest extends WebTestCase
             $cacheMock,
             new Filesystem(),
             $client->getKernel()->getBuildDir(),
+            'en',
         );
 
         $routeName = $adminRouteGenerator->findRouteName($dashboardControllerFqcn, $crudControllerFqcn, $action);


### PR DESCRIPTION
This PR is a fix for an issue I'm having in tests with a multilingual app using pretty urls. The issue does not occur when using old urls. My issue is that I had the following error when generating urls in tests using `CrudTestUrlGeneration` trait

```
Some mandatory parameters are missing ("_locale") to generate a URL for route "admin_..."
```

This exception is thrown in [UrlGenerator](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Routing/Generator/UrlGenerator.php#L150) when no locale is found in route defaults, request context or parameters.

When NOT using pretty urls, the `_locale` is present in [route defaults](https://github.com/symfony/symfony/blob/7.2/src/Symfony/Component/Routing/Generator/CompiledUrlGenerator.php#L55), but when using pretty urls there is no locale.

The PR adds the default `_locale` for all routes generated by EasyAdmin.