### PR TITLE
[BUG] fix(AdminUrlGenerator): unitialize before early returns

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -288,11 +288,14 @@ final class AdminUrlGenerator implements AdminUrlGeneratorInterface
         // if no route parameters are passed, the route doesn't point to any CRUD controller
         // action or to any custom action/route; consider it a link to the current dashboard
         if ([] === $routeParameters) {
+            $this->isInitialized = false;
+
             return $this->urlGenerator->generate($this->dashboardRoute, [], $urlType);
         }
 
         if (null !== $routeName = $this->get(EA::ROUTE_NAME)) {
             $adminRoutes = $this->cache->getItem(AdminRouteGenerator::CACHE_KEY_ROUTE_TO_FQCN)->get();
+            $this->isInitialized = false;
             if (null !== $adminRoutes && \array_key_exists($routeName, $adminRoutes)) {
                 return $this->urlGenerator->generate($routeName, $routeParameters[EA::ROUTE_PARAMS] ?? [], $urlType);
             }


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->

Hi ! I noticed that trying to upgrade after 4.16.1 (and this commit I believe https://github.com/EasyCorp/EasyAdminBundle/commit/dc4bc4cafe2695028e70d326e1dbc635d8a90ce2 ) while still not using pretty urls (we intend to, but it is a long journey ^^), some of the generated urls break.

For instance, the url for filter modal becomes `htps://localhost/admin?crudAction=renderFilters`. Every other param disappears.
I noticed that the previous generated url was one for the dashboard with then went trough this code bloc : 

```
        if ([] === $routeParameters) {
            return $this->urlGenerator->generate($this->dashboardRoute);
        }
```

I figured the previous `AdminUrlGenerator` was then not uninitialized, which might leak wrong params to the next generated url.

This seems at least to fix my issue, but I might be missing something, WDYT ?
