### PR TITLE
Add FieldFactory test and change json DBAL type to become ArrayField …

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -773,7 +773,7 @@ Doctrine Type             Recommended EasyAdmin Fields
 ``guid``                  ``TextField``
 ``integer``               ``IntegerField``
 ``json_array``            ``ArrayField``
-``json``                  ``TextField``, ``TextareaField``, ``CodeEditorField``
+``json``                  ``TextField``, ``TextareaField``, ``CodeEditorField``, ``ArrayField``
 ``object``                ``TextField``, ``TextareaField``, ``CodeEditorField``
 ``simple_array``          ``ArrayField``
 ``smallint``              ``IntegerField``

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -34,7 +34,7 @@ final class FieldFactory
      * @var array<string, class-string<FieldInterface>>
      */
     private static array $doctrineTypeToFieldFqcn = [
-        'array' => ArrayField::class, // don't use Types::ARRAY because it was removed in Doctrine ORM 3.0
+        'array' => ArrayField::class, // don't use Types::ARRAY because it was removed in Doctrine DBAL 4
         Types::BIGINT => TextField::class,
         Types::BINARY => TextareaField::class,
         Types::BLOB => TextareaField::class,
@@ -50,8 +50,8 @@ final class FieldFactory
         Types::FLOAT => NumberField::class,
         Types::GUID => TextField::class,
         Types::INTEGER => IntegerField::class,
-        Types::JSON => TextField::class,
-        'object' => TextField::class, // don't use Types::OBJECT because it was removed in Doctrine ORM 3.0
+        Types::JSON => ArrayField::class,
+        'object' => TextField::class, // don't use Types::OBJECT because it was removed in Doctrine DBAL 4
         Types::SIMPLE_ARRAY => ArrayField::class,
         Types::SMALLINT => IntegerField::class,
         Types::STRING => TextField::class,

--- a/tests/Factory/FieldFactoryTest.php
+++ b/tests/Factory/FieldFactoryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Factory;
+
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Field;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory\Project;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class FieldFactoryTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private FieldFactory $fieldFactory;
+
+    protected function setUp(): void
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $this->entityManager = $entityManager;
+
+        $adminContextMock = $this->getMockBuilder(AdminContextInterface::class)->disableOriginalConstructor()->getMock();
+        $adminContextMock->method('getCrud')->willReturn(new CrudDto());
+
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request(attributes: [EA::CONTEXT_REQUEST_ATTRIBUTE => $adminContextMock]));
+
+        $adminContextProvider = new AdminContextProvider($requestStack);
+
+        $authorizationCheckerInterface = $this->getMockBuilder(AuthorizationCheckerInterface::class)->disableOriginalConstructor()->getMock();
+        $authorizationCheckerInterface->method('isGranted')->willReturn(true);
+
+        $this->fieldFactory = new FieldFactory(
+            $adminContextProvider,
+            $authorizationCheckerInterface,
+            [],
+            new FormLayoutFactory(),
+        );
+    }
+
+    /**
+     * @dataProvider stringNames
+     */
+    public function testStringNamesAreTurnedIntoFields(string $entity, string $property, string $expectedField): void
+    {
+        $fieldCollection = FieldCollection::new([$property]);
+
+        $this->fieldFactory->processFields(new EntityDto($entity, $this->entityManager->getClassMetadata($entity)), $fieldCollection);
+
+        $this->assertSame(
+            $expectedField,
+            array_values(array_map(fn (FieldDto $field) => $field->getFieldFqcn(), (array) $fieldCollection->getIterator()))[0],
+            sprintf('Failed asserting that string "%s" is turned into a field of type "%s".', $property, $expectedField),
+        );
+    }
+
+    public static function stringNames(): \Generator
+    {
+        yield [Project::class, 'rolesJson', Field\ArrayField::class];
+        yield [Project::class, 'statesSimpleArray', Field\ArrayField::class];
+        yield [Project::class, 'internal', Field\BooleanField::class];
+        yield [Project::class, 'startDateMutable', Field\DateField::class];
+        yield [Project::class, 'startDateImmutable', Field\DateField::class];
+        yield [Project::class, 'startDateTimeMutable', Field\DateTimeField::class];
+        yield [Project::class, 'startDateTimeImmutable', Field\DateTimeField::class];
+        yield [Project::class, 'startDateTimeTzMutable', Field\DateTimeField::class];
+        yield [Project::class, 'startDateTimeTzImmutable', Field\DateTimeField::class];
+        yield [Project::class, 'id', Field\IdField::class];
+        yield [Project::class, 'countInteger', Field\IntegerField::class];
+        yield [Project::class, 'countSmallint', Field\IntegerField::class];
+        yield [Project::class, 'priceDecimal', Field\NumberField::class];
+        yield [Project::class, 'priceFloat', Field\NumberField::class];
+        yield [Project::class, 'description', Field\TextareaField::class];
+        yield [Project::class, 'name', Field\TextField::class];
+        yield [Project::class, 'startTimeMutable', Field\TimeField::class];
+        yield [Project::class, 'startTimeImmutable', Field\TimeField::class];
+    }
+}

--- a/tests/TestApplication/src/Entity/FieldFactory/Project.php
+++ b/tests/TestApplication/src/Entity/FieldFactory/Project.php
@@ -1,0 +1,295 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Project
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::SIMPLE_ARRAY)]
+    private array $statesSimpleArray = [];
+
+    #[ORM\Column(type: Types::JSON)]
+    private array $rolesJson = [];
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    #[ORM\Column(nullable: true)]
+    private ?\DateTime $startDate = null;
+
+    #[ORM\Column]
+    private bool $internal = false;
+
+    #[ORM\Column(type: Types::TEXT)]
+    private ?string $description = null;
+
+    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    private ?\DateTime $startDateMutable = null;
+
+    #[ORM\Column(type: Types::DATE_IMMUTABLE)]
+    private ?\DateTimeImmutable $startDateImmutable = null;
+
+    #[ORM\Column]
+    private ?\DateTime $startDateTimeMutable = null;
+
+    #[ORM\Column]
+    private ?\DateTimeImmutable $startDateTimeImmutable = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_MUTABLE)]
+    private ?\DateTime $startDateTimeTzMutable = null;
+
+    #[ORM\Column(type: Types::DATETIMETZ_IMMUTABLE)]
+    private ?\DateTimeImmutable $startDateTimeTzImmutable = null;
+
+    #[ORM\Column]
+    private ?int $countInteger = null;
+
+    #[ORM\Column(type: Types::SMALLINT)]
+    private ?int $countSmallint = null;
+
+    #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 0)]
+    private ?string $priceDecimal = null;
+
+    #[ORM\Column]
+    private ?float $priceFloat = null;
+
+    #[ORM\Column(type: Types::TIME_MUTABLE)]
+    private ?\DateTime $startTimeMutable = null;
+
+    #[ORM\Column(type: Types::TIME_IMMUTABLE)]
+    private ?\DateTimeImmutable $startTimeImmutable = null;
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getRolesJson(): array
+    {
+        return $this->rolesJson;
+    }
+
+    public function setRolesJson(array $rolesJson): static
+    {
+        $this->rolesJson = $rolesJson;
+
+        return $this;
+    }
+
+    public function getStatesSimpleArray(): array
+    {
+        return $this->statesSimpleArray;
+    }
+
+    public function setStatesSimpleArray(array $statesSimpleArray): static
+    {
+        $this->statesSimpleArray = $statesSimpleArray;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getStartDate(): ?\DateTime
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(?\DateTime $startDate): static
+    {
+        $this->startDate = $startDate;
+
+        return $this;
+    }
+
+    public function isInternal(): ?bool
+    {
+        return $this->internal;
+    }
+
+    public function setInternal(bool $internal): static
+    {
+        $this->internal = $internal;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): static
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getStartDateMutable(): ?\DateTime
+    {
+        return $this->startDateMutable;
+    }
+
+    public function setStartDateMutable(\DateTime $startDateMutable): static
+    {
+        $this->startDateMutable = $startDateMutable;
+
+        return $this;
+    }
+
+    public function getStartDateImmutable(): ?\DateTimeImmutable
+    {
+        return $this->startDateImmutable;
+    }
+
+    public function setStartDateImmutable(\DateTimeImmutable $startDateImmutable): static
+    {
+        $this->startDateImmutable = $startDateImmutable;
+
+        return $this;
+    }
+
+    public function getStartDateTimeMutable(): ?\DateTime
+    {
+        return $this->startDateTimeMutable;
+    }
+
+    public function setStartDateTimeMutable(\DateTime $startDateTimeMutable): static
+    {
+        $this->startDateTimeMutable = $startDateTimeMutable;
+
+        return $this;
+    }
+
+    public function getStartDateTimeImmutable(): ?\DateTimeImmutable
+    {
+        return $this->startDateTimeImmutable;
+    }
+
+    public function setStartDateTimeImmutable(\DateTimeImmutable $startDateTimeImmutable): static
+    {
+        $this->startDateTimeImmutable = $startDateTimeImmutable;
+
+        return $this;
+    }
+
+    public function getStartDateTimeTzMutable(): ?\DateTime
+    {
+        return $this->startDateTimeTzMutable;
+    }
+
+    public function setStartDateTimeTzMutable(\DateTime $startDateTimeTzMutable): static
+    {
+        $this->startDateTimeTzMutable = $startDateTimeTzMutable;
+
+        return $this;
+    }
+
+    public function getStartDateTimeTzImmutable(): ?\DateTimeImmutable
+    {
+        return $this->startDateTimeTzImmutable;
+    }
+
+    public function setStartDateTimeTzImmutable(\DateTimeImmutable $startDateTimeTzImmutable): static
+    {
+        $this->startDateTimeTzImmutable = $startDateTimeTzImmutable;
+
+        return $this;
+    }
+
+    public function getCountInteger(): ?int
+    {
+        return $this->countInteger;
+    }
+
+    public function setCountInteger(int $countInteger): static
+    {
+        $this->countInteger = $countInteger;
+
+        return $this;
+    }
+
+    public function getCountSmallint(): ?int
+    {
+        return $this->countSmallint;
+    }
+
+    public function setCountSmallint(int $countSmallint): static
+    {
+        $this->countSmallint = $countSmallint;
+
+        return $this;
+    }
+
+    public function getPriceDecimal(): ?string
+    {
+        return $this->priceDecimal;
+    }
+
+    public function setPriceDecimal(string $priceDecimal): static
+    {
+        $this->priceDecimal = $priceDecimal;
+
+        return $this;
+    }
+
+    public function getPriceFloat(): ?float
+    {
+        return $this->priceFloat;
+    }
+
+    public function setPriceFloat(float $priceFloat): static
+    {
+        $this->priceFloat = $priceFloat;
+
+        return $this;
+    }
+
+    public function getStartTimeMutable(): ?\DateTime
+    {
+        return $this->startTimeMutable;
+    }
+
+    public function setStartTimeMutable(\DateTime $startTimeMutable): static
+    {
+        $this->startTimeMutable = $startTimeMutable;
+
+        return $this;
+    }
+
+    public function getStartTimeImmutable(): ?\DateTimeImmutable
+    {
+        return $this->startTimeImmutable;
+    }
+
+    public function setStartTimeImmutable(\DateTimeImmutable $startTimeImmutable): static
+    {
+        $this->startTimeImmutable = $startTimeImmutable;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
…if not explicitly configured

Certainly no BC break because it wouldn't have worked anyway until now.

If a `json` DBAL type property defaults to `TextField` EasyAdminBundle throws an exception and by default it is not possible to create or edit an entity when it is a `TextField`.
Exception on `new` route: `The value of the "roles" field of the entity with ID = "" can't be converted into a string, so it cannot be represented by a TextField or a TextareaField.`
Of course apps still can configure it as `TextField`, `TextareaField`, `CodeEditorField`. This PR is just for default for cases like:

```php
    public function configureFields(string $pageName): iterable
    {
        return ['roles'];
    }
```

Also added a test.

Related to:
https://github.com/EasyCorp/EasyAdminBundle/issues/5680
https://github.com/EasyCorp/EasyAdminBundle/issues/6602