### PR TITLE
[feature] Pass entityDto to queryBuilderCallable in AssociationField

### DIFF
--- a/doc/fields/AssociationField.rst
+++ b/doc/fields/AssociationField.rst
@@ -122,7 +122,7 @@ If you already define custom queries in repository methods, you can reuse them
 inside the callable::
 
     yield AssociationField::new('...')->setQueryBuilder(
-        fn (QueryBuilder $queryBuilder): QueryBuilder => $queryBuilder->getEntityManager()->getRepository(Foo::class)->getSomeQueryBuilder();
+        fn (QueryBuilder $queryBuilder, ?EntityDto $dto): QueryBuilder => $queryBuilder->getEntityManager()->getRepository(Foo::class)->getSomeQueryBuilder();
     );
 
 Alternatively, you can use the `query_builder option`_ of Symfony's

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -482,7 +482,13 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $queryBuilderCallable = $field?->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE);
 
         if (null !== $queryBuilderCallable) {
-            $queryBuilderCallable($queryBuilder);
+            $entityId = $autocompleteContext[EA::ENTITY_ID] ?? '';
+            $entityFcqn = $autocompleteContext[EA::ENTITY_FQCN] ?? '';
+            if ('' !== $entityId && '' !== $entityFcqn) {
+                $entityDto = $this->container->get(EntityFactory::class)->create($entityFcqn, $entityId);
+            }
+
+            $queryBuilderCallable($queryBuilder, $entityDto ?? null);
         }
 
         $paginator = $this->container->get(PaginatorFactory::class)->create($queryBuilder);

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -168,6 +168,8 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                         EA::CRUD_CONTROLLER_FQCN => $context->getRequest()->attributes->get(EA::CRUD_CONTROLLER_FQCN) ?? $context->getRequest()->query->get(EA::CRUD_CONTROLLER_FQCN),
                         'propertyName' => $propertyName,
                         'originatingPage' => $context->getCrud()->getCurrentPage(),
+                        EA::ENTITY_ID => $entityDto->getPrimaryKeyValueAsString(),
+                        EA::ENTITY_FQCN => $entityDto->getFqcn(),
                     ])
                     ->generateUrl();
             } catch (RouteNotFoundException $e) {
@@ -177,12 +179,12 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
             $field->setFormTypeOption('attr.data-ea-autocomplete-endpoint-url', $autocompleteEndpointUrl ?? null);
         } else {
-            $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($field) {
+            $field->setFormTypeOptionIfNotSet('query_builder', static function (EntityRepository $repository) use ($entityDto, $field) {
                 // TODO: should this use `createIndexQueryBuilder` instead, so we get the default ordering etc.?
                 // it would then be identical to the one used in autocomplete action, but it is a bit complex getting it in here
                 $queryBuilder = $repository->createQueryBuilder('entity');
                 if (null !== $queryBuilderCallable = $field->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE)) {
-                    $queryBuilderCallable($queryBuilder);
+                    $queryBuilderCallable($queryBuilder, $entityDto);
                 }
 
                 return $queryBuilder;


### PR DESCRIPTION
I need to filter association entities based on current edit entity like this
```
        yield AssociationField::new('pid')
            ->setQueryBuilder(function (QueryBuilder $queryBuilder, ?EntityDto $dto) use ($entity, $pageName) {
                if (Crud::PAGE_EDIT === $pageName && $dto) {
                    $queryBuilder
                        ->where('entity.siteProduct = :id')
                        ->andWhere('entity.isDeleted = false')
                        ->setParameter('id', $dto->getPrimaryKeyValueAsString())
                    ;
                }

                return $queryBuilder;
            })
```