### PR TITLE
Use renderAsLink() instead of asTextLink() for Action::DELETE

### DIFF
--- a/src/Config/Actions.php
+++ b/src/Config/Actions.php
@@ -196,7 +196,7 @@ final class Actions
             return Action::new(Action::DELETE, t('action.delete', domain: 'EasyAdminBundle'), 'internal:delete')
                 ->linkToCrudAction(Action::DELETE)
                 ->asDangerAction()
-                ->asTextLink()
+                ->renderAsLink()
             ;
         }
 


### PR DESCRIPTION
fixes #7120
