### PR TITLE
Fix fileSize() method in Twig extension

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -97,9 +97,17 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
     public function fileSize(int $bytes): string
     {
         $size = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
-        $factor = (int) floor(log($bytes) / log(1024));
 
-        return (int) ($bytes / (1024 ** $factor)).@$size[$factor];
+        if (0 === $bytes) {
+            return '0B';
+        }
+
+        $factor = (int) floor(log($bytes) / log(1024));
+        $factor = min($factor, \count($size) - 1);
+
+        $scaledValue = (int) ($bytes / (1024 ** $factor));
+
+        return sprintf('%d%s', $scaledValue, $size[$factor]);
     }
 
     /**

--- a/tests/Twig/EasyAdminTwigExtensionTest.php
+++ b/tests/Twig/EasyAdminTwigExtensionTest.php
@@ -53,6 +53,32 @@ class EasyAdminTwigExtensionTest extends KernelTestCase
         $twigExtensionInstance->representAsString(new class {}, 'someMethod');
     }
 
+    /**
+     * @dataProvider provideValuesForFileSize
+     */
+    public function testFileSize(int $bytes, string $expected): void
+    {
+        $reflectedClass = new \ReflectionClass(EasyAdminTwigExtension::class);
+        $twigExtensionInstance = $reflectedClass->newInstanceWithoutConstructor();
+
+        $result = $twigExtensionInstance->fileSize($bytes);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function provideValuesForFileSize(): iterable
+    {
+        yield [0, '0B'];
+        yield [1, '1B'];
+        yield [1024, '1K'];
+        yield [1024 ** 2, '1M'];
+        yield [1024 ** 3, '1G'];
+        yield [1024 ** 4, '1T'];
+        yield [1024 ** 5, '1P'];
+        yield [1024 ** 6, '1E'];
+        yield [\PHP_INT_MAX, '8E'];
+    }
+
     public function provideValuesForRepresentAsString(): iterable
     {
         yield [null, ''];


### PR DESCRIPTION
## Summary
- handle zero and large numbers in `fileSize()`
- return scaled value with correct unit
- test `fileSize()` using a data provider with edge cases
