### PR TITLE
Mini refactor

### DIFF
--- a/src/Field/AvatarField.php
+++ b/src/Field/AvatarField.php
@@ -40,10 +40,7 @@ final class AvatarField implements FieldInterface
             ->setCustomOption(self::OPTION_HEIGHT, null);
     }
 
-    /**
-     * @param int|string $heightInPixels
-     */
-    public function setHeight($heightInPixels): self
+    public function setHeight(int|string $heightInPixels): self
     {
         $semanticHeights = [Size::SM => 18, Size::MD => 24, Size::LG => 48, Size::XL => 96];
 


### PR DESCRIPTION
Add types, no BC break because exception is thrown if `$heightInPixels` it is not an `int` or `string`.