### PR TITLE
Feat/field hide if function

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -39,6 +39,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CurrencyConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\DateTimeConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\EmailConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\FormConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\HideIfFieldConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\IdConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ImageConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\IntegerConfigurator;
@@ -406,6 +407,8 @@ return static function (ContainerConfigurator $container) {
         ->set(TimezoneConfigurator::class)
 
         ->set(UrlConfigurator::class)
+
+        ->set(HideIfFieldConfigurator::class)
 
         ->set(AssetPackage::class)
             ->arg(0, service('request_stack'))

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -91,6 +91,21 @@ final class FieldFactory
 
         $isDetailOrIndex = \in_array($currentPage, [Crud::PAGE_INDEX, Crud::PAGE_DETAIL], true);
         foreach ($fields as $fieldDto) {
+            $hideIf = $fieldDto->getCustomOption('hide_if');
+
+            if (\is_callable($hideIf)) {
+                $entity = $entityDto->getInstance();
+                $reflection = new \ReflectionFunction($hideIf);
+                $shouldHide = $reflection->getNumberOfParameters() > 0
+                    ? $hideIf($entity)
+                    : $hideIf();
+
+                if ($shouldHide) {
+                    $fields->unset($fieldDto);
+                    continue;
+                }
+            }
+
             if ((null !== $currentPage && false === $fieldDto->isDisplayedOn($currentPage))
                 || false === $this->authorizationChecker->isGranted(Permission::EA_VIEW_FIELD, $fieldDto)) {
                 $fields->unset($fieldDto);

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -91,21 +91,6 @@ final class FieldFactory
 
         $isDetailOrIndex = \in_array($currentPage, [Crud::PAGE_INDEX, Crud::PAGE_DETAIL], true);
         foreach ($fields as $fieldDto) {
-            $hideIf = $fieldDto->getCustomOption('hide_if');
-
-            if (\is_callable($hideIf)) {
-                $entity = $entityDto->getInstance();
-                $reflection = new \ReflectionFunction($hideIf);
-                $shouldHide = $reflection->getNumberOfParameters() > 0
-                    ? $hideIf($entity)
-                    : $hideIf();
-
-                if ($shouldHide) {
-                    $fields->unset($fieldDto);
-                    continue;
-                }
-            }
-
             if ((null !== $currentPage && false === $fieldDto->isDisplayedOn($currentPage))
                 || false === $this->authorizationChecker->isGranted(Permission::EA_VIEW_FIELD, $fieldDto)) {
                 $fields->unset($fieldDto);

--- a/src/Field/Configurator/HideIfFieldConfigurator.php
+++ b/src/Field/Configurator/HideIfFieldConfigurator.php
@@ -5,7 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 
 final class HideIfFieldConfigurator implements FieldConfiguratorInterface
 {

--- a/src/Field/Configurator/HideIfFieldConfigurator.php
+++ b/src/Field/Configurator/HideIfFieldConfigurator.php
@@ -2,10 +2,10 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 
 final class HideIfFieldConfigurator implements FieldConfiguratorInterface
 {

--- a/src/Field/Configurator/HideIfFieldConfigurator.php
+++ b/src/Field/Configurator/HideIfFieldConfigurator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
+
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore
+
+final class HideIfFieldConfigurator implements FieldConfiguratorInterface
+{
+    public function supports(FieldDto $field, EntityDto $entityDto): bool
+    {
+        return $field->getCustomOptions()->has('hideIf');
+    }
+
+    public function configure(FieldDto $field, EntityDto $entityDto, $context): void
+    {
+        $condition = $field->getCustomOption('hideIf');
+
+        if (null === $condition) {
+            return;
+        }
+
+        $shouldHide = false;
+
+        if (is_bool($condition)) {
+            $shouldHide = $condition;
+        } elseif (is_callable($condition)) {
+            $entityInstance = $entityDto->getInstance();
+            $shouldHide = (bool) $condition($entityInstance);
+        }
+
+        if ($shouldHide) {
+            $field->setDisplayedOn(KeyValueStore::new([]));
+        }
+    }
+}

--- a/src/Field/Configurator/HideIfFieldConfigurator.php
+++ b/src/Field/Configurator/HideIfFieldConfigurator.php
@@ -24,9 +24,9 @@ final class HideIfFieldConfigurator implements FieldConfiguratorInterface
 
         $shouldHide = false;
 
-        if (is_bool($condition)) {
+        if (\is_bool($condition)) {
             $shouldHide = $condition;
-        } elseif (is_callable($condition)) {
+        } elseif (\is_callable($condition)) {
             $entityInstance = $entityDto->getInstance();
             $shouldHide = (bool) $condition($entityInstance);
         }

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -520,7 +520,7 @@ trait FieldTrait
     public function hideIf(bool|callable $condition): static
     {
         $this->setCustomOption('hideIf', $condition);
-    
+
         return $this;
     }
 }

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -520,6 +520,7 @@ trait FieldTrait
     public function hideIf(bool|callable $condition): static
     {
         $this->setCustomOption('hideIf', $condition);
+    
         return $this;
     }
 }

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -507,35 +507,19 @@ trait FieldTrait
     }
 
     /**
-     * Hides this field if the given callable returns true.
+     * Hides this field based on a condition.
+     *
+     * The $condition can be:
+     * - a callable that returns a boolean (receives the entity as argument)
+     * - a boolean value
      *
      * Example usage:
      *     ->hideIf(fn($entity) => !$entity->isActive())
-     *     ->hideIf(fn() => !featureEnabled())
+     *     ->hideIf(true) // always hide
      */
-    public function hideIf(callable $callback): static
+    public function hideIf(bool|callable $condition): static
     {
-        $this->setCustomOption('hide_if', $callback);
-
+        $this->setCustomOption('hideIf', $condition);
         return $this;
-    }
-
-    /**
-     * Returns true if the field should be hidden for the given entity.
-     */
-    public function shouldHide(?object $entity = null): bool
-    {
-        $callback = $this->getCustomOption('hide_if');
-
-        if (!\is_callable($callback)) {
-            return false;
-        }
-
-        $reflection = new \ReflectionFunction($callback);
-        if ($reflection->getNumberOfParameters() > 0) {
-            return (bool) $callback($entity);
-        }
-
-        return (bool) $callback();
     }
 }

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -505,4 +505,37 @@ trait FieldTrait
     {
         return $this->dto;
     }
+
+    /**
+     * Hides this field if the given callable returns true.
+     *
+     * Example usage:
+     *     ->hideIf(fn($entity) => !$entity->isActive())
+     *     ->hideIf(fn() => !featureEnabled())
+     */
+    public function hideIf(callable $callback): static
+    {
+        $this->setCustomOption('hide_if', $callback);
+
+        return $this;
+    }
+
+    /**
+     * Returns true if the field should be hidden for the given entity.
+     */
+    public function shouldHide(?object $entity = null): bool
+    {
+        $callback = $this->getCustomOption('hide_if');
+
+        if (!\is_callable($callback)) {
+            return false;
+        }
+
+        $reflection = new \ReflectionFunction($callback);
+        if ($reflection->getNumberOfParameters() > 0) {
+            return (bool) $callback($entity);
+        }
+
+        return (bool) $callback();
+    }
 }


### PR DESCRIPTION
This version adds support for the ‘hideIf()’ function for form fields.

e.g.

```
yield TextField::new('property')
  ->hideIf(function($entity) {
     return !$entity->hasRequiredProperty();
  });
;
```

or 

```
yield TextField::new('property')
  ->hideIf(!$entity->isPublished());
;
```

Fixes: https://github.com/EasyCorp/EasyAdminBundle/issues/6922
