### PR TITLE
Allow the decoration of AdminRouteGenerator

### DIFF
--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -6,10 +6,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Cache\CacheWarmer;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\AdminContextFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
-use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteGenerator;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -44,7 +44,7 @@ class AdminRouterSubscriber implements EventSubscriberInterface
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly RequestMatcherInterface $requestMatcher,
         private readonly CacheItemPoolInterface $cache,
-        private readonly AdminRouteGenerator $adminRouteGenerator,
+        private readonly AdminRouteGeneratorInterface $adminRouteGenerator,
         private readonly string $buildDir,
         private readonly CrudControllerRegistry $crudControllerRegistry,
     ) {


### PR DESCRIPTION
Inject an AdminRouteGeneratorInterface in order to provide decorated AdminRouteGenerator


This modification allowed to decorated AdminRouteGenerator in order to change the pattern of easyadmin controller path like admin/{project-id}/orders for example.

This pull requets complete this one : https://github.com/EasyCorp/EasyAdminBundle/pull/7101