### PR TITLE
Allow defaultLocale to be null

### DIFF
--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -85,7 +85,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         private readonly CacheItemPoolInterface $cache,
         private readonly Filesystem $filesystem,
         private readonly string $buildDir,
-        private readonly string $defaultLocale,
+        private readonly ?string $defaultLocale,
         private readonly iterable $adminRouteControllers = [],
     ) {
     }


### PR DESCRIPTION
**Title:**  
Localized routes work only for DashboardController, not for CrudControllers when using prefix-based locale configuration

---

**Description:**  

I'm trying to control the current Symfony `_locale` using the `prefix` configuration in `easyadmin.routes`:

```yaml
easyadmin:
    resource: .
    type: easyadmin.routes
    prefix:
        en: '/en'
        de: ''
```
However, with this setup, localized links are generated only for the `DashboardController`s, while `CrudController`s do not get the proper locale prefixes.

When I change the `defaultLocale` parameter to `null` via a `CompilerPass`, all routes are generated correctly and everything works as expected.

CompierPass
```php
use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteGenerator;
use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
use Symfony\Component\DependencyInjection\ContainerBuilder;

class AllowLocaleInPrefixRoutesForEasyAdminPass implements CompilerPassInterface
{
    public function process(ContainerBuilder $container): void
    {
        $container->findDefinition(AdminRouteGenerator::class)
            ->setArgument(5, null)
        ;
    }
}
```

**Note:**  
There is probably a more correct way to handle this, but this workaround works for now.