### PR TITLE
Use native Doctrine methods to get mapping type and mappedBy

### DIFF
--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\JoinColumnMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -221,7 +222,8 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
 
         // TODO: check if it's correct to never make a boolean value required
         // I guess it's correct because Symfony Forms treat NULL as FALSE by default (i.e. in the database the value won't be NULL)
-        if ('boolean' === $doctrinePropertyMetadata->get('type')) {
+        if (isset($entityDto->getClassMetadata()->fieldMappings[$field->getProperty()])
+            && Types::BOOLEAN === $entityDto->getClassMetadata()->getFieldMapping($field->getProperty())['type']) {
             return false;
         }
 

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -158,13 +158,11 @@ final class EntityRepository implements EntityRepositoryInterface
 
                 if (1 === \count($sortFieldParts)) {
                     if ($entityDto->getClassMetadata()->isCollectionValuedAssociation($sortProperty)) {
-                        $metadata = $entityDto->getPropertyMetadata($sortProperty);
-
                         /** @var EntityManagerInterface $entityManager */
                         $entityManager = $this->doctrine->getManagerForClass($entityDto->getFqcn());
                         $countQueryBuilder = $entityManager->createQueryBuilder();
 
-                        if (ClassMetadata::MANY_TO_MANY === $metadata->get('type')) {
+                        if (ClassMetadata::MANY_TO_MANY === $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['type']) {
                             // many-to-many relation
                             $countQueryBuilder
                                 ->select($queryBuilder->expr()->count('subQueryEntity'))
@@ -176,7 +174,7 @@ final class EntityRepository implements EntityRepositoryInterface
                             $countQueryBuilder
                                 ->select($queryBuilder->expr()->count('subQueryEntity'))
                                 ->from($entityDto->getClassMetadata()->getAssociationTargetClass($sortProperty), 'subQueryEntity')
-                                ->where(sprintf('subQueryEntity.%s = entity', $metadata->get('mappedBy')));
+                                ->where(sprintf('subQueryEntity.%s = entity', $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['mappedBy']));
                         }
 
                         $queryBuilder->addSelect(sprintf('(%s) as HIDDEN sub_query_sort', $countQueryBuilder->getDQL()));

--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -42,8 +42,10 @@ final class FieldProvider
         ];
 
         foreach ($entityDto->getAllPropertyNames() as $propertyName) {
-            $metadata = $entityDto->getPropertyMetadata($propertyName);
-            if (!\in_array($propertyName, $excludedPropertyNames[$pageName], true) && !\in_array($metadata->get('type'), $excludedPropertyTypes[$pageName], true)) {
+            $isFieldMapping = isset($entityDto->getClassMetadata()->fieldMappings[$propertyName]);
+            $fieldMappingType = $isFieldMapping ? $entityDto->getClassMetadata()->getFieldMapping($propertyName)['type'] : null;
+            if (!\in_array($propertyName, $excludedPropertyNames[$pageName], true)
+                && (!$isFieldMapping || !\in_array($fieldMappingType, $excludedPropertyTypes[$pageName], true))) {
                 $defaultPropertyNames[] = $propertyName;
             }
         }


### PR DESCRIPTION
No BC break.

I plan only 2 more PRs to finally be able to deprecate `EntityDto::getPropertyMetadata()` and `FieldDto::$doctrineMetadata` and I hope it will be OK for you. Because `EntityDto::getPropertyMetadata()` and `FieldDto::$doctrineMetadata` currently mix up `AssociationMappings` and `FieldMappings` and if you use them you don't know what you will get. The reason why I do more small PRs and not one big PR is that one big PR takes more concentration and time and I fear to introduce a BC break.  