### PR TITLE
Deprecate unused method

### DIFF
--- a/src/Contracts/Provider/AdminContextProviderInterface.php
+++ b/src/Contracts/Provider/AdminContextProviderInterface.php
@@ -11,6 +11,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
  */
 interface AdminContextProviderInterface extends AdminContextInterface
 {
+    /**
+     * @deprecated since 4.27 and it will be removed in EasyAdmin 5.0 without a replacement
+     */
     public function hasContext(): bool;
 
     // the $throw parameter is deprecated and will be removed in 5.0

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -26,6 +26,9 @@ final class AdminContextProvider implements AdminContextProviderInterface
         $this->requestStack = $requestStack;
     }
 
+    /**
+     * @deprecated since 4.27 and it will be removed in EasyAdmin 5.0 without a replacement
+     */
     public function hasContext(): bool
     {
         $currentRequest = $this->requestStack->getCurrentRequest();


### PR DESCRIPTION
The method is not used in EA. Also it provides no extra value because client code can use `getContext()` and check for `NULL` instead.