### PR TITLE
Replace markRegExp by mark

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -182,17 +182,10 @@ class App {
         };
 
         const searchQueryTerms = tokenizeString(searchElement.value);
-        const searchQueryTermsHighlightRegexp = new RegExp(
-            searchQueryTerms
-                // escapes all characters that are special inside a RegExp
-                .map((term) => term.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&'))
-                .join('|'),
-            'i'
-        );
 
         const elementsToHighlight = document.querySelectorAll('table tbody td.searchable');
         const highlighter = new Mark(elementsToHighlight);
-        highlighter.markRegExp(searchQueryTermsHighlightRegexp);
+        highlighter.mark(searchQueryTerms, { separateWordSearch: false });
     }
 
     #createFilters() {


### PR DESCRIPTION
Hi,

Do you remember if there is any the reason to use `markRegExp()` instead of `mark()`?

I faced "an issue" while searching `sébastien`, returned results were correct, but the word `sebastien` (without accent) was not highlighted.
Using `markRegExp()`, it's not easy to handle accents.
But the `mark()` function has the option `diacritics` (`true` by default), to handle accents nicely.

See https://markjs.io