### PR TITLE
allow EasyCorp\Bundle\EasyAdminBundle\Config\Action::asTextLink(false)

### DIFF
--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -380,6 +380,8 @@ final class Action implements \Stringable
     {
         if ($asTextLink) {
             $this->dto->setStyle(ButtonStyle::Text);
+        } else {
+            $this->dto->setStyle(ButtonStyle::Solid);
         }
 
         return $this;


### PR DESCRIPTION
Previously, Action::asTextLink() only applied when the parameter was true. Passing false had no effect, leaving the Delete action always rendered as a text link. With this change, false is now explicitly supported. This allows developers to disable text links for actions such as DELETE on the index page.

This provides a workaround for issue #7120. Example usage:

    public function configureActions(Actions $actions): Actions
    {
        return $actions->update(CRUD::PAGE_INDEX, Action::DELETE, function (Action $action) {
            return $action->asTextLink(false);
        });
    }

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
