### PR TITLE
Create InvalidEntityException to replace RuntimeException in EntityUpdater

### DIFF
--- a/src/Exception/InvalidEntityException.php
+++ b/src/Exception/InvalidEntityException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Exception;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class InvalidEntityException extends \RuntimeException
+{
+    public function __construct(
+        public readonly ConstraintViolationListInterface $violations,
+    ) {
+        parent::__construct((string) $this->violations);
+    }
+}

--- a/src/Orm/EntityUpdater.php
+++ b/src/Orm/EntityUpdater.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Orm;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityUpdaterInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Exception\InvalidEntityException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -34,7 +35,7 @@ final class EntityUpdater implements EntityUpdaterInterface
         /** @var ConstraintViolationList $violations */
         $violations = $this->validator->validate($entityInstance);
         if (0 < \count($violations)) {
-            throw new \RuntimeException((string) $violations);
+            throw new InvalidEntityException($violations);
         }
 
         $entityDto->setInstance($entityInstance);


### PR DESCRIPTION
Why? Because this would allow the EntityUpdater or another layer to catch this exception specifically, in order to handle validation errors differently than what EasyAdmin proposes.

This is minor, but it can have a huge impact on what I'm working on :) 