### PR TITLE
Add a new #[AdminRoute] attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
         "psr-4": {
             "EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\TestApplication\\": "tests/TestApplication/src/",
             "EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\PrettyUrlsTestApplication\\": "tests/PrettyUrlsTestApplication/src/",
+            "EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\AdminRouteTestApplication\\": "tests/AdminRouteTestApplication/src/",
             "EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\": "tests/"
         }
     },

--- a/config/services.php
+++ b/config/services.php
@@ -201,6 +201,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(1, service('router'))
             ->arg(2, service(DashboardControllerRegistry::class))
             ->arg(3, service(AdminRouteGenerator::class))
+            ->arg(4, service('cache.easyadmin'))
 
         ->set('service_locator_'.AdminUrlGenerator::class, ServiceLocator::class)
             ->args([[AdminUrlGenerator::class => service(AdminUrlGenerator::class)]])
@@ -217,6 +218,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(3, service('filesystem'))
             ->arg(4, '%kernel.build_dir%')
             ->arg(5, '%kernel.default_locale%')
+            ->arg(6, tagged_iterator(EasyAdminExtension::TAG_ADMIN_ROUTE_CONTROLLER))
 
         ->set(AdminRouteLoader::class)
             ->arg(0, service(AdminRouteGenerator::class))
@@ -233,6 +235,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, service('security.logout_url_generator'))
             ->arg(3, service(AdminUrlGenerator::class))
             ->arg(4, service(MenuItemMatcherInterface::class))
+            ->arg(5, service('router'))
 
         ->set(MenuItemMatcher::class)
             ->arg(0, service(AdminUrlGenerator::class))

--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -438,14 +438,14 @@ The following example shows all kinds of actions in practice::
     of the shortcuts and utilities available in regular `Symfony controllers`_,
     such as ``$this->render()``, ``$this->redirect()``, and others.
 
-Custom actions can define the ``#[AdminAction]`` attribute to
+Custom actions can define the ``#[AdminRoute]`` attribute to
 :ref:`customize their route name, path and methods <crud_routes>`::
 
-    use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminAction;
+    use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
     // ...
 
 
-    #[AdminAction(routePath: '/invoice', routeName: 'view_invoice', methods: ['GET', 'POST'])]
+    #[AdminRoute(routePath: '/invoice', routeName: 'view_invoice')]
     public function renderInvoice(AdminContext $context)
     {
         // ...

--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -111,20 +111,26 @@ Admin route name                Admin route path
 ==============================  =====================================
 
 You can also customize the path and/or route name of CRUD controllers using the
-``#[AdminCrud]`` attribute with the following options:
+``#[AdminRoute]`` attribute with the following options:
 
 * ``routePath``: the value that represents the controller in the entire route path
   (e.g. a ``/foo`` path will result in ``/admin`` + ``/foo`` + ``/<action>``);
 * ``routeName``: the value that represents the controller in the full route name
   (e.g. a ``foo_bar`` route name will result in ``admin_`` + ``foo_bar`` + ``_<action>``).
 
+.. deprecated:: 4.25.0
+
+    In EasyAdmin versions prior to 4.25.0, instead of ``#[AdminRoute]`` you
+    had to use the ``#[AdminCrud]`` attribute, which is now deprecated and will
+    be removed in EasyAdmin 5.0.0.
+
 Using the same example as above, you can configure the route names and paths of
 the controller as follows::
 
-    use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminCrud;
+    use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
     // ...
 
-    #[AdminCrud(routePath: '/stock/current', routeName: 'stock')]
+    #[AdminRoute(routePath: '/stock/current', routeName: 'stock')]
     class ProductCrudController extends AbstractCrudController
     {
         // ...
@@ -146,16 +152,16 @@ Admin route name                Admin route path
 ==============================  =====================================
 
 Finally, you can also customize the route name and/or path of each CRUD controller
-action using the ``#[AdminAction]`` attribute::
+action using the ``#[AdminRoute]`` attribute::
 
-    use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminAction;
+    use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
     // ...
 
     class ProductCrudController extends AbstractCrudController
     {
         // ...
 
-        #[AdminAction(routePath: '/latest-products', routeName: 'latest')]
+        #[AdminRoute(routePath: '/latest-products', routeName: 'latest')]
         public function index(AdminContext $context)
         {
             // ...
@@ -168,8 +174,14 @@ will be ``admin_product_latest`` and the path will be ``/admin/product/latest-pr
 
 .. tip::
 
-    You can combine the ``#[AdminDashboard]``, ``#[AdminCrud]``, and ``#[AdminAction]``
+    You can combine the ``#[AdminDashboard]``, and ``#[AdminRoute]``
     attributes to customize some or all route names and paths.
+
+.. deprecated:: 4.25.0
+
+    In EasyAdmin versions prior to 4.25.0, instead of ``#[AdminRoute]`` you
+    had to use the ``#[AdminAction]`` attribute, which is now deprecated and
+    will be removed in EasyAdmin 5.0.0.
 
 Page Names and Constants
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/Attribute/AdminDashboard.php
+++ b/src/Attribute/AdminDashboard.php
@@ -12,11 +12,11 @@ class AdminDashboard
         /**
          * @var string|null $routePath The path of the Symfony route that will be created for the dashboard (e.g. '/admin)
          */
-        public /* ?string */ $routePath = null,
+        /* ?string */ public $routePath = null,
         /**
          * @var string|null $routeName The name of the Symfony route that will be created for the dashboard (e.g. 'admin')
          */
-        public /* ?string */ $routeName = null,
+        /* ?string */ public $routeName = null,
         /**
          * @var array{
          *     requirements?: array<string, string>,

--- a/src/Attribute/AdminRoute.php
+++ b/src/Attribute/AdminRoute.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Attribute;
+
+/**
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+class AdminRoute
+{
+    public function __construct(
+        /**
+         * @var string|null $routePath The path defined in this option is appended to the dashboard path and, for CRUD actions, also to the CRUD path (e.g. using '/invoice/send' here might result in /admin/invoice/send, /admin/orders/invoice/send, etc. depending on your backend)
+         */
+        public ?string $routePath = null,
+
+        /**
+         * @var string|null $routeName The route name defined here is appended to the dashboard route name and, for CRUD actions, also to the CRUD route name (e.g. using 'restock' here might result in admin_restock, admin_products_restock, etc. depending on your backend)
+         */
+        public ?string $routeName = null,
+
+        /**
+         * @var array{
+         *     requirements?: array<string, string>,
+         *     options?: array<string, mixed>,
+         *     defaults?: array<string, mixed>,
+         *     host?: string,
+         *     methods?: array<string>|string,
+         *     schemes?: array<string>|string,
+         *     condition?: string,
+         *     locale?: string,
+         *     format?: string,
+         *     utf8?: bool,
+         *     stateless?: bool,
+         * } $routeOptions Additional configuration options used when creating this admin route
+         */
+        public array $routeOptions = [],
+
+        /**
+         * @var class-string[]|false|null $allowedDashboards If defined, this admin route will be available only for the specified dashboards. Possible values:
+         *                                - false (default): Not set - inherit from the #[AdminRoute] attribute defined at the class level (if any)
+         *                                - null: Explicitly allow all dashboards (used to override the same option in the #[AdminRoute] attribute at class level)
+         *                                - []: Explicitly allow no dashboards
+         *                                - [FooDashboard::class, BarDashboard::class, ...]: Allow only specific dashboards
+         */
+        public array|false|null $allowedDashboards = false,
+
+        /**
+         * @var class-string[]|false|null $deniedDashboards If defined, this admin route won't be available for the specified dashboards. Possible values:
+         *                                - false (default): Not set - inherit from the #[AdminRoute] attribute defined at the class level (if any)
+         *                                - null: Explicitly deny none (used to override the same option in the #[AdminRoute] attribute at class level)
+         *                                - []: Explicitly deny no dashboards
+         *                                - [FooDashboard::class, BarDashboard::class, ...]: Deny specific dashboards
+         */
+        public array|false|null $deniedDashboards = false,
+    ) {
+    }
+}

--- a/src/DependencyInjection/Compiler/AdminRoutePass.php
+++ b/src/DependencyInjection/Compiler/AdminRoutePass.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\Compiler;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\EasyAdminExtension;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Compiler pass to automatically discover and tag controllers that use the
+ * #[AdminRoute] attribute in the controller class or any of its methods.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class AdminRoutePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $definition) {
+            if (null === $definition->getClass() || $definition->isAbstract()) {
+                continue;
+            }
+
+            $class = $container->getParameterBag()->resolveValue($definition->getClass());
+
+            // skip certain well-known vendor prefixes and certain common class suffixes
+            if (str_ends_with($class, 'Interface')
+                || str_ends_with($class, 'Test')
+                || str_starts_with($class, 'Symfony\\')
+                || str_starts_with($class, 'Doctrine\\')
+                || str_starts_with($class, 'Twig\\')
+                || str_starts_with($class, 'League\\')
+                || str_starts_with($class, 'Monolog\\')
+                || str_starts_with($class, 'Nelmio\\')
+                || str_starts_with($class, 'Nyholm\\')
+                || str_starts_with($class, 'Psr\\')
+                || str_starts_with($class, 'Zenstruck\\')
+            ) {
+                continue;
+            }
+
+            try {
+                // use class_exists with autoload disabled first to check if already loaded
+                if (!class_exists($class, false)) {
+                    $reflector = new \ReflectionClass($class);
+                } else {
+                    $reflector = new \ReflectionClass($class);
+                }
+            } catch (\Throwable $e) {
+                continue;
+            }
+
+            try {
+                // check first for class-level AdminRoute attribute
+                $hasClassAttribute = [] !== $reflector->getAttributes(AdminRoute::class);
+
+                // then, check for method-level AdminRoute attributes
+                $hasMethodAttribute = false;
+                foreach ($reflector->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                    if ([] !== $method->getAttributes(AdminRoute::class)) {
+                        $hasMethodAttribute = true;
+                        break;
+                    }
+                }
+
+                // if the class or any of its methods have the AdminRoute attribute, tag it
+                if ($hasClassAttribute || $hasMethodAttribute) {
+                    $definition->addTag(EasyAdminExtension::TAG_ADMIN_ROUTE_CONTROLLER);
+                }
+            } catch (\Throwable $e) {
+                // skip any class that causes issues
+                continue;
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/EasyAdminExtension.php
+++ b/src/DependencyInjection/EasyAdminExtension.php
@@ -19,6 +19,7 @@ class EasyAdminExtension extends Extension implements PrependExtensionInterface
 {
     public const TAG_CRUD_CONTROLLER = 'ea.crud_controller';
     public const TAG_DASHBOARD_CONTROLLER = 'ea.dashboard_controller';
+    public const TAG_ADMIN_ROUTE_CONTROLLER = 'ea.admin_route_controller';
     public const TAG_FIELD_CONFIGURATOR = 'ea.field_configurator';
     public const TAG_FILTER_CONFIGURATOR = 'ea.filter_configurator';
 

--- a/src/EasyAdminBundle.php
+++ b/src/EasyAdminBundle.php
@@ -2,7 +2,9 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle;
 
+use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\Compiler\AdminRoutePass;
 use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\CreateControllerRegistriesPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -16,6 +18,8 @@ class EasyAdminBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new CreateControllerRegistriesPass());
+        // run AdminRoutePass after autoconfiguration to ensure services are registered
+        $container->addCompilerPass(new AdminRoutePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);
     }
 
     public function getPath(): string

--- a/tests/AdminRouteTestApplication/config/packages/doctrine.php
+++ b/tests/AdminRouteTestApplication/config/packages/doctrine.php
@@ -1,0 +1,24 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container) {
+    $container->extension('doctrine', [
+        'dbal' => [
+            'url' => 'sqlite:///:memory:',
+        ],
+        'orm' => [
+            'auto_generate_proxy_classes' => true,
+            'auto_mapping' => true,
+            'mappings' => [
+                'AdminRouteTestApplication' => [
+                    'is_bundle' => false,
+                    'type' => 'attribute',
+                    'dir' => '%kernel.project_dir%/src/Entity',
+                    'prefix' => 'EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Entity',
+                    'alias' => 'AdminRouteTestApplication',
+                ],
+            ],
+        ],
+    ]);
+};

--- a/tests/AdminRouteTestApplication/config/packages/framework.php
+++ b/tests/AdminRouteTestApplication/config/packages/framework.php
@@ -1,0 +1,31 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container) {
+    $container->extension('framework', [
+        'secret' => 'test_admin_route_secret',
+        'test' => true,
+        'router' => [
+            'utf8' => true,
+        ],
+        'session' => [
+            'handler_id' => null,
+            'storage_factory_id' => 'session.storage.factory.mock_file',
+        ],
+        'profiler' => false,
+        'property_info' => [
+            'enabled' => true,
+        ],
+        'php_errors' => [
+            'log' => true,
+        ],
+        'cache' => [
+            'pools' => [
+                'cache.easyadmin' => [
+                    'adapter' => 'cache.adapter.filesystem',
+                ],
+            ],
+        ],
+    ]);
+};

--- a/tests/AdminRouteTestApplication/config/packages/security.php
+++ b/tests/AdminRouteTestApplication/config/packages/security.php
@@ -1,0 +1,28 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container) {
+    $container->extension('security', [
+        'password_hashers' => [
+            'Symfony\Component\Security\Core\User\InMemoryUser' => 'plaintext',
+        ],
+        'providers' => [
+            'test_users' => [
+                'memory' => [
+                    'users' => [
+                        'admin' => ['password' => 'admin', 'roles' => ['ROLE_ADMIN']],
+                    ],
+                ],
+            ],
+        ],
+        'firewalls' => [
+            'main' => [
+                'pattern' => '^/',
+                'provider' => 'test_users',
+                'http_basic' => true,
+            ],
+        ],
+        'access_control' => [],
+    ]);
+};

--- a/tests/AdminRouteTestApplication/config/packages/twig.php
+++ b/tests/AdminRouteTestApplication/config/packages/twig.php
@@ -1,0 +1,12 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container) {
+    $container->extension('twig', [
+        'default_path' => '%kernel.project_dir%/templates',
+        'debug' => '%kernel.debug%',
+        'strict_variables' => '%kernel.debug%',
+        'exception_controller' => null,
+    ]);
+};

--- a/tests/AdminRouteTestApplication/config/routes.php
+++ b/tests/AdminRouteTestApplication/config/routes.php
@@ -1,0 +1,8 @@
+<?php
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function (RoutingConfigurator $routes) {
+    // Import EasyAdmin routes with pretty URLs enabled
+    $routes->import('.', 'easyadmin.routes');
+};

--- a/tests/AdminRouteTestApplication/config/services.php
+++ b/tests/AdminRouteTestApplication/config/services.php
@@ -1,0 +1,14 @@
+<?php
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $container) {
+    $services = $container->services()
+        ->defaults()
+            ->autowire()
+            ->autoconfigure()
+            ->public();
+
+    $services->load('EasyCorp\\Bundle\\EasyAdminBundle\\Tests\\AdminRouteTestApplication\\Controller\\', '../src/Controller/')
+        ->tag('controller.service_arguments');
+};

--- a/tests/AdminRouteTestApplication/src/Controller/DashboardController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/DashboardController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use Symfony\Component\HttpFoundation\Response;
+
+#[AdminDashboard(
+    routePath: '/admin',
+    routeName: 'admin'
+)]
+class DashboardController extends AbstractDashboardController
+{
+    public function index(): Response
+    {
+        return $this->render('@EasyAdmin/page/dashboard.html.twig');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/FooController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/FooController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test case 2: Controller with class-level prefix and method-level routes.
+ */
+#[AdminRoute(
+    routePath: '/foo',
+    routeName: 'foo',
+    allowedDashboards: [DashboardController::class]
+)]
+class FooController extends AbstractController
+{
+    #[AdminRoute(
+        routePath: '/list',
+        routeName: 'list'
+    )]
+    public function list(): Response
+    {
+        return new Response('Foo List');
+    }
+
+    #[AdminRoute(
+        routePath: '/export/csv',
+        routeName: 'export_csv',
+        routeOptions: ['methods' => ['GET', 'POST']]
+    )]
+    public function exportCsv(): Response
+    {
+        return new Response('Export CSV');
+    }
+
+    /**
+     * This method overrides the class-level dashboard restrictions.
+     */
+    #[AdminRoute(
+        routePath: '/public-export',
+        routeName: 'public_export',
+        allowedDashboards: null,
+    )]
+    public function publicExport(): Response
+    {
+        return new Response('Public Export');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/InvokableController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/InvokableController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test case 1: Invokable controller with complete route definition.
+ */
+#[AdminRoute(
+    routePath: '/custom-invokable',
+    routeName: 'custom_invokable',
+    routeOptions: ['defaults' => ['_locale' => 'en']]
+)]
+class InvokableController extends AbstractController
+{
+    public function __invoke(): Response
+    {
+        return new Response('Invokable Controller Response');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/ReportsController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/ReportsController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test case 3: Controller with partial class-level configuration
+ * The class only defines the route path prefix, not the name.
+ */
+#[AdminRoute(
+    routePath: '/reports',
+    allowedDashboards: [SecondDashboardController::class]
+)]
+class ReportsController extends AbstractController
+{
+    #[AdminRoute(
+        routePath: '/sales',
+        routeName: 'sales_report'
+    )]
+    public function salesReport(): Response
+    {
+        return new Response('Sales Report');
+    }
+
+    #[AdminRoute(
+        routePath: '/inventory',
+        routeName: 'inventory_report'
+    )]
+    public function inventoryReport(): Response
+    {
+        return new Response('Inventory Report');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/SecondDashboardController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/SecondDashboardController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use Symfony\Component\HttpFoundation\Response;
+
+#[AdminDashboard(
+    routePath: '/second-admin',
+    routeName: 'second_admin'
+)]
+class SecondDashboardController extends AbstractDashboardController
+{
+    public function index(): Response
+    {
+        return $this->render('@EasyAdmin/page/dashboard.html.twig');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/StandaloneMethodsController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/StandaloneMethodsController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test case 4: Controller with only method-level routes (no class-level attribute).
+ */
+class StandaloneMethodsController extends AbstractController
+{
+    #[AdminRoute(
+        routePath: '/standalone/action1',
+        routeName: 'standalone_action1'
+    )]
+    public function action1(): Response
+    {
+        return new Response('Standalone Action 1');
+    }
+
+    #[AdminRoute(
+        routePath: '/standalone/action2',
+        routeName: 'standalone_action2',
+        routeOptions: ['methods' => ['POST']]
+    )]
+    public function action2(): Response
+    {
+        return new Response('Standalone Action 2');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Entity/Product.php
+++ b/tests/AdminRouteTestApplication/src/Entity/Product.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Product
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    #[ORM\Column]
+    private ?float $price = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getPrice(): ?float
+    {
+        return $this->price;
+    }
+
+    public function setPrice(float $price): self
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Kernel.php
+++ b/tests/AdminRouteTestApplication/src/Kernel.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Bundle\SecurityBundle\SecurityBundle;
+use Symfony\Bundle\TwigBundle\TwigBundle;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+use Symfony\UX\TwigComponent\TwigComponentBundle;
+
+class Kernel extends BaseKernel
+{
+    use MicroKernelTrait;
+
+    public function getProjectDir(): string
+    {
+        return \dirname(__DIR__);
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir().'/EasyAdminBundle/tests/AdminRouteTestApplication/var/cache/'.$this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir().'/EasyAdminBundle/tests/AdminRouteTestApplication/var/log';
+    }
+
+    /**
+     * @return iterable<BundleInterface>
+     */
+    public function registerBundles(): iterable
+    {
+        return [
+            new FrameworkBundle(),
+            new DoctrineBundle(),
+            new SecurityBundle(),
+            new TwigBundle(),
+            new TwigComponentBundle(),
+            new EasyAdminBundle(),
+        ];
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        $loader->load($this->getProjectDir().'/config/services.php');
+        $loader->load($this->getProjectDir().'/config/packages/*.php', 'glob');
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+        $routes->import($this->getProjectDir().'/config/routes.php');
+    }
+}

--- a/tests/Controller/AssetsControllerTest.php
+++ b/tests/Controller/AssetsControllerTest.php
@@ -56,9 +56,9 @@ class AssetsControllerTest extends AbstractCrudTestCase
         static::assertStringContainsString('<script src="/js7.js"></script>', $headHtmlContents);
         static::assertStringContainsString('</js7.js>; rel="preload"; as="script"; nopush,', $linkResponseHeaderContents);
         static::assertStringContainsString('<script src="/js8.js" defer></script>', $headHtmlContents);
-        static::assertStringContainsString('<script src="/js9.js" async></script>', $headHtmlContents);
-        static::assertStringContainsString('<script src="/js10.js" async defer></script>', $headHtmlContents);
-        static::assertStringContainsString('<script src="/js11.js" async defer></script>', $headHtmlContents);
+        static::assertMatchesRegularExpression('/<script src="\/js9\.js" async(="")?>/', $headHtmlContents);
+        static::assertMatchesRegularExpression('/<script src="\/js10\.js" async(="")? defer>/', $headHtmlContents);
+        static::assertMatchesRegularExpression('/<script src="\/js11\.js" async(="")? defer>/', $headHtmlContents);
         static::assertStringContainsString('</js11.js>; rel="preload"; as="script"; nopush', $linkResponseHeaderContents);
         static::assertStringContainsString('<script src="/js12.js" foo="bar"></script>', $headHtmlContents);
         static::assertStringContainsString('<script src="/js13.js" foo="bar" baz="qux"></script>', $headHtmlContents);

--- a/tests/Functional/AdminRouteTest.php
+++ b/tests/Functional/AdminRouteTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Kernel;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Routing\Route;
+
+class AdminRouteTest extends WebTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return Kernel::class;
+    }
+
+    protected function setUp(): void
+    {
+        if (version_compare(\Symfony\Component\HttpKernel\Kernel::VERSION,
+            '5.4.1', '<')) {
+            $this->markTestSkipped('AdminRoute attributes require Symfony 5.4.1 or higher');
+        }
+
+        parent::setUp();
+
+        // Create client which boots the kernel
+        $client = static::createClient();
+
+        // Enable pretty URLs for this test
+        $buildDir = $client->getKernel()->getContainer()->getParameter('kernel.build_dir');
+        $filesystem = new Filesystem();
+        $filesystem->touch($buildDir.'/easyadmin_pretty_urls_enabled');
+
+        // Shutdown kernel to allow tests to create their own clients
+        self::ensureKernelShutdown();
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up the pretty URLs marker file
+        $filesystem = new Filesystem();
+        $buildDir = sys_get_temp_dir().'/EasyAdminBundle/tests/AdminRouteTestApplication/var/cache';
+        $filesystem->remove($buildDir.'/test/easyadmin_pretty_urls_enabled');
+
+        parent::tearDown();
+    }
+
+    public function testInvokableControllerRoute(): void
+    {
+        $client = static::createClient();
+        $router = $client->getContainer()->get('router');
+
+        // Test that the invokable controller route exists
+        $route = $router->getRouteCollection()->get('admin_custom_invokable');
+        $this->assertNotNull($route);
+        $this->assertSame('/admin/custom-invokable', $route->getPath());
+
+        // Test the controller action
+        $defaults = $route->getDefaults();
+        $this->assertSame(
+            'EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller\InvokableController::__invoke',
+            $defaults['_controller']
+        );
+
+        // Test the locale default
+        $this->assertSame('en', $defaults['_locale']);
+
+        // Test that the second dashboard also has the route
+        $route2 = $router->getRouteCollection()->get('second_admin_custom_invokable');
+        $this->assertNotNull($route2);
+        $this->assertSame('/second-admin/custom-invokable', $route2->getPath());
+    }
+
+    public function testControllerWithClassAndMethodAttributes(): void
+    {
+        $client = static::createClient();
+        $router = $client->getContainer()->get('router');
+
+        // Debug: List all admin routes
+        $routes = $router->getRouteCollection();
+        $adminRoutes = [];
+        foreach ($routes as $name => $route) {
+            if (str_contains($name, 'foo')) {
+                $adminRoutes[$name] = $route->getPath();
+            }
+        }
+
+        // Test the list route (should combine class + method)
+        $listRoute = $router->getRouteCollection()->get('admin_foo_list');
+        $this->assertNotNull($listRoute, 'Foo routes found: '.json_encode($adminRoutes));
+        $this->assertSame('/admin/foo/list', $listRoute->getPath());
+        $this->assertSame(
+            'EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller\FooController::list',
+            $listRoute->getDefault('_controller')
+        );
+
+        // Test the export CSV route
+        $exportRoute = $router->getRouteCollection()->get('admin_foo_export_csv');
+        $this->assertNotNull($exportRoute);
+        $this->assertSame('/admin/foo/export/csv', $exportRoute->getPath());
+        $this->assertContains('GET', $exportRoute->getMethods());
+        $this->assertContains('POST', $exportRoute->getMethods());
+
+        // Test public export route (overrides dashboard restrictions)
+        $publicRoute = $router->getRouteCollection()->get('admin_foo_public_export');
+        $this->assertNotNull($publicRoute);
+        $this->assertSame('/admin/foo/public-export', $publicRoute->getPath());
+
+        // The second dashboard should also have the public export route
+        $publicRoute2 = $router->getRouteCollection()->get('second_admin_foo_public_export');
+        $this->assertNotNull($publicRoute2);
+        $this->assertSame('/second-admin/foo/public-export', $publicRoute2->getPath());
+
+        // But the second dashboard should NOT have the restricted routes
+        $this->assertNull($router->getRouteCollection()->get('second_admin_foo_list'));
+        $this->assertNull($router->getRouteCollection()->get('second_admin_foo_export_csv'));
+    }
+
+    public function testControllerWithPartialClassConfiguration(): void
+    {
+        $client = static::createClient();
+        $router = $client->getContainer()->get('router');
+
+        // ReportsController is restricted to SecondDashboardController
+        // So it should NOT have routes for the main dashboard
+        $this->assertNull($router->getRouteCollection()->get('admin_sales_report'));
+        $this->assertNull($router->getRouteCollection()->get('admin_inventory_report'));
+
+        // But it SHOULD have routes for the second dashboard
+        $salesRoute = $router->getRouteCollection()->get('second_admin_sales_report');
+        $this->assertNotNull($salesRoute);
+        $this->assertSame('/second-admin/reports/sales', $salesRoute->getPath());
+
+        $inventoryRoute = $router->getRouteCollection()->get('second_admin_inventory_report');
+        $this->assertNotNull($inventoryRoute);
+        $this->assertSame('/second-admin/reports/inventory', $inventoryRoute->getPath());
+    }
+
+    public function testStandaloneMethodRoutes(): void
+    {
+        $client = static::createClient();
+        $router = $client->getContainer()->get('router');
+
+        // Standalone methods should create routes for all dashboards
+        $action1Route = $router->getRouteCollection()->get('admin_standalone_action1');
+        $this->assertNotNull($action1Route);
+        $this->assertSame('/admin/standalone/action1', $action1Route->getPath());
+
+        $action2Route = $router->getRouteCollection()->get('admin_standalone_action2');
+        $this->assertNotNull($action2Route);
+        $this->assertSame('/admin/standalone/action2', $action2Route->getPath());
+        $this->assertContains('POST', $action2Route->getMethods());
+
+        // Should also exist for second dashboard
+        $action1Route2 = $router->getRouteCollection()->get('second_admin_standalone_action1');
+        $this->assertNotNull($action1Route2);
+        $this->assertSame('/second-admin/standalone/action1', $action1Route2->getPath());
+    }
+
+    public function testRouteAccessibility(): void
+    {
+        $client = static::createClient();
+        $client->setServerParameters(['PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => 'admin']);
+
+        // Test invokable controller
+        $client->request('GET', '/admin/custom-invokable');
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('Invokable Controller Response', $client->getResponse()->getContent());
+
+        // Test foo list
+        $client->request('GET', '/admin/foo/list');
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('Foo List', $client->getResponse()->getContent());
+
+        // Test standalone action
+        $client->request('GET', '/admin/standalone/action1');
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('Standalone Action 1', $client->getResponse()->getContent());
+
+        // Test reports (should work on second dashboard)
+        $client->request('GET', '/second-admin/reports/sales');
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('Sales Report', $client->getResponse()->getContent());
+    }
+
+    public function testRouteNamesAreCorrectlyGenerated(): void
+    {
+        $client = static::createClient();
+        $router = $client->getContainer()->get('router');
+        $routes = $router->getRouteCollection();
+
+        // Collect all AdminRoute-generated routes
+        $adminRoutes = [];
+        foreach ($routes as $name => $route) {
+            if ($route->hasDefault(EA::ROUTE_CREATED_BY_EASYADMIN)) {
+                $adminRoutes[$name] = $route;
+            }
+        }
+
+        // Check expected route names exist
+        $expectedRoutes = [
+            // Invokable controller routes
+            'admin_custom_invokable',
+            'second_admin_custom_invokable',
+
+            // Foo routes (only for main dashboard except public_export)
+            'admin_foo_list',
+            'admin_foo_export_csv',
+            'admin_foo_public_export',
+            'second_admin_foo_public_export',
+
+            // Reports routes (only for second dashboard)
+            'second_admin_sales_report',
+            'second_admin_inventory_report',
+
+            // Standalone routes (for all dashboards)
+            'admin_standalone_action1',
+            'admin_standalone_action2',
+            'second_admin_standalone_action1',
+            'second_admin_standalone_action2',
+        ];
+
+        foreach ($expectedRoutes as $routeName) {
+            $this->assertArrayHasKey($routeName, $adminRoutes, "Expected route '$routeName' not found");
+        }
+    }
+}

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -10,8 +10,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Kernel;
@@ -314,6 +316,12 @@ class AdminUrlGeneratorTest extends WebTestCase
         $adminRouteGenerator->method('findRouteName')->willReturn(null);
         $adminRouteGenerator->method('usesPrettyUrls')->willReturn(false);
 
-        return new AdminUrlGenerator($adminContextProvider, $router, $dashboardControllerRegistry, $adminRouteGenerator);
+        $cacheItem = new CacheItem();
+        $cacheItem->set([]);
+        $cacheMock = $this->getMockBuilder(CacheItemPoolInterface::class)->getMock();
+        $cacheMock->method('getItem')->willReturn($cacheItem);
+        $cacheMock->method('save')->willReturn(true);
+
+        return new AdminUrlGenerator($adminContextProvider, $router, $dashboardControllerRegistry, $adminRouteGenerator, $cacheMock);
     }
 }


### PR DESCRIPTION
Current situation:

* You can use `#[AdminCrud]` and `#[AdminAction]` to customize the pretty URLs used for CRUDs
* You can use those same attributes to generate admin URLs for custom actions added to CRUDs
* Independent controllers/actions defined elsewhere can be integrated with EasyAdmin dashboards, but the URLs are not pretty and they don't feel "fully integrated"

New situation after this PR:

* There's only one attribute: `#[AdminRoute]`
* It can:
  * Customize URLs of all CRUDs and actions
  * Generate admin routes for custom actions in CRUD controllers
  * Generate admin routes for any action of any Symfony controller

This allows you to generate pretty URLs for any action/controller and they use pretty URLs when linked from the menu like this:

```php
yield MenuItem::linkToRoute('My Custom Controller', '...', 'admin_some_route'); 
```

I need to update the docs even more to better explain how to integrate any Symfony controller into backends.