### PR TITLE
Add configurator tests

### DIFF
--- a/tests/Factory/FieldFactoryTest.php
+++ b/tests/Factory/FieldFactoryTest.php
@@ -12,7 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormLayoutFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory\Project;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain\Project;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 

--- a/tests/Field/Configurator/AssociationConfiguratorTest.php
+++ b/tests/Field/Configurator/AssociationConfiguratorTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Configurator;
+
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\AssociationConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Field\AbstractFieldTest;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\ProjectDomain\DeveloperCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\ProjectDomain\ProjectCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain\Developer;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain\Project;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain\ProjectTag;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class AssociationConfiguratorTest extends AbstractFieldTest
+{
+    private EntityDto $projectDto;
+
+    protected function setUp(): void
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $this->projectDto = new EntityDto(Project::class, $entityManager->getClassMetadata(Project::class));
+
+        $adminUrlGenerator = $this->getMockBuilder(AdminUrlGeneratorInterface::class)->disableOriginalConstructor()->getMock();
+
+        $this->configurator = new AssociationConfigurator(
+            static::getContainer()->get(EntityFactory::class),
+            $adminUrlGenerator,
+            static::getContainer()->get(RequestStack::class),
+            static::getContainer()->get(ControllerFactory::class),
+            static::getContainer()->get(FieldFactory::class),
+        );
+    }
+
+    protected function getEntityDto(): EntityDto
+    {
+        return $this->projectDto;
+    }
+
+    /**
+     * @dataProvider toOneAssociation
+     */
+    public function testToOneAssociation(FieldInterface $field): void
+    {
+        $field->getAsDto()->setDoctrineMetadata($this->projectDto->getPropertyMetadata($field->getAsDto()->getProperty())->all());
+        $field->setCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER, DeveloperCrudController::class);
+
+        $field = $this->configure($field, controllerFqcn: ProjectCrudController::class);
+        $this->assertSame('toOne', $field->getCustomOption(AssociationField::OPTION_DOCTRINE_ASSOCIATION_TYPE));
+        $this->assertSame(EntityType::class, $field->getFormType());
+        $this->assertSame(Developer::class, $field->getFormTypeOption('class'));
+    }
+
+    public static function toOneAssociation(): \Generator
+    {
+        yield [AssociationField::new('leadDeveloper')];
+    }
+
+    /**
+     * @dataProvider toManyAssociation
+     */
+    public function testToManyAssociation(FieldInterface $field): void
+    {
+        $field->getAsDto()->setDoctrineMetadata($this->projectDto->getPropertyMetadata($field->getAsDto()->getProperty())->all());
+        $field->setCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER, DeveloperCrudController::class);
+
+        $field = $this->configure($field, controllerFqcn: ProjectCrudController::class);
+        $this->assertSame('toMany', $field->getCustomOption(AssociationField::OPTION_DOCTRINE_ASSOCIATION_TYPE));
+        $this->assertSame(EntityType::class, $field->getFormType());
+        $this->assertSame(ProjectTag::class, $field->getFormTypeOption('class'));
+    }
+
+    public static function toManyAssociation(): \Generator
+    {
+        yield [AssociationField::new('projectTags')];
+    }
+
+    /**
+     * @dataProvider failsIfPropertyIsNotAssociation
+     */
+    public function testFailsIfPropertyIsNotAssociation(FieldInterface $field): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The "%s" field is not a Doctrine association, so it cannot be used as an association field.',
+            $field->getAsDto()->getProperty(),
+        ));
+
+        $this->configure($field);
+    }
+
+    public static function failsIfPropertyIsNotAssociation(): \Generator
+    {
+        yield [TextField::new('name')];
+        yield [TextField::new('price')];
+        yield [TextField::new('price.currency')];
+    }
+
+    /**
+     * @dataProvider failsOnOptionRenderAsEmbeddedCrudFormIfPropertyIsCollection
+     */
+    public function testFailsOnOptionRenderAsEmbeddedCrudFormIfPropertyIsCollection(FieldInterface $field): void
+    {
+        $field->setCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM, true)
+            ->setCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER, 'foo')
+        ;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The "%s" association field of "%s" is a to-many association but it\'s trying to use the "renderAsEmbeddedForm()" option, which is only available for to-one associations. If you want to use a CRUD form to render to-many associations, use a CollectionField instead of the AssociationField.',
+            $field->getAsDto()->getProperty(),
+            ProjectCrudController::class,
+        ));
+
+        $this->configure($field, controllerFqcn: ProjectCrudController::class);
+    }
+
+    public static function failsOnOptionRenderAsEmbeddedCrudFormIfPropertyIsCollection(): \Generator
+    {
+        yield [AssociationField::new('projectIssues')];
+        yield [AssociationField::new('favouriteProjectOf')];
+        yield [AssociationField::new('projectTags')];
+    }
+
+    /**
+     * @dataProvider failsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound
+     */
+    public function testFailsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound(FieldInterface $field): void
+    {
+        $field->getAsDto()->setDoctrineMetadata($this->projectDto->getPropertyMetadata($field->getAsDto()->getProperty())->all());
+        $field->setCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM, true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The "%s" association field of "%s" wants to render its contents using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "renderAsEmbeddedForm()" method.',
+            $field->getAsDto()->getProperty(),
+            ProjectCrudController::class,
+            $field->getAsDto()->getDoctrineMetadata()->get('targetEntity'),
+        ));
+
+        $this->configure($field, controllerFqcn: ProjectCrudController::class);
+    }
+
+    public static function failsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound(): \Generator
+    {
+        yield [AssociationField::new('latestRelease')];
+    }
+}

--- a/tests/Field/Configurator/CollectionConfiguratorTest.php
+++ b/tests/Field/Configurator/CollectionConfiguratorTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field\Configurator;
+
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CollectionConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Field\AbstractFieldTest;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\ProjectDomain\ProjectCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain\Project;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+
+class CollectionConfiguratorTest extends AbstractFieldTest
+{
+    private EntityDto $projectDto;
+
+    protected function setUp(): void
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $this->projectDto = new EntityDto(Project::class, $entityManager->getClassMetadata(Project::class));
+
+        /** @var CollectionConfigurator $collectionConfigurator */
+        $collectionConfigurator = static::getContainer()->get(CollectionConfigurator::class);
+        $this->configurator = $collectionConfigurator;
+    }
+
+    protected function getEntityDto(): EntityDto
+    {
+        return $this->projectDto;
+    }
+
+    /**
+     * @dataProvider fields
+     */
+    public function test(FieldInterface $field): void
+    {
+        $field = $this->configure($field);
+        $this->assertSame(CollectionType::class, $field->getFormType());
+    }
+
+    public static function fields(): \Generator
+    {
+        yield [CollectionField::new('projectIssues')];
+        yield [CollectionField::new('favouriteProjectOf')];
+        yield [CollectionField::new('projectTags')];
+    }
+
+    /**
+     * @dataProvider failsOnOptionEntryUsesCrudFormIfPropertyIsNotAssociation
+     */
+    public function testFailsOnOptionEntryUsesCrudFormIfPropertyIsNotAssociation(FieldInterface $field): void
+    {
+        $field->setCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM, true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The "%s" collection field of "%s" cannot use the "useEntryCrudForm()" method because it is not a Doctrine association.',
+            $field->getAsDto()->getProperty(),
+            ProjectCrudController::class,
+        ));
+
+        $this->configure($field, controllerFqcn: ProjectCrudController::class);
+    }
+
+    public static function failsOnOptionEntryUsesCrudFormIfPropertyIsNotAssociation(): \Generator
+    {
+        yield [TextField::new('name')];
+        yield [TextField::new('price')];
+        yield [TextField::new('price.currency')];
+    }
+
+    /**
+     * @dataProvider failsOnOptionEntryUsesCrudFormIfOptionEntryTypeIsUsed
+     */
+    public function testFailsOnOptionEntryUsesCrudFormIfOptionEntryTypeIsUsed(FieldInterface $field): void
+    {
+        $field->setCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM, true)
+            ->setCustomOption(CollectionField::OPTION_ENTRY_TYPE, 'foo')
+        ;
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The "%s" collection field of "%s" can render its entries using a Symfony Form (via the "setEntryType()" method) or using an EasyAdmin CRUD Form (via the "useEntryCrudForm()" method) but you cannot use both methods at the same time. Remove one of those two methods.',
+            $field->getAsDto()->getProperty(),
+            ProjectCrudController::class,
+        ));
+
+        $this->configure($field, controllerFqcn: ProjectCrudController::class);
+    }
+
+    public static function failsOnOptionEntryUsesCrudFormIfOptionEntryTypeIsUsed(): \Generator
+    {
+        yield [CollectionField::new('projectIssues')];
+        yield [CollectionField::new('favouriteProjectOf')];
+        yield [CollectionField::new('projectTags')];
+    }
+
+    /**
+     * @dataProvider failsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound
+     */
+    public function testFailsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound(FieldInterface $field): void
+    {
+        $field->getAsDto()->setDoctrineMetadata($this->projectDto->getPropertyMetadata($field->getAsDto()->getProperty())->all());
+        $field->setCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM, true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(sprintf('The "%s" collection field of "%s" wants to render its entries using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "useEntryCrudForm()" method.',
+            $field->getAsDto()->getProperty(),
+            ProjectCrudController::class,
+            $field->getAsDto()->getDoctrineMetadata()->get('targetEntity'),
+        ));
+
+        $this->configure($field, controllerFqcn: ProjectCrudController::class);
+    }
+
+    public static function failsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound(): \Generator
+    {
+        yield [CollectionField::new('projectIssues')];
+        yield [CollectionField::new('favouriteProjectOf')];
+        yield [CollectionField::new('projectTags')];
+    }
+}

--- a/tests/TestApplication/src/Controller/ProjectDomain/DeveloperCrudController.php
+++ b/tests/TestApplication/src/Controller/ProjectDomain/DeveloperCrudController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\ProjectDomain;
+
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain\Developer;
+
+/**
+ * @extends AbstractCrudController<Developer>
+ */
+class DeveloperCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Developer::class;
+    }
+}

--- a/tests/TestApplication/src/Controller/ProjectDomain/ProjectCrudController.php
+++ b/tests/TestApplication/src/Controller/ProjectDomain/ProjectCrudController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller\ProjectDomain;
+
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain\Project;
+
+/**
+ * @extends AbstractCrudController<Project>
+ */
+class ProjectCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Project::class;
+    }
+}

--- a/tests/TestApplication/src/Entity/ProjectDomain/Developer.php
+++ b/tests/TestApplication/src/Entity/ProjectDomain/Developer.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain;
 
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-class ProjectIssue
+class Developer
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -15,9 +15,8 @@ class ProjectIssue
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
-    #[ORM\ManyToOne(inversedBy: 'projectIssues')]
-    #[ORM\JoinColumn(nullable: false)]
-    private ?Project $project = null;
+    #[ORM\ManyToOne(inversedBy: 'favouriteProjectOf')]
+    private ?Project $favouriteProject = null;
 
     public function __toString(): string
     {
@@ -41,14 +40,14 @@ class ProjectIssue
         return $this;
     }
 
-    public function getProject(): ?Project
+    public function getFavouriteProject(): ?Project
     {
-        return $this->project;
+        return $this->favouriteProject;
     }
 
-    public function setProject(?Project $project): static
+    public function setFavouriteProject(?Project $favouriteProject): static
     {
-        $this->project = $project;
+        $this->favouriteProject = $favouriteProject;
 
         return $this;
     }

--- a/tests/TestApplication/src/Entity/ProjectDomain/Money.php
+++ b/tests/TestApplication/src/Entity/ProjectDomain/Money.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain;
 
 use Doctrine\ORM\Mapping as ORM;
 

--- a/tests/TestApplication/src/Entity/ProjectDomain/Project.php
+++ b/tests/TestApplication/src/Entity/ProjectDomain/Project.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;

--- a/tests/TestApplication/src/Entity/ProjectDomain/ProjectIssue.php
+++ b/tests/TestApplication/src/Entity/ProjectDomain/ProjectIssue.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain;
 
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-class Developer
+class ProjectIssue
 {
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -15,8 +15,9 @@ class Developer
     #[ORM\Column(length: 255)]
     private ?string $name = null;
 
-    #[ORM\ManyToOne(inversedBy: 'favouriteProjectOf')]
-    private ?Project $favouriteProject = null;
+    #[ORM\ManyToOne(inversedBy: 'projectIssues')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Project $project = null;
 
     public function __toString(): string
     {
@@ -40,14 +41,14 @@ class Developer
         return $this;
     }
 
-    public function getFavouriteProject(): ?Project
+    public function getProject(): ?Project
     {
-        return $this->favouriteProject;
+        return $this->project;
     }
 
-    public function setFavouriteProject(?Project $favouriteProject): static
+    public function setProject(?Project $project): static
     {
-        $this->favouriteProject = $favouriteProject;
+        $this->project = $project;
 
         return $this;
     }

--- a/tests/TestApplication/src/Entity/ProjectDomain/ProjectRelease.php
+++ b/tests/TestApplication/src/Entity/ProjectDomain/ProjectRelease.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain;
 
 use Doctrine\ORM\Mapping as ORM;
 

--- a/tests/TestApplication/src/Entity/ProjectDomain/ProjectTag.php
+++ b/tests/TestApplication/src/Entity/ProjectDomain/ProjectTag.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;


### PR DESCRIPTION
No BC break, this PR only adds tests

(Changes a test namespace `EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\FieldFactory` to `EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Entity\ProjectDomain` because now multiple tests use this namespace).