### PR TITLE
Set CrudFormType as default entry_type for CollectionFields if the pr…

### DIFF
--- a/doc/fields/CollectionField.rst
+++ b/doc/fields/CollectionField.rst
@@ -195,6 +195,11 @@ class name of the controller as the first argument::
 
     The ``useEntryCrudForm()`` method requires Symfony 6.1 or newer version.
 
+.. note::
+
+    For Doctrine associations you can omit ``useEntryCrudForm()``. If no Symfony Form option ``entry_type`` is set
+    ``CollectionFields`` for association properties per default use ``CrudFormType`` as ``entry_type``.
+
 JavaScript Events
 -----------------
 


### PR DESCRIPTION
…operty is an association

Allows to use:
```php
class ProjectCrudController
{
    public function configureFields(string $pageName): iterable
    {
        return [
            'projectIssues',
        ];
    }
}
```

instead of:
```php
class ProjectCrudController
{
    public function configureFields(string $pageName): iterable
    {
        return [
            CollectionField::new('projectIssues')->useEntryCrudForm()
        ];
    }
}
```

Only sets the default if:
- the property is a Doctrine association
- no ``entry_type`` was configured
- a CRUD controller can be found for the association target entity

Without this PR the ``entry_type`` defaults to ``TextType`` which makes no sense for associations and produces an error.
