### PR TITLE
add suport for enums in TextFields

### DIFF
--- a/src/Field/Configurator/TextConfigurator.php
+++ b/src/Field/Configurator/TextConfigurator.php
@@ -32,6 +32,11 @@ final class TextConfigurator implements FieldConfiguratorInterface
             return;
         }
 
+        // check if the given value is an enum
+        if (\is_object($value) && \enum_exists(\get_class($value))) {
+            $value = $value->value;    
+        }
+        
         if (!\is_string($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
             throw new \RuntimeException(sprintf('The value of the "%s" field of the entity with ID = "%s" can\'t be converted into a string, so it cannot be represented by a TextField or a TextareaField.', $field->getProperty(), $entityDto->getPrimaryKeyValue()));
         }
@@ -39,11 +44,11 @@ final class TextConfigurator implements FieldConfiguratorInterface
         $renderAsHtml = true === $field->getCustomOption(TextField::OPTION_RENDER_AS_HTML);
         $stripTags = true === $field->getCustomOption(TextField::OPTION_STRIP_TAGS);
         if ($renderAsHtml) {
-            $formattedValue = (string) $field->getValue();
+            $formattedValue = (string) $value;
         } elseif ($stripTags) {
-            $formattedValue = strip_tags((string) $field->getValue());
+            $formattedValue = strip_tags((string) $value);
         } else {
-            $formattedValue = htmlspecialchars((string) $field->getValue(), \ENT_NOQUOTES, null, false);
+            $formattedValue = htmlspecialchars((string) $value, \ENT_NOQUOTES, null, false);
         }
 
         $configuredMaxLength = $field->getCustomOption(TextField::OPTION_MAX_LENGTH);


### PR DESCRIPTION
this pr supports enum in the  TextConfigurator by using the backend value of the enum. This allows to automatically use enums for any Text Fields.