### PR TITLE
Use AdminUrlGenerator instead of Symfony URL generator

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -758,7 +758,7 @@ You can use any of these routes to generate the admin URLs thanks to the
     ]);
 
     // generating an admin URL in a Twig template
-    <a href="{{ path('admin_blog_post_edit', {entityId: post.id}) }}">Edit Blog Post</a>
+    <a href="{{ ea_url().setRoute('admin_blog_post_edit', {entityId: post.id}) }}">Edit Blog Post</a>
 
 Building Admin URLs
 ~~~~~~~~~~~~~~~~~~~

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -190,7 +190,7 @@
 
                         <div id="responsive-header-logo" class="text-truncate ms-auto">
                             {% block responsive_header_logo %}
-                                <a class="responsive-logo" title="{{ ea.dashboardTitle|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
+                                <a class="responsive-logo" title="{{ ea.dashboardTitle|striptags }}" href="{{ ea_url().setRoute(ea.dashboardRouteName) }}">
                                     {{ ea.dashboardTitle|raw }}
                                 </a>
                             {% endblock responsive_header_logo %}
@@ -224,7 +224,7 @@
                                     {% block header_navbar %}
                                         <div id="header-logo">
                                             {% block header_logo %}
-                                                <a class="logo" title="{{ ea.dashboardTitle|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
+                                                <a class="logo" title="{{ ea.dashboardTitle|striptags }}" href="{{ ea_url().setRoute(ea.dashboardRouteName) }}">
                                                     <span class="logo-custom">{{ ea.dashboardTitle|raw }}</span>
                                                     <span class="logo-compact"><twig:ea:Icon name="internal:home" /></span>
                                                 </a>

--- a/templates/page/login.html.twig
+++ b/templates/page/login.html.twig
@@ -29,7 +29,7 @@
                 {% block header_logo %}
                     {% if page_title %}
                         {% if ea.hasContext %}
-                            <a class="logo {{ page_title|length > 14 ? 'logo-long' }}" title="{{ page_title|striptags }}" href="{{ path(ea.dashboardRouteName) }}">
+                            <a class="logo {{ page_title|length > 14 ? 'logo-long' }}" title="{{ page_title|striptags }}" href="{{ ea_url().setRoute(ea.dashboardRouteName) }}">
                                 {{ page_title|raw }}
                             </a>
                         {% else %}
@@ -55,7 +55,7 @@
                     <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrf_token_intention) }}">
                 {% endif %}
 
-                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea.hasContext ? path(ea.dashboardRouteName) : '/') }}" />
+                <input type="hidden" name="{{ target_path_parameter|default('_target_path') }}" value="{{ target_path|default(ea.hasContext ? ea_url().setRoute(ea.dashboardRouteName) : '/') }}" />
 
                 {% block login_form_credentials_wrapper %}
                     <div class="form-group">


### PR DESCRIPTION
### Context

I'm decorating `AdminUrlGenerator` to allow using parameters in the admin path.

### Error

Some templates are using Symfony's [path](https://symfony.com/doc/current/reference/twig_reference.html#path) instead of `ea_url`, which generates this error:

> Twig\Error\RuntimeError
> 
> An exception has been thrown during the rendering of a template ("Some mandatory parameters are missing ("<parameter>") to generate a URL for route "some_dashboard".").
