### PR TITLE
disable switch if user has no permission to edit

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -338,7 +338,8 @@ return static function (ContainerConfigurator $container) {
 
         ->set(BooleanConfigurator::class)
             ->arg(0, service(AdminUrlGenerator::class))
-            ->arg(1, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
+            ->arg(1, new Reference(AuthorizationChecker::class))
+            ->arg(2, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
 
         ->set(CollectionConfigurator::class)
 


### PR DESCRIPTION
This PR aims to make the switch completely disabled on index page if the edit action is disabled or user does not have enough permission to execute edit action

```php
public function configureFields(string $pageName): iterable
    {
        return [
            BooleanField::new('isPublished'),
        ];
    }

public function configureActions(Actions $actions): Actions
    {
        return $actions
            ->disable(Action::EDIT) // completely disable EDIT action
            ->setPermission(Action::EDIT, 'ROLE_ADMIN') // minimum role to execute EDIT action
        ;
    }
```

current condition, the switch is toggleable when user clicks it then it creates an ajax request and gets 403 then switch disabled

---

I'm a little worried about reordering `BooleanConfigurator` constructor but if it does not reorder I get a deprecated message
```
Deprecated: Optional parameter $csrfTokenManager declared before required parameter $authChecker is implicitly treated as a required parameter
```