### PR TITLE
Always allow delete not persisted collection items

### DIFF
--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -216,7 +216,7 @@
                         {{ value|ea_as_string(to_string_method) }}
                     </button>
 
-                    {% if allows_deleting_items and not disabled %}
+                    {% if not value.id|default(false) or (allows_deleting_items and not disabled) %}
                         {{ delete_item_button }}
                     {% endif %}
                 </h2>


### PR DESCRIPTION
Sometimes you can accidentally add item and make it invalid (e.g. not fill some required field in subentry).
After submitting form (and before) you can not remove it or do something with that unnecessary item.
I thing it is nothing wrong to allow delete such entries as they not in database yet.

May be detection of such items not ideal cause there is may be entities without id field.