### PR TITLE
Fix translation domain for flash messages

### DIFF
--- a/templates/flash_messages.html.twig
+++ b/templates/flash_messages.html.twig
@@ -8,8 +8,9 @@
     <div id="flash-messages">
         {% for label, messages in flash_messages %}
             {% for message in messages %}
+                {% set translated_message = message|trans %}
                 <twig:ea:Alert variant="{{ label }}" withDismissButton>
-                    {{ message|trans|raw }}
+                    {{ translated_message|raw }}
                 </twig:ea:Alert>
             {% endfor %}
         {% endfor %}


### PR DESCRIPTION
Fix the flash message rendering in `templates/flash_messages.html.twig` by assigning the translated message to a variable before rendering. The `trans_default_domain` isn't working as expected because twig component `<twig:ea:Alert>` isn't "aware" of the context.

See #7197 