### PR TITLE
Fix the PHPdoc of the setFormThemes() method in Crud class

### DIFF
--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -383,7 +383,7 @@ class Crud
     }
 
     /**
-     * @param array<string, string> $themePaths
+     * @param array<string> $themePaths
      */
     public function setFormThemes(array $themePaths): self
     {


### PR DESCRIPTION
In my Symfony apps using EasyAdmin I started to see these PHPStan issues:

```
Parameter #1 $themePaths of method EasyCorp\Bundle\EasyAdminBundle\Config\Crud::setFormThemes() 
expects array<string, string>, array<int, string> given.
```