### PR TITLE
fix mark pretty url menu items in subfolder

### DIFF
--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -168,7 +168,7 @@ class MenuItemMatcher implements MenuItemMatcherInterface
         // 1) check all menu items for an exact match with the current URL
         // 2) if no match, check again with the current URL action changed to 'index'
         // 3) if still no match, check again with the current URL action changed to 'index' and no query parameters
-        $currentUrlWithoutHost = $request->getPathInfo();
+        $currentUrlWithoutHost = $request->getBasePath().$request->getPathInfo();
         $currentUrlQueryParams = $request->query->all();
         unset($currentUrlQueryParams['sort'], $currentUrlQueryParams['page'], $currentUrlQueryParams['query']);
         // sort them because menu items always have their query parameters sorted


### PR DESCRIPTION
marking current menu items does not work with pretty urls when symfony is installed in a subfolder

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
