### PR TITLE
fix: get controllers fqcn for route load

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -211,8 +211,8 @@ return static function (ContainerConfigurator $container) {
             ->tag('cache.pool')
 
         ->set(AdminRouteGenerator::class)
-            ->arg(0, tagged_iterator(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER))
-            ->arg(1, tagged_iterator(EasyAdminExtension::TAG_CRUD_CONTROLLER))
+            ->arg(0, abstract_arg(sprintf('class list of %s tag', EasyAdminExtension::TAG_DASHBOARD_CONTROLLER)))
+            ->arg(1, abstract_arg(sprintf('class list of %s tag', EasyAdminExtension::TAG_CRUD_CONTROLLER)))
             ->arg(2, service('cache.easyadmin'))
             ->arg(3, service('filesystem'))
             ->arg(4, '%kernel.build_dir%')

--- a/src/DependencyInjection/AdminRoutePass.php
+++ b/src/DependencyInjection/AdminRoutePass.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\DependencyInjection;
+
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteGenerator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @author Indra Gunawan <hello@indra.my.id>
+ */
+class AdminRoutePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $dashboardControllersFqcn = array_map(
+            static function ($serviceId) use ($container) {
+                return $container->getDefinition($serviceId)->getClass();
+            },
+            array_keys($container->findTaggedServiceIds(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER, true))
+        );
+
+        $crudControllersFqcn = array_map(
+            static function ($serviceId) use ($container) {
+                return $container->getDefinition($serviceId)->getClass();
+            },
+            array_keys($container->findTaggedServiceIds(EasyAdminExtension::TAG_CRUD_CONTROLLER, true))
+        );
+
+        $container->getDefinition(AdminRouteGenerator::class)
+            ->setArgument(0, $dashboardControllersFqcn)
+            ->setArgument(1, $crudControllersFqcn)
+        ;
+    }
+}

--- a/src/EasyAdminBundle.php
+++ b/src/EasyAdminBundle.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle;
 
+use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\AdminRoutePass;
 use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\CreateControllerRegistriesPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -16,6 +17,7 @@ class EasyAdminBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new CreateControllerRegistriesPass());
+        $container->addCompilerPass(new AdminRoutePass());
     }
 
     public function getPath(): string

--- a/src/Factory/ControllerFactory.php
+++ b/src/Factory/ControllerFactory.php
@@ -54,11 +54,7 @@ final class ControllerFactory
         try {
             $controllerCallable = $this->controllerResolver->getController($newRequest);
         } catch (\InvalidArgumentException $e) {
-            $controllerCallable = false;
-        }
-
-        if (false === $controllerCallable) {
-            throw new NotFoundHttpException(sprintf('Unable to find the controller "%s::%s".', $controllerFqcn, $controllerAction));
+            throw new NotFoundHttpException(sprintf('Unable to find the controller "%s::%s".', $controllerFqcn, $controllerAction), $e);
         }
 
         if (!\is_array($controllerCallable)) {

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -63,8 +63,8 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
     private ?bool $applicationUsesPrettyUrls = null;
 
     public function __construct(
-        private iterable $dashboardControllers,
-        private iterable $crudControllers,
+        private array $dashboardControllersFqcn,
+        private array $crudControllersFqcn,
         private CacheItemPoolInterface $cache,
         private Filesystem $filesystem,
         private string $buildDir,
@@ -100,8 +100,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         $adminRoutes = $this->cache->getItem(self::CACHE_KEY_FQCN_TO_ROUTE)->get();
 
         if (null === $dashboardFqcn) {
-            $dashboardControllers = iterator_to_array($this->dashboardControllers);
-            $dashboardFqcn = $dashboardControllers[array_key_first($dashboardControllers)]::class;
+            $dashboardFqcn = reset($this->dashboardControllersFqcn);
         }
 
         return $adminRoutes[$dashboardFqcn][$crudControllerFqcn ?? ''][$actionName ?? ''] ?? null;
@@ -117,8 +116,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         /** @var array<string> $addedRouteNames Temporary cache that stores the route names to ensure that we don't add duplicated admin routes */
         $addedRouteNames = [];
 
-        foreach ($this->dashboardControllers as $dashboardController) {
-            $dashboardFqcn = $dashboardController::class;
+        foreach ($this->dashboardControllersFqcn as $dashboardFqcn) {
             [$allowedCrudControllers, $deniedCrudControllers] = $this->getAllowedAndDeniedControllers($dashboardFqcn);
             $defaultRoutesConfig = $this->getDefaultRoutesConfig($dashboardFqcn);
             $dashboardRouteConfig = $this->getDashboardsRouteConfig()[$dashboardFqcn];
@@ -130,9 +128,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
             }
 
             // then, create the routes of the CRUD controllers associated with the dashboard
-            foreach ($this->crudControllers as $crudController) {
-                $crudControllerFqcn = $crudController::class;
-
+            foreach ($this->crudControllersFqcn as $crudControllerFqcn) {
                 if (null !== $allowedCrudControllers && !\in_array($crudControllerFqcn, $allowedCrudControllers, true)) {
                     continue;
                 }
@@ -231,8 +227,8 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
     {
         $config = [];
 
-        foreach ($this->dashboardControllers as $dashboardController) {
-            $reflectionClass = new \ReflectionClass($dashboardController);
+        foreach ($this->dashboardControllersFqcn as $dashboardControllerFqcn) {
+            $reflectionClass = new \ReflectionClass($dashboardControllerFqcn);
 
             // first, check if the dashboard uses the #[AdminDashboard] attribute to define its route configuration;
             // this is the recommended way for modern EasyAdmin applications

--- a/tests/Router/AdminRouteGeneratorTest.php
+++ b/tests/Router/AdminRouteGeneratorTest.php
@@ -10,7 +10,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller\S
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Cache\CacheItem;
-use Symfony\Component\DependencyInjection\Argument\RewindableGenerator;
 use Symfony\Component\Filesystem\Filesystem;
 
 class AdminRouteGeneratorTest extends WebTestCase
@@ -52,13 +51,13 @@ class AdminRouteGeneratorTest extends WebTestCase
             return $item;
         });
 
-        $dashboardControllers = new RewindableGenerator(function () {
-            yield DashboardController::class => new DashboardController();
-            yield SecondDashboardController::class => new SecondDashboardController();
-        }, 2);
+        $dashboardControllersFqcn = [
+            DashboardController::class,
+            SecondDashboardController::class,
+        ];
 
         $adminRouteGenerator = new AdminRouteGenerator(
-            $dashboardControllers,
+            $dashboardControllersFqcn,
             [],
             $cacheMock,
             new Filesystem(),


### PR DESCRIPTION
fixes #6509

current behaviour: injecting `tagged_iterator` to `AdminRouteGenerator` while it only needs the controller class fqcn, make it initialize all the controllers (https://github.com/EasyCorp/EasyAdminBundle/issues/6509#issuecomment-2459872219)

example controller

```php
class BookCrudController extends AbstractCrudController
{
    public function __construct(
        #[Autowire(env: 'NOT_EXISTS')]
        private string $notExistsEnv,
    ) {
    }

    public static function getEntityFqcn(): string
    {
        return Book::class;
    }

    public function configureFields(string $pageName): iterable
    {
        return [
            TextField::new('title'),
            BooleanField::new('isPublished'),
        ];
    }
}
```

proposed solution: use CompilerPass to get all class fqcn