### PR TITLE
CrudControllerInterface: add missing EntityDto generics

### DIFF
--- a/src/Contracts/Controller/CrudControllerInterface.php
+++ b/src/Contracts/Controller/CrudControllerInterface.php
@@ -66,8 +66,14 @@ interface CrudControllerInterface
 
     public function configureResponseParameters(KeyValueStore $responseParameters): KeyValueStore;
 
+    /**
+     * @param EntityDto<TEntity> $entityDto
+     */
     public function createIndexQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder;
 
+    /**
+     * @param class-string<TEntity> $entityFqcn
+     */
     public function createEntity(string $entityFqcn);
 
     /**
@@ -85,11 +91,23 @@ interface CrudControllerInterface
      */
     public function deleteEntity(EntityManagerInterface $entityManager, $entityInstance): void;
 
+    /**
+     * @param EntityDto<TEntity> $entityDto
+     */
     public function createEditFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface;
 
+    /**
+     * @param EntityDto<TEntity> $entityDto
+     */
     public function createEditForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface;
 
+    /**
+     * @param EntityDto<TEntity> $entityDto
+     */
     public function createNewFormBuilder(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormBuilderInterface;
 
+    /**
+     * @param EntityDto<TEntity> $entityDto
+     */
     public function createNewForm(EntityDto $entityDto, KeyValueStore $formOptions, AdminContext $context): FormInterface;
 }


### PR DESCRIPTION
Following https://github.com/EasyCorp/EasyAdminBundle/pull/6969 this adds missing generic PHPDoc to `CrudControllerInterface` methods that have `EntityDto` as an argument. Currently this results in PHPStan errors like

```
  38     Method MyEntityCrudController::createIndexQueryBuilder() has parameter $entityDto with generic class EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto but does not specify its types:
         TEntity
         🪪 missingType.generics
```