### PR TITLE
Improve form action rendering in datagrid by adjusting display and margin

### DIFF
--- a/assets/css/easyadmin-theme/datagrids.css
+++ b/assets/css/easyadmin-theme/datagrids.css
@@ -168,6 +168,11 @@ table.datagrid:not(.datagrid-empty) tr:not(.empty-row) td.actions.actions-as-dro
 .datagrid td.actions {
     text-align: right;
 }
+.datagrid td.actions:not(.actions-as-dropdown) form {
+    display: inline;
+    margin-inline-start: 10px;
+    margin-inline-end: 10px;
+}
 .datagrid td.actions a:not(.dropdown-item) {
     font-size: var(--font-size-sm);
     font-weight: 500;


### PR DESCRIPTION
See https://github.com/EasyCorp/EasyAdminBundle/issues/7249. This pull request introduces a small UI improvement for action buttons in data grids. Specifically, it adjusts the display and spacing of forms within action cells that are not rendered as dropdowns.

- UI/Styling Improvements:
  * In `assets/css/easyadmin-theme/datagrids.css`, forms inside `.datagrid td.actions` cells (excluding those with the `.actions-as-dropdown` class) are now displayed inline and given horizontal margins for better spacing.