### PR TITLE
Use PHP 8.2 readonly classes

### DIFF
--- a/src/ArgumentResolver/AdminContextResolver.php
+++ b/src/ArgumentResolver/AdminContextResolver.php
@@ -11,9 +11,9 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 /*
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AdminContextResolver implements ValueResolverInterface
+final readonly class AdminContextResolver implements ValueResolverInterface
 {
-    public function __construct(private readonly AdminContextProviderInterface $adminContextProvider)
+    public function __construct(private AdminContextProviderInterface $adminContextProvider)
     {
     }
 

--- a/src/ArgumentResolver/BatchActionDtoResolver.php
+++ b/src/ArgumentResolver/BatchActionDtoResolver.php
@@ -12,11 +12,10 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 /*
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class BatchActionDtoResolver implements ValueResolverInterface
+final readonly class BatchActionDtoResolver implements ValueResolverInterface
 {
-    public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
-    ) {
+    public function __construct(private AdminContextProviderInterface $adminContextProvider)
+    {
     }
 
     public function resolve(Request $request, ArgumentMetadata $argument): iterable

--- a/src/Config/Asset.php
+++ b/src/Config/Asset.php
@@ -8,9 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class Asset
+final readonly class Asset
 {
-    private function __construct(private readonly AssetDto $dto)
+    private function __construct(private AssetDto $dto)
     {
     }
 

--- a/src/Config/Assets.php
+++ b/src/Config/Assets.php
@@ -9,9 +9,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetsDto;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class Assets
+final readonly class Assets
 {
-    private function __construct(private readonly AssetsDto $dto)
+    private function __construct(private AssetsDto $dto)
     {
     }
 

--- a/src/Config/Filters.php
+++ b/src/Config/Filters.php
@@ -8,9 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterConfigDto;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class Filters
+final readonly class Filters
 {
-    private function __construct(private readonly FilterConfigDto $dto)
+    private function __construct(private FilterConfigDto $dto)
     {
     }
 

--- a/src/Config/Locale.php
+++ b/src/Config/Locale.php
@@ -8,9 +8,9 @@ use Symfony\Component\Intl\Locales;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class Locale
+final readonly class Locale
 {
-    private function __construct(private readonly LocaleDto $dto)
+    private function __construct(private LocaleDto $dto)
     {
     }
 

--- a/src/Config/UserMenu.php
+++ b/src/Config/UserMenu.php
@@ -9,9 +9,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class UserMenu
+final readonly class UserMenu
 {
-    private function __construct(private readonly UserMenuDto $dto)
+    private function __construct(private UserMenuDto $dto)
     {
     }
 

--- a/src/Context/ExceptionContext.php
+++ b/src/Context/ExceptionContext.php
@@ -7,16 +7,16 @@ use function Symfony\Component\String\u;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class ExceptionContext
+final readonly class ExceptionContext
 {
     /**
      * @param array<string> $parameters
      */
     public function __construct(
-        private readonly string $publicMessage,
-        private readonly string $debugMessage = '',
-        private readonly array $parameters = [],
-        private readonly int $statusCode = 500,
+        private string $publicMessage,
+        private string $debugMessage = '',
+        private array $parameters = [],
+        private int $statusCode = 500,
     ) {
     }
 

--- a/src/Dto/BatchActionDto.php
+++ b/src/Dto/BatchActionDto.php
@@ -7,17 +7,17 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
  *
  * @template TEntity of object = object
  */
-class BatchActionDto
+readonly class BatchActionDto
 {
     /**
      * @param array<mixed>          $entityIds
      * @param class-string<TEntity> $entityFqcn
      */
     public function __construct(
-        private readonly string $name,
-        private readonly array $entityIds,
-        private readonly string $entityFqcn,
-        private readonly string $csrfToken,
+        private string $name,
+        private array $entityIds,
+        private string $entityFqcn,
+        private string $csrfToken,
     ) {
     }
 

--- a/src/Dto/FilterConfigDto.php
+++ b/src/Dto/FilterConfigDto.php
@@ -8,9 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class FilterConfigDto
+final readonly class FilterConfigDto
 {
-    private readonly KeyValueStore $filters;
+    private KeyValueStore $filters;
 
     public function __construct()
     {

--- a/src/Dto/FormVarsDto.php
+++ b/src/Dto/FormVarsDto.php
@@ -9,9 +9,9 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class FormVarsDto
+final readonly class FormVarsDto
 {
-    public function __construct(private readonly ?FieldDto $fieldDto = null, private readonly ?EntityDto $entityDto = null)
+    public function __construct(private ?FieldDto $fieldDto = null, private ?EntityDto $entityDto = null)
     {
     }
 

--- a/src/Dto/I18nDto.php
+++ b/src/Dto/I18nDto.php
@@ -5,18 +5,18 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class I18nDto
+final readonly class I18nDto
 {
-    private readonly string $language;
+    private string $language;
 
     /**
      * @param array<string, mixed> $translationParameters
      */
     public function __construct(
-        private readonly string $locale,
-        private readonly string $textDirection,
-        private readonly string $translationDomain,
-        private readonly array $translationParameters,
+        private string $locale,
+        private string $textDirection,
+        private string $translationDomain,
+        private array $translationParameters,
     ) {
         // returns 'en' for 'en', 'en-US', 'en_US', 'en-US.UTF-8', 'en_US.UTF-8', etc.
         $this->language = explode('-', str_replace('_', '-', $this->locale))[0];

--- a/src/Dto/LocaleDto.php
+++ b/src/Dto/LocaleDto.php
@@ -5,12 +5,12 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 /**
  * @author Jakub Caban <kuba.iluvatar@gmail.com>
  */
-final class LocaleDto
+final readonly class LocaleDto
 {
     public function __construct(
-        private readonly string $locale,
-        private readonly string $name,
-        private readonly ?string $icon = null,
+        private string $locale,
+        private string $name,
+        private ?string $icon = null,
     ) {
     }
 

--- a/src/Dto/MainMenuDto.php
+++ b/src/Dto/MainMenuDto.php
@@ -5,12 +5,12 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class MainMenuDto
+final readonly class MainMenuDto
 {
     /**
      * @param MenuItemDto[] $items
      */
-    public function __construct(private readonly array $items)
+    public function __construct(private array $items)
     {
     }
 

--- a/src/Event/AfterEntityBuiltEvent.php
+++ b/src/Event/AfterEntityBuiltEvent.php
@@ -7,9 +7,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AfterEntityBuiltEvent
+final readonly class AfterEntityBuiltEvent
 {
-    public function __construct(private readonly EntityDto $entityDto)
+    public function __construct(private EntityDto $entityDto)
     {
     }
 

--- a/src/Event/AfterEntitySearchEvent.php
+++ b/src/Event/AfterEntitySearchEvent.php
@@ -6,12 +6,12 @@ use Doctrine\ORM\QueryBuilder;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 
-final class AfterEntitySearchEvent
+final readonly class AfterEntitySearchEvent
 {
     public function __construct(
-        private readonly QueryBuilder $queryBuilder,
-        private readonly SearchDto $searchDto,
-        private readonly EntityDto $entityDto,
+        private QueryBuilder $queryBuilder,
+        private SearchDto $searchDto,
+        private EntityDto $entityDto,
     ) {
     }
 

--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -30,16 +30,16 @@ use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  * @author Yonel Ceruto <yonelceruto@gmail.com>
  */
-class AdminRouterSubscriber implements EventSubscriberInterface
+readonly class AdminRouterSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly AdminContextFactory $adminContextFactory,
-        private readonly ControllerFactory $controllerFactory,
-        private readonly ControllerResolverInterface $controllerResolver,
-        private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly RequestMatcherInterface $requestMatcher,
-        private readonly CacheItemPoolInterface $cache,
-        private readonly AdminRouteGenerator $adminRouteGenerator,
+        private AdminContextFactory $adminContextFactory,
+        private ControllerFactory $controllerFactory,
+        private ControllerResolverInterface $controllerResolver,
+        private UrlGeneratorInterface $urlGenerator,
+        private RequestMatcherInterface $requestMatcher,
+        private CacheItemPoolInterface $cache,
+        private AdminRouteGenerator $adminRouteGenerator,
     ) {
     }
 

--- a/src/EventListener/CrudResponseListener.php
+++ b/src/EventListener/CrudResponseListener.php
@@ -12,11 +12,11 @@ use Twig\Environment;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CrudResponseListener
+final readonly class CrudResponseListener
 {
     public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
-        private readonly Environment $twig,
+        private AdminContextProviderInterface $adminContextProvider,
+        private Environment $twig,
     ) {
     }
 

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -19,12 +19,12 @@ use Twig\Error\RuntimeError;
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
-final class ExceptionListener
+final readonly class ExceptionListener
 {
     public function __construct(
-        private readonly bool $kernelDebug,
-        private readonly AdminContextProviderInterface $adminContextProvider,
-        private readonly Environment $twig,
+        private bool $kernelDebug,
+        private AdminContextProviderInterface $adminContextProvider,
+        private Environment $twig,
     ) {
     }
 

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -27,13 +27,13 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class ActionFactory
+final readonly class ActionFactory
 {
     public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
-        private readonly AuthorizationCheckerInterface $authChecker,
-        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
-        private readonly ?CsrfTokenManagerInterface $csrfTokenManager = null,
+        private AdminContextProviderInterface $adminContextProvider,
+        private AuthorizationCheckerInterface $authChecker,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private ?CsrfTokenManagerInterface $csrfTokenManager = null,
     ) {
     }
 

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -31,14 +31,14 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AdminContextFactory
+final readonly class AdminContextFactory
 {
     public function __construct(
-        private readonly ?TokenStorageInterface $tokenStorage,
-        private readonly MenuFactoryInterface $menuFactory,
-        private readonly EntityFactory $entityFactory,
-        private readonly AdminRouteGeneratorInterface $adminRouteGenerator,
-        private readonly CacheItemPoolInterface $cache,
+        private ?TokenStorageInterface $tokenStorage,
+        private MenuFactoryInterface $menuFactory,
+        private EntityFactory $entityFactory,
+        private AdminRouteGeneratorInterface $adminRouteGenerator,
+        private CacheItemPoolInterface $cache,
     ) {
     }
 

--- a/src/Factory/ControllerFactory.php
+++ b/src/Factory/ControllerFactory.php
@@ -11,9 +11,9 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 /**
  * @author Lukas Lücke <lukas@luecke.me>
  */
-final class ControllerFactory
+final readonly class ControllerFactory
 {
-    public function __construct(private readonly ControllerResolverInterface $controllerResolver)
+    public function __construct(private ControllerResolverInterface $controllerResolver)
     {
     }
 

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class EntityFactory
+final readonly class EntityFactory
 {
     public function __construct(
         private AuthorizationCheckerInterface $authorizationChecker,

--- a/src/Factory/FormFactory.php
+++ b/src/Factory/FormFactory.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class FormFactory
+final readonly class FormFactory
 {
-    public function __construct(private readonly FormFactoryInterface $symfonyFormFactory, private readonly AdminUrlGeneratorInterface $adminUrlGenerator)
+    public function __construct(private FormFactoryInterface $symfonyFormFactory, private AdminUrlGeneratorInterface $adminUrlGenerator)
     {
     }
 

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -25,15 +25,15 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class MenuFactory implements MenuFactoryInterface
+final readonly class MenuFactory implements MenuFactoryInterface
 {
     public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
-        private readonly AuthorizationCheckerInterface $authChecker,
-        private readonly LogoutUrlGenerator $logoutUrlGenerator,
-        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
-        private readonly MenuItemMatcherInterface $menuItemMatcher,
-        private readonly CacheItemPoolInterface $cache,
+        private AdminContextProviderInterface $adminContextProvider,
+        private AuthorizationCheckerInterface $authChecker,
+        private LogoutUrlGenerator $logoutUrlGenerator,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private MenuItemMatcherInterface $menuItemMatcher,
+        private CacheItemPoolInterface $cache,
     ) {
     }
 

--- a/src/Factory/PaginatorFactory.php
+++ b/src/Factory/PaginatorFactory.php
@@ -9,11 +9,11 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInter
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class PaginatorFactory
+final readonly class PaginatorFactory
 {
     public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
-        private readonly EntityPaginatorInterface $entityPaginator,
+        private AdminContextProviderInterface $adminContextProvider,
+        private EntityPaginatorInterface $entityPaginator,
     ) {
     }
 

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -31,15 +31,15 @@ use function Symfony\Component\Translation\t;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class AssociationConfigurator implements FieldConfiguratorInterface
+final readonly class AssociationConfigurator implements FieldConfiguratorInterface
 {
     public function __construct(
-        private readonly EntityFactory $entityFactory,
-        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
-        private readonly RequestStack $requestStack,
-        private readonly ControllerFactory $controllerFactory,
-        private readonly FieldFactory $fieldFactory,
-        private readonly CacheItemPoolInterface $cache,
+        private EntityFactory $entityFactory,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private RequestStack $requestStack,
+        private ControllerFactory $controllerFactory,
+        private FieldFactory $fieldFactory,
+        private CacheItemPoolInterface $cache,
     ) {
     }
 

--- a/src/Field/Configurator/BooleanConfigurator.php
+++ b/src/Field/Configurator/BooleanConfigurator.php
@@ -16,12 +16,12 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class BooleanConfigurator implements FieldConfiguratorInterface
+final readonly class BooleanConfigurator implements FieldConfiguratorInterface
 {
     public function __construct(
-        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
-        private readonly AuthorizationCheckerInterface $authChecker,
-        private readonly ?CsrfTokenManagerInterface $csrfTokenManager = null,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private AuthorizationCheckerInterface $authChecker,
+        private ?CsrfTokenManagerInterface $csrfTokenManager = null,
     ) {
     }
 

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -29,14 +29,14 @@ use function Symfony\Component\String\u;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CollectionConfigurator implements FieldConfiguratorInterface
+final readonly class CollectionConfigurator implements FieldConfiguratorInterface
 {
     public function __construct(
-        private readonly RequestStack $requestStack,
-        private readonly EntityFactory $entityFactory,
-        private readonly ControllerFactory $controllerFactory,
-        private readonly FieldFactory $fieldFactory,
-        private readonly CacheItemPoolInterface $cache,
+        private RequestStack $requestStack,
+        private EntityFactory $entityFactory,
+        private ControllerFactory $controllerFactory,
+        private FieldFactory $fieldFactory,
+        private CacheItemPoolInterface $cache,
     ) {
     }
 

--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -14,11 +14,11 @@ use Twig\Markup;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CommonPostConfigurator implements FieldConfiguratorInterface
+final readonly class CommonPostConfigurator implements FieldConfiguratorInterface
 {
     public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
-        private readonly string $charset,
+        private AdminContextProviderInterface $adminContextProvider,
+        private string $charset,
     ) {
     }
 

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -22,9 +22,9 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CommonPreConfigurator implements FieldConfiguratorInterface
+final readonly class CommonPreConfigurator implements FieldConfiguratorInterface
 {
-    public function __construct(private readonly PropertyAccessorInterface $propertyAccessor, private readonly EntityFactory $entityFactory)
+    public function __construct(private PropertyAccessorInterface $propertyAccessor, private EntityFactory $entityFactory)
     {
     }
 

--- a/src/Field/Configurator/CountryConfigurator.php
+++ b/src/Field/Configurator/CountryConfigurator.php
@@ -16,9 +16,9 @@ use Twig\Environment;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CountryConfigurator implements FieldConfiguratorInterface
+final readonly class CountryConfigurator implements FieldConfiguratorInterface
 {
-    public function __construct(private readonly Environment $twig)
+    public function __construct(private Environment $twig)
     {
     }
 

--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -16,9 +16,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TimeField;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class DateTimeConfigurator implements FieldConfiguratorInterface
+final readonly class DateTimeConfigurator implements FieldConfiguratorInterface
 {
-    public function __construct(private readonly IntlFormatterInterface $intlFormatter)
+    public function __construct(private IntlFormatterInterface $intlFormatter)
     {
     }
 

--- a/src/Field/Configurator/ImageConfigurator.php
+++ b/src/Field/Configurator/ImageConfigurator.php
@@ -13,9 +13,9 @@ use function Symfony\Component\String\u;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class ImageConfigurator implements FieldConfiguratorInterface
+final readonly class ImageConfigurator implements FieldConfiguratorInterface
 {
-    public function __construct(private readonly string $projectDir)
+    public function __construct(private string $projectDir)
     {
     }
 

--- a/src/Field/Configurator/NumberConfigurator.php
+++ b/src/Field/Configurator/NumberConfigurator.php
@@ -12,9 +12,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class NumberConfigurator implements FieldConfiguratorInterface
+final readonly class NumberConfigurator implements FieldConfiguratorInterface
 {
-    public function __construct(private readonly IntlFormatterInterface $intlFormatter)
+    public function __construct(private IntlFormatterInterface $intlFormatter)
     {
     }
 

--- a/src/Field/Configurator/PercentConfigurator.php
+++ b/src/Field/Configurator/PercentConfigurator.php
@@ -12,9 +12,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\PercentField;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class PercentConfigurator implements FieldConfiguratorInterface
+final readonly class PercentConfigurator implements FieldConfiguratorInterface
 {
-    public function __construct(private readonly IntlFormatterInterface $intlFormatter)
+    public function __construct(private IntlFormatterInterface $intlFormatter)
     {
     }
 

--- a/src/Maker/ClassMaker.php
+++ b/src/Maker/ClassMaker.php
@@ -6,11 +6,11 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
 use function Symfony\Component\String\u;
 
-final class ClassMaker
+final readonly class ClassMaker
 {
-    private readonly Filesystem $fs;
+    private Filesystem $fs;
 
-    public function __construct(private readonly KernelInterface $kernel, private readonly string $projectDir)
+    public function __construct(private KernelInterface $kernel, private string $projectDir)
     {
         $this->fs = new Filesystem();
     }

--- a/src/Menu/MenuItemMatcher.php
+++ b/src/Menu/MenuItemMatcher.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class MenuItemMatcher implements MenuItemMatcherInterface
+readonly class MenuItemMatcher implements MenuItemMatcherInterface
 {
     public function __construct(
         private AdminUrlGeneratorInterface $adminUrlGenerator,

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -29,14 +29,14 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class EntityRepository implements EntityRepositoryInterface
+final readonly class EntityRepository implements EntityRepositoryInterface
 {
     public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
-        private readonly ManagerRegistry $doctrine,
-        private readonly EntityFactory $entityFactory,
-        private readonly FormFactory $formFactory,
-        private readonly EventDispatcherInterface $eventDispatcher,
+        private AdminContextProviderInterface $adminContextProvider,
+        private ManagerRegistry $doctrine,
+        private EntityFactory $entityFactory,
+        private FormFactory $formFactory,
+        private EventDispatcherInterface $eventDispatcher,
     ) {
     }
 

--- a/src/Orm/EntityUpdater.php
+++ b/src/Orm/EntityUpdater.php
@@ -12,9 +12,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class EntityUpdater implements EntityUpdaterInterface
+final readonly class EntityUpdater implements EntityUpdaterInterface
 {
-    public function __construct(private readonly PropertyAccessorInterface $propertyAccessor, private readonly ValidatorInterface $validator)
+    public function __construct(private PropertyAccessorInterface $propertyAccessor, private ValidatorInterface $validator)
     {
     }
 

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -8,9 +8,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInter
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-final class AdminContextProvider implements AdminContextProviderInterface
+final readonly class AdminContextProvider implements AdminContextProviderInterface
 {
-    public function __construct(private readonly RequestStack $requestStack)
+    public function __construct(private RequestStack $requestStack)
     {
     }
 

--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -10,10 +10,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class FieldProvider
+final readonly class FieldProvider
 {
     public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
+        private AdminContextProviderInterface $adminContextProvider,
     ) {
     }
 

--- a/src/Security/AuthorizationChecker.php
+++ b/src/Security/AuthorizationChecker.php
@@ -12,9 +12,9 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class AuthorizationChecker implements AuthorizationCheckerInterface
+readonly class AuthorizationChecker implements AuthorizationCheckerInterface
 {
-    public function __construct(private readonly AuthorizationCheckerInterface $authorizationChecker)
+    public function __construct(private AuthorizationCheckerInterface $authorizationChecker)
     {
     }
 

--- a/src/Translation/TranslatableChoiceMessage.php
+++ b/src/Translation/TranslatableChoiceMessage.php
@@ -11,12 +11,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *
  * @internal
  */
-final class TranslatableChoiceMessage implements TranslatableInterface
+final readonly class TranslatableChoiceMessage implements TranslatableInterface
 {
     public function __construct(
         /** @var TranslatableMessage $message */
-        private readonly TranslatableInterface $message,
-        private readonly ?string $cssClass,
+        private TranslatableInterface $message,
+        private ?string $cssClass,
     ) {
     }
 

--- a/src/Translation/TranslatableChoiceMessageCollection.php
+++ b/src/Translation/TranslatableChoiceMessageCollection.php
@@ -10,12 +10,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *
  * @internal
  */
-final class TranslatableChoiceMessageCollection implements TranslatableInterface
+final readonly class TranslatableChoiceMessageCollection implements TranslatableInterface
 {
     public function __construct(
         /** @var TranslatableChoiceMessage[] */
-        private readonly array $choices,
-        private readonly bool $isRenderedAsBadge,
+        private array $choices,
+        private bool $isRenderedAsBadge,
     ) {
     }
 


### PR DESCRIPTION
The `5.x` branch requires PHP 8.2 so we can use readonly classes.
No BC breaks.
Build failures are unrelated.
