### PR TITLE
fix: array return for invokable Controllers

### DIFF
--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -309,7 +309,7 @@ class AdminRouterSubscriber implements EventSubscriberInterface
 
         $parameters = $this->requestMatcher->matchRequest($newRequest);
 
-        if(\is_array($parameters['_controller'])){
+        if (\is_array($parameters['_controller'])) {
             return $parameters['_controller'][0];
         }
 

--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -309,7 +309,7 @@ class AdminRouterSubscriber implements EventSubscriberInterface
 
         $parameters = $this->requestMatcher->matchRequest($newRequest);
 
-        if(is_array($parameters['_controller'])){
+        if(\is_array($parameters['_controller'])){
             return $parameters['_controller'][0];
         }
 

--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -309,6 +309,10 @@ class AdminRouterSubscriber implements EventSubscriberInterface
 
         $parameters = $this->requestMatcher->matchRequest($newRequest);
 
+        if(is_array($parameters['_controller'])){
+            return $parameters['_controller'][0];
+        }
+
         return $parameters['_controller'] ?? null;
     }
 


### PR DESCRIPTION
If the route name passed in "MenuItem::linkToRoute" matches a invoked controller, an array is returned instead of an String. 

This is the easiest way to intercept this. 

Tested with Symfony 7.3. 
Since there are no tests for it yet, I can't extend anything, and I don't have enough knowledge of the code base to create new tests.