### PR TITLE
Allow for custom routes to use EasyAdmin's context, especially in templates

### DIFF
--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -253,7 +253,7 @@ class AdminRouterSubscriber implements EventSubscriberInterface
      */
     private function getDashboardControllerFqcn(Request $request): ?string
     {
-        $controller = $request->attributes->get('_controller');
+        $controller = $request->attributes->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $request->attributes->get('_controller');
         $controllerFqcn = null;
 
         if (\is_string($controller)) {


### PR DESCRIPTION
Currently, if you create a normal Controller class and render a template that contains this code:

```twig
{% extends '@EasyAdmin/page/content.html.twig' %}
```

You end up having this error:

`An exception has been thrown during the rendering of a template ("Call to a member function getTemplatePath() on null").`

The reason for this bug is that there is no AdminContext set in the request, because the request is not served by a `DashboardControllerInterface` nor a `CrudControllerInterface`.

Considering the fact that it's possible to create an AdminContext without a CrudController (makes sense, for the main page for example), as of the signature of the `AdminContextFactory::create()` method: 

```php
public function create(
    Request $request,
    DashboardControllerInterface $dashboardController,
    ?CrudControllerInterface $crudController,
    ?string $actionName = null
): AdminContext
```

This PR allows doing things like this:

```php
#[Route('/admin/my_route', name: 'admin_my_route', defaults: [
    EA::DASHBOARD_CONTROLLER_FQCN => DashboardController::class,
])]
```

And since the `EA::DASHBOARD_CONTROLLER_FQCN` Request attribute is only set in routes generated by EasyAdmin, there should be no conflicts with the existing codebase or with existing admins around.

And by doing so, you can create **any** controller and still use EasyAdmin's base templates 👌

**Note:** I'm using exactly this one-line change in one of my projects, so having this PR merged would be great 😁