### PR TITLE
Fix autocomplete context crud controller for embedded forms

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -158,8 +158,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                     ->setController($targetCrudControllerFqcn)
                     ->setAction('autocomplete')
                     ->set(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT, [
-                        // when using pretty URLs, the data is in the request attributes instead of the autocomplete context
-                        EA::CRUD_CONTROLLER_FQCN => $context->getRequest()->attributes->get(EA::CRUD_CONTROLLER_FQCN) ?? $context->getRequest()->query->get(EA::CRUD_CONTROLLER_FQCN),
+                        EA::CRUD_CONTROLLER_FQCN => $context->getCrudControllers()->findCrudFqcnByEntityFqcn($entityDto->getFqcn()),
                         'propertyName' => $propertyName,
                         'originatingPage' => $context->getCrud()->getCurrentPage(),
                     ])


### PR DESCRIPTION
If you have embedded form with association autocomplete field and have defined `setQueryBuilder` there, then it will not applied as `crudControllerFqcn` comes from request now.
But request has info about parent controller, not embedded. So configurator can not find field with configured query builder and it does not applied.