### PR TITLE
Refactor EntityDto

### DIFF
--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -150,7 +150,7 @@ final class FieldFactory
             if ($fieldDto->getProperty() === $entityDto->getPrimaryKeyName()) {
                 $guessedFieldFqcn = IdField::class;
             } else {
-                $doctrinePropertyType = $entityDto->getPropertyMetadata($fieldDto->getProperty())->get('type');
+                $doctrinePropertyType = $entityDto->getPropertyDataType($fieldDto->getProperty());
                 $guessedFieldFqcn = self::$doctrineTypeToFieldFqcn[$doctrinePropertyType] ?? null;
 
                 if (null === $guessedFieldFqcn) {

--- a/src/Factory/FilterFactory.php
+++ b/src/Factory/FilterFactory.php
@@ -99,12 +99,6 @@ final class FilterFactory
             return EntityFilter::class;
         }
 
-        $metadata = $entityDto->getPropertyMetadata($propertyName);
-
-        if ($metadata->isEmpty()) {
-            return TextFilter::class;
-        }
-
-        return self::$doctrineTypeToFilterClass[$metadata->get('type')] ?? TextFilter::class;
+        return self::$doctrineTypeToFilterClass[$entityDto->getPropertyDataType($propertyName)] ?? TextFilter::class;
     }
 }

--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -97,7 +97,7 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
         if (!$entityDto->hasProperty($field->getProperty())) {
             return;
         }
-        $doctrineDataType = $entityDto->getPropertyMetadata($field->getProperty())->get('type');
+        $doctrineDataType = $entityDto->getPropertyDataType($field->getProperty());
         $isImmutableDateTime = \in_array($doctrineDataType, [Types::DATETIMETZ_IMMUTABLE, Types::DATETIME_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE], true);
         if ($isImmutableDateTime) {
             $field->setFormTypeOptionIfNotSet('input', 'datetime_immutable');

--- a/src/Filter/Configurator/ComparisonConfigurator.php
+++ b/src/Filter/Configurator/ComparisonConfigurator.php
@@ -24,7 +24,7 @@ final class ComparisonConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyType = $entityDto->getPropertyMetadata($filterDto->getProperty())->get('type');
+        $propertyType = $entityDto->getPropertyDataType($filterDto->getProperty());
 
         if (Types::DATEINTERVAL === $propertyType) {
             $filterDto->setFormTypeOption('value_type', DateIntervalType::class);

--- a/src/Filter/Configurator/DateTimeConfigurator.php
+++ b/src/Filter/Configurator/DateTimeConfigurator.php
@@ -25,7 +25,7 @@ final class DateTimeConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyType = $entityDto->getPropertyMetadata($filterDto->getProperty())->get('type');
+        $propertyType = $entityDto->getPropertyDataType($filterDto->getProperty());
 
         if (Types::DATE_MUTABLE === $propertyType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', DateType::class);

--- a/src/Filter/Configurator/NumericConfigurator.php
+++ b/src/Filter/Configurator/NumericConfigurator.php
@@ -24,7 +24,7 @@ final class NumericConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyType = $entityDto->getPropertyMetadata($filterDto->getProperty())->get('type');
+        $propertyType = $entityDto->getPropertyDataType($filterDto->getProperty());
 
         if (Types::DECIMAL === $propertyType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'string');

--- a/src/Filter/Configurator/TextConfigurator.php
+++ b/src/Filter/Configurator/TextConfigurator.php
@@ -24,7 +24,7 @@ final class TextConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyType = $entityDto->getPropertyMetadata($filterDto->getProperty())->get('type');
+        $propertyType = $entityDto->getPropertyDataType($filterDto->getProperty());
 
         if (Types::JSON === $propertyType) {
             $filterDto->setFormTypeOption('value_type', TextareaType::class);


### PR DESCRIPTION
A little refactoring. I did two seperate commits and explained both of them in the commit message.

Note to first commit: there is no interface but all the conrete classes I removed are extending the same abstract class `AssociationMapping` which implements the method `type()` which can be used instead of doing the same implementation in EasyAdmin.

Note to second commit: concerning the newly introduced return types in `getPropertyDataType` I am quite sure that this cannot break any client code since `type` is always `int` (for associations) or `string` (for Doctrine types). An exception is thrown otherwise in `getPropertyMetadata`.

