### PR TITLE
Fix some more deprecations related to Doctrine

### DIFF
--- a/src/Filter/Configurator/ComparisonConfigurator.php
+++ b/src/Filter/Configurator/ComparisonConfigurator.php
@@ -30,7 +30,10 @@ final class ComparisonConfigurator implements FilterConfiguratorInterface
 
         $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($filterDto->getProperty());
 
-        if (Types::DATEINTERVAL === $fieldMapping['type']) {
+        // @phpstan-ignore-next-line (backward compatibility with Doctrine ORM 2.x)
+        $fieldType = \is_array($fieldMapping) ? ($fieldMapping['type'] ?? null) : $fieldMapping->type;
+
+        if (Types::DATEINTERVAL === $fieldType) {
             $filterDto->setFormTypeOption('value_type', DateIntervalType::class);
             $filterDto->setFormTypeOption('comparison_type_options.type', 'datetime');
         }

--- a/src/Filter/Configurator/DateTimeConfigurator.php
+++ b/src/Filter/Configurator/DateTimeConfigurator.php
@@ -31,25 +31,28 @@ final class DateTimeConfigurator implements FilterConfiguratorInterface
 
         $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($filterDto->getProperty());
 
-        if (Types::DATE_MUTABLE === $fieldMapping['type']) {
+        // @phpstan-ignore-next-line (backward compatibility with Doctrine ORM 2.x)
+        $fieldType = \is_array($fieldMapping) ? ($fieldMapping['type'] ?? null) : $fieldMapping->type;
+
+        if (Types::DATE_MUTABLE === $fieldType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', DateType::class);
         }
 
-        if (Types::DATE_IMMUTABLE === $fieldMapping['type']) {
+        if (Types::DATE_IMMUTABLE === $fieldType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', DateType::class);
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'datetime_immutable');
         }
 
-        if (Types::TIME_MUTABLE === $fieldMapping['type']) {
+        if (Types::TIME_MUTABLE === $fieldType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', TimeType::class);
         }
 
-        if (Types::TIME_IMMUTABLE === $fieldMapping['type']) {
+        if (Types::TIME_IMMUTABLE === $fieldType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', TimeType::class);
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'datetime_immutable');
         }
 
-        if (\in_array($fieldMapping['type'], [Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_IMMUTABLE], true)) {
+        if (\in_array($fieldType, [Types::DATETIME_IMMUTABLE, Types::DATETIMETZ_IMMUTABLE], true)) {
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'datetime_immutable');
         }
     }

--- a/src/Filter/Configurator/NumericConfigurator.php
+++ b/src/Filter/Configurator/NumericConfigurator.php
@@ -30,11 +30,14 @@ final class NumericConfigurator implements FilterConfiguratorInterface
 
         $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($filterDto->getProperty());
 
-        if (Types::DECIMAL === $fieldMapping['type']) {
+        // @phpstan-ignore-next-line (backward compatibility with Doctrine ORM 2.x)
+        $fieldType = \is_array($fieldMapping) ? ($fieldMapping['type'] ?? null) : $fieldMapping->type;
+
+        if (Types::DECIMAL === $fieldType) {
             $filterDto->setFormTypeOptionIfNotSet('value_type_options.input', 'string');
         }
 
-        if (\in_array($fieldMapping['type'], [Types::BIGINT, Types::INTEGER, Types::SMALLINT], true)) {
+        if (\in_array($fieldType, [Types::BIGINT, Types::INTEGER, Types::SMALLINT], true)) {
             $filterDto->setFormTypeOptionIfNotSet('value_type', IntegerType::class);
         }
     }


### PR DESCRIPTION
```
User Deprecated: Using ArrayAccess on Doctrine\ORM\Mapping\FieldMapping
is deprecated and will not be possible in Doctrine ORM 4.0.
```
[ComparisonConfigurator](https://github.com/EasyCorp/EasyAdminBundle/blob/4.x/src/Filter/Configurator/ComparisonConfigurator.php)
[DateTimeConfigurator](https://github.com/EasyCorp/EasyAdminBundle/blob/4.x/src/Filter/Configurator/DateTimeConfigurator.php)
[NumericConfigurator](https://github.com/EasyCorp/EasyAdminBundle/blob/4.x/src/Filter/Configurator/NumericConfigurator.php)