### PR TITLE
Dispatch autocomplete event on the select element

### DIFF
--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -55,14 +55,14 @@ export default class Autocomplete {
             maxOptions: null,
         });
 
-        document.dispatchEvent(
-            new CustomEvent('ea.autocomplete.pre-connect', { detail: { config, prefix: 'autocomplete' } })
+        element.dispatchEvent(
+            new CustomEvent('ea.autocomplete.pre-connect', { detail: { config, prefix: 'autocomplete' }, bubbles: true })
         );
 
         const tomSelect = new TomSelect(element, config);
 
-        document.dispatchEvent(
-            new CustomEvent('ea.autocomplete.connect', { detail: { tomSelect, config, prefix: 'autocomplete' } })
+        element.dispatchEvent(
+            new CustomEvent('ea.autocomplete.connect', { detail: { tomSelect, config, prefix: 'autocomplete' }, bubbles: true })
         );
 
         return tomSelect;


### PR DESCRIPTION
I tried to use [autocomplete events](https://github.com/EasyCorp/EasyAdminBundle/pull/7048) recently implemented by @Deksor to customize an autocomplete in my project but there is no way to know from which autocomplete the event has been triggered (especially the pre-connect event).

In my case, I do not want to customize all autocompletes, but only few of them depending on an attribut added on the select.

This PR change the way autocomplete events are dispatched.
We now dispatch the event on the select element instead of the document.
 
I added `bubbles: true` to keep BC with:
``` js
document.addEventListener('ea.autocomplete.connect', (event) => {
    // custom code goes here
    console.log(event.target); // now returns the select dom element 
});
```

We can remove the `bubbles: true`, but in that case it will be required to listen the event directly on select:
``` js
document.querySelector('select').addEventListener('ea.autocomplete.connect', (event) => {
    // custom code goes here
    console.log(event.target); // now returns the select dom element 
});
```