### PR TITLE
Change AdminRouterSubscriber::getSymfonyControllerFqcn so it generates relative paths

### DIFF
--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -289,7 +289,7 @@ class AdminRouterSubscriber implements EventSubscriberInterface
     {
         $routeName = $request->query->get(EA::ROUTE_NAME);
         $routeParams = $request->query->all()[EA::ROUTE_PARAMS] ?? [];
-        $url = $this->urlGenerator->generate($routeName, $routeParams);
+        $url = $this->urlGenerator->generate($routeName, $routeParams, UrlGeneratorInterface::RELATIVE_PATH);
 
         $newRequest = $request->duplicate();
         $newRequest->attributes->remove('_controller');


### PR DESCRIPTION
Change the behavior of "\EasyCorp\Bundle\EasyAdminBundle\EventListener\AdminRouterSubscriber::getSymfonyControllerFqcn" to generate relative path instead of absolute path, so it is compatible with applications running behind a proxy under a permanent subpath prefix (AKA sub-folder, sub-url or sub-path - using the HTTP header `x-forwarded-prefix`).

Linked issue: https://github.com/EasyCorp/EasyAdminBundle/issues/6805