### PR TITLE
Add support for 'contains all' comparison in array filters

### DIFF
--- a/src/Form/Filter/Type/ArrayFilterType.php
+++ b/src/Form/Filter/Type/ArrayFilterType.php
@@ -27,7 +27,11 @@ class ArrayFilterType extends AbstractType
             static fn ($data) => $data,
             static function ($data) {
                 if (null === $data['value'] || [] === $data['value']) {
-                    $data['comparison'] = ComparisonType::CONTAINS === $data['comparison'] ? 'IS NULL' : 'IS NOT NULL';
+                    $data['comparison'] = \in_array(
+                        $data['comparison'],
+                        [ComparisonType::CONTAINS, ComparisonType::CONTAINS_ALL],
+                        true
+                    ) ? 'IS NULL' : 'IS NOT NULL';
                 } else {
                     $data['value'] = (array) $data['value'];
                 }

--- a/src/Form/Type/ComparisonType.php
+++ b/src/Form/Type/ComparisonType.php
@@ -20,6 +20,7 @@ class ComparisonType extends AbstractType
     public const LTE = '<=';
     public const BETWEEN = 'between';
     public const CONTAINS = 'like';
+    public const CONTAINS_ALL = 'like_all';
     public const NOT_CONTAINS = 'not like';
     public const STARTS_WITH = 'like*';
     public const ENDS_WITH = '*like';
@@ -59,6 +60,7 @@ class ComparisonType extends AbstractType
                     ],
                     'array' => [
                         'filter.label.contains' => self::CONTAINS,
+                        'filter.label.contains_all' => self::CONTAINS_ALL,
                         'filter.label.not_contains' => self::NOT_CONTAINS,
                     ],
                     'choice', 'entity' => [

--- a/tests/Form/Filter/Type/ArrayFilterTypeTest.php
+++ b/tests/Form/Filter/Type/ArrayFilterTypeTest.php
@@ -40,6 +40,14 @@ class ArrayFilterTypeTest extends FilterTypeTest
         ];
 
         yield [
+            ['comparison' => ComparisonType::CONTAINS_ALL, 'value' => ['bar', 'baz']],
+            ['comparison' => 'like', 'value' => ['bar', 'baz']],
+            [],
+            'SELECT o FROM Object o WHERE o.foo like :foo_1 AND o.foo like :foo_2',
+            [new Parameter('foo_1', '%"bar"%'), new Parameter('foo_2', '%"baz"%')],
+        ];
+
+        yield [
             ['comparison' => ComparisonType::NOT_CONTAINS, 'value' => ['foo', 'bar']],
             ['comparison' => 'not like', 'value' => ['foo', 'bar']],
             [],
@@ -59,7 +67,27 @@ class ArrayFilterTypeTest extends FilterTypeTest
         ];
 
         yield [
+            ['comparison' => ComparisonType::CONTAINS_ALL, 'value' => []],
+            ['comparison' => 'IS NULL', 'value' => []],
+            [],
+            'SELECT o FROM Object o WHERE o.foo IS NULL',
+            [],
+        ];
+
+        yield [
             ['comparison' => ComparisonType::CONTAINS, 'value' => null],
+            ['comparison' => 'IS NULL', 'value' => null],
+            [
+                'value_type_options' => [
+                    'choices' => ['a' => 'a', 'b' => 'b', 'c' => 'c'],
+                ],
+            ],
+            'SELECT o FROM Object o WHERE o.foo IS NULL',
+            [],
+        ];
+
+        yield [
+            ['comparison' => ComparisonType::CONTAINS_ALL, 'value' => null],
             ['comparison' => 'IS NULL', 'value' => null],
             [
                 'value_type_options' => [

--- a/translations/EasyAdminBundle.ar.php
+++ b/translations/EasyAdminBundle.ar.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'أصغر من أو يساوي',
         'label.is_between' => 'بين',
         'label.contains' => 'يحتوي',
+        'label.contains_all' => 'يحتوي على الكل',
         'label.not_contains' => 'لا يحتوي',
         'label.starts_with' => 'يبدء بـ',
         'label.ends_with' => 'ينتهي بـ',

--- a/translations/EasyAdminBundle.bg.php
+++ b/translations/EasyAdminBundle.bg.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'е по-малко или равно на',
         'label.is_between' => 'е между',
         'label.contains' => 'съдържа',
+        'label.contains_all' => 'съдържа всички',
         'label.not_contains' => 'не съдържа',
         'label.starts_with' => 'започва с',
         'label.ends_with' => 'завършва със',

--- a/translations/EasyAdminBundle.ca.php
+++ b/translations/EasyAdminBundle.ca.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'és menor o igual a',
         'label.is_between' => 'està entre',
         'label.contains' => 'conté',
+        'label.contains_all' => 'conté tot',
         'label.not_contains' => 'no conté',
         'label.starts_with' => 'comença amb',
         'label.ends_with' => 'acaba amb',

--- a/translations/EasyAdminBundle.cs.php
+++ b/translations/EasyAdminBundle.cs.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'je menší než nebo rovno',
         'label.is_between' => 'je mezi',
         'label.contains' => 'obsahuje',
+        'label.contains_all' => 'obsahuje všechny',
         'label.not_contains' => 'neobsahuje',
         'label.starts_with' => 'začíná na',
         'label.ends_with' => 'končí na',

--- a/translations/EasyAdminBundle.da.php
+++ b/translations/EasyAdminBundle.da.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'er mindre end eller lig med',
         'label.is_between' => 'er i mellem',
         'label.contains' => 'indeholder',
+        'label.contains_all' => 'indeholder alle',
         'label.not_contains' => 'indeholder ikke',
         'label.starts_with' => 'starter med',
         'label.ends_with' => 'slutter med',

--- a/translations/EasyAdminBundle.de.php
+++ b/translations/EasyAdminBundle.de.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'ist kleiner oder gleich',
         'label.is_between' => 'ist zwischen',
         'label.contains' => 'enthält',
+        'label.contains_all' => 'enthält alle',
         'label.not_contains' => 'enthält nicht',
         'label.starts_with' => 'beginnt mit',
         'label.ends_with' => 'endet mit',

--- a/translations/EasyAdminBundle.el.php
+++ b/translations/EasyAdminBundle.el.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'είναι μικρότερο ή ίσο με',
         'label.is_between' => 'είναι μεταξύ',
         'label.contains' => 'περιέχει',
+        'label.contains_all' => 'περιέχει όλα',
         'label.not_contains' => 'δεν περιέχει',
         'label.starts_with' => 'ξεκινάει με',
         'label.ends_with' => 'τελειώνει με',

--- a/translations/EasyAdminBundle.en.php
+++ b/translations/EasyAdminBundle.en.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'is less than or equal to',
         'label.is_between' => 'is between',
         'label.contains' => 'contains',
+        'label.contains_all' => 'contains all',
         'label.not_contains' => 'doesn\'t contain',
         'label.starts_with' => 'starts with',
         'label.ends_with' => 'ends with',

--- a/translations/EasyAdminBundle.es.php
+++ b/translations/EasyAdminBundle.es.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'es menor o igual que',
         'label.is_between' => 'está entre',
         'label.contains' => 'contiene',
+        'label.contains_all' => 'contiene todo',
         'label.not_contains' => 'no contiene',
         'label.starts_with' => 'empieza por',
         'label.ends_with' => 'acaba en',

--- a/translations/EasyAdminBundle.eu.php
+++ b/translations/EasyAdminBundle.eu.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'txikiagoa edo berdina da',
         'label.is_between' => 'tartean dago',
         'label.contains' => 'dauka',
+        'label.contains_all' => 'dauka guztiak',
         'label.not_contains' => 'ez dauka',
         'label.starts_with' => 'honela hasten da',
         'label.ends_with' => 'honela amaitzen da',

--- a/translations/EasyAdminBundle.fa.php
+++ b/translations/EasyAdminBundle.fa.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'کوچکتر یا مساوی با',
         'label.is_between' => 'در بین',
         'label.contains' => 'شامل',
+        'label.contains_all' => 'شامل همه',
         'label.not_contains' => 'شامل نمی‌شود',
         'label.starts_with' => 'شروع می‌شود با',
         'label.ends_with' => 'پایان می‌یابد با',

--- a/translations/EasyAdminBundle.fi.php
+++ b/translations/EasyAdminBundle.fi.php
@@ -84,6 +84,7 @@ return [
         // 'label.is_less_than_or_equal_to' => '',
         // 'label.is_between' => '',
         // 'label.contains' => '',
+        // 'label.contains_all' => '',
         // 'label.not_contains' => '',
         // 'label.starts_with' => '',
         // 'label.ends_with' => '',

--- a/translations/EasyAdminBundle.fr.php
+++ b/translations/EasyAdminBundle.fr.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'est inférieur(e) ou égal(e) à',
         'label.is_between' => 'est entre',
         'label.contains' => 'contient',
+        'label.contains_all' => 'contient tout',
         'label.not_contains' => 'ne contient pas',
         'label.starts_with' => 'commence par',
         'label.ends_with' => 'finit par',

--- a/translations/EasyAdminBundle.gl.php
+++ b/translations/EasyAdminBundle.gl.php
@@ -84,6 +84,7 @@ return [
         // 'label.is_less_than_or_equal_to' => '',
         // 'label.is_between' => '',
         // 'label.contains' => '',
+        // 'label.contains_all' => '',
         // 'label.not_contains' => '',
         // 'label.starts_with' => '',
         // 'label.ends_with' => '',

--- a/translations/EasyAdminBundle.he.php
+++ b/translations/EasyAdminBundle.he.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'קטן/שווה לערך',
         'label.is_between' => 'בין',
         'label.contains' => 'מכיל',
+        'label.contains_all' => 'מכיל הכל',
         'label.not_contains' => 'לא מכיל',
         'label.starts_with' => 'מתחיל עם',
         'label.ends_with' => 'מסתיים עם',

--- a/translations/EasyAdminBundle.hr.php
+++ b/translations/EasyAdminBundle.hr.php
@@ -84,6 +84,7 @@ return [
         // 'label.is_less_than_or_equal_to' => '',
         // 'label.is_between' => '',
         // 'label.contains' => '',
+        // 'label.contains_all' => '',
         // 'label.not_contains' => '',
         // 'label.starts_with' => '',
         // 'label.ends_with' => '',

--- a/translations/EasyAdminBundle.hu.php
+++ b/translations/EasyAdminBundle.hu.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'kisebb vagy egyenlő',
         'label.is_between' => 'kettő között',
         'label.contains' => 'tartalmazza',
+        'label.contains_all' => 'tartalmaz mindent',
         'label.not_contains' => 'nem tartalmazza',
         'label.starts_with' => 'így kezdődik',
         'label.ends_with' => 'így végződik',

--- a/translations/EasyAdminBundle.hy.php
+++ b/translations/EasyAdminBundle.hy.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'փոքր է կամ հավասար է',
         'label.is_between' => 'միջակայքում է',
         'label.contains' => 'պարունակում է',
+        'label.contains_all' => 'պարունակում է բոլորը',
         'label.not_contains' => 'չի պարունակում',
         'label.starts_with' => 'սկսվում է',
         'label.ends_with' => 'ավարտվում է',

--- a/translations/EasyAdminBundle.id.php
+++ b/translations/EasyAdminBundle.id.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'kurang dari atau sama dengan',
         'label.is_between' => 'antara',
         'label.contains' => 'mengandung',
+        'label.contains_all' => 'mengandung semua',
         'label.not_contains' => 'tidak mengandung',
         'label.starts_with' => 'dimulai dari',
         'label.ends_with' => 'berakhiran dengan',

--- a/translations/EasyAdminBundle.it.php
+++ b/translations/EasyAdminBundle.it.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'è minore o uguale di',
         'label.is_between' => 'è tra',
         'label.contains' => 'contiene',
+        'label.contains_all' => 'contiene tutto',
         'label.not_contains' => 'non contiene',
         'label.starts_with' => 'inizia con',
         'label.ends_with' => 'finisce con',

--- a/translations/EasyAdminBundle.lb.php
+++ b/translations/EasyAdminBundle.lb.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'ass méi kleng wéi oder gläich',
         'label.is_between' => 'ass tëscht',
         'label.contains' => 'enthält',
+        'label.contains_all' => 'enthält alles',
         'label.not_contains' => 'enthält net',
         'label.starts_with' => 'fänkt u mat',
         'label.ends_with' => 'hält op mat',

--- a/translations/EasyAdminBundle.lt.php
+++ b/translations/EasyAdminBundle.lt.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'mažesnis arba lygus',
         'label.is_between' => 'tarp',
         'label.contains' => 'turi',
+        'label.contains_all' => 'turi visus',
         'label.not_contains' => 'neturi',
         'label.starts_with' => 'prasideda',
         'label.ends_with' => 'pasibaigia',

--- a/translations/EasyAdminBundle.mk.php
+++ b/translations/EasyAdminBundle.mk.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'е помало или еднакво со',
         'label.is_between' => 'е помеѓу',
         'label.contains' => 'содржи',
+        'label.contains_all' => 'содржи сè',
         'label.not_contains' => 'не содржи',
         'label.starts_with' => 'започнува со',
         'label.ends_with' => 'завршува со',

--- a/translations/EasyAdminBundle.nl.php
+++ b/translations/EasyAdminBundle.nl.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'is minder dan of gelijk aan',
         'label.is_between' => 'ligt tussen',
         'label.contains' => 'bevat',
+        'label.contains_all' => 'bevat alles',
         'label.not_contains' => 'bevat niet',
         'label.starts_with' => 'start met',
         'label.ends_with' => 'eindigt met',

--- a/translations/EasyAdminBundle.no.php
+++ b/translations/EasyAdminBundle.no.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'er mindre enn eller lik som',
         'label.is_between' => 'er mellom',
         'label.contains' => 'inneholder',
+        'label.contains_all' => 'inneholder alle',
         'label.not_contains' => 'inneholder ikke',
         'label.starts_with' => 'starter med',
         'label.ends_with' => 'ender med',

--- a/translations/EasyAdminBundle.pl.php
+++ b/translations/EasyAdminBundle.pl.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'mniejszy lub równy',
         'label.is_between' => 'pomiędzy',
         'label.contains' => 'zawiera',
+        'label.contains_all' => 'zawiera wszystkie',
         'label.not_contains' => 'nie zawiera',
         'label.starts_with' => 'zaczyna się od',
         'label.ends_with' => 'kończy się na',

--- a/translations/EasyAdminBundle.pt.php
+++ b/translations/EasyAdminBundle.pt.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'é menor ou igual a',
         'label.is_between' => 'é entre',
         'label.contains' => 'contém',
+        'label.contains_all' => 'contém tudo',
         'label.not_contains' => 'não contém',
         'label.starts_with' => 'começa com',
         'label.ends_with' => 'termina com',

--- a/translations/EasyAdminBundle.pt_BR.php
+++ b/translations/EasyAdminBundle.pt_BR.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'é menor ou igual a',
         'label.is_between' => 'entre',
         'label.contains' => 'contém',
+        'label.contains_all' => 'contém tudo',
         'label.not_contains' => 'não contém',
         'label.starts_with' => 'começa com',
         'label.ends_with' => 'termina com',

--- a/translations/EasyAdminBundle.ro.php
+++ b/translations/EasyAdminBundle.ro.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'este mai mic sau egal cu',
         'label.is_between' => 'e între',
         'label.contains' => 'conține',
+        'label.contains_all' => 'conține tot',
         'label.not_contains' => 'nu conține',
         'label.starts_with' => 'începe cu',
         'label.ends_with' => 'termină cu',

--- a/translations/EasyAdminBundle.ru.php
+++ b/translations/EasyAdminBundle.ru.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'меньше или равно',
         'label.is_between' => 'между',
         'label.contains' => 'содержит',
+        'label.contains_all' => 'содержит всё',
         'label.not_contains' => 'не содержит',
         'label.starts_with' => 'начинается с',
         'label.ends_with' => 'заканчивается на',

--- a/translations/EasyAdminBundle.sk.php
+++ b/translations/EasyAdminBundle.sk.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'je menšie ako alebo rovné',
         'label.is_between' => 'je medzi',
         'label.contains' => 'obsahuje',
+        'label.contains_all' => 'obsahuje všetky',
         'label.not_contains' => 'neobsahuje',
         'label.starts_with' => 'začína na',
         'label.ends_with' => 'končí na',

--- a/translations/EasyAdminBundle.sl.php
+++ b/translations/EasyAdminBundle.sl.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'je manjše od ali enako',
         'label.is_between' => 'je med',
         'label.contains' => 'vsebuje',
+        'label.contains_all' => 'vsebuje vse',
         'label.not_contains' => 'ne vsebuje',
         'label.starts_with' => 'se začne',
         'label.ends_with' => 'se konča',

--- a/translations/EasyAdminBundle.sr_RS.php
+++ b/translations/EasyAdminBundle.sr_RS.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'je manje ili jednako',
         'label.is_between' => 'je između',
         'label.contains' => 'sadrži',
+        'label.contains_all' => 'sadrži sve',
         'label.not_contains' => 'ne sadrži',
         'label.starts_with' => 'počinje sa',
         'label.ends_with' => 'završava se se',

--- a/translations/EasyAdminBundle.sv.php
+++ b/translations/EasyAdminBundle.sv.php
@@ -84,6 +84,7 @@ return [
         // 'label.is_less_than_or_equal_to' => '',
         // 'label.is_between' => '',
         // 'label.contains' => '',
+        // 'label.contains_all' => '',
         // 'label.not_contains' => '',
         // 'label.starts_with' => '',
         // 'label.ends_with' => '',

--- a/translations/EasyAdminBundle.tr.php
+++ b/translations/EasyAdminBundle.tr.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'Küçüktür veya eşittir',
         'label.is_between' => 'arasında',
         'label.contains' => 'Metin şunları içeriyor',
+        'label.contains_all' => 'Metin bunların hepsini içeriyor',
         'label.not_contains' => 'Metin şunları içermiyor',
         'label.starts_with' => 'Metin şununla başlıyor',
         'label.ends_with' => 'Metin şununla bitiyor',

--- a/translations/EasyAdminBundle.uk.php
+++ b/translations/EasyAdminBundle.uk.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => 'менше ніж або рівно',
         'label.is_between' => 'між',
         'label.contains' => 'містить',
+        'label.contains_all' => 'містить все',
         'label.not_contains' => 'не містить',
         'label.starts_with' => 'починається з',
         'label.ends_with' => 'закінчується на',

--- a/translations/EasyAdminBundle.zh_CN.php
+++ b/translations/EasyAdminBundle.zh_CN.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => '小于或等于',
         'label.is_between' => '之间',
         'label.contains' => '包含',
+        'label.contains_all' => '包含所有',
         'label.not_contains' => '不包含',
         'label.starts_with' => '起始于',
         'label.ends_with' => '结束于',

--- a/translations/EasyAdminBundle.zh_TW.php
+++ b/translations/EasyAdminBundle.zh_TW.php
@@ -84,6 +84,7 @@ return [
         'label.is_less_than_or_equal_to' => '小於或等於',
         'label.is_between' => '處於範圍',
         'label.contains' => '包含',
+        'label.contains_all' => '包含所有',
         'label.not_contains' => '不包含',
         'label.starts_with' => '開始於',
         'label.ends_with' => '結尾於',


### PR DESCRIPTION
Currently, there’s no way to filter entities that contain _all_ of the elements from a given filter.
This PR introduces this feature.

I noticed that test files are a bit outdated/abandoned in the repo, but if you can point me in the right direction, I’ll be happy to add proper test coverage for the new functionality.