### PR TITLE
Deprecate passing MenuItemInterface to UserMenuDto

### DIFF
--- a/src/Config/UserMenu.php
+++ b/src/Config/UserMenu.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
 
 /**
@@ -65,7 +66,12 @@ final class UserMenu
      */
     public function addMenuItems(array $items): self
     {
-        $this->dto->setItems(array_merge($items, $this->dto->getItems()));
+        $itemsDto = array_map(
+            static fn (MenuItemInterface $item): MenuItemDto => $item->getAsDto(),
+            $items
+        );
+
+        $this->dto->setItems(array_merge($itemsDto, $this->dto->getItems()));
 
         return $this;
     }
@@ -75,7 +81,12 @@ final class UserMenu
      */
     public function setMenuItems(array $items): self
     {
-        $this->dto->setItems($items);
+        $itemsDto = array_map(
+            static fn (MenuItemInterface $item): MenuItemDto => $item->getAsDto(),
+            $items
+        );
+
+        $this->dto->setItems($itemsDto);
 
         return $this;
     }

--- a/src/Dto/UserMenuDto.php
+++ b/src/Dto/UserMenuDto.php
@@ -2,8 +2,6 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
-
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
@@ -13,7 +11,7 @@ final class UserMenuDto
     private bool $displayAvatar = true;
     private ?string $name = null;
     private ?string $avatarUrl = null;
-    /** @var MenuItemInterface[]|MenuItemDto[] */
+    /** @var array<MenuItemDto> */
     private array $items = [];
 
     public function isNameDisplayed(): bool
@@ -57,7 +55,7 @@ final class UserMenuDto
     }
 
     /**
-     * @return MenuItemInterface[]|MenuItemDto[]
+     * @return array<MenuItemDto>
      */
     public function getItems(): array
     {
@@ -65,14 +63,25 @@ final class UserMenuDto
     }
 
     /**
-     * When configuring the application, you are passed an array of
-     * MenuItemInterface objects; after building the user menu contents,
-     * this method is called with MenuItemDto objects.
-     *
-     * @param MenuItemInterface[]|MenuItemDto[] $items
+     * @param array<MenuItemDto> $items
      */
     public function setItems(array $items): void
     {
+        foreach ($items as $item) {
+            if (!$item instanceof MenuItemDto) {
+                trigger_deprecation(
+                    'easycorp/easyadmin-bundle',
+                    '4.25.0',
+                    'Argument "%s" for "%s" must be one of these types: %s. Passing type %s will cause an error in 5.0.0.',
+                    '$items',
+                    __METHOD__,
+                    '"array<MenuItemDto>"',
+                    '"array<MenuItemInterface>"'
+                );
+                break;
+            }
+        }
+
         $this->items = $items;
     }
 }

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -52,7 +52,7 @@ final class MenuFactory implements MenuFactoryInterface
     }
 
     /**
-     * @param MenuItemInterface[] $menuItems
+     * @param array<MenuItemDto|MenuItemInterface> $menuItems
      *
      * @return MenuItemDto[]
      */
@@ -63,14 +63,19 @@ final class MenuFactory implements MenuFactoryInterface
         $translationDomain = $adminContext->getI18n()->getTranslationDomain() ?? '';
 
         $builtItems = [];
-        foreach ($menuItems as $i => $menuItem) {
-            $menuItemDto = $menuItem->getAsDto();
+        foreach ($menuItems as $menuItem) {
+            if ($menuItem instanceof MenuItemDto) {
+                $menuItemDto = $menuItem;
+            } else {
+                $menuItemDto = $menuItem->getAsDto();
+            }
+
             if (false === $this->authChecker->isGranted(Permission::EA_VIEW_MENU_ITEM, $menuItemDto)) {
                 continue;
             }
 
             $subItems = [];
-            foreach ($menuItemDto->getSubItems() as $j => $menuSubItemDto) {
+            foreach ($menuItemDto->getSubItems() as $menuSubItemDto) {
                 if (false === $this->authChecker->isGranted(Permission::EA_VIEW_MENU_ITEM, $menuSubItemDto)) {
                     continue;
                 }


### PR DESCRIPTION
This could be a path to resolve the last point of https://github.com/EasyCorp/EasyAdminBundle/pull/6994#issuecomment-2992652832

This way
- setItems and getItems always works with `array<MenuItemDto>`
- `buildMenuItems` supports both cause it's used by createUserMenu and createMainMenu

I tried to stay BC but if preferred/safer this can be merged in 5.x
