### PR TITLE
Remove orphaned `</div>` in `layout.html.twig`

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -390,7 +390,6 @@
                 {% endblock main_content_wrapper %}
             {% endblock wrapper %}
         </div>
-        </div>
     {% endblock wrapper_wrapper %}
 
     {% block body_javascript %}{% endblock body_javascript %}


### PR DESCRIPTION
Fix #6774 
