### PR TITLE
Handle non-array autocomplete data input

### DIFF
--- a/src/Form/EventListener/CrudAutocompleteSubscriber.php
+++ b/src/Form/EventListener/CrudAutocompleteSubscriber.php
@@ -49,6 +49,10 @@ class CrudAutocompleteSubscriber implements EventSubscriberInterface
             $options['choices'] = [];
         } else {
             if (false === $options['id_reader']->isIntId()) {
+                if (!\is_array($data['autocomplete'])) {
+                    $data['autocomplete'] = [$data['autocomplete']];
+                }
+
                 $data['autocomplete'] = array_map(
                     fn ($v) => Ulid::isValid($v) ? Ulid::fromBase32($v)->toRfc4122() : $v,
                     $data['autocomplete']


### PR DESCRIPTION
Since `autocomplete` can be a `string`, the commit https://github.com/EasyCorp/EasyAdminBundle/commit/59a75dce1f545b30fb92625416c6eb7d13483ce0 introduced an error by passing it to `array_map`