### PR TITLE
Always return to index when using SAVE_AND_RETURN button

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -639,8 +639,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
                 ->setAction(Action::EDIT)
                 ->setEntityId($context->getEntity()->getPrimaryKeyValue())
                 ->generateUrl(),
-            Action::SAVE_AND_RETURN => $context->getRequest()->headers->get('referer')
-                ?? $this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl(),
+            Action::SAVE_AND_RETURN => $this->container->get(AdminUrlGenerator::class)->setAction(Action::INDEX)->generateUrl(),
             Action::SAVE_AND_ADD_ANOTHER => $this->container->get(AdminUrlGenerator::class)->setAction(Action::NEW)->generateUrl(),
             default => $this->generateUrl($context->getDashboardRouteName()),
         };


### PR DESCRIPTION
Fixes: #6830

Note: #6822 fixed the deprected usage of the getReferrer, but the getReferrer method returned empty, thus the redirect to the list was working