### PR TITLE
Fix hiding and showing of fields in AssociationField and CollectionFi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ tests-coverage-view-in-browser: ## Open the generated HTML coverage in your defa
 
 ## —— Linters —————————————————————————————————
 linter-code-syntax: ## Lint PHP code (in dry-run mode, does not edit files)
-	docker run --rm -it --pull always -w=/app -v $(shell pwd):/app oskarstark/php-cs-fixer-ga:latest --diff -vvv --dry-run --using-cache=no
+	docker run --rm -it --pull always -w=/app -v "$(shell pwd)":/app oskarstark/php-cs-fixer-ga:latest --diff -vvv --dry-run --using-cache=no
 linter-docs: ## Lint docs
 	docker run --rm -it --pull always -e DOCS_DIR='/docs' -v $(shell pwd)/doc:/docs oskarstark/doctor-rst:latest --short
 

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -144,7 +144,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         }
 
         $entities = $this->container->get(EntityFactory::class)->createCollection($context->getEntity(), $paginator->getResults());
-        $this->container->get(EntityFactory::class)->processFieldsForAll($entities, $fields);
+        $this->container->get(EntityFactory::class)->processFieldsForAll($entities, $fields, Crud::PAGE_INDEX);
         $procesedFields = $entities->first()?->getFields() ?? FieldCollection::new([]);
         $context->getCrud()->setFieldAssets($this->getFieldAssets($procesedFields));
         $actions = $this->container->get(EntityFactory::class)->processActionsForAll($entities, $context->getCrud()->getActionsConfig());
@@ -184,7 +184,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             throw new InsufficientEntityPermissionException($context);
         }
 
-        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_DETAIL)));
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_DETAIL)), Crud::PAGE_DETAIL);
         $context->getCrud()->setFieldAssets($this->getFieldAssets($context->getEntity()->getFields()));
         $this->container->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
 
@@ -219,7 +219,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             throw new InsufficientEntityPermissionException($context);
         }
 
-        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_EDIT)));
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_EDIT)), Crud::PAGE_EDIT);
         $context->getCrud()->setFieldAssets($this->getFieldAssets($context->getEntity()->getFields()));
         $this->container->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
         /** @var TEntity $entityInstance */
@@ -305,7 +305,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         /** @var class-string<TEntity> $entityFqcn */
         $entityFqcn = $context->getEntity()->getFqcn();
         $context->getEntity()->setInstance($this->createEntity($entityFqcn));
-        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_NEW)));
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_NEW)), Crud::PAGE_NEW);
         $context->getCrud()->setFieldAssets($this->getFieldAssets($context->getEntity()->getFields()));
         $this->container->get(EntityFactory::class)->processActions($context->getEntity(), $context->getCrud()->getActionsConfig());
 
@@ -495,7 +495,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
     public function renderFilters(AdminContext $context): KeyValueStore
     {
         $fields = FieldCollection::new($this->configureFields(Crud::PAGE_INDEX));
-        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), $fields);
+        $this->container->get(EntityFactory::class)->processFields($context->getEntity(), $fields, Crud::PAGE_INDEX);
         $filters = $this->container->get(FilterFactory::class)->create($context->getCrud()->getFiltersConfig(), $context->getEntity()->getFields(), $context->getEntity());
 
         /** @var FormInterface&FiltersFormType $filtersForm */

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -38,15 +38,31 @@ final class EntityFactory
         $this->eventDispatcher = $eventDispatcher;
     }
 
-    public function processFields(EntityDto $entityDto, FieldCollection $fields): void
+    public function processFields(EntityDto $entityDto, FieldCollection $fields, ?string $pageName = null): void
     {
-        $this->fieldFactory->processFields($entityDto, $fields);
+        if (null === $pageName) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.27.0',
+                'Argument "$pageName" is missing. Omitting it will cause an error in 5.0.0.',
+            );
+        }
+
+        $this->fieldFactory->processFields($entityDto, $fields, $pageName);
     }
 
-    public function processFieldsForAll(EntityCollection $entities, FieldCollection $fields): void
+    public function processFieldsForAll(EntityCollection $entities, FieldCollection $fields, ?string $pageName = null): void
     {
+        if (null === $pageName) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.27.0',
+                'Argument "$pageName" is missing. Omitting it will cause an error in 5.0.0.',
+            );
+        }
+
         foreach ($entities as $entity) {
-            $this->processFields($entity, clone $fields);
+            $this->processFields($entity, clone $fields, $pageName);
             $entities->set($entity);
         }
     }

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -71,12 +71,20 @@ final class FieldFactory
     {
     }
 
-    public function processFields(EntityDto $entityDto, FieldCollection $fields): void
+    public function processFields(EntityDto $entityDto, FieldCollection $fields, ?string $currentPage = null): void
     {
         $this->preProcessFields($fields, $entityDto);
 
         $context = $this->adminContextProvider->getContext();
-        $currentPage = $context->getCrud()->getCurrentPage();
+
+        if (null === $currentPage) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.27.0',
+                'Argument "$currentPage" is missing. Omitting it will cause an error in 5.0.0.',
+            );
+            $currentPage = $context->getCrud()->getCurrentPage();
+        }
 
         $isDetailOrIndex = \in_array($currentPage, [Crud::PAGE_INDEX, Crud::PAGE_DETAIL], true);
         foreach ($fields as $fieldDto) {
@@ -89,14 +97,6 @@ final class FieldFactory
 
             // "form rows" only make sense in pages that contain forms
             if ($isDetailOrIndex && EaFormRowType::class === $fieldDto->getFormType()) {
-                $fields->unset($fieldDto);
-
-                continue;
-            }
-
-            // when creating new entities with "useEntryCrudForm" on an edit page we must
-            // explicitly check for the "new" page because $currentPage will be "edit"
-            if ($isDetailOrIndex && (null === $entityDto->getInstance()) && !$fieldDto->isDisplayedOn(Crud::PAGE_NEW)) {
                 $fields->unset($fieldDto);
 
                 continue;

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -304,14 +304,16 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         if (null === $associatedEntity) {
             $targetCrudControllerAction = Action::NEW;
             $targetCrudControllerPageName = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_NEW_PAGE_NAME) ?? Crud::PAGE_NEW;
+            $crudPageName = Crud::PAGE_NEW;
         } else {
             $targetCrudControllerAction = Action::EDIT;
             $targetCrudControllerPageName = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_EDIT_PAGE_NAME) ?? Crud::PAGE_EDIT;
+            $crudPageName = Crud::PAGE_EDIT;
         }
 
         $field->setFormTypeOption(
             'entityDto',
-            $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, $targetCrudControllerAction, $targetCrudControllerPageName),
+            $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, $targetCrudControllerAction, $targetCrudControllerPageName, $crudPageName),
         );
     }
 
@@ -319,7 +321,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
      * @param class-string $entityFqcn
      * @param class-string $crudControllerFqcn
      */
-    private function createEntityDto(string $entityFqcn, string $crudControllerFqcn, string $crudControllerAction, string $crudControllerPageName): EntityDto
+    private function createEntityDto(string $entityFqcn, string $crudControllerFqcn, string $crudControllerAction, string $crudControllerPageName, string $crudPageName): EntityDto
     {
         $entityDto = $this->entityFactory->create($entityFqcn);
 
@@ -331,7 +333,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
         $fields = $crudController->configureFields($crudControllerPageName);
 
-        $this->entityFactory->processFields($entityDto, FieldCollection::new($fields));
+        $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
 
         return $entityDto;
     }

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -101,11 +101,11 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             }
 
             $crudEditPageName = $field->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_EDIT_PAGE_NAME) ?? Crud::PAGE_EDIT;
-            $editEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::EDIT, $crudEditPageName);
+            $editEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::EDIT, $crudEditPageName, Crud::PAGE_EDIT);
             $field->setFormTypeOption('entry_options.entityDto', $editEntityDto);
 
             $crudNewPageName = $field->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_NEW_PAGE_NAME) ?? Crud::PAGE_NEW;
-            $newEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::NEW, $crudNewPageName);
+            $newEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, Action::NEW, $crudNewPageName, Crud::PAGE_NEW);
 
             try {
                 $field->setFormTypeOption('prototype_options.entityDto', $newEntityDto);
@@ -157,7 +157,7 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
      * @param class-string $targetEntityFqcn
      * @param class-string $targetCrudControllerFqcn
      */
-    private function createEntityDto(string $targetEntityFqcn, string $targetCrudControllerFqcn, string $crudAction, string $pageName): EntityDto
+    private function createEntityDto(string $targetEntityFqcn, string $targetCrudControllerFqcn, string $crudAction, string $crudControllerPageName, string $crudPageName): EntityDto
     {
         $entityDto = $this->entityFactory->create($targetEntityFqcn);
 
@@ -167,9 +167,9 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             $this->requestStack->getMainRequest()
         );
 
-        $fields = $crudController->configureFields($pageName);
+        $fields = $crudController->configureFields($crudControllerPageName);
 
-        $this->entityFactory->processFields($entityDto, FieldCollection::new($fields));
+        $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
 
         return $entityDto;
     }

--- a/tests/Factory/FieldFactoryTest.php
+++ b/tests/Factory/FieldFactoryTest.php
@@ -4,59 +4,140 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Factory;
 
 use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field;
-use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory\Project;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class FieldFactoryTest extends KernelTestCase
 {
-    private EntityManagerInterface $entityManager;
+    private EntityDto $projectDto;
     private FieldFactory $fieldFactory;
 
     protected function setUp(): void
     {
         /** @var EntityManagerInterface $entityManager */
         $entityManager = static::getContainer()->get(EntityManagerInterface::class);
-        $this->entityManager = $entityManager;
-
-        $adminContextMock = $this->getMockBuilder(AdminContextInterface::class)->disableOriginalConstructor()->getMock();
-        $adminContextMock->method('getCrud')->willReturn(new CrudDto());
-
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request(attributes: [EA::CONTEXT_REQUEST_ATTRIBUTE => $adminContextMock]));
-
-        $adminContextProvider = new AdminContextProvider($requestStack);
+        $this->projectDto = new EntityDto(Project::class, $entityManager->getClassMetadata(Project::class));
 
         $authorizationCheckerInterface = $this->getMockBuilder(AuthorizationCheckerInterface::class)->disableOriginalConstructor()->getMock();
         $authorizationCheckerInterface->method('isGranted')->willReturn(true);
 
         $this->fieldFactory = new FieldFactory(
-            $adminContextProvider,
+            $this->getMockBuilder(AdminContextProviderInterface::class)->disableOriginalConstructor()->getMock(),
             $authorizationCheckerInterface,
             [],
             new FormLayoutFactory(),
         );
     }
 
+    public function testEmpty(): void
+    {
+        $fieldCollection = FieldCollection::new([]);
+
+        $this->fieldFactory->processFields($this->projectDto, $fieldCollection, Crud::PAGE_INDEX);
+
+        $this->assertEmpty($fieldCollection);
+    }
+
+    /**
+     * @dataProvider removesFieldsOnPage
+     */
+    public function testRemovesFieldsOnPage(string $pageName, FieldInterface $field): void
+    {
+        $fieldCollection = FieldCollection::new([$field]);
+
+        $this->fieldFactory->processFields($this->projectDto, $fieldCollection, $pageName);
+
+        $this->assertEmpty($fieldCollection);
+    }
+
+    public static function removesFieldsOnPage(): \Generator
+    {
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->hideOnIndex()];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->onlyOnDetail()];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->onlyOnForms()];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->onlyWhenCreating()];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->onlyWhenUpdating()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->hideOnDetail()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->onlyOnIndex()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->onlyOnForms()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->onlyWhenCreating()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->onlyWhenUpdating()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->hideOnForm()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->hideWhenUpdating()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->onlyOnDetail()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->onlyOnIndex()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->onlyWhenCreating()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->hideOnForm()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->hideWhenCreating()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->onlyOnDetail()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->onlyOnIndex()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->onlyWhenUpdating()];
+    }
+
+    /**
+     * @dataProvider keepsFieldsOnPage
+     */
+    public function testKeepsFieldsOnPage(string $pageName, FieldInterface $field): void
+    {
+        $fieldCollection = FieldCollection::new([$field]);
+
+        $this->fieldFactory->processFields($this->projectDto, $fieldCollection, $pageName);
+
+        // Remove layout fields
+        foreach ($fieldCollection as $field) {
+            if (\in_array($field->getProperty(), ['ea_form_fieldset', 'ea_form_fieldset_close'])) {
+                $fieldCollection->unset($field);
+            }
+        }
+
+        $this->assertCount(1, $fieldCollection);
+    }
+
+    public static function keepsFieldsOnPage(): \Generator
+    {
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->onlyOnIndex()];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->hideOnDetail()];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->hideOnForm()];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->hideWhenUpdating()];
+        yield [Crud::PAGE_INDEX, Field\TextField::new('name')->hideWhenCreating()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->onlyOnDetail()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->hideOnIndex()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->hideOnForm()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->hideWhenUpdating()];
+        yield [Crud::PAGE_DETAIL, Field\TextField::new('name')->hideWhenCreating()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->onlyOnForms()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->onlyWhenUpdating()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->hideOnIndex()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->hideOnDetail()];
+        yield [Crud::PAGE_EDIT, Field\TextField::new('name')->hideWhenCreating()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->onlyOnForms()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->onlyWhenCreating()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->hideOnIndex()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->hideOnDetail()];
+        yield [Crud::PAGE_NEW, Field\TextField::new('name')->hideWhenUpdating()];
+    }
+
     /**
      * @dataProvider stringNames
      */
-    public function testStringNamesAreTurnedIntoFields(string $entity, string $property, string $expectedField): void
+    public function testStringNamesAreTurnedIntoFields(string $property, string $expectedField): void
     {
         $fieldCollection = FieldCollection::new([$property]);
 
-        $this->fieldFactory->processFields(new EntityDto($entity, $this->entityManager->getClassMetadata($entity)), $fieldCollection);
+        $this->fieldFactory->processFields($this->projectDto, $fieldCollection, Crud::PAGE_INDEX);
 
         $this->assertSame(
             $expectedField,
@@ -67,23 +148,23 @@ class FieldFactoryTest extends KernelTestCase
 
     public static function stringNames(): \Generator
     {
-        yield [Project::class, 'rolesJson', Field\ArrayField::class];
-        yield [Project::class, 'statesSimpleArray', Field\ArrayField::class];
-        yield [Project::class, 'internal', Field\BooleanField::class];
-        yield [Project::class, 'startDateMutable', Field\DateField::class];
-        yield [Project::class, 'startDateImmutable', Field\DateField::class];
-        yield [Project::class, 'startDateTimeMutable', Field\DateTimeField::class];
-        yield [Project::class, 'startDateTimeImmutable', Field\DateTimeField::class];
-        yield [Project::class, 'startDateTimeTzMutable', Field\DateTimeField::class];
-        yield [Project::class, 'startDateTimeTzImmutable', Field\DateTimeField::class];
-        yield [Project::class, 'id', Field\IdField::class];
-        yield [Project::class, 'countInteger', Field\IntegerField::class];
-        yield [Project::class, 'countSmallint', Field\IntegerField::class];
-        yield [Project::class, 'priceDecimal', Field\NumberField::class];
-        yield [Project::class, 'priceFloat', Field\NumberField::class];
-        yield [Project::class, 'description', Field\TextareaField::class];
-        yield [Project::class, 'name', Field\TextField::class];
-        yield [Project::class, 'startTimeMutable', Field\TimeField::class];
-        yield [Project::class, 'startTimeImmutable', Field\TimeField::class];
+        yield ['rolesJson', Field\ArrayField::class];
+        yield ['statesSimpleArray', Field\ArrayField::class];
+        yield ['internal', Field\BooleanField::class];
+        yield ['startDateMutable', Field\DateField::class];
+        yield ['startDateImmutable', Field\DateField::class];
+        yield ['startDateTimeMutable', Field\DateTimeField::class];
+        yield ['startDateTimeImmutable', Field\DateTimeField::class];
+        yield ['startDateTimeTzMutable', Field\DateTimeField::class];
+        yield ['startDateTimeTzImmutable', Field\DateTimeField::class];
+        yield ['id', Field\IdField::class];
+        yield ['countInteger', Field\IntegerField::class];
+        yield ['countSmallint', Field\IntegerField::class];
+        yield ['priceDecimal', Field\NumberField::class];
+        yield ['priceFloat', Field\NumberField::class];
+        yield ['description', Field\TextareaField::class];
+        yield ['name', Field\TextField::class];
+        yield ['startTimeMutable', Field\TimeField::class];
+        yield ['startTimeImmutable', Field\TimeField::class];
     }
 }


### PR DESCRIPTION
…eld if crud form is used

`FieldFactory` removes configured fields by checking against the current page (for example `Crud::PAGE_NEW`) here: `$fieldDto->isDisplayedOn($currentPage)`.

Now consider using one of:
- `AssociactionField::new(...)->renderAsEmbeddedForm()`
- `CollectionField::new(...)->useEntryCrudForm()`

`FieldFactory` gets the `$currentPage` of the request: `$this->adminContextProvider->getContext()->getCrud()->getCurrentPage()`. If there are nested CRUD forms (like in the 2 above examples) there have to be multiple current pages. One for the root entity and one for every nested CRUD form. For example when editing (`Crud::PAGE_EDIT`) the root entity we can add new (`Crud::PAGE_NEW`) items to a collection.

This is not possible and a partial fix was introduced in https://github.com/EasyCorp/EasyAdminBundle/pull/5704 and edited in https://github.com/EasyCorp/EasyAdminBundle/pull/7061. This fix produced another error (for example removing fields on `index` pages, I can elaborate if necessary).

This PR reverts the partial fixes and adds a new fix by passing different `$currentPage` to `FieldFactory` a) for the root entity and b) for nested CRUD forms.