### PR TITLE
Allow 'notice' and 'error' flash message keys

### DIFF
--- a/src/Twig/Component/Option/AlertVariant.php
+++ b/src/Twig/Component/Option/AlertVariant.php
@@ -12,9 +12,15 @@ enum AlertVariant: string
     case Info = 'info';
     case Light = 'light';
     case Dark = 'dark';
+    case Notice = 'notice'; // commonly used according to https://symfony.com/doc/current/session.html#flash-messages
+    case Error = 'error'; // commonly used according to https://symfony.com/doc/current/session.html#flash-messages
 
     public function asBootstrapCssClass(): string
     {
-        return 'alert-'.$this->value;
+        return 'alert-'.match ($this) {
+            self::Primary, self::Secondary, self::Success, self::Danger, self::Warning, self::Info, self::Light, self::Dark => $this->value,
+            self::Notice => 'success',
+            self::Error => 'danger',
+        };
     }
 }

--- a/src/Twig/Component/Option/AlertVariant.php
+++ b/src/Twig/Component/Option/AlertVariant.php
@@ -19,7 +19,7 @@ enum AlertVariant: string
     {
         return 'alert-'.match ($this) {
             self::Primary, self::Secondary, self::Success, self::Danger, self::Warning, self::Info, self::Light, self::Dark => $this->value,
-            self::Notice => 'success',
+            self::Notice => 'info',
             self::Error => 'danger',
         };
     }


### PR DESCRIPTION
Fixes part 1 of issue 7014 (allowing the "commonly used" flash keys).