### PR TITLE
Handle potential null return in first() of EntityCollection fixing deprecation

### DIFF
--- a/src/Collection/EntityCollection.php
+++ b/src/Collection/EntityCollection.php
@@ -39,7 +39,7 @@ final class EntityCollection implements CollectionInterface
 
     public function first(): ?EntityDto
     {
-        return $this->entities[array_key_first($this->entities)] ?? null;
+        return $this->entities[array_key_first($this->entities) ?? ''] ?? null;
     }
 
     public function offsetExists(mixed $offset): bool


### PR DESCRIPTION
This pull request makes a minor update to the `first()` method in the `EntityCollection` class to handle cases where the collection may be empty.