### PR TITLE
Add custom options support to ActionDto.

### DIFF
--- a/src/Attribute/AdminDashboard.php
+++ b/src/Attribute/AdminDashboard.php
@@ -12,11 +12,11 @@ class AdminDashboard
         /**
          * @var string|null $routePath The path of the Symfony route that will be created for the dashboard (e.g. '/admin)
          */
-        public /* ?string */ $routePath = null,
+        /* ?string */ public $routePath = null,
         /**
          * @var string|null $routeName The name of the Symfony route that will be created for the dashboard (e.g. 'admin')
          */
-        public /* ?string */ $routeName = null,
+        /* ?string */ public $routeName = null,
         /**
          * @var array{
          *     requirements?: array<string, string>,

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
@@ -32,6 +33,17 @@ final class ActionDto
     private array $translationParameters = [];
     /** @var callable|null */
     private $displayCallable;
+    private KeyValueStore $customOptions;
+
+    public function __construct()
+    {
+        $this->customOptions = KeyValueStore::new();
+    }
+
+    public function __clone()
+    {
+        $this->customOptions = clone $this->customOptions;
+    }
 
     public function getType(): string
     {
@@ -331,5 +343,28 @@ final class ActionDto
         }
 
         return $action;
+    }
+
+    public function getCustomOptions(): KeyValueStore
+    {
+        return $this->customOptions;
+    }
+
+    public function getCustomOption(string $optionName): mixed
+    {
+        return $this->customOptions->get($optionName);
+    }
+
+    /**
+     * @param array<string, mixed> $customOptions
+     */
+    public function setCustomOptions(array $customOptions): void
+    {
+        $this->customOptions = KeyValueStore::new($customOptions);
+    }
+
+    public function setCustomOption(string $optionName, mixed $optionValue): void
+    {
+        $this->customOptions->set($optionName, $optionValue);
     }
 }


### PR DESCRIPTION
custom option of action level can be useful for voters, such as storing entityDto