### PR TITLE
Improve deprecation message about return type

### DIFF
--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -56,7 +56,7 @@ class Crud
     /**
      * @param TranslatableInterface|string|callable $label The callable signature is: fn ($entityInstance, $pageName): string
      *
-     * @psalm-param mixed $label
+     * @phpstan-param mixed $label
      */
     public function setEntityLabelInSingular($label): self
     {
@@ -80,7 +80,7 @@ class Crud
     /**
      * @param TranslatableInterface|string|callable $label The callable signature is: fn ($entityInstance, $pageName): string
      *
-     * @psalm-param mixed $label
+     * @phpstan-param mixed $label
      */
     public function setEntityLabelInPlural($label): self
     {
@@ -104,7 +104,7 @@ class Crud
     /**
      * @param TranslatableInterface|string|callable $title The callable signature is: fn ($entityInstance): string
      *
-     * @psalm-param mixed $title
+     * @phpstan-param mixed $title
      */
     public function setPageTitle(string $pageName, $title): self
     {

--- a/src/Contracts/Controller/CrudControllerInterface.php
+++ b/src/Contracts/Controller/CrudControllerInterface.php
@@ -43,7 +43,7 @@ interface CrudControllerInterface
     /**
      * @return FieldInterface[]|string[]
      *
-     * @psalm-return iterable<FieldInterface|string>
+     * @phpstan-return iterable<FieldInterface|string>
      */
     public function configureFields(string $pageName): iterable;
 
@@ -74,7 +74,9 @@ interface CrudControllerInterface
     /**
      * @param class-string<TEntity> $entityFqcn
      *
-     * @return TEntity
+     * @return object
+     *
+     * @phpstan-return TEntity
      */
     public function createEntity(string $entityFqcn);
 

--- a/src/Contracts/Controller/DashboardControllerInterface.php
+++ b/src/Contracts/Controller/DashboardControllerInterface.php
@@ -26,7 +26,7 @@ interface DashboardControllerInterface
     /**
      * @return MenuItemInterface[]
      *
-     * @psalm-return iterable<MenuItemInterface>
+     * @phpstan-return iterable<MenuItemInterface>
      */
     public function configureMenuItems(): iterable;
 

--- a/src/Contracts/Event/EntityLifecycleEventInterface.php
+++ b/src/Contracts/Event/EntityLifecycleEventInterface.php
@@ -10,7 +10,9 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Event;
 interface EntityLifecycleEventInterface
 {
     /**
-     * @return TEntity
+     * @return object
+     *
+     * @phpstan-return TEntity
      */
     public function getEntityInstance();
 }

--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -99,7 +99,9 @@ final class EntityDto
     }
 
     /**
-     * @return TEntity|null
+     * @return object|null
+     *
+     * @phpstan-return TEntity|null
      */
     public function getInstance()/* : ?object */
     {


### PR DESCRIPTION
Seems like the `@return TEntity` gives a weird deprecation message @javiereguiluz, cf issue 
https://github.com/EasyCorp/EasyAdminBundle/issues/6995

So I updated the phpdoc to
```
@return object

@phpstan-return TEntity
```

Also, I saw some `@psalm-`. Annotation.

Since you're using phpstan for SA and not psalm ;
I would recommend to use `@phpstan` everywhere so I updated those tag.

Closes https://github.com/EasyCorp/EasyAdminBundle/issues/6995 I think