### PR TITLE
Check currency property path first

### DIFF
--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -66,20 +66,21 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
             throw new \InvalidArgumentException(sprintf('You must define the currency for the "%s" money field.', $field->getProperty()));
         }
 
+        $entityInstance = $entityDto->getInstance();
+        $isPropertyReadable = (null !== $entityInstance) && $this->propertyAccessor->isReadable($entityInstance, $currencyPropertyPath);
+
+        if ($isPropertyReadable && (null !== $currencyCode = $this->propertyAccessor->getValue($entityInstance, $currencyPropertyPath))) {
+            return $currencyCode;
+        }
+
         if (null === $field->getValue()) {
             return null;
         }
 
-        $entityInstance = $entityDto->getInstance();
-        $isPropertyReadable = (null !== $entityInstance) && $this->propertyAccessor->isReadable($entityInstance, $currencyPropertyPath);
         if (!$isPropertyReadable) {
             throw new \InvalidArgumentException(sprintf('The "%s" field path used by the "%s" field to get the currency value from the "%s" entity is not readable.', $currencyPropertyPath, $field->getProperty(), $entityDto->getName()));
         }
 
-        if (null === $currencyCode = $this->propertyAccessor->getValue($entityInstance, $currencyPropertyPath)) {
-            throw new \InvalidArgumentException(sprintf('The currency value for the "%s" field cannot be null, but that\'s the value returned by the "%s" field path applied on the "%s" entity.', $field->getProperty(), $currencyPropertyPath, $entityDto->getName()));
-        }
-
-        return $currencyCode;
+        throw new \InvalidArgumentException(sprintf('The currency value for the "%s" field cannot be null, but that\'s the value returned by the "%s" field path applied on the "%s" entity.', $field->getProperty(), $currencyPropertyPath, $entityDto->getName()));
     }
 }


### PR DESCRIPTION
The `MoneyField` has a `currencyPropertyPath` option to show the currency based on another field.

When the field value is empty, `currencyPropertyPath` is skipped.
I believe this was implemented like this because the currency cannot be required on the creation form when the entity does not exist yet.

But this does not work properly when the `MoneyField` is optional.
If no value was saved, the currency is not displayed on the edit form.

In order to fix this, I suggest to always check if the `currencyPropertyPath` returns a value before checking if the field value is empty.

Before:
<img width="1594" height="179" alt="image" src="https://github.com/user-attachments/assets/53c4d280-3c31-4ae0-a856-c8c8d0e47c15" />


After: (currency is now showing on the middle field)
<img width="1593" height="212" alt="image" src="https://github.com/user-attachments/assets/7f2eaac2-8503-444c-b64d-f9f1fc247c85" />
