### PR TITLE
fix: remaining calls to deprecated getReferrer method

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -387,7 +387,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $event->getResponse();
         }
 
-        if (null !== $referrer = $context->getReferrer()) {
+        if (null !== $referrer = $context->getRequest()->headers->get('referrer')) {
             return $this->redirect($referrer);
         }
 
@@ -450,7 +450,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             return $event->getResponse();
         }
 
-        return $this->redirect($batchActionDto->getReferrerUrl());
+        return $this->redirect($context->getRequest()->headers->get('referer'));
     }
 
     public function autocomplete(AdminContext $context): JsonResponse
@@ -638,7 +638,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
                 ->setAction(Action::EDIT)
                 ->setEntityId($context->getEntity()->getPrimaryKeyValue())
                 ->generateUrl(),
-            Action::SAVE_AND_RETURN => $context->getReferrer()
+            Action::SAVE_AND_RETURN => $context->getRequest()->headers->get('referer')
                 ?? $this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl(),
             Action::SAVE_AND_ADD_ANOTHER => $this->container->get(AdminUrlGenerator::class)->setAction(Action::NEW)->generateUrl(),
             default => $this->generateUrl($context->getDashboardRouteName()),


### PR DESCRIPTION
Hi,

Small PR to fix deprecations caused by remaining calls still made to the deprecated `getReferrer()` method in #6684