### PR TITLE
Fix trailing spaces in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Dev Environment
 ---------------
 
 EasyAdmin ships a DDEV environment, which allows you to run EasyAdmin in a Symfony Framework project
-providing example entities and CRUD Controllers. 
+providing example entities and CRUD Controllers.
 
 **Requirements:**
 

--- a/doc/tests.rst
+++ b/doc/tests.rst
@@ -92,7 +92,7 @@ asserts for EasyAdmin web testing:
 * ``CrudTestIndexAsserts``: providing asserts for the index page of EasyAdmin;
 * ``CrudTestFormAsserts`` : providing asserts for the form page of EasyAdmin.
 
-.. note:: 
+.. note::
 
     The trait can be used on its own but, in that case, the class that is using
     it needs both:


### PR DESCRIPTION
## Summary
- remove space at the end of `doc/tests.rst` line 95
- clean trailing whitespace on README line 45