### PR TITLE
Fix some deprecations related to Doctrine

### DIFF
--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
 use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Intl\IntlFormatterInterface;
@@ -96,8 +97,11 @@ final class DateTimeConfigurator implements FieldConfiguratorInterface
         }
 
         $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($field->getProperty());
+        // Doctrine ORM 2.x returns an array and Doctrine ORM 3.x returns a FieldMapping object
+        // @phpstan-ignore function.impossibleType, nullCoalesce.offset (backward compatibility with Doctrine ORM 2.x)
+        $fieldType = \is_array($fieldMapping) ? ($fieldMapping['type'] ?? null) : $fieldMapping->type;
 
-        $isImmutableDateTime = \in_array($fieldMapping['type'], [Types::DATETIMETZ_IMMUTABLE, Types::DATETIME_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE], true);
+        $isImmutableDateTime = \in_array($fieldType, [Types::DATETIMETZ_IMMUTABLE, Types::DATETIME_IMMUTABLE, Types::DATE_IMMUTABLE, Types::TIME_IMMUTABLE], true);
         if ($isImmutableDateTime) {
             $field->setFormTypeOptionIfNotSet('input', 'datetime_immutable');
         }


### PR DESCRIPTION
Fixes these:

```
User Deprecated: Using ArrayAccess on Doctrine\ORM\Mapping\FieldMapping
is deprecated and will not be possible in Doctrine ORM 4.0.
Use the corresponding property instead.
(ArrayAccessImplementation.php:31 called by CommonPreConfigurator.php:231,
https://github.com/doctrine/orm/pull/11211, package doctrine/orm)

User Deprecated: Using ArrayAccess on Doctrine\ORM\Mapping\FieldMapping
is deprecated and will not be possible in Doctrine ORM 4.0.
Use the corresponding property instead.
(ArrayAccessImplementation.php:31 called by DateTimeConfigurator.php:101,
https://github.com/doctrine/orm/pull/11211, package doctrine/orm)
```