### PR TITLE
Fix CrudAutocompleteSubscriber to handle array of ULID

### DIFF
--- a/src/Form/EventListener/CrudAutocompleteSubscriber.php
+++ b/src/Form/EventListener/CrudAutocompleteSubscriber.php
@@ -6,6 +6,7 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Uid\Ulid;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -47,6 +48,13 @@ class CrudAutocompleteSubscriber implements EventSubscriberInterface
         if (!isset($data['autocomplete']) || '' === $data['autocomplete']) {
             $options['choices'] = [];
         } else {
+            if (false === $options['id_reader']->isIntId()) {
+                $data['autocomplete'] = array_map(
+                    fn ($v) => Ulid::isValid($v) ? Ulid::fromBase32($v)->toRfc4122() : $v,
+                    $data['autocomplete']
+                );
+            }
+
             $options['choices'] = $options['em']->getRepository($options['class'])->findBy([
                 $options['id_reader']->getIdField() => $data['autocomplete'],
             ]);


### PR DESCRIPTION
On using an Autocomplete field with entity based on ULID identifier,  doctrine throws a PDOException:
```
An exception occurred while executing a query: SQLSTATE[22P02]: Invalid text representation: 7 ERROR: invalid input syntax for type uuid: "01K6Z0XD6EH905PS22SF7A0NYA"
CONTEXT: unnamed portal parameter $1 = '...'
```
This error has been reported in doctrine using Doctrine\DBAL\Connection::PARAM_STR_ARRAY as reported here [doctrine/dbal/issues/4660](https://github.com/doctrine/dbal/issues/4660#issuecomment-1294765036)

Please read this related issue #6867

In consequence, when we use an Association Field autocomplete with a collection of ULID identifier , CrudAutoCompleteSubscriber crash while querying

cc @silasjoisten 