### PR TITLE
Use a default template value for recently created Generics

### DIFF
--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -22,7 +22,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  *
- * @template TEntity of object
+ * @template TEntity of object = object
  */
 final class EntityDto
 {


### PR DESCRIPTION
I tried the recent 4.24.8 branch and getting some errors I tried to fix.

This
- avoid error like reported in PR https://github.com/EasyCorp/EasyAdminBundle/pull/6981#issue-3137120502
- avoid ~200 missing generic types in EasyAdminBundle code base

So it should be simpler for user to start using those generics.

It will still be possible later to improve the typing of existing interface like
```
interface EntityRepositoryInterface
{
    public function createQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder;
}
```
into
```
/** @template TEntity of object */
interface EntityRepositoryInterface
{
    /** @param EntityDto<TEntity> $entityDto */
    public function createQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder;
}
```
when needed.