### PR TITLE
FIX: Handle potential null for excludedPropertyNames

### DIFF
--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -60,8 +60,8 @@ final class FieldProvider
                 $fieldMappingType = property_exists($fieldMapping, 'type') ? $fieldMapping->type : $fieldMapping['type'];
             }
 
-            if (!\in_array($propertyName, $excludedPropertyNames[$pageName], true)
-                && (!$isFieldMapping || !\in_array($fieldMappingType, $excludedPropertyTypes[$pageName], true))) {
+            if (!\in_array($propertyName, $excludedPropertyNames[$pageName] ?? [], true)
+                && (!$isFieldMapping || !\in_array($fieldMappingType, $excludedPropertyTypes[$pageName] ?? [], true))) {
                 $defaultPropertyNames[] = $propertyName;
             }
         }


### PR DESCRIPTION
With the [filter autocomplete](https://github.com/EasyCorp/EasyAdminBundle/commit/a637449dbdcff329e533ebb8a6ba6ba9c7af0f7f) , there was some issue with the index "renderFilters"

<img width="1236" height="824" alt="image" src="https://github.com/user-attachments/assets/2cadaabf-7d9a-4445-8dc5-16c99187370b" />

After the fix, you can have the result:
<img width="1340" height="371" alt="image" src="https://github.com/user-attachments/assets/80d8ad0d-8bf1-4f68-bec0-67cb32422d53" />
