### PR TITLE
Fix type related phpdoc

### DIFF
--- a/src/Dto/SearchDto.php
+++ b/src/Dto/SearchDto.php
@@ -22,7 +22,7 @@ final class SearchDto
      * @param array<string>|null          $searchableProperties
      * @param array<string, 'ASC'|'DESC'> $defaultSort
      * @param array<string, 'ASC'|'DESC'> $customSort
-     * @param array<string>|null          $appliedFilters
+     * @param array<string, mixed>|null   $appliedFilters
      */
     public function __construct(
         private readonly Request $request,
@@ -110,7 +110,7 @@ final class SearchDto
     }
 
     /**
-     * @return string[]|null
+     * @return array<string, mixed>|null
      */
     public function getAppliedFilters(): ?array
     {


### PR DESCRIPTION
This is not the mot useful PR of all time, but it's depiling my mails.

It fixes a phpdoc (so phpstan) error, see  comment here: https://github.com/EasyCorp/EasyAdminBundle/pull/6994/files/8c15bd421069435bff1460bfa49bf0aefb477b46#r2332525353 

The property is not only string[] but string[][] or string[][][]
<img width="267" height="163" alt="image" src="https://github.com/user-attachments/assets/5a0816e1-131e-48ea-aa49-600425b7a1c4" />
