### PR TITLE
setDefaultColumns didn't work on ChoiceField if CustomOption Widget Autocomplete is set

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -94,7 +94,9 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
 
         if (ChoiceField::WIDGET_AUTOCOMPLETE === $field->getCustomOption(ChoiceField::OPTION_WIDGET)) {
             $field->setFormTypeOption('attr.data-ea-widget', 'ea-autocomplete');
-            $field->setDefaultColumns($isMultipleChoice ? 'col-md-8 col-xxl-6' : 'col-md-6 col-xxl-5');
+            if ('' === $field->getDefaultColumns()) {
+                $field->setDefaultColumns($isMultipleChoice ? 'col-md-8 col-xxl-6' : 'col-md-6 col-xxl-5');
+            }
         }
 
         $field->setFormTypeOptionIfNotSet('placeholder', '');


### PR DESCRIPTION
fix https://github.com/EasyCorp/EasyAdminBundle/issues/7239

just check if value is not set before, to avoid breaking projects that specifically rely on the classes.

An alternative would be to delete the line.