### PR TITLE
Deprecate `ActionConfigDto::getActions`

### DIFF
--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -81,7 +81,7 @@ final class Actions
     public function reorder(string $pageName, array $orderedActionNames): self
     {
         $newActionOrder = [];
-        $currentActions = $this->dto->getActions();
+        $currentActions = $this->dto->getActionList();
         foreach ($orderedActionNames as $actionName) {
             if (!\array_key_exists($actionName, $currentActions[$pageName])) {
                 throw new \InvalidArgumentException(sprintf('The "%s" action does not exist in the "%s" page, so you cannot set its order.', $actionName, $pageName));

--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -39,6 +39,9 @@ final class ActionConfigDto
         }
     }
 
+    /**
+     * @deprecated since 4.25.0 and it will be removed in EasyAdmin 5.0.0.
+     */
     public function setPageName(?string $pageName): void
     {
         $this->pageName = $pageName;
@@ -109,16 +112,55 @@ final class ActionConfigDto
 
     /**
      * @return ActionCollection|array<string,array<string,ActionDto>>
+     *
+     * @deprecated since 4.25.0 and it will be removed in EasyAdmin 5.0.0. Use `getPageActions` or `getActionList` instead.
      */
     public function getActions(): ActionCollection|array
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.25.0',
+            'Calling "%s" is deprecated and will be removed in 5.0.0. Use `getPageActions` or `getActionList` instead.',
+            __METHOD__,
+        );
+
         return null === $this->pageName ? $this->actions : ActionCollection::new($this->actions[$this->pageName]);
+    }
+
+    public function getPageActions(string $pageName): ActionCollection
+    {
+        return ActionCollection::new($this->actions[$pageName]);
+    }
+
+    /**
+     * @return array<string,array<string,ActionDto>>
+     */
+    public function getActionList(): array
+    {
+        return $this->actions;
+    }
+
+    /**
+     * @param array<string, ActionDto> $newActions
+     *
+     * @deprecated since 4.25.0 and it will be removed in EasyAdmin 5.0.0. Use `setPageActions` instead.
+     */
+    public function setActions(string $pageName, array $newActions): void
+    {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.25.0',
+            'Calling "%s" is deprecated and will be removed in 5.0.0. Use `setPageActions` instead.',
+            __METHOD__,
+        );
+
+        $this->actions[$pageName] = $newActions;
     }
 
     /**
      * @param array<string, ActionDto> $newActions
      */
-    public function setActions(string $pageName, array $newActions): void
+    public function setPageActions(string $pageName, array $newActions): void
     {
         $this->actions[$pageName] = $newActions;
     }

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -36,7 +36,7 @@ final class ActionFactory
     {
         $currentPage = $this->adminContextProvider->getContext()->getCrud()->getCurrentPage();
         $entityActions = [];
-        foreach ($actionsDto->getActions()->all() as $actionDto) {
+        foreach ($actionsDto->getPageActions($currentPage)->all() as $actionDto) {
             if (!$actionDto->isEntityAction()) {
                 continue;
             }
@@ -79,7 +79,7 @@ final class ActionFactory
 
         $currentPage = $this->adminContextProvider->getContext()->getCrud()->getCurrentPage();
         $globalActions = [];
-        foreach ($actionsDto->getActions()->all() as $actionDto) {
+        foreach ($actionsDto->getPageActions($currentPage)->all() as $actionDto) {
             if (!$actionDto->isGlobalAction() && !$actionDto->isBatchAction()) {
                 continue;
             }

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -132,7 +132,7 @@ final class AdminContextFactory
         return $crudDto;
     }
 
-    private function getActionConfig(DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ?string $pageName): ActionConfigDto
+    private function getActionConfig(DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ?string $pageName = null): ActionConfigDto
     {
         if (null === $crudController) {
             return new ActionConfigDto();


### PR DESCRIPTION
Some errors reported by PHPStan level 7 is related to the fact that 
```
$actionsDto->getActions()->all()
```
might be non-ok if getActions return an array, since the return type is
```
@return ActionCollection|array<string,array<string,ActionDto>>
```

The issue is this method does two things
- returning everything 
- or returning the value of a single page name.

A solution could be to split the method in two: `getPageActions` and `getActionList` (naming is challengeable).
Also `getPageActions` can take the `pageName` as args rather than relying on a private property since the page is accessible with
```
$this->adminContextProvider->getContext()->getCrud()->getCurrentPage()
```
(and you might want to know the actions of another page)

Then I deprecated `setPageName` (but I cannot trigger a deprecation since it has to be used in easyAdmin code for BC)

This PR should solve issue like https://github.com/EasyCorp/EasyAdminBundle/issues/6531 or at least helps for debug.