### PR TITLE
Enhance content header help with pointer cursor

### DIFF
--- a/assets/css/easyadmin-theme/base.css
+++ b/assets/css/easyadmin-theme/base.css
@@ -508,9 +508,12 @@ a.user-menu-wrapper .user-details:hover {
     line-height: var(--font-size-lg);
 }
 
+.content-header-help {
+    cursor: pointer;
+}
+
 .content-header-help i {
     color: var(--text-muted);
-    cursor: pointer;
     font-size: 21px;
 }
 


### PR DESCRIPTION
This pull request makes a minor improvement to the user interface by moving the `cursor: pointer` style from the `.content-header-help i` selector to the parent `.content-header-help` selector. This ensures the pointer cursor appears when hovering over the entire help area, not just the icon (which isn't `<i>`, by the way).

- UI improvement:
  * Moved `cursor: pointer` from `.content-header-help i` to `.content-header-help` for better hover behavior.