### PR TITLE
Update docs for ArrayField

### DIFF
--- a/doc/fields/ArrayField.rst
+++ b/doc/fields/ArrayField.rst
@@ -1,7 +1,7 @@
 EasyAdmin Array Field
 =====================
 
-This field displays the contents of a Doctrine property of type ``array`` and it
+This field displays the contents of a property which is mapped to a `Doctrine Array type`_ and it
 allows to add new elements dynamically using JavaScript.
 
 In :ref:`form pages (edit and new) <crud-pages>` it looks like this:
@@ -13,8 +13,9 @@ Basic Information
 -----------------
 
 * **PHP Class**: ``EasyCorp\Bundle\EasyAdminBundle\Field\ArrayField``
-* **Doctrine DBAL Type** used to store this value: ``array``, ``simple_array``
-  or ``json_array``
+* **Doctrine DBAL v4 Type** used to store this value: ``simple_array`` or ``json``
+* **Doctrine DBAL v3 Type** used to store this value: ``array``, ``simple_array`` or ``json``
+* **Doctrine DBAL v2 Type** used to store this value: ``array``, ``simple_array``, ``json_array`` or ``json``
 * **Symfony Form Type** used to render the field: `CollectionType`_
 * **Rendered as**:
 
@@ -30,4 +31,5 @@ Options
 
 This field does not define any custom option.
 
+.. _`Doctrine Array type`: https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#array-types
 .. _`CollectionType`: https://symfony.com/doc/current/reference/forms/types/collection.html


### PR DESCRIPTION
- Make it even more clear
- Add link
- Update for DBAL v4

PS: to be sure I checked it, `json` works fine (just like `simple_array`)
