### PR TITLE
Support for objects in ChoiceField

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -139,7 +139,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
                 $selectedValue instanceof \UnitEnum => $selectedValue->name,
                 default => $selectedValue,
             };
-            if (is_object($selectedValue) && $selectedValue instanceof Stringable) {
+            if (is_object($selectedValue) && $selectedValue instanceof \Stringable) {
                 $selectedValue = (string)$selectedValue;
             }
             if (null !== $selectedLabel = $flippedChoices[$selectedValue] ?? null) {

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -137,11 +137,9 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
                 // We check if $allChoicesAreEnums is true for enum's and choices array is generated using ->name as index
                 $selectedValue instanceof \BackedEnum => $allChoicesAreEnums && $choicesSupportTranslatableInterface ? $selectedValue->name : $selectedValue->value,
                 $selectedValue instanceof \UnitEnum => $selectedValue->name,
+                \is_object($selectedValue) && $selectedValue instanceof \Stringable => (string) $selectedValue,
                 default => $selectedValue,
             };
-            if (\is_object($selectedValue) && $selectedValue instanceof \Stringable) {
-                $selectedValue = (string) $selectedValue;
-            }
             if (null !== $selectedLabel = $flippedChoices[$selectedValue] ?? null) {
                 if ($selectedLabel instanceof TranslatableInterface) {
                     $choiceMessage = $selectedLabel;

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -139,7 +139,10 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
                 $selectedValue instanceof \UnitEnum => $selectedValue->name,
                 default => $selectedValue,
             };
-            if (null !== $selectedLabel = $flippedChoices[(string) $selectedValue] ?? null) {
+            if (is_object($selectedValue) && $selectedValue instanceof Stringable) {
+                $selectedValue = (string)$selectedValue;
+            }
+            if (null !== $selectedLabel = $flippedChoices[$selectedValue] ?? null) {
                 if ($selectedLabel instanceof TranslatableInterface) {
                     $choiceMessage = $selectedLabel;
                 } else {

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -139,8 +139,8 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
                 $selectedValue instanceof \UnitEnum => $selectedValue->name,
                 default => $selectedValue,
             };
-            if (is_object($selectedValue) && $selectedValue instanceof \Stringable) {
-                $selectedValue = (string)$selectedValue;
+            if (\is_object($selectedValue) && $selectedValue instanceof \Stringable) {
+                $selectedValue = (string) $selectedValue;
             }
             if (null !== $selectedLabel = $flippedChoices[$selectedValue] ?? null) {
                 if ($selectedLabel instanceof TranslatableInterface) {

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -139,7 +139,7 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
                 $selectedValue instanceof \UnitEnum => $selectedValue->name,
                 default => $selectedValue,
             };
-            if (null !== $selectedLabel = $flippedChoices[$selectedValue] ?? null) {
+            if (null !== $selectedLabel = $flippedChoices[(string) $selectedValue] ?? null) {
                 if ($selectedLabel instanceof TranslatableInterface) {
                     $choiceMessage = $selectedLabel;
                 } else {


### PR DESCRIPTION
I currently working on a project which uses the oauth server and clients from league. The server is using values objects for grants, redirect uris and scopes.

Just by using a ChoiceField I got the error:

```
Uncaught PHP Exception TypeError: "Cannot access offset of type League\Bundle\OAuth2ServerBundle\ValueObject\Grant on array" at ChoiceConfigurator.php line 142 {"exception":"[object] (TypeError(code: 0): Cannot access offset of type League\\Bundle\\OAuth2ServerBundle\\ValueObject\\Grant on array at [...]/vendor/easycorp/easyadmin-bundle/src/Field/Configurator/ChoiceConfigurator.php:142)"} []
```

This is a simple fix to provide support for any object which implements stringable.
