### PR TITLE
fix(chore): resolve problem of inherit attribute

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -309,10 +309,22 @@ final class EntityRepository implements EntityRepositoryInterface
                     ? $associatedEntityDto->getFqcn()
                     : $entityDto->getFqcn()
                 ;
+
                 /** @var \ReflectionNamedType|\ReflectionUnionType|null $idClassType */
-                $idClassType = (new \ReflectionProperty($entityFqcn, $propertyName))->getType();
+                $idClassType = null;
+                $reflectionClass = new \ReflectionClass($entityFqcn);
+
+                while (false !== $reflectionClass) {
+                    if ($reflectionClass->hasProperty($propertyName)) {
+                        $reflection = $reflectionClass->getProperty($propertyName);
+                        $idClassType = $reflection->getType();
+                        break;
+                    }
+                    $reflectionClass = $reflectionClass->getParentClass();
+                }
 
                 if (null !== $idClassType) {
+                    /** @var \ReflectionNamedType|\ReflectionUnionType|null $idClassType */
                     $idClassName = $idClassType->getName();
 
                     if (class_exists($idClassName)) {


### PR DESCRIPTION
fix #6849 #6853 

This pull request addresses an issue where EasyAdmin fails to handle inherited properties during global search. Specifically, the issue arises when EasyAdmin tries to reflect on a property that exists in a parent class but not in the current class. The current implementation of property reflection does not account for inherited properties in parent classes, leading to errors when performing a global search.

