### PR TITLE
Keep icon compatibility after enable useCustomIconSet

### DIFF
--- a/templates/components/Icon.html.twig
+++ b/templates/components/Icon.html.twig
@@ -6,8 +6,9 @@
     {% elseif icon.svgContents %}
         {{ icon.svgContents|raw }}
     {% else %}
+        {% set prefixesToReplace = {'fa fa-': 'fa:', 'fas fa-': 'fa-solid:', 'fa-solid fa-': 'fa6-solid:'} %}
         {% guard function ux_icon %}
-            {{ ux_icon(icon.name, attributes.all) }}
+            {{ ux_icon(icon.name|replace(prefixesToReplace), attributes.all) }}
         {% endguard %}
     {% endif %}
 </span>


### PR DESCRIPTION
I think that before switching to version 5, the icons should remain compatible after enable `->useCustomIconSet()`.