### PR TITLE
Add fragment support to AdminUrlGenerator

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -820,6 +820,7 @@ Use the ``unsetAll()`` method to remove all existing query parameters::
             $url = $this->adminUrlGenerator
                 ->setController(SomeCrudController::class)
                 ->setAction('theActionName')
+                ->setFragment('tab-main')
                 ->generateUrl();
 
             // ...
@@ -848,7 +849,8 @@ method (it will be called automatically for you):
 
     {% set url = ea_url()
         .setController('App\\Controller\\Admin\\SomeCrudController')
-        .setAction('theActionName') %}
+        .setAction('theActionName')
+        .setFragment('tab-main') %}
 
 Generating CRUD URLs from outside EasyAdmin
 ...........................................

--- a/src/Config/Option/EA.php
+++ b/src/Config/Option/EA.php
@@ -28,6 +28,7 @@ final class EA
     public const ROUTE_NAME = 'routeName';
     public const ROUTE_PARAMS = 'routeParams';
     public const ROUTE_CREATED_BY_EASYADMIN = 'routeCreatedByEasyAdmin';
+    public const ROUTE_FRAGMENT = '_fragment';
     public const SORT = 'sort';
     /** @deprecated this parameter is no longer used because menu items are now highlighted automatically */
     public const SUBMENU_INDEX = 'submenuIndex';

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -76,6 +76,13 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         return $this;
     }
 
+    public function setFragment(string $fragment): AdminUrlGeneratorInterface
+    {
+        $this->setRouteParameter(EA::ROUTE_FRAGMENT, $fragment);
+
+        return $this;
+    }
+
     public function get(string $paramName): mixed
     {
         if (false === $this->isInitialized) {

--- a/src/Router/AdminUrlGeneratorInterface.php
+++ b/src/Router/AdminUrlGeneratorInterface.php
@@ -23,6 +23,8 @@ interface AdminUrlGeneratorInterface
 
     public function setEntityId(mixed $entityId): self;
 
+    public function setFragment(string $fragment): self;
+
     public function get(string $paramName): mixed;
 
     public function set(string $paramName, mixed $paramValue): self;

--- a/tests/Router/AdminUrlGeneratorTest.php
+++ b/tests/Router/AdminUrlGeneratorTest.php
@@ -281,6 +281,14 @@ class AdminUrlGeneratorTest extends WebTestCase
         $this->assertSame('http://localhost/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CSomeCrudController&foo=bar&foo1=bar1', $adminUrlGenerator->generateUrl());
     }
 
+    public function testSetFragment()
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        $adminUrlGenerator->setFragment('tab-1');
+        $this->assertSame('http://localhost/admin?foo=bar#tab-1', $adminUrlGenerator->generateUrl());
+    }
+
     private function getAdminUrlGenerator(bool $signedUrls = false, bool $absoluteUrls = true): AdminUrlGeneratorInterface
     {
         self::bootKernel();


### PR DESCRIPTION
This PR adds support for setting a URL fragment (hash anchor) with the AdminUrlGenerator class, enabling developers to generate admin URLs that scroll to specific sections of a page or reference/activate a specific tab (e.g. #tab-main).

Fixes: #7218