### PR TITLE
Allow adding entry_options to collections field

### DIFF
--- a/src/Field/CollectionField.php
+++ b/src/Field/CollectionField.php
@@ -17,6 +17,7 @@ final class CollectionField implements FieldInterface
     public const OPTION_ALLOW_ADD = 'allowAdd';
     public const OPTION_ALLOW_DELETE = 'allowDelete';
     public const OPTION_ENTRY_IS_COMPLEX = 'entryIsComplex';
+    public const OPTION_ENTRY_OPTIONS = 'entryOptions';
     public const OPTION_ENTRY_TYPE = 'entryType';
     public const OPTION_ENTRY_TO_STRING_METHOD = 'entryToStringMethod';
     public const OPTION_SHOW_ENTRY_LABEL = 'showEntryLabel';
@@ -42,6 +43,7 @@ final class CollectionField implements FieldInterface
             ->setCustomOption(self::OPTION_ALLOW_ADD, true)
             ->setCustomOption(self::OPTION_ALLOW_DELETE, true)
             ->setCustomOption(self::OPTION_ENTRY_IS_COMPLEX, null)
+            ->setCustomOption(self::OPTION_ENTRY_OPTIONS, null)
             ->setCustomOption(self::OPTION_ENTRY_TYPE, null)
             ->setCustomOption(self::OPTION_ENTRY_TO_STRING_METHOD, null)
             ->setCustomOption(self::OPTION_SHOW_ENTRY_LABEL, false)
@@ -80,6 +82,16 @@ final class CollectionField implements FieldInterface
     public function setEntryType(string $formTypeFqcn): self
     {
         $this->setCustomOption(self::OPTION_ENTRY_TYPE, $formTypeFqcn);
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $entryOptions
+     */
+    public function setEntryOptions(array $entryOptions): self
+    {
+        $this->setCustomOption(self::OPTION_ENTRY_OPTIONS, $entryOptions);
 
         return $this;
     }

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -56,6 +56,15 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             $field->setFormTypeOption('entry_type', $entryTypeFqcn);
         }
 
+        if (null !== $entryOptions = $field->getCustomOptions()->get(CollectionField::OPTION_ENTRY_OPTIONS)) {
+            $existingEntryOptions = $field->getFormTypeOption('entry_options');
+            if (!\is_array($existingEntryOptions)) {
+                $existingEntryOptions = [];
+            }
+
+            $field->setFormTypeOption('entry_options', array_replace_recursive($existingEntryOptions, $entryOptions));
+        }
+
         $autocompletableFormTypes = [CountryType::class, CurrencyType::class, LanguageType::class, LocaleType::class, TimezoneType::class];
         if (\in_array($entryTypeFqcn, $autocompletableFormTypes, true)) {
             $field->setFormTypeOption('entry_options.attr.data-ea-widget', 'ea-autocomplete');


### PR DESCRIPTION
This adds the ability to pass entry options to a collections field.

The use case for example is using a collection of VichFileType's and you want to pass options on to the child forms such as the download_uri.

```
            CollectionField::new('attachments', 'Attachments')
                ->setEntryType(VichFileType::class)
                ->setEntryOptions([
                    'download_label' => 'Download',
                    'download_uri' => function ($entity) {
                        if (!$entity || !$entity->getFile() || !$entity->getFile()->getName()) {
                            return null;
                        }

                        return $this->generateUrl('easyadmin_entity_download', [
                            'attachmentId' => $entity->getId(),
                        ]);
                    },
                ])
                ...
```

