### PR TITLE
Remove Doctrine metadata from FieldDto

### DIFF
--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -505,6 +505,9 @@ final class FieldDto
         $this->customOptions->set($optionName, $optionValue);
     }
 
+    /**
+     * @deprecated since 4.27 and to be removed in 5.0, use $entityDto->getClassMetadata() instead
+     */
     public function getDoctrineMetadata(): KeyValueStore
     {
         return $this->doctrineMetadata;
@@ -512,6 +515,8 @@ final class FieldDto
 
     /**
      * @param array<string, mixed> $metadata
+     *
+     * @deprecated since 4.27 and to be removed in 5.0 without replacement
      */
     public function setDoctrineMetadata(array $metadata): void
     {

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -48,7 +48,10 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
 
         // if no choices are passed to the field, check if it's related to an Enum;
         // in that case, get all the possible values of the Enum (Doctrine supports only BackedEnum as enumType)
-        $enumTypeClass = $field->getDoctrineMetadata()->get('enumType');
+        $enumTypeClass = null;
+        if (isset($entityDto->getClassMetadata()->fieldMappings[$field->getProperty()])) {
+            $enumTypeClass = $entityDto->getClassMetadata()->getFieldMapping($field->getProperty())['enumType'] ?? null;
+        }
         if (0 === \count($choices) && null !== $enumTypeClass && enum_exists($enumTypeClass)) {
             $choices = $enumTypeClass::cases();
             $allChoicesAreEnums = true;

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -85,15 +85,19 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             $field->setCustomOption(CollectionField::OPTION_ENTRY_IS_COMPLEX, $isComplexEntry);
         }
 
-        $field->setFormattedValue($this->formatCollection($field, $context));
+        $field->setFormattedValue($this->formatCollection($field, $entityDto, $context));
 
         $this->configureEntryType($field, $entityDto, $context);
     }
 
-    private function formatCollection(FieldDto $field, AdminContext $context): int|string
+    private function formatCollection(FieldDto $field, EntityDto $entityDto, AdminContext $context): int|string
     {
-        $doctrineMetadata = $field->getDoctrineMetadata();
-        if ('array' !== $doctrineMetadata->get('type') && !$field->getValue() instanceof PersistentCollection) {
+        $doctrineType = null;
+        if (isset($entityDto->getClassMetadata()->fieldMappings[$field->getProperty()])) {
+            $doctrineType = $entityDto->getClassMetadata()->getFieldMapping($field->getProperty())['type'];
+        }
+
+        if ('array' !== $doctrineType && !$field->getValue() instanceof PersistentCollection) {
             return $this->countNumElements($field->getValue());
         }
 

--- a/src/Filter/ArrayFilter.php
+++ b/src/Filter/ArrayFilter.php
@@ -71,7 +71,12 @@ final class ArrayFilter implements FilterInterface
         $parameterName = $filterDataDto->getParameterName();
         $value = $filterDataDto->getValue();
 
-        $useQuotes = Types::SIMPLE_ARRAY === $fieldDto->getDoctrineMetadata()->get('type');
+        $doctrineType = null;
+        if (isset($entityDto->getClassMetadata()->fieldMappings[$fieldDto->getProperty()])) {
+            $doctrineType = $entityDto->getClassMetadata()->getFieldMapping($fieldDto->getProperty())['type'];
+        }
+
+        $useQuotes = Types::SIMPLE_ARRAY === $doctrineType;
 
         if (null === $value || [] === $value) {
             $queryBuilder->andWhere(sprintf('%s.%s %s', $alias, $property, $comparison));

--- a/tests/Field/Configurator/AssociationConfiguratorTest.php
+++ b/tests/Field/Configurator/AssociationConfiguratorTest.php
@@ -137,7 +137,7 @@ class AssociationConfiguratorTest extends AbstractFieldTest
      */
     public function testFailsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound(FieldInterface $field): void
     {
-        $field->getAsDto()->setDoctrineMetadata((array) $this->projectDto->getClassMetadata()->getAssociationMapping($field->getAsDto()->getProperty()));
+        $field->getAsDto()->setDoctrineMetadata($associationMapping = (array) $this->projectDto->getClassMetadata()->getAssociationMapping($field->getAsDto()->getProperty()));
         $field->setCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM, true);
 
         $this->expectException(\RuntimeException::class);
@@ -145,7 +145,7 @@ class AssociationConfiguratorTest extends AbstractFieldTest
             'The "%s" association field of "%s" wants to render its contents using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "renderAsEmbeddedForm()" method.',
             $field->getAsDto()->getProperty(),
             ProjectCrudController::class,
-            $field->getAsDto()->getDoctrineMetadata()->get('targetEntity'),
+            $associationMapping['targetEntity'],
         ));
 
         $this->configure($field, controllerFqcn: ProjectCrudController::class);

--- a/tests/Field/Configurator/CollectionConfiguratorTest.php
+++ b/tests/Field/Configurator/CollectionConfiguratorTest.php
@@ -104,14 +104,14 @@ class CollectionConfiguratorTest extends AbstractFieldTest
      */
     public function testFailsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound(FieldInterface $field): void
     {
-        $field->getAsDto()->setDoctrineMetadata((array) $this->projectDto->getClassMetadata()->getAssociationMapping($field->getAsDto()->getProperty()));
+        $field->getAsDto()->setDoctrineMetadata($associationMapping = (array) $this->projectDto->getClassMetadata()->getAssociationMapping($field->getAsDto()->getProperty()));
         $field->setCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM, true);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(sprintf('The "%s" collection field of "%s" wants to render its entries using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "useEntryCrudForm()" method.',
             $field->getAsDto()->getProperty(),
             ProjectCrudController::class,
-            $field->getAsDto()->getDoctrineMetadata()->get('targetEntity'),
+            $associationMapping['targetEntity'],
         ));
 
         $this->configure($field, controllerFqcn: ProjectCrudController::class);


### PR DESCRIPTION
There is no need to add Doctrine metadata to FieldDto because at all places where it is used we can use Doctrine Metadata from EntityDto.
