### PR TITLE
Hide empty button labels when using button icons

### DIFF
--- a/assets/css/easyadmin-theme/buttons.css
+++ b/assets/css/easyadmin-theme/buttons.css
@@ -255,6 +255,10 @@ fieldset:disabled a.btn {
     margin-inline-start: 0;
 }
 
+.btn > .btn-icon + .btn-label:empty {
+    display: none;
+}
+
 .btn-sm:not(:has(.btn-label)) {
     padding: var(--button-padding-y-sm);
 }


### PR DESCRIPTION
This pull request introduces a minor UI improvement to button components in the EasyAdmin theme. The main change ensures that if a button's label is empty, the label element will not be displayed, resulting in cleaner button rendering.

Button rendering improvement:

* In `buttons.css`, added a rule so that `.btn-label` elements that are empty and directly follow a `.btn-icon` within a `.btn` will be hidden from display.