### PR TITLE
Symfony-ux inspired events for autocomplete

### DIFF
--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -55,7 +55,17 @@ export default class Autocomplete {
             maxOptions: null,
         });
 
-        return new TomSelect(element, config);
+        document.dispatchEvent(
+            new CustomEvent('ea.autocomplete.pre-connect', { detail: { config, prefix: 'autocomplete' } })
+        );
+
+        const tomSelect = new TomSelect(element, config);
+
+        document.dispatchEvent(
+            new CustomEvent('ea.autocomplete.connect', { detail: { tomSelect, config, prefix: 'autocomplete' } })
+        );
+
+        return tomSelect;
     }
 
     #createAutocompleteWithHtmlContents(element) {


### PR DESCRIPTION
Hello !
I am making this PR because I need to be able to customize autocomplete fields in my project to improve performance and fine tune some specific features of my website.

In symfony-ux autocomplete, it is very easy thanks to a couple of events dispatched right before and right after the autocomplete fields have been created : https://symfony.com/bundles/ux-autocomplete/current/index.html#extending-tom-select.

So I took inspiration from this part of symfony-ux autocomplete's code:
https://github.com/symfony/ux-autocomplete/blob/2.x/assets/src/controller.ts

I am aware that someone has suggested to use symfony-ux in easyadmin :
https://github.com/EasyCorp/EasyAdminBundle/issues/6967

But for the time being (whether ea moves to symfony-ux or not) is it possible to dispatch these events every time an Autocomplete object is created by EasyAdmin's frontend ?

This would simplify greatly the process of customizing autocomplete fields in easyadmin !

Instead of manually grabbing the select element by its id and finding tomselect in that select, it would become as simple as 

```js
document.addEventListener('ea.autocomplete.connect', (event) => {
    // custom code goes here
});
```