### PR TITLE
deps: remove ext-json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "php": ">=8.1",
-        "ext-json": "*",
         "doctrine/doctrine-bundle": "^2.5|^3.0",
         "doctrine/orm": "^2.12|^3.0",
         "symfony/asset": "^5.4|^6.0|^7.0|^8.0",


### PR DESCRIPTION
This extension is always active since PHP 8.0: https://www.php.net/manual/en/json.installation.php

I _stole_ the idea from: 

- https://github.com/VincentLanglet/Twig-CS-Fixer/issues/416