### PR TITLE
Remove nl2br

### DIFF
--- a/templates/crud/field/textarea.html.twig
+++ b/templates/crud/field/textarea.html.twig
@@ -4,7 +4,7 @@
 {% set render_as_html = field.customOptions.get('renderAsHtml') %}
 {% if ea().crud.currentAction == 'detail' %}
     <span title="{{ field.value }}">
-        {{ render_as_html ? field.formattedValue|raw|nl2br : field.formattedValue|nl2br }}
+        {{ render_as_html ? field.formattedValue|raw : field.formattedValue|nl2br }}
     </span>
 {% else %}
     <span title="{{ field.value }}">


### PR DESCRIPTION
No need for `nl2br` filter call on html, iIt just adds unnecessary `<br>`-s to html.

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
