### PR TITLE
Make fields implement FieldTraitAwareInterface instead of FieldInterface

### DIFF
--- a/src/Contracts/Field/FieldTraitAwareInterface.php
+++ b/src/Contracts/Field/FieldTraitAwareInterface.php
@@ -122,6 +122,4 @@ interface FieldTraitAwareInterface extends FieldInterface
      * @internal
      */
     public function setDefaultColumns(int|string $cols): self;
-
-    public function setIcon(?string $iconCssClass, string $invokingMethod = 'FormField::setIcon()'): self;
 }

--- a/src/Contracts/Field/FieldTraitAwareInterface.php
+++ b/src/Contracts/Field/FieldTraitAwareInterface.php
@@ -122,4 +122,6 @@ interface FieldTraitAwareInterface extends FieldInterface
      * @internal
      */
     public function setDefaultColumns(int|string $cols): self;
+
+    public function setIcon(?string $iconCssClass, string $invokingMethod = 'FormField::setIcon()'): self;
 }

--- a/src/Field/ArrayField.php
+++ b/src/Field/ArrayField.php
@@ -3,14 +3,14 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class ArrayField implements FieldInterface
+final class ArrayField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AssociationField implements FieldInterface
+final class AssociationField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/AvatarField.php
+++ b/src/Field/AvatarField.php
@@ -3,14 +3,14 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\Size;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AvatarField implements FieldInterface
+final class AvatarField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/BooleanField.php
+++ b/src/Field/BooleanField.php
@@ -4,14 +4,14 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class BooleanField implements FieldInterface
+final class BooleanField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/ChoiceField.php
+++ b/src/Field/ChoiceField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class ChoiceField implements FieldInterface
+final class ChoiceField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/CodeEditorField.php
+++ b/src/Field/CodeEditorField.php
@@ -3,14 +3,14 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CodeEditorType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CodeEditorField implements FieldInterface
+final class CodeEditorField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/CollectionField.php
+++ b/src/Field/CollectionField.php
@@ -3,14 +3,14 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CollectionField implements FieldInterface
+final class CollectionField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/ColorField.php
+++ b/src/Field/ColorField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\ColorType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class ColorField implements FieldInterface
+final class ColorField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/CountryField.php
+++ b/src/Field/CountryField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CountryField implements FieldInterface
+final class CountryField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/CurrencyField.php
+++ b/src/Field/CurrencyField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CurrencyField implements FieldInterface
+final class CurrencyField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/DateField.php
+++ b/src/Field/DateField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class DateField implements FieldInterface
+final class DateField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/DateTimeField.php
+++ b/src/Field/DateTimeField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class DateTimeField implements FieldInterface
+final class DateTimeField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/EmailField.php
+++ b/src/Field/EmailField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class EmailField implements FieldInterface
+final class EmailField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/Field.php
+++ b/src/Field/Field.php
@@ -2,13 +2,13 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class Field implements FieldInterface
+final class Field implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -503,4 +503,9 @@ trait FieldTrait
     {
         return $this->dto;
     }
+
+    public function setIcon(?string $iconCssClass, string $invokingMethod = 'FormField::setIcon()'): self
+    {
+        return $this;
+    }
 }

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormColumnOpenType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormFieldsetOpenType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\Layout\EaFormRowType;
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class FormField implements FieldInterface
+final class FormField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/FormField.php
+++ b/src/Field/FormField.php
@@ -142,7 +142,7 @@ final class FormField implements FieldTraitAwareInterface
             ->setValue(true);
     }
 
-    public function setIcon(string $iconCssClass): self
+    public function setIcon(?string $iconCssClass, string $invokingMethod = 'FormField::setIcon()'): self
     {
         $this->setCustomOption(self::OPTION_ICON, $iconCssClass);
 

--- a/src/Field/HiddenField.php
+++ b/src/Field/HiddenField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class HiddenField implements FieldInterface
+final class HiddenField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/IdField.php
+++ b/src/Field/IdField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class IdField implements FieldInterface
+final class IdField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -4,7 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Image;
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class ImageField implements FieldInterface
+final class ImageField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/IntegerField.php
+++ b/src/Field/IntegerField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class IntegerField implements FieldInterface
+final class IntegerField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/LanguageField.php
+++ b/src/Field/LanguageField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\LanguageType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class LanguageField implements FieldInterface
+final class LanguageField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/LocaleField.php
+++ b/src/Field/LocaleField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\LocaleType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class LocaleField implements FieldInterface
+final class LocaleField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/MoneyField.php
+++ b/src/Field/MoneyField.php
@@ -3,7 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Intl\Currencies;
 use Symfony\Contracts\Translation\TranslatableInterface;
@@ -11,7 +11,7 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class MoneyField implements FieldInterface
+final class MoneyField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/NumberField.php
+++ b/src/Field/NumberField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class NumberField implements FieldInterface
+final class NumberField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/PercentField.php
+++ b/src/Field/PercentField.php
@@ -3,14 +3,14 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class PercentField implements FieldInterface
+final class PercentField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/SlugField.php
+++ b/src/Field/SlugField.php
@@ -3,14 +3,14 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\SlugType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Jonathan Scheiber <contact@jmsche.fr>
  */
-final class SlugField implements FieldInterface
+final class SlugField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/TelephoneField.php
+++ b/src/Field/TelephoneField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class TelephoneField implements FieldInterface
+final class TelephoneField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/TextEditorField.php
+++ b/src/Field/TextEditorField.php
@@ -3,14 +3,14 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\TextEditorType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class TextEditorField implements FieldInterface
+final class TextEditorField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/TextField.php
+++ b/src/Field/TextField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class TextField implements FieldInterface
+final class TextField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/TextareaField.php
+++ b/src/Field/TextareaField.php
@@ -3,14 +3,14 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class TextareaField implements FieldInterface
+final class TextareaField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/TimeField.php
+++ b/src/Field/TimeField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class TimeField implements FieldInterface
+final class TimeField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/TimezoneField.php
+++ b/src/Field/TimezoneField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class TimezoneField implements FieldInterface
+final class TimezoneField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 

--- a/src/Field/UrlField.php
+++ b/src/Field/UrlField.php
@@ -2,14 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldTraitAwareInterface;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class UrlField implements FieldInterface
+final class UrlField implements FieldTraitAwareInterface
 {
     use FieldTrait;
 


### PR DESCRIPTION
**Short description of what this feature will allow to do:**

The `FieldTraitAwareInterface` was added to the repository to serve as the interface for fields that use `FieldTrait`. However, none of the fields that actually use `FieldTrait` implement this interface—they only implement `FieldInterface`. This makes `FieldTraitAwareInterface` effectively unused and defeats its intended purpose.

**Example of how to use this feature**

This change would enable us to create field factories that return `FieldTraitAwareInterface` instances, which could then be manipulated using the methods provided by `FieldTrait`. We have found this approach particularly valuable for defining fields outside of CRUD controllers, allowing them to be reused across different components.

Closes #7010