### PR TITLE
fix: Do not override HTML attribute `title` if already set for Action…

### DIFF
--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -157,9 +157,10 @@ final class ActionFactory
     private function processActionLabel(ActionDto $actionDto, ?EntityDto $entityDto, string $translationDomain, array $defaultTranslationParameters): void
     {
         $label = $actionDto->getLabel();
+        $title = $actionDto->getHtmlAttributes()['title'] ?? '';
 
         // FALSE means that action doesn't show a visible label in the interface
-        if (false === $label) {
+        if (false === $label && '' === trim($title)) {
             $actionDto->setHtmlAttribute('title', $actionDto->getName());
 
             return;


### PR DESCRIPTION
If an action has no label but has the HTML attribute already set, it should not be replaced by the action name.

Use case example:

```php
$moveDown = Action::new('moveDown', false, 'fa fa-angle-down')
    ->setHtmlAttributes(['title' => $this->trans('Move Down')])
    ->linkToCrudAction('moveDown')
    ->displayIf(static fn(SortableEntityInterface $entity): bool => $entity->getPosition() < $entityCount - 1)
;
```