### PR TITLE
Added autocomplete connect event to ALL tomselect connect

### DIFF
--- a/assets/js/autocomplete.js
+++ b/assets/js/autocomplete.js
@@ -93,7 +93,17 @@ export default class Autocomplete {
             },
         });
 
-        return new TomSelect(element, config);
+        element.dispatchEvent(
+            new CustomEvent('ea.autocomplete.pre-connect', { detail: { config, prefix: 'autocomplete' }, bubbles: true })
+        );
+
+        const tomSelect = new TomSelect(element, config);
+
+        element.dispatchEvent(
+            new CustomEvent('ea.autocomplete.connect', { detail: { tomSelect, config, prefix: 'autocomplete' }, bubbles: true })
+        );
+
+        return tomSelect;
     }
 
     #createAutocompleteWithRemoteData(element, autocompleteEndpointUrl) {
@@ -138,7 +148,17 @@ export default class Autocomplete {
             },
         });
 
-        return new TomSelect(element, config);
+        element.dispatchEvent(
+            new CustomEvent('ea.autocomplete.pre-connect', { detail: { config, prefix: 'autocomplete' }, bubbles: true })
+        );
+
+        const tomSelect = new TomSelect(element, config);
+
+        element.dispatchEvent(
+            new CustomEvent('ea.autocomplete.connect', { detail: { tomSelect, config, prefix: 'autocomplete' }, bubbles: true })
+        );
+
+        return tomSelect;
     }
 
     #stripTags(string) {


### PR DESCRIPTION
After doing this PR back in july https://github.com/EasyCorp/EasyAdminBundle/pull/7048

I realize that I forgot to add the same events for the two other kinds of TomSelect when they connect ...

My project has some remote data autocomplete, so I need to listen to these events as well.

I also took into consideration the tweaks made here
https://github.com/EasyCorp/EasyAdminBundle/pull/7087

(I didn't see that PR back then, but note that you could also access the select field via event.detail.tomSelect.input )