### PR TITLE
Fixed some deprecations for Symfony 7.4

### DIFF
--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -62,9 +62,9 @@ class DataCollector extends BaseDataCollector
     {
         return [
             'CRUD Controller FQCN' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
-            'CRUD Action' => $context->getRequest()->get(EA::CRUD_ACTION),
-            'Entity ID' => $context->getRequest()->get(EA::ENTITY_ID),
-            'Sort' => $context->getRequest()->get(EA::SORT),
+            'CRUD Action' => $context->getRequest()->attributes->get(EA::CRUD_ACTION),
+            'Entity ID' => $context->getRequest()->attributes->get(EA::ENTITY_ID),
+            'Sort' => $context->getRequest()->attributes->get(EA::SORT),
         ];
     }
 

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -48,7 +48,7 @@ final class AdminContextProvider implements AdminContextProviderInterface
             throw new \LogicException('Cannot use the EasyAdmin context: no request is available.');
         }
 
-        return $currentRequest?->get(EA::CONTEXT_REQUEST_ATTRIBUTE);
+        return $currentRequest?->attributes->get(EA::CONTEXT_REQUEST_ATTRIBUTE);
     }
 
     public function getRequest(): Request

--- a/templates/crud/index.html.twig
+++ b/templates/crud/index.html.twig
@@ -87,8 +87,8 @@
 
 {% block main %}
     {# sort can be multiple; let's consider the sorting field the first one #}
-    {% set sort_field_name = app.request.get('sort')|keys|first %}
-    {% set sort_order = app.request.get('sort')|first %}
+    {% set sort_field_name = app.request.attributes.get('sort')|keys|first %}
+    {% set sort_order = app.request.attributes.get('sort')|first %}
     {% set some_results_are_hidden = entities|reduce((some_results_are_hidden, entity) => some_results_are_hidden or not entity.isAccessible, false) %}
     {% set has_footer = entities|length != 0 %}
     {% set has_search = ea.crud.isSearchEnabled %}


### PR DESCRIPTION
* The label should not be checked for being empty — TranslatableMessage::__toString() is deprecated.
* Request->get() is also deprecated.
