### PR TITLE
Guess secific fields for association properties

### DIFF
--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -163,6 +163,11 @@ final class EntityDto
         return $this->actions;
     }
 
+    public function getClassMetadata(): ClassMetadata
+    {
+        return $this->metadata;
+    }
+
     /**
      * Returns the names of all properties defined in the entity, no matter
      * if they are used or not in the application.

--- a/tests/Factory/FieldFactoryTest.php
+++ b/tests/Factory/FieldFactoryTest.php
@@ -166,5 +166,12 @@ class FieldFactoryTest extends KernelTestCase
         yield ['name', Field\TextField::class];
         yield ['startTimeMutable', Field\TimeField::class];
         yield ['startTimeImmutable', Field\TimeField::class];
+        yield ['price.amount', Field\IntegerField::class];
+        yield ['price.currency', Field\TextField::class];
+        yield ['latestRelease', Field\AssociationField::class];
+        yield ['leadDeveloper', Field\AssociationField::class];
+        yield ['projectIssues', Field\CollectionField::class];
+        yield ['favouriteProjectOf', Field\AssociationField::class];
+        yield ['projectTags', Field\AssociationField::class];
     }
 }

--- a/tests/Field/Configurator/ChoiceConfiguratorTest.php
+++ b/tests/Field/Configurator/ChoiceConfiguratorTest.php
@@ -34,7 +34,7 @@ class ChoiceConfiguratorTest extends AbstractFieldTest
     /**
      * @dataProvider fieldTypes
      */
-    public function testSupporsField(string $fieldType, bool $expectedResult): void
+    public function testSupportsField(string $fieldType, bool $expectedResult): void
     {
         $this->checkPhpVersion();
 

--- a/tests/TestApplication/src/Entity/FieldFactory/Developer.php
+++ b/tests/TestApplication/src/Entity/FieldFactory/Developer.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class Developer
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    #[ORM\ManyToOne(inversedBy: 'favouriteProjectOf')]
+    private ?Project $favouriteProject = null;
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getFavouriteProject(): ?Project
+    {
+        return $this->favouriteProject;
+    }
+
+    public function setFavouriteProject(?Project $favouriteProject): static
+    {
+        $this->favouriteProject = $favouriteProject;
+
+        return $this;
+    }
+}

--- a/tests/TestApplication/src/Entity/FieldFactory/Money.php
+++ b/tests/TestApplication/src/Entity/FieldFactory/Money.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Embeddable]
+class Money
+{
+    #[ORM\Column]
+    private int $amount;
+
+    #[ORM\Column]
+    private string $currency;
+
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(int $amount): static
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): static
+    {
+        $this->currency = $currency;
+
+        return $this;
+    }
+}

--- a/tests/TestApplication/src/Entity/FieldFactory/ProjectIssue.php
+++ b/tests/TestApplication/src/Entity/FieldFactory/ProjectIssue.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class ProjectIssue
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    #[ORM\ManyToOne(inversedBy: 'projectIssues')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Project $project = null;
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getProject(): ?Project
+    {
+        return $this->project;
+    }
+
+    public function setProject(?Project $project): static
+    {
+        $this->project = $project;
+
+        return $this;
+    }
+}

--- a/tests/TestApplication/src/Entity/FieldFactory/ProjectRelease.php
+++ b/tests/TestApplication/src/Entity/FieldFactory/ProjectRelease.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class ProjectRelease
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/tests/TestApplication/src/Entity/FieldFactory/ProjectTag.php
+++ b/tests/TestApplication/src/Entity/FieldFactory/ProjectTag.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+class ProjectTag
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    /**
+     * @var Collection<int, Project>
+     */
+    #[ORM\ManyToMany(targetEntity: Project::class, mappedBy: 'projectTags')]
+    private Collection $projects;
+
+    public function __construct()
+    {
+        $this->projects = new ArrayCollection();
+    }
+
+    public function __toString(): string
+    {
+        return $this->name;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Project>
+     */
+    public function getProjects(): Collection
+    {
+        return $this->projects;
+    }
+
+    public function addProject(Project $project): static
+    {
+        if (!$this->projects->contains($project)) {
+            $this->projects->add($project);
+            $project->addProjectTag($this);
+        }
+
+        return $this;
+    }
+
+    public function removeProject(Project $project): static
+    {
+        if ($this->projects->removeElement($project)) {
+            $project->removeProjectTag($this);
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
New feature, no BC breaks.

Before this PR:

```php
class ProjectCrudController extends AbstractCrudController
{
    public function configureFields(string $pageName): iterable
    {
        return [
            AssociationField::new('latestRelease'),
            AssociationField::new('leadDeveloper'),
            CollectionField::new('projectIssues'), // See note below
            AssociationField::new('favouriteProjectOf'),
            AssociationField::new('projectTags'),
        ];
}
```

After this PR you can omit the specific Fields:
```php
class ProjectCrudController extends AbstractCrudController
{
    public function configureFields(string $pageName): iterable
    {
        return [
            'latestRelease',
            'leadDeveloper',
            'projectIssues', // See note below
            'favouriteProjectOf',
            'projectTags',
        ];
}
```

Note:
- `CollectionField` is guessed only on `OneToMany` associations with `orphanRemoval: true`. On all other associations `AssociationField` is guessed.
- Doctrine `Embeddable` objects are not changed, I just added them to the test to make sure nothing is changed.