### PR TITLE
urlUsesPrettyUrls requires a valid value

### DIFF
--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -48,7 +48,7 @@ if (interface_exists(ValueResolverInterface::class)) {
 
         private function getReferrerUrl(AdminContext $adminContext, Request $request): string
         {
-            $urlUsesPrettyUrls = $request->attributes->has(EA::CRUD_CONTROLLER_FQCN);
+            $urlUsesPrettyUrls = $request->attributes->has(EA::CRUD_CONTROLLER_FQCN) && $request->attributes->get(EA::CRUD_CONTROLLER_FQCN);
             if ($urlUsesPrettyUrls) {
                 $crudControllerFqcn = $request->attributes->get(EA::CRUD_CONTROLLER_FQCN);
             } else {
@@ -103,7 +103,7 @@ if (interface_exists(ValueResolverInterface::class)) {
 
         private function getReferrerUrl(AdminContext $adminContext, Request $request): string
         {
-            $urlUsesPrettyUrls = $request->attributes->has(EA::CRUD_CONTROLLER_FQCN);
+            $urlUsesPrettyUrls = $request->attributes->has(EA::CRUD_CONTROLLER_FQCN) && $request->attributes->get(EA::CRUD_CONTROLLER_FQCN);
             if ($urlUsesPrettyUrls) {
                 $crudControllerFqcn = $request->attributes->get(EA::CRUD_CONTROLLER_FQCN);
             } else {


### PR DESCRIPTION
if crudControllerFqcn = null it's not a pretty url

This PR is how I fixed my error:
```
EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator::setController(): 
Argument #1 ($crudControllerFqcn) must be of type string, null given, 
called in vendor\easycorp\easyadmin-bundle\src\ArgumentResolver\BatchActionDtoResolver.php on line 66
```

The class was:
```php
class BuyingGuideCrudController extends AbstractCrudController
{
    // ...
    public function configureActions(Actions $actions): Actions
    {
        // ...

        $publishAction = Action::new('doPublish', 'Publier', 'fa fa-share-square')
            ->linkToCrudAction("publish");

        $unpublishAction = Action::new('doUnpublish', 'Retirer la publication', 'fa fa-minus-square')
            ->linkToCrudAction("unpublish");


        return $actions
            ->add(Crud::PAGE_INDEX, $toPreviewBuyingGuide)
            ->addBatchAction($publishAction)
            ->addBatchAction($unpublishAction);
    }

    // ...
    
    public function publish(BatchActionDto $batchActionDto): Response
    {
        // ...
```
