### PR TITLE
Add some Generics

### DIFF
--- a/.ddev/example/Controller/Admin/BlogArticleCrudController.php
+++ b/.ddev/example/Controller/Admin/BlogArticleCrudController.php
@@ -15,6 +15,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 
+/**
+ * @extends AbstractCrudController<BlogArticle>
+ */
 #[AdminCrud(routePath: '/blog-article')]
 class BlogArticleCrudController extends AbstractCrudController
 {

--- a/.ddev/example/Controller/Admin/CategoryCrudController.php
+++ b/.ddev/example/Controller/Admin/CategoryCrudController.php
@@ -8,6 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
+/**
+ * @extends AbstractCrudController<Category>
+ */
 #[AdminCrud(routePath: '/category')]
 class CategoryCrudController extends AbstractCrudController
 {

--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -982,8 +982,8 @@ user locale. You can also use ``TranslatableMessage`` objects to define any text
 content in your backends (e.g. the label of some field, the help contents of
 some page, etc.)::
 
-    use function Symfony\Component\Translation\t;
     use Symfony\Component\Translation\TranslatableMessage;
+    use function Symfony\Component\Translation\t;
 
     // creating translatable messages using objects
     TextField::new('firstName', new TranslatableMessage('Name'))

--- a/src/Contracts/Controller/CrudControllerInterface.php
+++ b/src/Contracts/Controller/CrudControllerInterface.php
@@ -22,9 +22,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @template TEntity of object
  */
 interface CrudControllerInterface
 {
+    /**
+     * @return class-string<TEntity>
+     */
     public static function getEntityFqcn(): string;
 
     public function configureCrud(Crud $crud): Crud;
@@ -65,10 +70,19 @@ interface CrudControllerInterface
 
     public function createEntity(string $entityFqcn);
 
+    /**
+     * @param TEntity $entityInstance
+     */
     public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void;
 
+    /**
+     * @param TEntity $entityInstance
+     */
     public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void;
 
+    /**
+     * @param TEntity $entityInstance
+     */
     public function deleteEntity(EntityManagerInterface $entityManager, $entityInstance): void;
 
     public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface;

--- a/src/Contracts/Event/EntityLifecycleEventInterface.php
+++ b/src/Contracts/Event/EntityLifecycleEventInterface.php
@@ -4,8 +4,13 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Event;
 
 /**
  * @author: Benjamin Leibinger <mail@leibinger.io>
+ *
+ * @template TEntity of object
  */
 interface EntityLifecycleEventInterface
 {
+    /**
+     * @return TEntity
+     */
     public function getEntityInstance();
 }

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -65,6 +65,10 @@ use function Symfony\Component\String\u;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @template TEntity of object
+ *
+ * @implements  CrudControllerInterface<TEntity>
  */
 abstract class AbstractCrudController extends AbstractController implements CrudControllerInterface
 {

--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -21,12 +21,17 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @template TEntity of object
  */
 final class EntityDto
 {
     private bool $isAccessible = true;
+    /** @var class-string<TEntity> */
     private string $fqcn;
+    /** @var ClassMetadata<TEntity> */
     private ClassMetadata $metadata;
+    /** @var TEntity|null */
     private $instance;
     private $primaryKeyName;
     private mixed $primaryKeyValue = null;
@@ -34,6 +39,11 @@ final class EntityDto
     private ?FieldCollection $fields = null;
     private ?ActionCollection $actions = null;
 
+    /**
+     * @param class-string<TEntity>  $entityFqcn
+     * @param ClassMetadata<TEntity> $entityMetadata
+     * @param TEntity|null           $entityInstance
+     */
     public function __construct(string $entityFqcn, ClassMetadata $entityMetadata, string|Expression|null $entityPermission = null, /* ?object */ $entityInstance = null)
     {
         if (!\is_object($entityInstance)
@@ -61,6 +71,9 @@ final class EntityDto
         return $this->toString();
     }
 
+    /**
+     * @return class-string<TEntity>
+     */
     public function getFqcn(): string
     {
         return $this->fqcn;
@@ -84,6 +97,9 @@ final class EntityDto
         return sprintf('%s #%s', $this->getName(), substr($this->getPrimaryKeyValueAsString(), 0, 16));
     }
 
+    /**
+     * @return TEntity|null
+     */
     public function getInstance()/* : ?object */
     {
         return $this->instance;
@@ -246,6 +262,9 @@ final class EntityDto
         return \array_key_exists($propertyNameParts[0], $this->metadata->embeddedClasses);
     }
 
+    /**
+     * @param TEntity|null $newEntityInstance
+     */
     public function setInstance(?object $newEntityInstance): void
     {
         if (null !== $this->instance && null !== $newEntityInstance && !$newEntityInstance instanceof $this->fqcn) {
@@ -256,6 +275,9 @@ final class EntityDto
         $this->primaryKeyValue = null;
     }
 
+    /**
+     * @param TEntity $newEntityInstance
+     */
     public function newWithInstance(/* object */ $newEntityInstance): self
     {
         if (!\is_object($newEntityInstance)) {

--- a/src/Event/AbstractLifecycleEvent.php
+++ b/src/Event/AbstractLifecycleEvent.php
@@ -6,11 +6,21 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Event\EntityLifecycleEventInterfac
 
 /**
  * @author: Benjamin Leibinger <mail@leibinger.io>
+ *
+ * @template TEntity of object
+ *
+ * @implements EntityLifecycleEventInterface<TEntity>
  */
 abstract class AbstractLifecycleEvent implements EntityLifecycleEventInterface
 {
+    /**
+     * @var TEntity
+     */
     protected $entityInstance;
 
+    /**
+     * @param TEntity $entityInstance
+     */
     public function __construct(/* ?object */ $entityInstance)
     {
         if (!\is_object($entityInstance)

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -12,7 +12,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
-/*
+/**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class SecurityVoter extends Voter

--- a/tests/PrettyUrlsTestApplication/src/Controller/BlogPostCrudController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/BlogPostCrudController.php
@@ -9,6 +9,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class BlogPostCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/PrettyUrlsTestApplication/src/Controller/CategoryCrudController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/CategoryCrudController.php
@@ -16,6 +16,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Config\Actio
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @extends AbstractCrudController<Category>
+ */
 class CategoryCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/PrettyUrlsTestApplication/src/Controller/UserCrudController.php
+++ b/tests/PrettyUrlsTestApplication/src/Controller/UserCrudController.php
@@ -13,6 +13,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\PrettyUrlsTestApplication\Entity\User;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @extends AbstractCrudController<User>
+ */
 #[AdminCrud('/user-editor', 'external_user_editor')]
 class UserCrudController extends AbstractCrudController
 {

--- a/tests/TestApplication/src/Controller/ActionsCrudController.php
+++ b/tests/TestApplication/src/Controller/ActionsCrudController.php
@@ -12,6 +12,8 @@ use function Symfony\Component\Translation\t;
 
 /**
  * Tests the configureActions() method and the generated actions.
+ *
+ * @extends AbstractCrudController<Category>
  */
 class ActionsCrudController extends AbstractCrudController
 {

--- a/tests/TestApplication/src/Controller/AssetsController.php
+++ b/tests/TestApplication/src/Controller/AssetsController.php
@@ -9,6 +9,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
 /**
  * Tests all the different ways of configuring asn customizing the assets.
+ *
+ * @extends AbstractCrudController<BlogPost>
  */
 class AssetsController extends AbstractCrudController
 {

--- a/tests/TestApplication/src/Controller/BlogPostCrudController.php
+++ b/tests/TestApplication/src/Controller/BlogPostCrudController.php
@@ -9,6 +9,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class BlogPostCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/CategoryCrudController.php
+++ b/tests/TestApplication/src/Controller/CategoryCrudController.php
@@ -18,6 +18,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Config\Action as AppAc
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @extends AbstractCrudController<Category>
+ */
 class CategoryCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/CustomFieldAttributeCrudController.php
+++ b/tests/TestApplication/src/Controller/CustomFieldAttributeCrudController.php
@@ -7,6 +7,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class CustomFieldAttributeCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/ErrorFieldDoesNotBelongToAnyTabCrudController.php
+++ b/tests/TestApplication/src/Controller/ErrorFieldDoesNotBelongToAnyTabCrudController.php
@@ -7,6 +7,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Category;
 
+/**
+ * @extends AbstractCrudController<Category>
+ */
 class ErrorFieldDoesNotBelongToAnyTabCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/FormFieldHelpController.php
+++ b/tests/TestApplication/src/Controller/FormFieldHelpController.php
@@ -13,6 +13,8 @@ use function Symfony\Component\Translation\t;
 /**
  * Used to test the ->setHelp() method of fields and how that
  * help message is rendered in the form.
+ *
+ * @extends AbstractCrudController<BlogPost>
  */
 class FormFieldHelpController extends AbstractCrudController
 {

--- a/tests/TestApplication/src/Controller/FormFieldLabelController.php
+++ b/tests/TestApplication/src/Controller/FormFieldLabelController.php
@@ -13,6 +13,8 @@ use function Symfony\Component\Translation\t;
 
 /**
  * Used to test the different types of labels that fields can configure.
+ *
+ * @extends AbstractCrudController<BlogPost>
  */
 class FormFieldLabelController extends AbstractCrudController
 {

--- a/tests/TestApplication/src/Controller/FormFieldValueController.php
+++ b/tests/TestApplication/src/Controller/FormFieldValueController.php
@@ -7,6 +7,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class FormFieldValueController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/FormFieldsetsCrudController.php
+++ b/tests/TestApplication/src/Controller/FormFieldsetsCrudController.php
@@ -8,6 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class FormFieldsetsCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/Search/AnyTermsCrudSearchController.php
+++ b/tests/TestApplication/src/Controller/Search/AnyTermsCrudSearchController.php
@@ -7,6 +7,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SearchMode;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class AnyTermsCrudSearchController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/Search/CustomCrudSearchController.php
+++ b/tests/TestApplication/src/Controller/Search/CustomCrudSearchController.php
@@ -6,6 +6,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class CustomCrudSearchController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/Search/DefaultCrudSearchController.php
+++ b/tests/TestApplication/src/Controller/Search/DefaultCrudSearchController.php
@@ -6,6 +6,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class DefaultCrudSearchController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/Search/IdTermCrudSearchController.php
+++ b/tests/TestApplication/src/Controller/Search/IdTermCrudSearchController.php
@@ -6,6 +6,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\BlogPost;
 
+/**
+ * @extends AbstractCrudController<BlogPost>
+ */
 class IdTermCrudSearchController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/Sort/BillCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/BillCrudController.php
@@ -8,6 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Bill;
 
+/**
+ * @extends AbstractCrudController<Bill>
+ */
 class BillCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/Sort/CustomerCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/CustomerCrudController.php
@@ -8,6 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Customer;
 
+/**
+ * @extends AbstractCrudController<Customer>
+ */
 class CustomerCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/Sort/PageCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/PageCrudController.php
@@ -8,6 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Page;
 
+/**
+ * @extends AbstractCrudController<Page>
+ */
 class PageCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/tests/TestApplication/src/Controller/Sort/WebsiteCrudController.php
+++ b/tests/TestApplication/src/Controller/Sort/WebsiteCrudController.php
@@ -8,6 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Website;
 
+/**
+ * @extends AbstractCrudController<Website>
+ */
 class WebsiteCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string


### PR DESCRIPTION
Hi @javiereguiluz 

I recently tried easy admin and it works fine but I'm getting some PHPStan error because methods like
`CrudControllerInterface::updateEntity` has no param type. Since this interface has a method `getEntityFqcn` we could make it a generic. Same for some others classes.

This would be really useful for PHPStan users like me.

Also, I tried the phpstan level 6 on this codebase and there is
- Error for array without detailled
- Error for generics without detailled
- 351 errors for missing parameter/return type.

Would you be interested if I improve the type-coverage of this projet to bump phpstan to level 6 ?