### PR TITLE
PoC using first field to build table is wrong.

### DIFF
--- a/src/Attribute/AdminDashboard.php
+++ b/src/Attribute/AdminDashboard.php
@@ -12,11 +12,11 @@ class AdminDashboard
         /**
          * @var string|null $routePath The path of the Symfony route that will be created for the dashboard (e.g. '/admin)
          */
-        public /* ?string */ $routePath = null,
+        /* ?string */ public $routePath = null,
         /**
          * @var string|null $routeName The name of the Symfony route that will be created for the dashboard (e.g. 'admin')
          */
-        public /* ?string */ $routeName = null,
+        /* ?string */ public $routeName = null,
         /**
          * @var array{
          *     requirements?: array<string, string>,

--- a/tests/TestApplication/src/Security/CustomVoter.php
+++ b/tests/TestApplication/src/Security/CustomVoter.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Security;
+
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * Custom voter that allows to ban an entity and its property from being processed.
+ *
+ * This is only for testing purposes, to simulate the behavior of the FieldFactory::processFields() method when
+ * EA_VIEW_FIELD will return FALSE, on first entity, which is used to build table theaders.
+ */
+class CustomVoter extends Voter
+{
+    private ?object $banEntity = null;
+    private ?string $banEntityProperty = null;
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return Permission::exists($attribute);
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        static $entities = [];
+
+        if ($subject instanceof EntityDto && $subject->getInstance()) {
+            $entities[] = $subject;
+        }
+
+        foreach ($entities as $entityDto) {
+            if ($this->banEntity && $entityDto->getInstance() === $this->banEntity) {
+                // imitate the behavior of FieldFactory::processFields()
+                // which removes the field from the entity if it is not granted
+                if ($subject instanceof FieldDto) {
+                    if ($fieldDto = $entityDto->getFields()?->getByProperty($this->banEntityProperty)) {
+                        $entityDto->getFields()->unset($fieldDto);
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public function ban(object $entity, ?string $propertyName = null): void
+    {
+        $this->banEntity = $entity;
+        $this->banEntityProperty = $propertyName;
+    }
+
+    public function removeBan(): void
+    {
+        $this->banEntity = null;
+        $this->banEntityProperty = null;
+    }
+}

--- a/tests/VoterTest.php
+++ b/tests/VoterTest.php
@@ -37,7 +37,6 @@ class VoterTest extends AbstractCrudTestCase
     public function testingVoter()
     {
         // Arrange
-        $expectedAmountMapping = [];
         $entities = $this->repository->findAll();
 
         /** @var CustomVoter $voter */
@@ -49,13 +48,6 @@ class VoterTest extends AbstractCrudTestCase
         \Closure::bind(function () {
             $this->strategy = new UnanimousStrategy();
         }, $accessDecisionManager, $accessDecisionManager)();
-
-        /**
-         * @var Website $entity
-         */
-        foreach ($entities as $entity) {
-            $expectedAmountMapping[$entity->getName()] = $entity->getPages()->count();
-        }
 
         // Act
         $crawler = $this->client->request('GET', $this->generateIndexUrl());

--- a/tests/VoterTest.php
+++ b/tests/VoterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\Sort\WebsiteCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\Website;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Security\CustomVoter;
+use Symfony\Component\Security\Core\Authorization\Strategy\UnanimousStrategy;
+
+class VoterTest extends AbstractCrudTestCase
+{
+    /**
+     * @var EntityRepository
+     */
+    private $repository;
+
+    protected function getControllerFqcn(): string
+    {
+        return WebsiteCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->repository = $this->entityManager->getRepository(Website::class);
+    }
+
+    public function testingVoter()
+    {
+        // Arrange
+        $expectedAmountMapping = [];
+        $entities = $this->repository->findAll();
+
+        /** @var CustomVoter $voter */
+        $voter = $this->getContainer()->get(CustomVoter::class);
+        $voter->ban($entities[0], 'name');
+
+        // UnanimousStrategy
+        $accessDecisionManager = $this->getContainer()->get('security.access.decision_manager');
+        \Closure::bind(function () {
+            $this->strategy = new UnanimousStrategy();
+        }, $accessDecisionManager, $accessDecisionManager)();
+
+        /**
+         * @var Website $entity
+         */
+        foreach ($entities as $entity) {
+            $expectedAmountMapping[$entity->getName()] = $entity->getPages()->count();
+        }
+
+        // Act
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        // Assert
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('th[data-column="pages"]');
+        $this->assertSelectorExists('th[data-column="name"]');
+    }
+}


### PR DESCRIPTION
Adding custom test as PoC that shows if field(s) from entity is banned, table is broken - which is a wrong behavior

```
17) EasyCorp\Bundle\EasyAdminBundle\Tests\VoterTest::testingVoter
Failed asserting that the Crawler matches selector "th[data-column="name"]".

/home/runner/work/EasyAdminBundle/EasyAdminBundle/vendor/symfony/framework-bundle/Test/DomCrawlerAssertionsTrait.php:29
/home/runner/work/EasyAdminBundle/EasyAdminBundle/tests/VoterTest.php:58
```

