### PR TITLE
Mark all controller registries as deprecated

### DIFF
--- a/src/Registry/CrudControllerRegistry.php
+++ b/src/Registry/CrudControllerRegistry.php
@@ -4,6 +4,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @deprecated since 4.25.0, will be removed in EasyAdmin 5.0.0. This registry is generally not needed by developers in newer versions of EasyAdmin. If you require similar functionality, use the equivalent item in the Symfony Cache pool managed by EasyAdmin (inject the "cache.easyadmin" service).
  */
 final class CrudControllerRegistry
 {

--- a/src/Registry/DashboardControllerRegistry.php
+++ b/src/Registry/DashboardControllerRegistry.php
@@ -5,6 +5,9 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 use EasyCorp\Bundle\EasyAdminBundle\Cache\CacheWarmer;
 use function Symfony\Component\String\u;
 
+/**
+ * @deprecated since 4.25.0, will be removed in EasyAdmin 5.0.0. This registry is generally not needed by developers in newer versions of EasyAdmin. If you require similar functionality, use the equivalent item in the Symfony Cache pool managed by EasyAdmin (inject the "cache.easyadmin" service).
+ */
 final class DashboardControllerRegistry implements DashboardControllerRegistryInterface
 {
     private array $controllerFqcnToRouteMap = [];

--- a/src/Registry/DashboardControllerRegistryInterface.php
+++ b/src/Registry/DashboardControllerRegistryInterface.php
@@ -2,6 +2,9 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 
+/**
+ * @deprecated since 4.25.0, will be removed in EasyAdmin 5.0.0. This registry is generally not needed by developers in newer versions of EasyAdmin.
+ */
 interface DashboardControllerRegistryInterface
 {
     public function getControllerFqcnByContextId(string $contextId): ?string;


### PR DESCRIPTION
These registries should not be needed by developers ... but EasyAdmin 5.x will offer something equivalent via some cache pool items.