### PR TITLE
remove $ so cut-and-paste works

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Installation
 EasyAdmin 4 requires PHP 8.0.2 or higher and Symfony 5.4 or higher. Run the
 following command to install it in your application:
 
-```
-$ composer require easycorp/easyadmin-bundle
+```bash
+composer require easycorp/easyadmin-bundle
 ```
 
 Documentation


### PR DESCRIPTION
I use the little gitclip widget to install bundles, but it leaves the $ on now.  This fixes that.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
