### PR TITLE
fix: EntityConfigurator DI

### DIFF
--- a/src/Filter/Configurator/EntityConfigurator.php
+++ b/src/Filter/Configurator/EntityConfigurator.php
@@ -10,7 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
-use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
@@ -19,7 +19,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 final class EntityConfigurator implements FilterConfiguratorInterface
 {
     public function __construct(
-        private AdminUrlGenerator $adminUrlGenerator,
+        private AdminUrlGeneratorInterface $adminUrlGenerator,
     ) {
     }
 


### PR DESCRIPTION
To keep consistancy on the code and allow hooks of `AdminUrlGenerator`, we have to use `AdminUrlGeneratorInterface` in constructor instead of `AdminUrlGenerator`.