### PR TITLE
Improve admin route

### DIFF
--- a/src/Attribute/AdminRoute.php
+++ b/src/Attribute/AdminRoute.php
@@ -5,7 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Attribute;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class AdminRoute
 {
     public function __construct(

--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Menu;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
@@ -209,7 +210,10 @@ class MenuItemMatcher implements MenuItemMatcherInterface
         // to match the same URL with the 'index' action. This ensures e.g. that the
         // /admin/post menu item is highlighted when visiting related URLs such as
         // /admin/post/new, /admin/post/37/edit, etc.
-        if (null === $crudControllerFqcn = $request->attributes->get(EA::CRUD_CONTROLLER_FQCN)) {
+        // But only try to generate the index CRUD URL if we know the controller is a EasyAdmin CRUD controller
+        // (e.g. ignore this in custom admin routes created with #[AdminRoute] and unrelated to CRUD)
+        $crudControllerFqcn = $request->attributes->get(EA::CRUD_CONTROLLER_FQCN);
+        if (null === $crudControllerFqcn || !is_subclass_of($crudControllerFqcn, CrudControllerInterface::class)) {
             return $menuItems;
         }
 

--- a/tests/AdminRouteTestApplication/src/Controller/PrefixedController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/PrefixedController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use Symfony\Component\HttpFoundation\Response;
+
+#[AdminRoute('/api', 'api')] // this acts as a prefix since there are method routes
+class PrefixedController
+{
+    #[AdminRoute('/users', 'users')]
+    public function listUsers(): Response
+    {
+        return new Response('User list');
+    }
+
+    #[AdminRoute('/users/{id}', 'user_detail')]
+    public function getUserDetail(string $id): Response
+    {
+        return new Response(sprintf('User detail: %s', $id));
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/RepeatedRouteController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/RepeatedRouteController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use Symfony\Component\HttpFoundation\Response;
+
+class RepeatedRouteController
+{
+    #[AdminRoute('/route1/{id}', 'route1')]
+    #[AdminRoute('/route2/{id}', 'route2')]
+    public function twoRoutes(string $id): Response
+    {
+        return new Response(sprintf('ID: %s', $id));
+    }
+
+    #[AdminRoute('/multiple/route1', 'multiple_route1')]
+    #[AdminRoute('/multiple/route2', 'multiple_route2')]
+    #[AdminRoute('/multiple/route3', 'multiple_route3')]
+    public function multipleRoutes(): Response
+    {
+        return new Response('Multiple routes to same action');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/SameActionOneCrudController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/SameActionOneCrudController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Entity\Product;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test case 6: Method-level route in CRUD controller with the same name as other CRUD controller's method-level route.
+ *
+ * @see the related controller SameActionTwoCrudController.php
+ */
+class SameActionOneCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Product::class;
+    }
+
+    #[AdminRoute(path: '/same-action-name', name: 'same_action_name')]
+    public function sameActionName(): Response
+    {
+        return new Response('Same action name');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/SameActionTwoCrudController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/SameActionTwoCrudController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Entity\Product;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test case 6: Method-level route in CRUD controller with the same name as other CRUD controller's method-level route.
+ *
+ * @see the related controller SameActionOneCrudController.php
+ */
+class SameActionTwoCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Product::class;
+    }
+
+    #[AdminRoute(path: '/same-action-name', name: 'same_action_name')]
+    public function sameActionName(): Response
+    {
+        return new Response('Same action name');
+    }
+}

--- a/tests/AdminRouteTestApplication/src/Controller/StandaloneMethodsCrudController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/StandaloneMethodsCrudController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Entity\Product;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test case 5: CRUD controller with only method-level routes (no class-level attribute).
+ */
+class StandaloneMethodsCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Product::class;
+    }
+
+    #[AdminRoute(
+        path: '/crud/action1',
+        name: 'crud_action1'
+    )]
+    public function action1(): Response
+    {
+        return new Response('Standalone CRUD Action 1');
+    }
+
+    #[AdminRoute(
+        path: '/crud/action2',
+        name: 'crud_action2',
+        options: ['methods' => ['POST']]
+    )]
+    public function action2(): Response
+    {
+        return new Response('Standalone CRUD Action 2');
+    }
+}


### PR DESCRIPTION
This PR:

* Allows to define multiple `#[AdminRoute]` for the same action
* Fixes the handling of class-level AdminRoute attributes (fixes #7078 )