### PR TITLE
Error message div should not inherit widget attr.class CSS classes

### DIFF
--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -3,7 +3,7 @@
 
 {% block form_start %}
     {% if form.vars.errors|length > 0 and 'ea_crud' in form.vars.block_prefixes|default([]) %}
-        {{ form_errors(form, {attr: { class: 'global-invalid-feedback' }}) }}
+        {{ form_errors(form, {attr: { errorClass: 'global-invalid-feedback' }}) }}
     {% endif %}
 
     {{ parent() }}
@@ -22,7 +22,7 @@
 {% block form_errors %}
     {% if errors|length > 0 %}
         {% for error in errors %}
-            <div class="{{ attr.class|default('') }} invalid-feedback d-block">{{ error.message }}</div>
+            <div class="{{ attr.errorClass|default('') }} invalid-feedback d-block">{{ error.message }}</div>
         {% endfor %}
     {% endif %}
 {% endblock form_errors %}


### PR DESCRIPTION
Resulted in hilarious case of `tinymce` class being applied to the error message div and that error message div being initialized and displayed as a TinyMCE instance :)