### PR TITLE
Fix generating locale change URLs for custom route

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -143,7 +143,9 @@
 
                             {% for localeDto in ea.dashboardLocales %}
                                 {% if ea.usePrettyUrls %}
-                                    {% set url = ea_url().set('_locale', localeDto.locale).set('entityId', app.request.attributes.get('entityId')) %}
+                                    {# TODO symfony>=6.4 app.current_route_parameters #}
+                                    {% set current_route_params = app.request.attributes.get('_route_params') %}
+                                    {% set url = ea_url(current_route_params).set('_locale', localeDto.locale).set('entityId', app.request.attributes.get('entityId')) %}
                                 {% else %}
                                     {% set url = ea_url().set('_locale', localeDto.locale) %}
                                 {% endif %}


### PR DESCRIPTION
Fix https://github.com/EasyCorp/EasyAdminBundle/issues/7082

A custom route with required params that use the layout template break because it misses the current route params to generate the locale change URLs