### PR TITLE
fix custom action not working when url has a search query

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -303,7 +303,7 @@
                                                         {% if app.request.get('query') %}
                                                             {% set search_reset_url = ea_url().unset('query') %}
                                                             {% if ea.usePrettyUrls %}
-                                                                {% set search_reset_url = ea_url().unset('query').setController(ea.request.attributes.get('crudControllerFqcn')).setAction('index').set('page', 1) %}
+                                                                {% set search_reset_url = ea_url().unset('query').setController(crudController).setAction('index').set('page', 1) %}
                                                             {% endif %}
                                                             <a href="{{ search_reset_url }}" class="content-search-reset">
                                                                 <twig:ea:Icon name="internal:xmark" />


### PR DESCRIPTION
the controller was not retrieved from the ugly url

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
