### PR TITLE
Fix typo which renames parameter

### DIFF
--- a/src/Asset/AssetPackage.php
+++ b/src/Asset/AssetPackage.php
@@ -32,13 +32,13 @@ final class AssetPackage implements PackageInterface
         );
     }
 
-    public function getUrl(string $assetPath): string
+    public function getUrl(string $path): string
     {
-        return $this->package->getUrl($assetPath);
+        return $this->package->getUrl($path);
     }
 
-    public function getVersion(string $assetPath): string
+    public function getVersion(string $path): string
     {
-        return $this->package->getVersion($assetPath);
+        return $this->package->getVersion($path);
     }
 }


### PR DESCRIPTION
No BC break.
Must have been a typo since even in older Symfony versions (including 5.4), the parameters where named `$path`: https://github.com/symfony/symfony/commits/7.4/src/Symfony/Component/Asset/PackageInterface.php.
