### PR TITLE
Made the cache warmer optional

### DIFF
--- a/src/Cache/CacheWarmer.php
+++ b/src/Cache/CacheWarmer.php
@@ -25,7 +25,7 @@ final class CacheWarmer implements CacheWarmerInterface
 
     public function isOptional(): bool
     {
-        return false;
+        return true;
     }
 
     public function warmUp(string $cacheDir, ?string $buildDir = null): array


### PR DESCRIPTION
I originally made the cache warmer required because the application cannot work without this information. But, Nicolas recommended to make it optional, so let's do that. See https://github.com/symfony/symfony/issues/59445#issuecomment-2607628660