### PR TITLE
fix: keep filter name even if field hidden on forms

### DIFF
--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -96,7 +96,7 @@ final class FieldFactory
 
             // when creating new entities with "useEntryCrudForm" on an edit page we must
             // explicitly check for the "new" page because $currentPage will be "edit"
-            if ((null === $entityDto->getInstance()) && !$fieldDto->isDisplayedOn(Crud::PAGE_NEW)) {
+            if ($isDetailOrIndex && (null === $entityDto->getInstance()) && !$fieldDto->isDisplayedOn(Crud::PAGE_NEW)) {
                 $fields->unset($fieldDto);
 
                 continue;


### PR DESCRIPTION
This PR fix #6114 (the issue still exists on v4.24.9).

I'm not sure my code is correct, but it works good on all cases I have tested.

---

Bonus: before that, the fields that were in a trait did not have the label in the filters. Now they do.

Example:

```php
class BlablaCrudController extends AbstractCrudController
{
    use MetadataFieldsTrait;

    public function configureFilters(Filters $filters): Filters
    {
        return $filters
            ->add('a')
            ->add('b')
            ->add('c')

            // those fields now have label
            ->add('createdAt')
            ->add('updatedAt');
    }

    public function configureFields(string $pageName): iterable
    {
        return [
            TextField::new('a', 'Label A'),
            TextField::new('b', 'Label B'),
            TextField::new('c', 'Label C'),

            ...$this->getMetadataFields(), // from the trait, with createdAt and updatedAt
        ];
    }
}
```

---

# Here is the original issue:

EasyAdmin version: 4.8.11
#### Description:
Fields configured as hideOnForm() or onlyOnDetail() get wrong labels in filter form.
Long story short. I have an entity with fields like lastRunAt, createdAt, etc. I don't want them to be editable, but I want to be able to filter by them.
#### Steps to reproduce:
1) create simple entity with name (text) and lastRunAt (datetime) fields - fields types doesn't matter
2) create CRUD for entity
3) configure fields
```php
public function configureFields(string $pageName): iterable
{
    return [
        IntegerField::new('id', t('command.label.id'))
            ->hideOnIndex()
            ->hideOnForm(),
        TextField::new('name', t('command.label.name')),
        DateTimeField::new('lastRunAt', t('command.label.lastRunAt'))
            ->hideOnForm(),
    ];
}
```
4) configure filters
```php
public function configureFilters(Filters $filters): Filters
{
    return $filters
        ->add('name')
        ->add('lastRunAt');
}
```
5) open index page and open modal with filters form
Label gets lost at FieldFactory on AJAX request to render filters action.
https://github.com/EasyCorp/EasyAdminBundle/blob/25960cc9dfb9f1724d29e0dd38e60617efdc79f1/src/Factory/FieldFactory.php#L94-L100
#### Screenshots:
![obraz](https://github.com/EasyCorp/EasyAdminBundle/assets/78872068/b0631b0f-7103-4a0f-b629-d6e86673ee4c)
![obraz](https://github.com/EasyCorp/EasyAdminBundle/assets/78872068/64e19a9a-8261-4a18-837b-6915a81ea5b2)
