### PR TITLE
fix incorrect method names

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -878,8 +878,8 @@ contents to the ``<head>`` and/or ``<body>`` elements of the backend pages::
         ->addCssFiles('bundle/some-bundle/foo.css', 'some-custom-styles.css')
         ->addJsFiles('admin/some-custom-code.js')
         ->addWebpackEncoreEntry('admin-maps')
-        ->addHtmlContentToHead('<link rel="dns-prefetch" href="https://assets.example.com">')
-        ->addHtmlContentToBody('<!-- generated at '.time().' -->')
+        ->addHtmlContentsToHead('<link rel="dns-prefetch" href="https://assets.example.com">')
+        ->addHtmlContentsToBody('<!-- generated at '.time().' -->')
     ;
 
 By default, these web assets are loaded in all backend pages. If you need a more


### PR DESCRIPTION
the method names using the plural, contents, not content.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
