### PR TITLE
Refactor EntityDto: deprecate 3 methods and allow access to ClassMeta…

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -56,7 +56,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             ?? $context->getCrudControllers()->findCrudFqcnByEntityFqcn($targetEntityFqcn);
 
         if (true === $field->getCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM)) {
-            if (false === $entityDto->isToOneAssociation($propertyName)) {
+            if (false === $entityDto->getClassMetadata()->isSingleValuedAssociation($propertyName)) {
                 throw new \RuntimeException(
                     sprintf(
                         'The "%s" association field of "%s" is a to-many association but it\'s trying to use the "renderAsEmbeddedForm()" option, which is only available for to-one associations. If you want to use a CRUD form to render to-many associations, use a CollectionField instead of the AssociationField.',
@@ -130,11 +130,11 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 //   * the route is not found, which happens when the associated entity is not accessible from this dashboard; do nothing in that case either.
             }
         } else {
-            if ($entityDto->isToOneAssociation($propertyName)) {
+            if ($entityDto->getClassMetadata()->isSingleValuedAssociation($propertyName)) {
                 $this->configureToOneAssociation($field);
             }
 
-            if ($entityDto->isToManyAssociation($propertyName)) {
+            if ($entityDto->getClassMetadata()->isCollectionValuedAssociation($propertyName)) {
                 $this->configureToManyAssociation($field);
             }
         }

--- a/src/Filter/Configurator/ComparisonConfigurator.php
+++ b/src/Filter/Configurator/ComparisonConfigurator.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
 
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -24,9 +25,21 @@ final class ComparisonConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyType = $entityDto->getPropertyDataType($filterDto->getProperty());
+        if (!isset($entityDto->getClassMetadata()->fieldMappings[$filterDto->getProperty()])) {
+            return;
+        }
 
-        if (Types::DATEINTERVAL === $propertyType) {
+        // Doctrine ORM 2.x returns an array and Doctrine ORM 3.x returns a FieldMapping object
+        /** @var FieldMapping|array $fieldMapping */
+        /** @phpstan-ignore-next-line */
+        $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($filterDto->getProperty());
+        if (\is_array($fieldMapping)) {
+            $doctrineFieldMappingType = $fieldMapping['type'];
+        } else {
+            $doctrineFieldMappingType = $fieldMapping->type;
+        }
+
+        if (Types::DATEINTERVAL === $doctrineFieldMappingType) {
             $filterDto->setFormTypeOption('value_type', DateIntervalType::class);
             $filterDto->setFormTypeOption('comparison_type_options.type', 'datetime');
         }

--- a/src/Filter/Configurator/DateTimeConfigurator.php
+++ b/src/Filter/Configurator/DateTimeConfigurator.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
 
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -25,27 +26,39 @@ final class DateTimeConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyType = $entityDto->getPropertyDataType($filterDto->getProperty());
+        if (!isset($entityDto->getClassMetadata()->fieldMappings[$filterDto->getProperty()])) {
+            return;
+        }
 
-        if (Types::DATE_MUTABLE === $propertyType) {
+        // Doctrine ORM 2.x returns an array and Doctrine ORM 3.x returns a FieldMapping object
+        /** @var FieldMapping|array $fieldMapping */
+        /** @phpstan-ignore-next-line */
+        $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($filterDto->getProperty());
+        if (\is_array($fieldMapping)) {
+            $doctrineFieldMappingType = $fieldMapping['type'];
+        } else {
+            $doctrineFieldMappingType = $fieldMapping->type;
+        }
+
+        if (Types::DATE_MUTABLE === $doctrineFieldMappingType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', DateType::class);
         }
 
-        if (Types::DATE_IMMUTABLE === $propertyType) {
+        if (Types::DATE_IMMUTABLE === $doctrineFieldMappingType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', DateType::class);
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'datetime_immutable');
         }
 
-        if (Types::TIME_MUTABLE === $propertyType) {
+        if (Types::TIME_MUTABLE === $doctrineFieldMappingType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', TimeType::class);
         }
 
-        if (Types::TIME_IMMUTABLE === $propertyType) {
+        if (Types::TIME_IMMUTABLE === $doctrineFieldMappingType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', TimeType::class);
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'datetime_immutable');
         }
 
-        if (\in_array($propertyType, [Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_IMMUTABLE], true)) {
+        if (\in_array($doctrineFieldMappingType, [Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_IMMUTABLE], true)) {
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'datetime_immutable');
         }
     }

--- a/src/Filter/Configurator/EntityConfigurator.php
+++ b/src/Filter/Configurator/EntityConfigurator.php
@@ -31,10 +31,10 @@ final class EntityConfigurator implements FilterConfiguratorInterface
         $doctrineMetadata = $entityDto->getPropertyMetadata($propertyName);
         // TODO: add the 'em' form type option too?
         $filterDto->setFormTypeOptionIfNotSet('value_type_options.class', $doctrineMetadata->get('targetEntity'));
-        $filterDto->setFormTypeOptionIfNotSet('value_type_options.multiple', $entityDto->isToManyAssociation($propertyName));
+        $filterDto->setFormTypeOptionIfNotSet('value_type_options.multiple', $entityDto->getClassMetadata()->isCollectionValuedAssociation($propertyName));
         $filterDto->setFormTypeOptionIfNotSet('value_type_options.attr.data-ea-widget', 'ea-autocomplete');
 
-        if ($entityDto->isToOneAssociation($propertyName)) {
+        if ($entityDto->getClassMetadata()->isSingleValuedAssociation($propertyName)) {
             // don't show the 'empty value' placeholder when all join columns are required,
             // because an empty filter value would always return no result
             $numberOfRequiredJoinColumns = \count(array_filter(

--- a/src/Filter/Configurator/NumericConfigurator.php
+++ b/src/Filter/Configurator/NumericConfigurator.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
 
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -24,13 +25,25 @@ final class NumericConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyType = $entityDto->getPropertyDataType($filterDto->getProperty());
+        if (!isset($entityDto->getClassMetadata()->fieldMappings[$filterDto->getProperty()])) {
+            return;
+        }
 
-        if (Types::DECIMAL === $propertyType) {
+        // Doctrine ORM 2.x returns an array and Doctrine ORM 3.x returns a FieldMapping object
+        /** @var FieldMapping|array $fieldMapping */
+        /** @phpstan-ignore-next-line */
+        $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($filterDto->getProperty());
+        if (\is_array($fieldMapping)) {
+            $doctrineFieldMappingType = $fieldMapping['type'];
+        } else {
+            $doctrineFieldMappingType = $fieldMapping->type;
+        }
+
+        if (Types::DECIMAL === $doctrineFieldMappingType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'string');
         }
 
-        if (\in_array($propertyType, [Types::BIGINT, Types::INTEGER, Types::SMALLINT], true)) {
+        if (\in_array($doctrineFieldMappingType, [Types::BIGINT, Types::INTEGER, Types::SMALLINT], true)) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', IntegerType::class);
         }
     }

--- a/src/Filter/Configurator/TextConfigurator.php
+++ b/src/Filter/Configurator/TextConfigurator.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
 
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -24,14 +25,26 @@ final class TextConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyType = $entityDto->getPropertyDataType($filterDto->getProperty());
+        if (!isset($entityDto->getClassMetadata()->fieldMappings[$filterDto->getProperty()])) {
+            return;
+        }
 
-        if (Types::JSON === $propertyType) {
+        // Doctrine ORM 2.x returns an array and Doctrine ORM 3.x returns a FieldMapping object
+        /** @var FieldMapping|array $fieldMapping */
+        /** @phpstan-ignore-next-line */
+        $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($filterDto->getProperty());
+        if (\is_array($fieldMapping)) {
+            $doctrineFieldMappingType = $fieldMapping['type'];
+        } else {
+            $doctrineFieldMappingType = $fieldMapping->type;
+        }
+
+        if (Types::JSON === $doctrineFieldMappingType) {
             $filterDto->setFormTypeOption('value_type', TextareaType::class);
         }
 
         // don't use Types::OBJECT because it was removed in Doctrine ORM 3.0
-        if (\in_array($propertyType, [Types::BLOB, 'object', Types::TEXT], true)) {
+        if (\in_array($doctrineFieldMappingType, [Types::BLOB, 'object', Types::TEXT], true)) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', TextareaType::class);
         }
     }

--- a/src/Filter/EntityFilter.php
+++ b/src/Filter/EntityFilter.php
@@ -54,7 +54,7 @@ final class EntityFilter implements FilterInterface
         $value = $filterDataDto->getValue();
         $isMultiple = (bool) $filterDataDto->getFormTypeOption('value_type_options.multiple');
 
-        if ($entityDto->isToManyAssociation($property)) {
+        if ($entityDto->getClassMetadata()->isCollectionValuedAssociation($property)) {
             // the 'ea_' prefix is needed to avoid errors when using reserved words as assocAlias ('order', 'group', etc.)
             // see https://github.com/EasyCorp/EasyAdminBundle/pull/4344
             $assocAlias = 'ea_'.$filterDataDto->getParameterName();


### PR DESCRIPTION
Another refactoring. Please just tell me if you have better things to do than checking my refactoring PRs 😬

Notes:
- I paid a lot of attention to not break anything and not change any existing behaviour of the code
- I deprecated the methods because they are just wrappers over `ClassMetadata` and provide no extra value IMHO. If they don't exist anymore there is less EA code to maintain and IMHO the client code is easier to follow if there is no extra wrapper between Doctrine and the client code.
- `getPropertyDataType()` is not only a wrapper over `ClassMetadata` but also mixes `FieldMapping` with `AssociationMapping` and so it returns sometimes `string` sometimes `int` -> so it makes things even more complicated than just using `ClassMetadata` itself. I also plan a PR for deprecating `getPropertyMetadata` (in the first place because it mixes `FieldMapping` with `AssociationMapping`).
- I replaced some `\array_key_exists` with `isset` simply because Doctrine ORM (and also `Symfony\Bridge\Doctrine\Form\DoctrineOrmTypeGuesser`) checks the same thing with `isset` instead of `\array_key_exists`
- in 4.0.0 my change introduces 9 times the following code which looks a little ugly:

```php
// Doctrine ORM 2.x returns an array and Doctrine ORM 3.x returns a FieldMapping object
/** @var FieldMapping|array $fieldMapping */
/** @phpstan-ignore-next-line */
$fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($propertyName);
if (\is_array($fieldMapping)) {
    $type = $fieldMapping['type'];
} else {
    $type = $fieldMapping->type;
}
```

But in 5.0.0 all occurances can be changed from 9 lines to 1 line:

```php
$type = $entityDto->getClassMetadata()->getFieldMapping($propertyName)->type;
```