### PR TITLE
Update dashboards.rst

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -70,6 +70,7 @@ first in your application. To do so, create this file:
     easyadmin:
         resource: .
         type: easyadmin.routes
+        prefix: /admin
 
 .. note::
 


### PR DESCRIPTION
Added /admin prefix to the easyadmin.yaml because without it pretty admin urls are not secured by the global ^/admin access control.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
