### PR TITLE
Deprecate 4 methods to cleanup EntityFactory

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -251,11 +251,9 @@ return static function (ContainerConfigurator $container) {
             ->arg(4, service('event_dispatcher'))
 
         ->set(EntityFactory::class)
-            ->arg(0, service(FieldFactory::class))
-            ->arg(1, service(ActionFactory::class))
-            ->arg(2, service(AuthorizationChecker::class))
-            ->arg(3, service('doctrine'))
-            ->arg(4, service('event_dispatcher'))
+            ->arg(0, service(AuthorizationChecker::class))
+            ->arg(1, service('doctrine'))
+            ->arg(2, service('event_dispatcher'))
 
         ->set(EntityPaginator::class)
             ->arg(0, service(AdminUrlGenerator::class))
@@ -337,6 +335,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(1, new Reference(AdminUrlGenerator::class))
             ->arg(2, service('request_stack'))
             ->arg(3, service(ControllerFactory::class))
+            ->arg(4, new Reference(FieldFactory::class))
 
         ->set(AvatarConfigurator::class)
 
@@ -396,6 +395,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, service('request_stack'))
             ->arg(1, service(EntityFactory::class))
             ->arg(2, service(ControllerFactory::class))
+            ->arg(3, new Reference(FieldFactory::class))
 
         ->set(SlugConfigurator::class)
 

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use EasyCorp\Bundle\EasyAdminBundle\Collection\ActionCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\EntityCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
@@ -159,6 +160,15 @@ final class ActionFactory
         }
 
         return ActionCollection::new($processedItems);
+    }
+
+    public function processGlobalActionsAndEntityActionsForAll(EntityCollection $entityDtos, ActionConfigDto $actionConfigDto): ActionCollection
+    {
+        foreach ($entityDtos as $entityDto) {
+            $this->processEntityActions($entityDto, clone $actionConfigDto);
+        }
+
+        return $this->processGlobalActions($actionConfigDto);
     }
 
     private function processAction(string $pageName, ActionDto $actionDto, ?EntityDto $entityDto = null): ActionDto

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\FieldMapping;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\EntityCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
@@ -133,6 +134,22 @@ final class FieldFactory
         }
 
         $entityDto->setFields($fields);
+    }
+
+    public function processFieldsForAll(EntityCollection $entityDtos, FieldCollection $fields, ?string $currentPage = null): void
+    {
+        if (null === $currentPage) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.27.0',
+                'Argument "$currentPage" is missing. Omitting it will cause an error in 5.0.0.',
+            );
+        }
+
+        foreach ($entityDtos as $entityDto) {
+            $this->processFields($entityDto, clone $fields, $currentPage);
+            $entityDtos->set($entityDto);
+        }
     }
 
     private function replaceGenericFieldsWithSpecificFields(FieldCollection $fields, EntityDto $entityDto): void

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -15,6 +15,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
@@ -35,7 +36,16 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
         private readonly RequestStack $requestStack,
         private readonly ControllerFactory $controllerFactory,
+        private readonly ?FieldFactory $fieldFactory = null,
     ) {
+        if (null === $this->fieldFactory) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.27.0',
+                'Not passing argument "$fieldFactory" to the "%s" constructor is deprecated.',
+                self::class
+            );
+        }
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
@@ -328,7 +338,11 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
         $fields = $crudController->configureFields($crudControllerPageName);
 
-        $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+        if (null === $this->fieldFactory) {
+            $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+        } else {
+            $this->fieldFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+        }
 
         return $entityDto;
     }

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -12,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
@@ -32,7 +33,16 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
         private readonly RequestStack $requestStack,
         private readonly EntityFactory $entityFactory,
         private readonly ControllerFactory $controllerFactory,
+        private readonly ?FieldFactory $fieldFactory = null,
     ) {
+        if (null === $this->fieldFactory) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.27.0',
+                'Not passing argument "$fieldFactory" to the "%s" constructor is deprecated.',
+                self::class
+            );
+        }
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
@@ -165,7 +175,11 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
 
         $fields = $crudController->configureFields($crudControllerPageName);
 
-        $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+        if (null === $this->fieldFactory) {
+            $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+        } else {
+            $this->fieldFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+        }
 
         return $entityDto;
     }


### PR DESCRIPTION
Deprecates `EntityFactory` methodes which are wrappers over `FieldFactory` and `ActionFactory`.

Deprecates them because:
- makes client code harder to read
- more responsibilities (processing `Fields` and processing `Actions`) for `EntityFactory` than needed
- more dependencies (`FieldFactory` and `ActionFactory`) for `EntityFactory` than needed
- more code to maintain and to test
