### PR TITLE
Fix alert component: avoid twig error when withDismissButton not set

### DIFF
--- a/templates/components/Alert.html.twig
+++ b/templates/components/Alert.html.twig
@@ -1,7 +1,7 @@
 <div {{ attributes.defaults({class: this.defaultCssClass(), role: 'alert'}) }}>
     <twig:block name="content"></twig:block>
 
-    {% if withDismissButton %}
+    {% if withDismissButton is defined %}
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     {% endif %}
 </div>


### PR DESCRIPTION
Hi,

A little PR to avoid the twig error :

> Variable "withDismissButton" does not exist.

And allow to create alerts without the close button : 

```twig
<twig:ea:Alert variant="{{ label }}">
    {{ message|trans|raw }}
</twig:ea:Alert>
```

Currently  only this works : 
```twig
<twig:ea:Alert variant="{{ label }}" withDismissButton>
    {{ message|trans|raw }}
</twig:ea:Alert>
```