### PR TITLE
Render 'content_footer' block with raw filter in layout

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -378,7 +378,7 @@
                                     {% set content_footer = block('content_footer') is defined ? block('content_footer') : '' %}
                                     {% if content_footer is not empty %}
                                         <section class="content-footer">
-                                            {{ content_footer }}
+                                            {{ content_footer|raw }}
                                         </section>
                                     {% endif %}
                                 {% endblock %}


### PR DESCRIPTION
Rendering `content_footer|raw` enables to use HTML in the block. Currently there is no other way of using HTML when defining the `content_footer` block in your own template. And this shouldn't cause any BC-problems AFAIK.