### PR TITLE
Fixed an issue with the new AdminRoute attribute

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -294,9 +294,7 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         if (null !== $routeName = $this->get(EA::ROUTE_NAME)) {
             $adminRoutes = $this->cache->getItem(AdminRouteGenerator::CACHE_KEY_ROUTE_TO_FQCN)->get();
             if (null !== $adminRoutes && \array_key_exists($routeName, $adminRoutes)) {
-                unset($routeParameters[EA::ROUTE_NAME]);
-
-                return $this->urlGenerator->generate($routeName, $routeParameters, $urlType);
+                return $this->urlGenerator->generate($routeName, $routeParameters[EA::ROUTE_PARAMS] ?? [], $urlType);
             }
 
             return $this->urlGenerator->generate($this->dashboardRoute, $routeParameters, $urlType);


### PR DESCRIPTION
It went almost unnoticed, but the `AdminRoute` attribute introduced in #7062 is one of the most relevant features we've added in years. It means that you can serve any Symfony controller action fully embedded in your dashboard(s) and with pretty URLs.

I'm upgrading some of my apps to it and I found this bug while doing so.