### PR TITLE
Remove default `_locale` parameter in AdminRouteGenerator

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -216,7 +216,6 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, service('cache.easyadmin'))
             ->arg(3, service('filesystem'))
             ->arg(4, '%kernel.build_dir%')
-            ->arg(5, '%kernel.default_locale%')
 
         ->set(AdminRouteLoader::class)
             ->arg(0, service(AdminRouteGenerator::class))

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -68,7 +68,6 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         private CacheItemPoolInterface $cache,
         private Filesystem $filesystem,
         private string $buildDir,
-        private string $defaultLocale,
     ) {
     }
 
@@ -166,7 +165,6 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
                     }
 
                     $defaults = [
-                        '_locale' => $this->defaultLocale,
                         '_controller' => $crudControllerFqcn.'::'.$actionName,
                         EA::ROUTE_CREATED_BY_EASYADMIN => true,
                         EA::DASHBOARD_CONTROLLER_FQCN => $dashboardFqcn,

--- a/tests/Router/AdminRouteGeneratorTest.php
+++ b/tests/Router/AdminRouteGeneratorTest.php
@@ -63,7 +63,6 @@ class AdminRouteGeneratorTest extends WebTestCase
             $cacheMock,
             new Filesystem(),
             $client->getKernel()->getBuildDir(),
-            'en',
         );
 
         $routeName = $adminRouteGenerator->findRouteName($dashboardControllerFqcn, $crudControllerFqcn, $action);


### PR DESCRIPTION
It is overriding the selected route locale in localized routes.

Fix #6842

I tried to add a new dashboard in `EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Controller` with localized routes, but still, couldn't make it so easy to test it. Any tips?
