### PR TITLE
Add tests for all fields

### DIFF
--- a/tests/Field/ArrayFieldTest.php
+++ b/tests/Field/ArrayFieldTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ArrayField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\ArrayConfigurator;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class ArrayFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new ArrayConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = ArrayField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(TextType::class, $fieldDto->getFormTypeOption('entry_type'));
+        self::assertTrue($fieldDto->getFormTypeOption('allow_add'));
+        self::assertTrue($fieldDto->getFormTypeOption('allow_delete'));
+        self::assertTrue($fieldDto->getFormTypeOption('delete_empty'));
+        self::assertFalse($fieldDto->getFormTypeOption('entry_options.label'));
+        self::assertSame(CollectionType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-array', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithEmptyArray(): void
+    {
+        $field = ArrayField::new('foo');
+        $field->setValue([]);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('label/empty', $fieldDto->getTemplateName());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = ArrayField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('label/empty', $fieldDto->getTemplateName());
+    }
+
+    public function testFieldWithValuesOnIndexPage(): void
+    {
+        $field = ArrayField::new('foo');
+        $field->setValue(['item1', 'item2', 'item3']);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('item1, item2, item3', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithValuesOnDetailPage(): void
+    {
+        $field = ArrayField::new('foo');
+        $field->setValue(['item1', 'item2', 'item3']);
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, actionName: Action::DETAIL);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertSame(['item1', 'item2', 'item3'], $fieldDto->getValue());
+        self::assertNull($fieldDto->getFormattedValue());
+        self::assertStringContainsString('<ul>', $html);
+        self::assertStringContainsString('<li>item1</li>', $html);
+        self::assertStringContainsString('<li>item2</li>', $html);
+        self::assertStringContainsString('<li>item3</li>', $html);
+    }
+
+    public function testFieldWithSingleValueOnIndexPage(): void
+    {
+        $field = ArrayField::new('foo');
+        $field->setValue(['single_item']);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('single_item', $fieldDto->getFormattedValue());
+    }
+
+    public function testFormTypeOptionsAreNotOverriddenIfAlreadySet(): void
+    {
+        $field = ArrayField::new('foo');
+        $field->setFormTypeOption('allow_add', false);
+        $field->setFormTypeOption('allow_delete', false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getFormTypeOption('allow_add'));
+        self::assertFalse($fieldDto->getFormTypeOption('allow_delete'));
+    }
+}

--- a/tests/Field/AssociationFieldTest.php
+++ b/tests/Field/AssociationFieldTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+
+class AssociationFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // AssociationField configurator requires Doctrine and other services:
+        // let's use a no-op configurator to test the field options
+        $this->configurator = new class implements FieldConfiguratorInterface {
+            public function supports(FieldDto $field, EntityDto $entityDto): bool
+            {
+                return AssociationField::class === $field->getFieldFqcn();
+            }
+
+            public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
+            {
+                // no-op for basic option testing
+            }
+        };
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = AssociationField::new('category');
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE));
+        self::assertNull($fieldDto->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER));
+        self::assertSame(AssociationField::WIDGET_AUTOCOMPLETE, $fieldDto->getCustomOption(AssociationField::OPTION_WIDGET));
+        self::assertNull($fieldDto->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE));
+        self::assertFalse($fieldDto->getCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM));
+        self::assertTrue($fieldDto->getCustomOption(AssociationField::OPTION_ESCAPE_HTML_CONTENTS));
+        self::assertSame(EntityType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-association', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = AssociationField::new('category');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testAutocomplete(): void
+    {
+        $field = AssociationField::new('category');
+        $field->autocomplete();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE));
+    }
+
+    public function testRenderAsNativeWidget(): void
+    {
+        $field = AssociationField::new('category');
+        $field->renderAsNativeWidget();
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(AssociationField::WIDGET_NATIVE, $fieldDto->getCustomOption(AssociationField::OPTION_WIDGET));
+    }
+
+    public function testRenderAsAutocompleteWidget(): void
+    {
+        $field = AssociationField::new('category');
+        $field->renderAsNativeWidget(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(AssociationField::WIDGET_AUTOCOMPLETE, $fieldDto->getCustomOption(AssociationField::OPTION_WIDGET));
+    }
+
+    public function testSetCrudController(): void
+    {
+        $crudControllerFqcn = 'App\\Controller\\CategoryCrudController';
+        $field = AssociationField::new('category');
+        $field->setCrudController($crudControllerFqcn);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($crudControllerFqcn, $fieldDto->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER));
+    }
+
+    public function testSetQueryBuilder(): void
+    {
+        $queryBuilder = static fn (QueryBuilder $qb): QueryBuilder => $qb->andWhere('entity.active = true');
+        $field = AssociationField::new('category');
+        $field->setQueryBuilder($queryBuilder);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($queryBuilder, $fieldDto->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE));
+    }
+
+    public function testRenderAsEmbeddedForm(): void
+    {
+        $field = AssociationField::new('category');
+        $field->renderAsEmbeddedForm();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM));
+    }
+
+    public function testRenderAsEmbeddedFormWithController(): void
+    {
+        $crudControllerFqcn = 'App\\Controller\\CategoryCrudController';
+        $field = AssociationField::new('category');
+        $field->renderAsEmbeddedForm($crudControllerFqcn);
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM));
+        self::assertSame($crudControllerFqcn, $fieldDto->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER));
+    }
+
+    public function testRenderAsEmbeddedFormWithPageNames(): void
+    {
+        $crudControllerFqcn = 'App\\Controller\\CategoryCrudController';
+        $field = AssociationField::new('category');
+        $field->renderAsEmbeddedForm($crudControllerFqcn, 'custom_new', 'custom_edit');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('custom_new', $fieldDto->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_NEW_PAGE_NAME));
+        self::assertSame('custom_edit', $fieldDto->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_EDIT_PAGE_NAME));
+    }
+
+    public function testSetSortProperty(): void
+    {
+        $field = AssociationField::new('category');
+        $field->setSortProperty('name');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('name', $fieldDto->getCustomOption(AssociationField::OPTION_SORT_PROPERTY));
+    }
+
+    public function testRenderAsHtml(): void
+    {
+        $field = AssociationField::new('category');
+        $field->renderAsHtml();
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(AssociationField::OPTION_ESCAPE_HTML_CONTENTS));
+    }
+
+    public function testDontRenderAsHtml(): void
+    {
+        $field = AssociationField::new('category');
+        $field->renderAsHtml(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(AssociationField::OPTION_ESCAPE_HTML_CONTENTS));
+    }
+}

--- a/tests/Field/AvatarFieldTest.php
+++ b/tests/Field/AvatarFieldTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\Size;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AvatarField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\AvatarConfigurator;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class AvatarFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new AvatarConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = AvatarField::new('avatar');
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(AvatarField::OPTION_IS_GRAVATAR_EMAIL));
+        // Default height is set by the configurator (24 on index, 48 on detail)
+        self::assertSame(24, $fieldDto->getCustomOption(AvatarField::OPTION_HEIGHT));
+        self::assertSame(TextType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-avatar', $fieldDto->getCssClass());
+    }
+
+    public function testDefaultHeightOnIndexPage(): void
+    {
+        $field = AvatarField::new('avatar');
+        $fieldDto = $this->configure($field, Crud::PAGE_INDEX);
+
+        // On index page, default height is 24
+        self::assertSame(24, $fieldDto->getCustomOption(AvatarField::OPTION_HEIGHT));
+    }
+
+    public function testDefaultHeightOnDetailPage(): void
+    {
+        $field = AvatarField::new('avatar');
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        // On detail page, default height is 48
+        self::assertSame(48, $fieldDto->getCustomOption(AvatarField::OPTION_HEIGHT));
+    }
+
+    public function testSetHeightWithInteger(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setHeight(100);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(100, $fieldDto->getCustomOption(AvatarField::OPTION_HEIGHT));
+    }
+
+    public function testSetHeightWithSemanticSizeSmall(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setHeight(Size::SM);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(18, $fieldDto->getCustomOption(AvatarField::OPTION_HEIGHT));
+    }
+
+    public function testSetHeightWithSemanticSizeMedium(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setHeight(Size::MD);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(24, $fieldDto->getCustomOption(AvatarField::OPTION_HEIGHT));
+    }
+
+    public function testSetHeightWithSemanticSizeLarge(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setHeight(Size::LG);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(48, $fieldDto->getCustomOption(AvatarField::OPTION_HEIGHT));
+    }
+
+    public function testSetHeightWithSemanticSizeExtraLarge(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setHeight(Size::XL);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(96, $fieldDto->getCustomOption(AvatarField::OPTION_HEIGHT));
+    }
+
+    public function testSetHeightThrowsExceptionForZeroOrNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        AvatarField::new('avatar')->setHeight(0);
+    }
+
+    public function testSetIsGravatarEmail(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setIsGravatarEmail();
+        $field->setValue('test@example.com');
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(AvatarField::OPTION_IS_GRAVATAR_EMAIL));
+    }
+
+    public function testGravatarUrlGeneration(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setIsGravatarEmail(true);
+        $field->setValue('test@example.com');
+        $fieldDto = $this->configure($field);
+
+        $formattedValue = $fieldDto->getFormattedValue();
+        self::assertStringStartsWith('https://www.gravatar.com/avatar/', $formattedValue);
+        self::assertStringContainsString(md5('test@example.com'), $formattedValue);
+    }
+
+    public function testSetGravatarDefaultImage(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setGravatarDefaultImage('identicon');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('identicon', $fieldDto->getCustomOption(AvatarField::OPTION_GRAVATAR_DEFAULT_IMAGE));
+    }
+
+    public function testSetGravatarDefaultImageWithUrl(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setGravatarDefaultImage('https://example.com/default.png');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('https://example.com/default.png', $fieldDto->getCustomOption(AvatarField::OPTION_GRAVATAR_DEFAULT_IMAGE));
+    }
+
+    public function testSetGravatarDefaultImageThrowsExceptionForInvalidValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        AvatarField::new('avatar')->setGravatarDefaultImage('invalid_value');
+    }
+
+    public function testGravatarDefaultImageInUrl(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setIsGravatarEmail(true);
+        $field->setValue('test@example.com');
+        $field->setGravatarDefaultImage('identicon');
+        $fieldDto = $this->configure($field);
+
+        $formattedValue = $fieldDto->getFormattedValue();
+        self::assertStringContainsString('d=identicon', $formattedValue);
+    }
+
+    public function testDefaultGravatarDefaultImage(): void
+    {
+        $field = AvatarField::new('avatar');
+        $field->setIsGravatarEmail(true);
+        $field->setValue('test@example.com');
+        $fieldDto = $this->configure($field);
+
+        // Default gravatar image is 'mp'
+        $formattedValue = $fieldDto->getFormattedValue();
+        self::assertStringContainsString('d=mp', $formattedValue);
+    }
+}

--- a/tests/Field/BooleanFieldTest.php
+++ b/tests/Field/BooleanFieldTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\BooleanConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class BooleanFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+
+        // Create mock dependencies for the BooleanConfigurator
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $authChecker->method('isGranted')->willReturn(false);
+
+        $csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+
+        $adminUrlGenerator = static::getContainer()->get(AdminUrlGenerator::class);
+
+        $this->configurator = new BooleanConfigurator($adminUrlGenerator, $authChecker, $csrfTokenManager);
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = BooleanField::new('active');
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(BooleanField::OPTION_RENDER_AS_SWITCH));
+        self::assertFalse($fieldDto->getCustomOption(BooleanField::OPTION_HIDE_VALUE_WHEN_TRUE));
+        self::assertFalse($fieldDto->getCustomOption(BooleanField::OPTION_HIDE_VALUE_WHEN_FALSE));
+        self::assertSame(CheckboxType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-boolean', $fieldDto->getCssClass());
+    }
+
+    /**
+     * @testWith [true]
+     *           [false]
+     *           [null]
+     */
+    public function testFieldValue(?bool $value): void
+    {
+        $field = BooleanField::new('active');
+        $field->setValue($value);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($value, $fieldDto->getValue());
+    }
+
+    public function testRenderAsSwitch(): void
+    {
+        $field = BooleanField::new('active');
+        $field->renderAsSwitch();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(BooleanField::OPTION_RENDER_AS_SWITCH));
+        self::assertStringContainsString('has-switch', $fieldDto->getCssClass());
+    }
+
+    public function testRenderNotAsSwitch(): void
+    {
+        $field = BooleanField::new('active');
+        $field->renderAsSwitch(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(BooleanField::OPTION_RENDER_AS_SWITCH));
+        self::assertStringNotContainsString('has-switch', $fieldDto->getCssClass());
+    }
+
+    public function testHideValueWhenTrue(): void
+    {
+        $field = BooleanField::new('active');
+        $field->hideValueWhenTrue();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(BooleanField::OPTION_HIDE_VALUE_WHEN_TRUE));
+    }
+
+    public function testDontHideValueWhenTrue(): void
+    {
+        $field = BooleanField::new('active');
+        $field->hideValueWhenTrue(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(BooleanField::OPTION_HIDE_VALUE_WHEN_TRUE));
+    }
+
+    public function testHideValueWhenFalse(): void
+    {
+        $field = BooleanField::new('active');
+        $field->hideValueWhenFalse(true);
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(BooleanField::OPTION_HIDE_VALUE_WHEN_FALSE));
+    }
+
+    public function testDontHideValueWhenFalse(): void
+    {
+        $field = BooleanField::new('active');
+        $field->hideValueWhenFalse(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(BooleanField::OPTION_HIDE_VALUE_WHEN_FALSE));
+    }
+
+    public function testSwitchAddsCssClass(): void
+    {
+        $field = BooleanField::new('active');
+        $field->renderAsSwitch();
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('checkbox-switch', $fieldDto->getFormTypeOption('label_attr.class'));
+    }
+
+    public function testTemplateRendersSwitchOnIndexPage(): void
+    {
+        $field = BooleanField::new('active');
+        $field->setValue(true);
+        $field->renderAsSwitch();
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('form-switch', $html);
+        self::assertStringContainsString('<input type="checkbox"', $html);
+        self::assertStringContainsString('checked', $html);
+    }
+
+    public function testTemplateRendersBadgeOnDetailPage(): void
+    {
+        $field = BooleanField::new('active');
+        $field->setValue(true);
+        $field->renderAsSwitch(true);
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        // on detail page, even with renderAsSwitch=true, it shows a badge
+        self::assertStringContainsString('badge', $html);
+        self::assertStringContainsString('badge-boolean-true', $html);
+        self::assertStringNotContainsString('form-switch', $html);
+    }
+
+    public function testTemplateRendersBadgeWhenNotSwitch(): void
+    {
+        $field = BooleanField::new('active');
+        $field->setValue(false);
+        $field->renderAsSwitch(false);
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('badge', $html);
+        self::assertStringContainsString('badge-boolean-false', $html);
+        self::assertStringNotContainsString('form-switch', $html);
+    }
+
+    public function testTemplateHidesValueWhenTrueAndOptionEnabled(): void
+    {
+        $field = BooleanField::new('active');
+        $field->setValue(true);
+        $field->renderAsSwitch(false);
+        $field->hideValueWhenTrue();
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        // badge should be hidden when value is true and hideValueWhenTrue is enabled (on index page)
+        self::assertStringNotContainsString('badge-boolean-true', $html);
+    }
+
+    public function testTemplateHidesValueWhenFalseAndOptionEnabled(): void
+    {
+        $field = BooleanField::new('active');
+        $field->setValue(false);
+        $field->renderAsSwitch(false);
+        $field->hideValueWhenFalse();
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        // badge should be hidden when value is false and hideValueWhenFalse is enabled (on index page)
+        self::assertStringNotContainsString('badge-boolean-false', $html);
+    }
+
+    public function testTemplateShowsValueWhenTrueAndHideOptionDisabled(): void
+    {
+        $field = BooleanField::new('active');
+        $field->setValue(true);
+        $field->renderAsSwitch(false);
+        $field->hideValueWhenTrue(false);
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('badge-boolean-true', $html);
+    }
+
+    public function testTemplateSwitchNotCheckedWhenFalse(): void
+    {
+        $field = BooleanField::new('active');
+        $field->setValue(false);
+        $field->renderAsSwitch();
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('form-switch', $html);
+        self::assertStringContainsString('<input type="checkbox"', $html);
+        self::assertStringNotContainsString('checked', $html);
+    }
+}

--- a/tests/Field/ChoiceFieldTest.php
+++ b/tests/Field/ChoiceFieldTest.php
@@ -10,24 +10,20 @@ use function Symfony\Component\Translation\t;
 
 class ChoiceFieldTest extends AbstractFieldTest
 {
-    private array $choices;
-
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->choices = ['a' => 1, 'b' => 2, 'c' => 3];
-
         $this->configurator = new ChoiceConfigurator();
     }
 
-    public function testFieldWithoutChoices()
+    public function testFieldWithoutChoices(): void
     {
         $field = ChoiceField::new('foo');
         self::assertSame([], $this->configure($field)->getFormTypeOption(ChoiceField::OPTION_CHOICES));
     }
 
-    public function testFieldWithEmptyChoices()
+    public function testFieldWithEmptyChoices(): void
     {
         $field = ChoiceField::new('foo')->setChoices([]);
         self::assertSame([], $this->configure($field)->getFormTypeOption(ChoiceField::OPTION_CHOICES));
@@ -80,17 +76,18 @@ class ChoiceFieldTest extends AbstractFieldTest
         self::assertSame(StatusBackedEnum::Deleted->name, (string) $this->configure($field)->getFormattedValue());
     }
 
-    public function testFieldWithChoiceGeneratorCallback()
+    public function testFieldWithChoiceGeneratorCallback(): void
     {
-        $field = ChoiceField::new('foo')->setChoices(static function () { return ['foo' => 1, 'bar' => 2]; });
+        $choices = ['foo' => 1, 'bar' => 2];
+        $field = ChoiceField::new('foo')->setChoices(static fn (): array => $choices);
 
-        self::assertSame(['foo' => 1, 'bar' => 2], $this->configure($field)->getFormTypeOption(ChoiceField::OPTION_CHOICES));
+        self::assertSame($choices, $this->configure($field)->getFormTypeOption(ChoiceField::OPTION_CHOICES));
 
         $field->setValue(1);
         self::assertSame('foo', (string) $this->configure($field)->getFormattedValue());
     }
 
-    public function testFieldWithTranslatableChoices()
+    public function testFieldWithTranslatableChoices(): void
     {
         $field = ChoiceField::new('foo')->setTranslatableChoices([1 => t('foo'), 2 => 'bar']);
 
@@ -101,19 +98,19 @@ class ChoiceFieldTest extends AbstractFieldTest
         self::assertSame('bar', (string) $this->configure($field)->getFormattedValue());
     }
 
-    public function testFieldWithWrongVisualOptions()
+    public function testFieldWithWrongVisualOptions(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $field = ChoiceField::new('foo')->setChoices($this->choices);
+        $field = ChoiceField::new('foo')->setChoices(['a' => 1, 'b' => 2, 'c' => 3]);
         $field->renderExpanded();
         $field->renderAsNativeWidget(false);
         $this->configure($field);
     }
 
-    public function testDefaultWidget()
+    public function testDefaultWidget(): void
     {
-        $field = ChoiceField::new('foo')->setChoices($this->choices);
+        $field = ChoiceField::new('foo')->setChoices(['a' => 1, 'b' => 2, 'c' => 3]);
 
         $field->renderExpanded(false);
         $field->setCustomOption(ChoiceField::OPTION_WIDGET, null);
@@ -126,15 +123,16 @@ class ChoiceFieldTest extends AbstractFieldTest
         self::assertSame('ea-autocomplete', $fieldDto->getFormTypeOption('attr.data-ea-widget'));
     }
 
-    public function testFieldFormOptions()
+    public function testFieldFormOptions(): void
     {
-        $field = ChoiceField::new('foo')->setChoices($this->choices);
+        $choices = ['a' => 1, 'b' => 2, 'c' => 3];
+        $field = ChoiceField::new('foo')->setChoices($choices);
         $field->renderExpanded();
         $field->allowMultipleChoices();
 
         self::assertSame(
             [
-                'choices' => $this->choices,
+                'choices' => $choices,
                 'multiple' => true,
                 'expanded' => true,
                 'placeholder' => '',
@@ -144,9 +142,9 @@ class ChoiceFieldTest extends AbstractFieldTest
         );
     }
 
-    public function testBadges()
+    public function testBadges(): void
     {
-        $field = ChoiceField::new('foo')->setChoices($this->choices);
+        $field = ChoiceField::new('foo')->setChoices(['a' => 1, 'b' => 2, 'c' => 3]);
 
         $field->setValue(1);
         self::assertSame('a', (string) $this->configure($field)->getFormattedValue());
@@ -166,10 +164,10 @@ class ChoiceFieldTest extends AbstractFieldTest
         $field->setValue([1, 3])->renderAsBadges([1 => 'warning', '3' => 'danger']);
         self::assertSame('<span class="badge badge-warning">a</span><span class="badge badge-danger">c</span>', (string) $this->configure($field)->getFormattedValue());
 
-        $field->setValue(1)->renderAsBadges(function ($value) { return $value > 1 ? 'success' : 'primary'; });
+        $field->setValue(1)->renderAsBadges(static fn (mixed $value): string => $value > 1 ? 'success' : 'primary');
         self::assertSame('<span class="badge badge-primary">a</span>', (string) $this->configure($field)->getFormattedValue());
 
-        $field->setValue([1, 3])->renderAsBadges(function ($value) { return $value > 1 ? 'success' : 'primary'; });
+        $field->setValue([1, 3])->renderAsBadges(static fn (mixed $value): string => $value > 1 ? 'success' : 'primary');
         self::assertSame('<span class="badge badge-primary">a</span><span class="badge badge-success">c</span>', (string) $this->configure($field)->getFormattedValue());
     }
 }

--- a/tests/Field/CodeEditorFieldTest.php
+++ b/tests/Field/CodeEditorFieldTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CodeEditorField;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CodeEditorType;
+
+class CodeEditorFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // CodeEditorField has no dedicated configurator, but we need to set formattedValue
+        $this->configurator = new class implements FieldConfiguratorInterface {
+            public function supports(FieldDto $field, EntityDto $entityDto): bool
+            {
+                return CodeEditorField::class === $field->getFieldFqcn();
+            }
+
+            public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
+            {
+                // set formattedValue to value (like CommonPreConfigurator does for most fields)
+                if (null === $field->getFormattedValue()) {
+                    $field->setFormattedValue($field->getValue());
+                }
+            }
+        };
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = CodeEditorField::new('code');
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CodeEditorField::OPTION_INDENT_WITH_TABS));
+        self::assertSame('markdown', $fieldDto->getCustomOption(CodeEditorField::OPTION_LANGUAGE));
+        self::assertNull($fieldDto->getCustomOption(CodeEditorField::OPTION_NUM_OF_ROWS));
+        self::assertSame(4, $fieldDto->getCustomOption(CodeEditorField::OPTION_TAB_SIZE));
+        self::assertTrue($fieldDto->getCustomOption(CodeEditorField::OPTION_SHOW_LINE_NUMBERS));
+        self::assertSame(CodeEditorType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-code_editor', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithCodeValue(): void
+    {
+        $code = "function hello() {\n    console.log('Hello');\n}";
+        $field = CodeEditorField::new('code');
+        $field->setValue($code);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($code, $fieldDto->getValue());
+    }
+
+    public function testSetIndentWithTabs(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setIndentWithTabs(true);
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CodeEditorField::OPTION_INDENT_WITH_TABS));
+    }
+
+    public function testSetIndentWithSpaces(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setIndentWithTabs(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CodeEditorField::OPTION_INDENT_WITH_TABS));
+    }
+
+    /**
+     * @testWith ["css"]
+     *           ["dockerfile"]
+     *           ["js"]
+     *           ["javascript"]
+     *           ["markdown"]
+     *           ["nginx"]
+     *           ["php"]
+     *           ["shell"]
+     *           ["sql"]
+     *           ["twig"]
+     *           ["xml"]
+     *           ["yaml-frontmatter"]
+     *           ["yaml"]
+     */
+    public function testSetLanguage(string $language): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setLanguage($language);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($language, $fieldDto->getCustomOption(CodeEditorField::OPTION_LANGUAGE));
+    }
+
+    public function testSetLanguageThrowsExceptionForInvalidLanguage(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        CodeEditorField::new('code')->setLanguage('invalid_language');
+    }
+
+    public function testSetNumOfRows(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setNumOfRows(20);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(20, $fieldDto->getCustomOption(CodeEditorField::OPTION_NUM_OF_ROWS));
+    }
+
+    public function testSetNumOfRowsThrowsExceptionForZeroOrNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        CodeEditorField::new('code')->setNumOfRows(0);
+    }
+
+    public function testSetTabSize(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setTabSize(2);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(2, $fieldDto->getCustomOption(CodeEditorField::OPTION_TAB_SIZE));
+    }
+
+    public function testSetTabSizeThrowsExceptionForZeroOrNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        CodeEditorField::new('code')->setTabSize(0);
+    }
+
+    public function testHideLineNumbers(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->hideLineNumbers(true);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CodeEditorField::OPTION_SHOW_LINE_NUMBERS));
+    }
+
+    public function testShowLineNumbers(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->hideLineNumbers(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CodeEditorField::OPTION_SHOW_LINE_NUMBERS));
+    }
+
+    public function testTemplateRendersCodeEditorOnDetailPage(): void
+    {
+        $code = 'console.log("Hello");';
+        $field = CodeEditorField::new('code');
+        $field->setValue($code);
+        $field->setLanguage('javascript');
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('data-ea-code-editor-field="true"', $html);
+        self::assertStringContainsString('data-language="javascript"', $html);
+        // the code is HTML-escaped in the template
+        self::assertStringContainsString('console.log', $html);
+        self::assertStringContainsString('Hello', $html);
+    }
+
+    /**
+     * Note: Testing the index page template is skipped because it uses the Icon component
+     * which requires a fully initialized AdminContext with AssetsDto. The detail page
+     * template tests above are sufficient to verify the core code editor rendering.
+     */
+    public function testTemplateRespectsLanguageSetting(): void
+    {
+        $code = 'SELECT * FROM users;';
+        $field = CodeEditorField::new('code');
+        $field->setValue($code);
+        $field->setLanguage('sql');
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('data-language="sql"', $html);
+    }
+
+    public function testTemplateRespectsTabSizeSetting(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setValue('code');
+        $field->setTabSize(2);
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('data-tab-size="2"', $html);
+    }
+
+    public function testTemplateRespectsIndentWithTabsSetting(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setValue('code');
+        $field->setIndentWithTabs(true);
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('data-indent-with-tabs="true"', $html);
+    }
+
+    public function testTemplateRespectsShowLineNumbersSetting(): void
+    {
+        $field = CodeEditorField::new('code');
+        $field->setValue('code');
+        $field->hideLineNumbers(true);
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('data-show-line-numbers="false"', $html);
+    }
+}

--- a/tests/Field/CollectionFieldTest.php
+++ b/tests/Field/CollectionFieldTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class CollectionFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // CollectionField configurator is complex and requires services:
+        // let's use a no-op configurator to test the field options
+        $this->configurator = new class implements FieldConfiguratorInterface {
+            public function supports(FieldDto $field, EntityDto $entityDto): bool
+            {
+                return CollectionField::class === $field->getFieldFqcn();
+            }
+
+            public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
+            {
+                // No-op for basic option testing
+            }
+        };
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = CollectionField::new('items');
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_ALLOW_ADD));
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_ALLOW_DELETE));
+        self::assertNull($fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_IS_COMPLEX));
+        self::assertNull($fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_TYPE));
+        self::assertNull($fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_TO_STRING_METHOD));
+        self::assertFalse($fieldDto->getCustomOption(CollectionField::OPTION_SHOW_ENTRY_LABEL));
+        self::assertFalse($fieldDto->getCustomOption(CollectionField::OPTION_RENDER_EXPANDED));
+        self::assertFalse($fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM));
+        self::assertSame(CollectionType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-collection', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = CollectionField::new('items');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithArrayValue(): void
+    {
+        $field = CollectionField::new('items');
+        $field->setValue(['item1', 'item2', 'item3']);
+        $fieldDto = $this->configure($field);
+
+        self::assertCount(3, $fieldDto->getValue());
+    }
+
+    public function testAllowAdd(): void
+    {
+        $field = CollectionField::new('items');
+        $field->allowAdd();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_ALLOW_ADD));
+    }
+
+    public function testDisallowAdd(): void
+    {
+        $field = CollectionField::new('items');
+        $field->allowAdd(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CollectionField::OPTION_ALLOW_ADD));
+    }
+
+    public function testAllowDelete(): void
+    {
+        $field = CollectionField::new('items');
+        $field->allowDelete();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_ALLOW_DELETE));
+    }
+
+    public function testDisallowDelete(): void
+    {
+        $field = CollectionField::new('items');
+        $field->allowDelete(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CollectionField::OPTION_ALLOW_DELETE));
+    }
+
+    public function testSetEntryIsComplex(): void
+    {
+        $field = CollectionField::new('items');
+        $field->setEntryIsComplex();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_IS_COMPLEX));
+    }
+
+    public function testSetEntryIsNotComplex(): void
+    {
+        $field = CollectionField::new('items');
+        $field->setEntryIsComplex(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_IS_COMPLEX));
+    }
+
+    public function testSetEntryType(): void
+    {
+        $field = CollectionField::new('items');
+        $field->setEntryType(TextType::class);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(TextType::class, $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_TYPE));
+    }
+
+    public function testSetEntryToStringMethodWithString(): void
+    {
+        $field = CollectionField::new('items');
+        $field->setEntryToStringMethod('getName');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('getName', $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_TO_STRING_METHOD));
+    }
+
+    public function testSetEntryToStringMethodWithCallable(): void
+    {
+        $callable = static fn ($entry): string => (string) $entry;
+        $field = CollectionField::new('items');
+        $field->setEntryToStringMethod($callable);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($callable, $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_TO_STRING_METHOD));
+    }
+
+    public function testShowEntryLabel(): void
+    {
+        $field = CollectionField::new('items');
+        $field->showEntryLabel();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_SHOW_ENTRY_LABEL));
+    }
+
+    public function testHideEntryLabel(): void
+    {
+        $field = CollectionField::new('items');
+        $field->showEntryLabel(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CollectionField::OPTION_SHOW_ENTRY_LABEL));
+    }
+
+    public function testRenderExpanded(): void
+    {
+        $field = CollectionField::new('items');
+        $field->renderExpanded();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_RENDER_EXPANDED));
+    }
+
+    public function testRenderCollapsed(): void
+    {
+        $field = CollectionField::new('items');
+        $field->renderExpanded(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CollectionField::OPTION_RENDER_EXPANDED));
+    }
+
+    public function testUseEntryCrudForm(): void
+    {
+        $crudControllerFqcn = 'App\\Controller\\ItemCrudController';
+        $field = CollectionField::new('items');
+        $field->useEntryCrudForm($crudControllerFqcn);
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM));
+        self::assertSame($crudControllerFqcn, $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_CONTROLLER_FQCN));
+    }
+
+    public function testUseEntryCrudFormWithPageNames(): void
+    {
+        $crudControllerFqcn = 'App\\Controller\\ItemCrudController';
+        $field = CollectionField::new('items');
+        $field->useEntryCrudForm($crudControllerFqcn, 'custom_new', 'custom_edit');
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM));
+        self::assertSame('custom_new', $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_NEW_PAGE_NAME));
+        self::assertSame('custom_edit', $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_EDIT_PAGE_NAME));
+    }
+}

--- a/tests/Field/ColorFieldTest.php
+++ b/tests/Field/ColorFieldTest.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ColorField;
+use Symfony\Component\Form\Extension\Core\Type\ColorType;
+
+class ColorFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // ColorField has no dedicated configurator, but we need to set formattedValue like CommonPreConfigurator does
+        $this->configurator = new class implements FieldConfiguratorInterface {
+            public function supports(FieldDto $field, EntityDto $entityDto): bool
+            {
+                return ColorField::class === $field->getFieldFqcn();
+            }
+
+            public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
+            {
+                // set formattedValue to value (like CommonPreConfigurator does for most fields)
+                if (null === $field->getFormattedValue()) {
+                    $field->setFormattedValue($field->getValue());
+                }
+            }
+        };
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = ColorField::new('color');
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(ColorField::OPTION_SHOW_SAMPLE));
+        self::assertFalse($fieldDto->getCustomOption(ColorField::OPTION_SHOW_VALUE));
+        self::assertSame(ColorType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-color', $fieldDto->getCssClass());
+        self::assertSame('crud/field/color', $fieldDto->getTemplateName());
+    }
+
+    public function testFieldWithValue(): void
+    {
+        $field = ColorField::new('color');
+        $field->setValue('#ff5733');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('#ff5733', $fieldDto->getValue());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = ColorField::new('color');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testShowSample(): void
+    {
+        $field = ColorField::new('color');
+        $field->showSample();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(ColorField::OPTION_SHOW_SAMPLE));
+    }
+
+    public function testHideSample(): void
+    {
+        $field = ColorField::new('color');
+        $field->showSample(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(ColorField::OPTION_SHOW_SAMPLE));
+    }
+
+    public function testShowValue(): void
+    {
+        $field = ColorField::new('color');
+        $field->showValue();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(ColorField::OPTION_SHOW_VALUE));
+    }
+
+    public function testHideValue(): void
+    {
+        $field = ColorField::new('color');
+        $field->showValue(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(ColorField::OPTION_SHOW_VALUE));
+    }
+
+    public function testShowBothSampleAndValue(): void
+    {
+        $field = ColorField::new('color');
+        $field->showSample();
+        $field->showValue();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(ColorField::OPTION_SHOW_SAMPLE));
+        self::assertTrue($fieldDto->getCustomOption(ColorField::OPTION_SHOW_VALUE));
+    }
+
+    public function testTemplateShowsSampleWhenEnabled(): void
+    {
+        $field = ColorField::new('color');
+        $field->setValue('#ff5733');
+        $field->showSample();
+        $field->showValue(false);
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('class="color-sample"', $html);
+        self::assertStringContainsString('style="background: #ff5733', $html);
+        // the color value should only appear in attributes, not as text content after the span
+        self::assertDoesNotMatchRegularExpression('/<\/span>\s*#ff5733/', $html);
+    }
+
+    public function testTemplateHidesSampleWhenDisabled(): void
+    {
+        $field = ColorField::new('color');
+        $field->setValue('#ff5733');
+        $field->showSample(false);
+        $field->showValue();
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringNotContainsString('class="color-sample"', $html);
+        // the color value should appear as text content (not just in attributes)
+        self::assertMatchesRegularExpression('/^\s*#ff5733\s*$/', $html);
+    }
+
+    public function testTemplateShowsValueWhenEnabled(): void
+    {
+        $field = ColorField::new('color');
+        $field->setValue('#00ff00');
+        $field->showSample(false);
+        $field->showValue();
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        // the color value should appear as text content (not just in attributes)
+        self::assertMatchesRegularExpression('/^\s*#00ff00\s*$/', $html);
+    }
+
+    public function testTemplateShowsBothSampleAndValue(): void
+    {
+        $field = ColorField::new('color');
+        $field->setValue('#0000ff');
+        $field->showSample();
+        $field->showValue();
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('class="color-sample"', $html);
+        self::assertStringContainsString('background: #0000ff', $html);
+        // the value should appear as text content after the sample span
+        self::assertMatchesRegularExpression('/<\/span>\s*#0000ff\s*$/', $html);
+    }
+
+    public function testTemplateShowsNothingWhenBothDisabled(): void
+    {
+        $field = ColorField::new('color');
+        $field->setValue('#ffffff');
+        $field->showSample(false);
+        $field->showValue(false);
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringNotContainsString('color-sample', $html);
+        self::assertStringNotContainsString('#ffffff', $html);
+    }
+}

--- a/tests/Field/Configurator/CommonPreConfiguratorTest.php
+++ b/tests/Field/Configurator/CommonPreConfiguratorTest.php
@@ -22,14 +22,14 @@ class CommonPreConfiguratorTest extends AbstractFieldTest
         $this->configurator = new CommonPreConfigurator($propertyAccessor, $entityFactory);
     }
 
-    public function testShouldKeepExistingValue()
+    public function testShouldKeepExistingValue(): void
     {
         $field = Field::new('foo')->setValue('bar');
 
         $this->assertSame('bar', $this->configure($field)->getValue());
     }
 
-    public function testShouldKeepExistingFormattedValue()
+    public function testShouldKeepExistingFormattedValue(): void
     {
         $field = Field::new('foo')->setFormattedValue('bar');
 

--- a/tests/Field/CountryFieldTest.php
+++ b/tests/Field/CountryFieldTest.php
@@ -16,7 +16,7 @@ class CountryFieldTest extends AbstractFieldTest
         parent::setUp();
     }
 
-    public function testDefaultFieldOptions()
+    public function testDefaultFieldOptions(): void
     {
         $this->initializeConfigurator();
 
@@ -33,7 +33,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertFalse($fieldDto->getCustomOption(CountryField::OPTION_ALLOW_MULTIPLE_CHOICES));
     }
 
-    public function testDefaultOptionsForFormPages()
+    public function testDefaultOptionsForFormPages(): void
     {
         $this->initializeConfigurator();
 
@@ -50,7 +50,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertSame('true', $fieldDto->getFormTypeOption('attr.data-ea-autocomplete-render-items-as-html'));
     }
 
-    public function testUnknownCountryCode()
+    public function testUnknownCountryCode(): void
     {
         $this->initializeConfigurator();
 
@@ -70,7 +70,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertSame(['UNKNOWN' => 'Unknown "es" country code', 'KR' => 'South Korea'], $fieldDto->getFormattedValue());
     }
 
-    public function testSingleCountryCode()
+    public function testSingleCountryCode(): void
     {
         $this->initializeConfigurator();
 
@@ -86,7 +86,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertSame(['ES' => 'España'], $fieldDto->getFormattedValue());
     }
 
-    public function testMultipleCountryCodes()
+    public function testMultipleCountryCodes(): void
     {
         $this->initializeConfigurator();
 
@@ -102,7 +102,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertSame(['BD' => 'Бангладеш', 'PG' => 'Папуа-Нова Гвінея', 'SV' => 'Сальвадор'], $fieldDto->getFormattedValue());
     }
 
-    public function testRemovingSomeCountries()
+    public function testRemovingSomeCountries(): void
     {
         $this->initializeConfigurator();
 
@@ -117,7 +117,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertArrayNotHasKey('KP', $formSelectChoicesWithCountryCodesAsKeys);
     }
 
-    public function testShowingOnlySomeCountries()
+    public function testShowingOnlySomeCountries(): void
     {
         $this->initializeConfigurator();
 
@@ -131,7 +131,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertSame($countryCodesSortedAlphabeticallyByCounryEnglishName, array_values($formSelectChoices));
     }
 
-    public function testShowingWrongCountryCodeInForms()
+    public function testShowingWrongCountryCodeInForms(): void
     {
         $this->initializeConfigurator();
 
@@ -145,7 +145,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertSame(['CL', 'EG'], array_values($formSelectChoices));
     }
 
-    public function testSelectingMultipleChoices()
+    public function testSelectingMultipleChoices(): void
     {
         $this->initializeConfigurator();
 
@@ -157,7 +157,7 @@ class CountryFieldTest extends AbstractFieldTest
         self::assertTrue($fieldDto->getFormTypeOption('multiple'));
     }
 
-    public function testUsingAlpha3Format()
+    public function testUsingAlpha3Format(): void
     {
         $this->initializeConfigurator();
 

--- a/tests/Field/CurrencyFieldTest.php
+++ b/tests/Field/CurrencyFieldTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CurrencyConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CurrencyField;
+use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
+
+class CurrencyFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new CurrencyConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = CurrencyField::new('currency');
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_CODE));
+        self::assertTrue($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_NAME));
+        self::assertTrue($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_SYMBOL));
+        self::assertSame('ea-autocomplete', $fieldDto->getFormTypeOption('attr.data-ea-widget'));
+        self::assertFalse($fieldDto->getFormTypeOption('choice_translation_domain'));
+        self::assertSame(CurrencyType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-currency', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithValidCurrencyCode(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->setValue('USD');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('USD', $fieldDto->getValue());
+        self::assertIsArray($fieldDto->getFormattedValue());
+        self::assertSame('US Dollar', $fieldDto->getFormattedValue()['name']);
+        self::assertSame('$', $fieldDto->getFormattedValue()['symbol']);
+    }
+
+    public function testFieldWithEurCurrency(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->setValue('EUR');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('EUR', $fieldDto->getValue());
+        self::assertIsArray($fieldDto->getFormattedValue());
+        self::assertSame('Euro', $fieldDto->getFormattedValue()['name']);
+        self::assertSame('€', $fieldDto->getFormattedValue()['symbol']);
+    }
+
+    public function testFieldWithInvalidCurrencyCode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $field = CurrencyField::new('currency');
+        $field->setValue('INVALID');
+        $this->configure($field);
+    }
+
+    public function testShowCode(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->showCode();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_CODE));
+    }
+
+    public function testHideCode(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->showCode(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_CODE));
+    }
+
+    public function testShowName(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->showName();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_NAME));
+    }
+
+    public function testHideName(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->showName(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_NAME));
+    }
+
+    public function testShowSymbol(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->showSymbol();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_SYMBOL));
+    }
+
+    public function testHideSymbol(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->showSymbol(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(CurrencyField::OPTION_SHOW_SYMBOL));
+    }
+
+    public function testFormTypeOptionsAreNotOverriddenIfAlreadySet(): void
+    {
+        $field = CurrencyField::new('currency');
+        $field->setFormTypeOption('attr.data-ea-widget', 'custom-widget');
+        $field->setFormTypeOption('choice_translation_domain', 'messages');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('custom-widget', $fieldDto->getFormTypeOption('attr.data-ea-widget'));
+        self::assertSame('messages', $fieldDto->getFormTypeOption('choice_translation_domain'));
+    }
+}

--- a/tests/Field/DateFieldTest.php
+++ b/tests/Field/DateFieldTest.php
@@ -16,7 +16,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->configurator = new DateTimeConfigurator(new IntlFormatter());
     }
 
-    public function testFieldWithWrongTimezone()
+    public function testFieldWithWrongTimezone(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -24,7 +24,7 @@ class DateFieldTest extends AbstractFieldTest
         $field->setTimezone('this-timezone-does-not-exist');
     }
 
-    public function testFieldWithoutTimezone()
+    public function testFieldWithoutTimezone(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);
@@ -33,7 +33,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertNull($fieldDto->getCustomOption(DateTimeField::OPTION_TIMEZONE));
     }
 
-    public function testFieldWithTimezone()
+    public function testFieldWithTimezone(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);
@@ -43,7 +43,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertSame('Europe/Madrid', $fieldDto->getCustomOption(DateTimeField::OPTION_TIMEZONE));
     }
 
-    public function testFieldWithWrongFormat()
+    public function testFieldWithWrongFormat(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -52,7 +52,7 @@ class DateFieldTest extends AbstractFieldTest
         $field->setFormat(DateTimeField::FORMAT_NONE);
     }
 
-    public function testFieldWithEmptyFormat()
+    public function testFieldWithEmptyFormat(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -61,7 +61,7 @@ class DateFieldTest extends AbstractFieldTest
         $field->setFormat('');
     }
 
-    public function testFieldWithPredefinedFormat()
+    public function testFieldWithPredefinedFormat(): void
     {
         $field = DateField::new('foo')->setValue(new \DateTime('2006-01-02 15:04:05'));
         $field->setFieldFqcn(DateField::class);
@@ -72,7 +72,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertSame('January 2, 2006', $fieldDto->getFormattedValue());
     }
 
-    public function testFieldWithCustomPattern()
+    public function testFieldWithCustomPattern(): void
     {
         $field = DateField::new('foo')->setValue(new \DateTime('2006-01-02 15:04:05'));
         $field->setFieldFqcn(DateField::class);
@@ -84,7 +84,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertMatchesRegularExpression('/^15:04:05 GMT(\+00:00)? PM$/', $fieldDto->getFormattedValue());
     }
 
-    public function testFieldDefaultWidget()
+    public function testFieldDefaultWidget(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);
@@ -93,7 +93,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(DateField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsNativeWidget()
+    public function testFieldRenderAsNativeWidget(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);
@@ -105,7 +105,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertTrue($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotNativeWidget()
+    public function testFieldRenderAsNotNativeWidget(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);
@@ -115,7 +115,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_CHOICE, $fieldDto->getCustomOption(DateField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsChoice()
+    public function testFieldRenderAsChoice(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);
@@ -127,7 +127,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertTrue($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotChoice()
+    public function testFieldRenderAsNotChoice(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);
@@ -137,7 +137,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(DateField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsText()
+    public function testFieldRenderAsText(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);
@@ -149,7 +149,7 @@ class DateFieldTest extends AbstractFieldTest
         $this->assertFalse($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotText()
+    public function testFieldRenderAsNotText(): void
     {
         $field = DateField::new('foo');
         $field->setFieldFqcn(DateField::class);

--- a/tests/Field/DateTimeFieldTest.php
+++ b/tests/Field/DateTimeFieldTest.php
@@ -15,7 +15,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->configurator = new DateTimeConfigurator(new IntlFormatter());
     }
 
-    public function testFieldWithWrongTimezone()
+    public function testFieldWithWrongTimezone(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -23,7 +23,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $field->setTimezone('this-timezone-does-not-exist');
     }
 
-    public function testFieldWithoutTimezone()
+    public function testFieldWithoutTimezone(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -32,7 +32,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertNull($fieldDto->getCustomOption(DateTimeField::OPTION_TIMEZONE));
     }
 
-    public function testFieldWithTimezone()
+    public function testFieldWithTimezone(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -42,7 +42,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertSame('Europe/Madrid', $fieldDto->getCustomOption(DateTimeField::OPTION_TIMEZONE));
     }
 
-    public function testFieldWithWrongFormat()
+    public function testFieldWithWrongFormat(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -51,7 +51,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $field->setFormat(DateTimeField::FORMAT_NONE);
     }
 
-    public function testFieldWithEmptyDateFormat()
+    public function testFieldWithEmptyDateFormat(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -60,7 +60,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $field->setFormat('');
     }
 
-    public function testFieldWithEmptyDateAndTimeFormats()
+    public function testFieldWithEmptyDateAndTimeFormats(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -69,7 +69,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $field->setFormat('', '');
     }
 
-    public function testFieldWithNoneDateAndTimeFormats()
+    public function testFieldWithNoneDateAndTimeFormats(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -78,7 +78,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $field->setFormat(DateTimeField::FORMAT_NONE, DateTimeField::FORMAT_NONE);
     }
 
-    public function testFieldWithPredefinedFormat()
+    public function testFieldWithPredefinedFormat(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -89,7 +89,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertSame('January 16, 2015', $fieldDto->getFormattedValue());
     }
 
-    public function testFieldWithCustomPattern()
+    public function testFieldWithCustomPattern(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -101,7 +101,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertMatchesRegularExpression('/^00:00:00 GMT(\+00:00)? AM$/', $fieldDto->getFormattedValue());
     }
 
-    public function testFieldDefaultWidget()
+    public function testFieldDefaultWidget(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -110,7 +110,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(DateTimeField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsNativeWidget()
+    public function testFieldRenderAsNativeWidget(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -122,7 +122,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertTrue($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotNativeWidget()
+    public function testFieldRenderAsNotNativeWidget(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -132,7 +132,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_CHOICE, $fieldDto->getCustomOption(DateTimeField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsChoice()
+    public function testFieldRenderAsChoice(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -144,7 +144,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertTrue($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotChoice()
+    public function testFieldRenderAsNotChoice(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -154,7 +154,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(DateTimeField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsText()
+    public function testFieldRenderAsText(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);
@@ -166,7 +166,7 @@ class DateTimeFieldTest extends AbstractFieldTest
         $this->assertFalse($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotText()
+    public function testFieldRenderAsNotText(): void
     {
         $field = DateTimeField::new('foo')->setValue(new \DateTime('2015-01-16'));
         $field->setFieldFqcn(DateTimeField::class);

--- a/tests/Field/EmailFieldTest.php
+++ b/tests/Field/EmailFieldTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\EmailConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+
+class EmailFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new EmailConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = EmailField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('email', $fieldDto->getFormTypeOption('attr.inputmode'));
+        self::assertSame(EmailType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-email', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithValue(): void
+    {
+        $field = EmailField::new('foo');
+        $field->setValue('test@example.com');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('test@example.com', $fieldDto->getValue());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = EmailField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testInputModeIsNotOverriddenIfAlreadySet(): void
+    {
+        $field = EmailField::new('foo');
+        $field->setFormTypeOption('attr.inputmode', 'text');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('text', $fieldDto->getFormTypeOption('attr.inputmode'));
+    }
+}

--- a/tests/Field/FieldTraitTest.php
+++ b/tests/Field/FieldTraitTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 
 class FieldTraitTest extends TestCase
 {
-    public function testSetFormTypeOption()
+    public function testSetFormTypeOption(): void
     {
         $field = TextField::new('test');
         $field->setFormTypeOption('entry_options.attr.class', 'foo');
@@ -16,7 +16,7 @@ class FieldTraitTest extends TestCase
         $this->assertSame('foo', $formTypeOptions['entry_options']['attr']['class']);
     }
 
-    public function testSetFormTypeOptionIfNotSet()
+    public function testSetFormTypeOptionIfNotSet(): void
     {
         $field = TextField::new('test');
         $field->setFormTypeOption('entry_options.attr.class', 'foo');

--- a/tests/Field/FormFieldTest.php
+++ b/tests/Field/FormFieldTest.php
@@ -9,7 +9,7 @@ use Symfony\Component\Uid\Ulid;
 class FormFieldTest extends TestCase
 {
     /** @dataProvider defaultPropertySuffixProvider */
-    public function testDefaultSetPropertySuffix(FormField $formField)
+    public function testDefaultSetPropertySuffix(FormField $formField): void
     {
         $this->assertTrue(Ulid::isValid($formField->getAsDto()->getPropertyNameSuffix()));
     }
@@ -23,7 +23,7 @@ class FormFieldTest extends TestCase
     }
 
     /** @dataProvider propertySuffixProvider */
-    public function testSetPropertySuffix(FormField $formField, string $expectedPropertyName, string $expectedPropertyNameSuffix)
+    public function testSetPropertySuffix(FormField $formField, string $expectedPropertyName, string $expectedPropertyNameSuffix): void
     {
         $dto = $formField->getAsDto();
         $this->assertSame($expectedPropertyName, $dto->getPropertyNameWithSuffix());

--- a/tests/Field/HiddenFieldTest.php
+++ b/tests/Field/HiddenFieldTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\HiddenField;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+
+class HiddenFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // HiddenField has no dedicated configurator
+        $this->configurator = new class implements FieldConfiguratorInterface {
+            public function supports(FieldDto $field, EntityDto $entityDto): bool
+            {
+                return HiddenField::class === $field->getFieldFqcn();
+            }
+
+            public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
+            {
+                // No-op: HiddenField has no special configuration
+            }
+        };
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = HiddenField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(HiddenType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-hidden', $fieldDto->getCssClass());
+        self::assertSame('crud/field/hidden', $fieldDto->getTemplateName());
+    }
+
+    public function testFieldWithValue(): void
+    {
+        $field = HiddenField::new('foo');
+        $field->setValue('hidden_value');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('hidden_value', $fieldDto->getValue());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = HiddenField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithIntegerValue(): void
+    {
+        $field = HiddenField::new('foo');
+        $field->setValue(123);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(123, $fieldDto->getValue());
+    }
+}

--- a/tests/Field/IdFieldTest.php
+++ b/tests/Field/IdFieldTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\IdConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class IdFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new IdConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = IdField::new('id');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(TextType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-id', $fieldDto->getCssClass());
+        self::assertSame('crud/field/id', $fieldDto->getTemplateName());
+        self::assertNull($fieldDto->getCustomOption(IdField::OPTION_MAX_LENGTH));
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = IdField::new('id');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+        self::assertNull($fieldDto->getFormattedValue());
+    }
+
+    public function testFieldTruncatesValueOnIndexPage(): void
+    {
+        $field = IdField::new('id');
+        $field->setValue('123456789012345');
+        $fieldDto = $this->configure($field);
+
+        // default maxLength is 7, and truncate() includes the ellipsis in the count
+        self::assertSame('123456…', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldDoesNotTruncateOnDetailPage(): void
+    {
+        $field = IdField::new('id');
+        $field->setValue('123456789012345');
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        self::assertSame('123456789012345', $fieldDto->getValue());
+    }
+
+    public function testSetMaxLength(): void
+    {
+        $field = IdField::new('id');
+        $field->setValue('123456789012345');
+        $field->setMaxLength(5);
+        $fieldDto = $this->configure($field);
+
+        // truncate() includes the ellipsis in the count, so maxLength=5 gives 4 chars + ellipsis
+        self::assertSame('1234…', $fieldDto->getFormattedValue());
+        self::assertSame(5, $fieldDto->getCustomOption(IdField::OPTION_MAX_LENGTH));
+    }
+
+    public function testSetMaxLengthUnlimited(): void
+    {
+        $field = IdField::new('id');
+        $field->setValue('123456789012345');
+        $field->setMaxLength(-1);
+        $fieldDto = $this->configure($field);
+
+        // -1 means unlimited, so the value should not be truncated
+        self::assertSame('123456789012345', $fieldDto->getValue());
+    }
+
+    public function testSetMaxLengthThrowsExceptionForZero(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        IdField::new('id')->setMaxLength(0);
+    }
+}

--- a/tests/Field/ImageFieldTest.php
+++ b/tests/Field/ImageFieldTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
+use Symfony\Component\Validator\Constraints\Image;
+use Symfony\Component\Validator\Constraints\NotNull;
+
+class ImageFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // ImageField configurator requires Symfony services for file handling
+        // For these tests, we'll use a no-op configurator to test the field options
+        $this->configurator = new class implements FieldConfiguratorInterface {
+            public function supports(FieldDto $field, EntityDto $entityDto): bool
+            {
+                return ImageField::class === $field->getFieldFqcn();
+            }
+
+            public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
+            {
+                // no-op for basic option testing
+            }
+        };
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = ImageField::new('image');
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getCustomOption(ImageField::OPTION_BASE_PATH));
+        self::assertNull($fieldDto->getCustomOption(ImageField::OPTION_UPLOAD_DIR));
+        self::assertSame('[name].[extension]', $fieldDto->getCustomOption(ImageField::OPTION_UPLOADED_FILE_NAME_PATTERN));
+        self::assertSame(FileUploadType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-image', $fieldDto->getCssClass());
+    }
+
+    public function testDefaultFileConstraints(): void
+    {
+        $field = ImageField::new('image');
+        $fieldDto = $this->configure($field);
+
+        $constraints = $fieldDto->getCustomOption(ImageField::OPTION_FILE_CONSTRAINTS);
+        self::assertIsArray($constraints);
+        self::assertCount(1, $constraints);
+        self::assertInstanceOf(Image::class, $constraints[0]);
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = ImageField::new('image');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithFilename(): void
+    {
+        $field = ImageField::new('image');
+        $field->setValue('profile.jpg');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('profile.jpg', $fieldDto->getValue());
+    }
+
+    public function testSetBasePath(): void
+    {
+        $field = ImageField::new('image');
+        $field->setBasePath('/uploads/images/');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('/uploads/images/', $fieldDto->getCustomOption(ImageField::OPTION_BASE_PATH));
+    }
+
+    public function testSetUploadDir(): void
+    {
+        $field = ImageField::new('image');
+        $field->setUploadDir('public/uploads/images/');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('public/uploads/images/', $fieldDto->getCustomOption(ImageField::OPTION_UPLOAD_DIR));
+    }
+
+    public function testSetUploadedFileNamePatternWithString(): void
+    {
+        $field = ImageField::new('image');
+        $field->setUploadedFileNamePattern('[year]/[month]/[slug].[extension]');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('[year]/[month]/[slug].[extension]', $fieldDto->getCustomOption(ImageField::OPTION_UPLOADED_FILE_NAME_PATTERN));
+    }
+
+    public function testSetUploadedFileNamePatternWithClosure(): void
+    {
+        $pattern = fn ($file) => 'custom_'.$file->getFilename();
+        $field = ImageField::new('image');
+        $field->setUploadedFileNamePattern($pattern);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($pattern, $fieldDto->getCustomOption(ImageField::OPTION_UPLOADED_FILE_NAME_PATTERN));
+    }
+
+    public function testSetFileConstraintsWithSingleConstraint(): void
+    {
+        $supportsNamedMaxSize = false;
+
+        $constructor = (new \ReflectionClass(Image::class))->getConstructor();
+        if ($constructor instanceof \ReflectionMethod) {
+            foreach ($constructor->getParameters() as $parameter) {
+                if ('maxSize' === $parameter->getName()) {
+                    $supportsNamedMaxSize = true;
+                    break;
+                }
+            }
+        }
+
+        if ($supportsNamedMaxSize) {
+            $constraint = new Image(maxSize: '5M');
+        } else {
+            $constraint = new Image(['maxSize' => '5M']);
+        }
+
+        $field = ImageField::new('image');
+        $field->setFileConstraints($constraint);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($constraint, $fieldDto->getCustomOption(ImageField::OPTION_FILE_CONSTRAINTS));
+    }
+
+    public function testSetFileConstraintsWithMultipleConstraints(): void
+    {
+        $supportsNamedMaxSize = false;
+
+        $constructor = (new \ReflectionClass(Image::class))->getConstructor();
+        if ($constructor instanceof \ReflectionMethod) {
+            foreach ($constructor->getParameters() as $parameter) {
+                if ('maxSize' === $parameter->getName()) {
+                    $supportsNamedMaxSize = true;
+                    break;
+                }
+            }
+        }
+
+        if ($supportsNamedMaxSize) {
+            $imageConstraint = new Image(maxSize: '5M');
+        } else {
+            $imageConstraint = new Image(['maxSize' => '5M']);
+        }
+
+        $constraints = [
+            $imageConstraint,
+            new NotNull(),
+        ];
+        $field = ImageField::new('image');
+        $field->setFileConstraints($constraints);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($constraints, $fieldDto->getCustomOption(ImageField::OPTION_FILE_CONSTRAINTS));
+    }
+
+    public function testUploadPatternPlaceholders(): void
+    {
+        // test various placeholders that can be used
+        $patterns = [
+            '[day]',
+            '[month]',
+            '[year]',
+            '[timestamp]',
+            '[name]',
+            '[slug]',
+            '[extension]',
+            '[contenthash]',
+            '[randomhash]',
+            '[uuid]',
+            '[ulid]',
+        ];
+
+        foreach ($patterns as $pattern) {
+            $field = ImageField::new('image');
+            $field->setUploadedFileNamePattern($pattern);
+            $fieldDto = $this->configure($field);
+
+            self::assertSame($pattern, $fieldDto->getCustomOption(ImageField::OPTION_UPLOADED_FILE_NAME_PATTERN));
+        }
+    }
+
+    public function testComplexUploadPattern(): void
+    {
+        $pattern = '[year]/[month]/[day]/[slug]-[contenthash].[extension]';
+        $field = ImageField::new('image');
+        $field->setUploadedFileNamePattern($pattern);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($pattern, $fieldDto->getCustomOption(ImageField::OPTION_UPLOADED_FILE_NAME_PATTERN));
+    }
+}

--- a/tests/Field/IntegerFieldTest.php
+++ b/tests/Field/IntegerFieldTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\IntegerConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+
+class IntegerFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new IntegerConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = IntegerField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getCustomOption(IntegerField::OPTION_NUMBER_FORMAT));
+        self::assertNull($fieldDto->getCustomOption(IntegerField::OPTION_THOUSANDS_SEPARATOR));
+        self::assertSame(IntegerType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-integer', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+        self::assertNull($fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithIntegerValue(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(12345);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(12345, $fieldDto->getValue());
+        self::assertSame(12345, $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithNegativeValue(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(-99);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(-99, $fieldDto->getValue());
+    }
+
+    public function testSetNumberFormat(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(42);
+        $field->setNumberFormat('%05d');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('%05d', $fieldDto->getCustomOption(IntegerField::OPTION_NUMBER_FORMAT));
+        self::assertSame('00042', $fieldDto->getFormattedValue());
+    }
+
+    public function testSetThousandsSeparator(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(1234567);
+        $field->setThousandsSeparator(',');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(',', $fieldDto->getCustomOption(IntegerField::OPTION_THOUSANDS_SEPARATOR));
+        self::assertSame('1,234,567', $fieldDto->getFormattedValue());
+    }
+
+    public function testSetThousandsSeparatorWithDifferentSeparator(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(1234567);
+        $field->setThousandsSeparator(' ');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(' ', $fieldDto->getCustomOption(IntegerField::OPTION_THOUSANDS_SEPARATOR));
+        self::assertSame('1 234 567', $fieldDto->getFormattedValue());
+    }
+
+    public function testNumberFormatTakesPrecedenceOverThousandsSeparator(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(1234567);
+        $field->setNumberFormat('%08d');
+        $field->setThousandsSeparator(',');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('01234567', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithZeroValue(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(0);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(0, $fieldDto->getValue());
+        self::assertSame(0, $fieldDto->getFormattedValue());
+    }
+
+    public function testFormattedValueWithLargeNumber(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(9876543210);
+        $field->setThousandsSeparator(',');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('9,876,543,210', $fieldDto->getFormattedValue());
+    }
+
+    public function testFormattedValueWithNegativeAndThousandsSeparator(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(-1234567);
+        $field->setThousandsSeparator(',');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('-1,234,567', $fieldDto->getFormattedValue());
+    }
+
+    public function testThousandsSeparatorWithDot(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(1234567);
+        $field->setThousandsSeparator('.');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('1.234.567', $fieldDto->getFormattedValue());
+    }
+
+    public function testNumberFormatWithHexadecimal(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(255);
+        $field->setNumberFormat('0x%02X');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('0xFF', $fieldDto->getFormattedValue());
+    }
+
+    public function testSmallNumberWithThousandsSeparator(): void
+    {
+        $field = IntegerField::new('foo');
+        $field->setValue(999);
+        $field->setThousandsSeparator(',');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('999', $fieldDto->getFormattedValue());
+    }
+}

--- a/tests/Field/LanguageFieldTest.php
+++ b/tests/Field/LanguageFieldTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\LanguageConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\LanguageField;
+use Symfony\Component\Form\Extension\Core\Type\LanguageType;
+
+class LanguageFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new LanguageConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = LanguageField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(LanguageField::OPTION_SHOW_CODE));
+        self::assertTrue($fieldDto->getCustomOption(LanguageField::OPTION_SHOW_NAME));
+        self::assertSame(LanguageField::FORMAT_ISO_639_ALPHA2, $fieldDto->getCustomOption(LanguageField::OPTION_LANGUAGE_CODE_FORMAT));
+        self::assertNull($fieldDto->getCustomOption(LanguageField::OPTION_LANGUAGE_CODES_TO_KEEP));
+        self::assertNull($fieldDto->getCustomOption(LanguageField::OPTION_LANGUAGE_CODES_TO_REMOVE));
+        self::assertSame('ea-autocomplete', $fieldDto->getFormTypeOption('attr.data-ea-widget'));
+        self::assertSame(LanguageType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-language', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithValidLanguageCode(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->setValue('en');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('en', $fieldDto->getValue());
+        self::assertSame('English', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithSpanishLanguageCode(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->setValue('es');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('es', $fieldDto->getValue());
+        self::assertSame('Spanish', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithInvalidLanguageCode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $field = LanguageField::new('foo');
+        $field->setValue('invalid');
+        $this->configure($field);
+    }
+
+    public function testShowCode(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->showCode();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(LanguageField::OPTION_SHOW_CODE));
+    }
+
+    public function testHideCode(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->showCode(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(LanguageField::OPTION_SHOW_CODE));
+    }
+
+    public function testShowName(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->showName();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(LanguageField::OPTION_SHOW_NAME));
+    }
+
+    public function testHideName(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->showName(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(LanguageField::OPTION_SHOW_NAME));
+    }
+
+    public function testUseAlpha3Codes(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->useAlpha3Codes();
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(LanguageField::FORMAT_ISO_639_ALPHA3, $fieldDto->getCustomOption(LanguageField::OPTION_LANGUAGE_CODE_FORMAT));
+    }
+
+    public function testUseAlpha2Codes(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->useAlpha3Codes(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(LanguageField::FORMAT_ISO_639_ALPHA2, $fieldDto->getCustomOption(LanguageField::OPTION_LANGUAGE_CODE_FORMAT));
+    }
+
+    public function testFieldWithAlpha3LanguageCode(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->setValue('eng');
+        $field->useAlpha3Codes();
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('eng', $fieldDto->getValue());
+        self::assertSame('English', $fieldDto->getFormattedValue());
+    }
+
+    public function testIncludeOnly(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->includeOnly(['en', 'es', 'fr']);
+        $fieldDto = $this->configure($field, Crud::PAGE_EDIT);
+        $choices = $fieldDto->getFormTypeOption('choices');
+
+        self::assertSame(['en', 'es', 'fr'], $fieldDto->getCustomOption(LanguageField::OPTION_LANGUAGE_CODES_TO_KEEP));
+        self::assertCount(3, $choices);
+        self::assertContains('en', $choices);
+        self::assertContains('es', $choices);
+        self::assertContains('fr', $choices);
+    }
+
+    public function testRemove(): void
+    {
+        $field = LanguageField::new('foo');
+        $field->remove(['en', 'es']);
+        $fieldDto = $this->configure($field, Crud::PAGE_EDIT);
+        $choices = $fieldDto->getFormTypeOption('choices');
+
+        self::assertSame(['en', 'es'], $fieldDto->getCustomOption(LanguageField::OPTION_LANGUAGE_CODES_TO_REMOVE));
+        self::assertNotContains('en', $choices);
+        self::assertNotContains('es', $choices);
+    }
+
+    public function testFormTypeOptionsOnFormPages(): void
+    {
+        $field = LanguageField::new('foo');
+        $fieldDto = $this->configure($field, Crud::PAGE_EDIT);
+
+        self::assertNotNull($fieldDto->getFormTypeOption('choices'));
+        self::assertNull($fieldDto->getFormTypeOption('choice_loader'));
+        self::assertFalse($fieldDto->getFormTypeOption('choice_translation_domain'));
+    }
+}

--- a/tests/Field/LocaleFieldTest.php
+++ b/tests/Field/LocaleFieldTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\LocaleConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\LocaleField;
+use Symfony\Component\Form\Extension\Core\Type\LocaleType;
+
+class LocaleFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new LocaleConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = LocaleField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(LocaleField::OPTION_SHOW_CODE));
+        self::assertTrue($fieldDto->getCustomOption(LocaleField::OPTION_SHOW_NAME));
+        self::assertNull($fieldDto->getCustomOption(LocaleField::OPTION_LOCALE_CODES_TO_KEEP));
+        self::assertNull($fieldDto->getCustomOption(LocaleField::OPTION_LOCALE_CODES_TO_REMOVE));
+        self::assertSame('ea-autocomplete', $fieldDto->getFormTypeOption('attr.data-ea-widget'));
+        self::assertSame(LocaleType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-locale', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithValidLocaleCode(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->setValue('en');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('en', $fieldDto->getValue());
+        self::assertSame('English', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithLocaleCodeWithCountry(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->setValue('en_US');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('en_US', $fieldDto->getValue());
+        self::assertSame('English (United States)', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithSpanishLocale(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->setValue('es_ES');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('es_ES', $fieldDto->getValue());
+        self::assertSame('Spanish (Spain)', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithInvalidLocaleCode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $field = LocaleField::new('foo');
+        $field->setValue('invalid_code');
+        $this->configure($field);
+    }
+
+    public function testShowCode(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->showCode();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(LocaleField::OPTION_SHOW_CODE));
+    }
+
+    public function testHideCode(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->showCode(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(LocaleField::OPTION_SHOW_CODE));
+    }
+
+    public function testShowName(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->showName();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(LocaleField::OPTION_SHOW_NAME));
+    }
+
+    public function testHideName(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->showName(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(LocaleField::OPTION_SHOW_NAME));
+    }
+
+    public function testIncludeOnly(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->includeOnly(['en', 'es', 'fr']);
+        $fieldDto = $this->configure($field, Crud::PAGE_EDIT);
+        $choices = $fieldDto->getFormTypeOption('choices');
+
+        self::assertSame(['en', 'es', 'fr'], $fieldDto->getCustomOption(LocaleField::OPTION_LOCALE_CODES_TO_KEEP));
+        self::assertCount(3, $choices);
+        self::assertContains('en', $choices);
+        self::assertContains('es', $choices);
+        self::assertContains('fr', $choices);
+    }
+
+    public function testRemove(): void
+    {
+        $field = LocaleField::new('foo');
+        $field->remove(['en', 'es']);
+        $fieldDto = $this->configure($field, Crud::PAGE_EDIT);
+        $choices = $fieldDto->getFormTypeOption('choices');
+
+        self::assertSame(['en', 'es'], $fieldDto->getCustomOption(LocaleField::OPTION_LOCALE_CODES_TO_REMOVE));
+        self::assertNotContains('en', $choices);
+        self::assertNotContains('es', $choices);
+    }
+
+    public function testFormTypeOptionsOnFormPages(): void
+    {
+        $field = LocaleField::new('foo');
+        $fieldDto = $this->configure($field, Crud::PAGE_EDIT);
+
+        self::assertNotNull($fieldDto->getFormTypeOption('choices'));
+        self::assertNull($fieldDto->getFormTypeOption('choice_loader'));
+        self::assertFalse($fieldDto->getFormTypeOption('choice_translation_domain'));
+    }
+}

--- a/tests/Field/MoneyFieldTest.php
+++ b/tests/Field/MoneyFieldTest.php
@@ -16,7 +16,7 @@ class MoneyFieldTest extends AbstractFieldTest
         $this->configurator = new MoneyConfigurator(new IntlFormatter(), static::getContainer()->get('property_accessor'));
     }
 
-    public function testFieldWithoutCurrency()
+    public function testFieldWithoutCurrency(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -24,7 +24,7 @@ class MoneyFieldTest extends AbstractFieldTest
         $this->configure($field);
     }
 
-    public function testNullFieldWithoutCurrency()
+    public function testNullFieldWithoutCurrency(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -32,7 +32,7 @@ class MoneyFieldTest extends AbstractFieldTest
         $this->configure($field);
     }
 
-    public function testFieldWithNullValues()
+    public function testFieldWithNullValues(): void
     {
         $field = MoneyField::new('foo')->setValue(null)->setCurrency('EUR');
         $fieldDto = $this->configure($field);
@@ -40,7 +40,7 @@ class MoneyFieldTest extends AbstractFieldTest
         self::assertSame('EUR', $fieldDto->getCustomOption(MoneyField::OPTION_CURRENCY));
     }
 
-    public function testFieldWithWrongCurrency()
+    public function testFieldWithWrongCurrency(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -48,7 +48,7 @@ class MoneyFieldTest extends AbstractFieldTest
         $this->configure($field);
     }
 
-    public function testFieldWithHardcodedCurrency()
+    public function testFieldWithHardcodedCurrency(): void
     {
         $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
         $fieldDto = $this->configure($field);
@@ -74,7 +74,7 @@ class MoneyFieldTest extends AbstractFieldTest
         return $this->entityDto = $entityDto;
     }
 
-    public function testFieldWithPropertyPathCurrency()
+    public function testFieldWithPropertyPathCurrency(): void
     {
         $field = MoneyField::new('foo')->setValue(100)->setCurrencyPropertyPath('bar');
         $fieldDto = $this->configure($field);
@@ -82,7 +82,7 @@ class MoneyFieldTest extends AbstractFieldTest
         self::assertSame('USD', $fieldDto->getFormTypeOption('currency'));
     }
 
-    public function testFieldDecimals()
+    public function testFieldDecimals(): void
     {
         $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
         $fieldDto = $this->configure($field);
@@ -95,28 +95,31 @@ class MoneyFieldTest extends AbstractFieldTest
         self::assertSame(3, $fieldDto->getFormTypeOption('scale'));
     }
 
-    public function testFieldsDefaultsToCents()
+    public function testFieldsDefaultsToCents(): void
     {
         $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
         $fieldDto = $this->configure($field);
+
         self::assertSame('€1.00', $fieldDto->getFormattedValue());
         self::assertSame(100, $fieldDto->getFormTypeOption('divisor'));
     }
 
-    public function testFieldCents()
+    public function testFieldCents(): void
     {
         $field = MoneyField::new('foo')->setValue(100)->setCurrency('EUR');
         $field->setStoredAsCents(false);
         $fieldDto = $this->configure($field);
+
         self::assertSame('€100.00', $fieldDto->getFormattedValue());
         self::assertSame(1, $fieldDto->getFormTypeOption('divisor'));
     }
 
-    public function testFieldWithCustomDivisor()
+    public function testFieldWithCustomDivisor(): void
     {
         $field = MoneyField::new('foo')->setValue(725)->setCurrency('EUR');
         $field->setFormTypeOption('divisor', 10000);
         $fieldDto = $this->configure($field);
+
         self::assertSame('€0.07', $fieldDto->getFormattedValue());
         self::assertSame(10000, $fieldDto->getFormTypeOption('divisor'));
     }

--- a/tests/Field/NumberFieldTest.php
+++ b/tests/Field/NumberFieldTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\NumberConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
+use EasyCorp\Bundle\EasyAdminBundle\Intl\IntlFormatter;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+
+class NumberFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new NumberConfigurator(new IntlFormatter());
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = NumberField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getCustomOption(NumberField::OPTION_NUM_DECIMALS));
+        self::assertSame(\NumberFormatter::ROUND_HALFUP, $fieldDto->getCustomOption(NumberField::OPTION_ROUNDING_MODE));
+        self::assertFalse($fieldDto->getCustomOption(NumberField::OPTION_STORED_AS_STRING));
+        self::assertNull($fieldDto->getCustomOption(NumberField::OPTION_NUMBER_FORMAT));
+        self::assertNull($fieldDto->getCustomOption(NumberField::OPTION_THOUSANDS_SEPARATOR));
+        self::assertNull($fieldDto->getCustomOption(NumberField::OPTION_DECIMAL_SEPARATOR));
+        self::assertSame(NumberType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-number', $fieldDto->getCssClass());
+    }
+
+    public function testFormTypeOptions(): void
+    {
+        $field = NumberField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('number', $fieldDto->getFormTypeOption('input'));
+        self::assertSame(\NumberFormatter::ROUND_HALFUP, $fieldDto->getFormTypeOption('rounding_mode'));
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithFloatValue(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(123.456);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(123.456, $fieldDto->getValue());
+    }
+
+    public function testSetNumDecimals(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(123.456789);
+        $field->setNumDecimals(2);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(2, $fieldDto->getCustomOption(NumberField::OPTION_NUM_DECIMALS));
+        self::assertSame(2, $fieldDto->getFormTypeOption('scale'));
+        self::assertMatchesRegularExpression('/123[.,]46/', $fieldDto->getFormattedValue());
+    }
+
+    public function testSetNumDecimalsThrowsExceptionForNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        NumberField::new('foo')->setNumDecimals(-1);
+    }
+
+    /**
+     * @testWith [0, "ROUND_DOWN"]
+     *           [1, "ROUND_FLOOR"]
+     *           [2, "ROUND_UP"]
+     *           [3, "ROUND_CEILING"]
+     *           [5, "ROUND_HALF_DOWN"]
+     *           [6, "ROUND_HALF_EVEN"]
+     *           [4, "ROUND_HALF_UP"]
+     */
+    public function testSetRoundingMode(int $mode, string $modeName): void
+    {
+        $field = NumberField::new('foo');
+        $field->setRoundingMode($mode);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($mode, $fieldDto->getCustomOption(NumberField::OPTION_ROUNDING_MODE));
+        self::assertSame($mode, $fieldDto->getFormTypeOption('rounding_mode'));
+    }
+
+    public function testSetRoundingModeThrowsExceptionForInvalidMode(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        NumberField::new('foo')->setRoundingMode(999);
+    }
+
+    public function testSetStoredAsString(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setStoredAsString(true);
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(NumberField::OPTION_STORED_AS_STRING));
+        self::assertSame('string', $fieldDto->getFormTypeOption('input'));
+    }
+
+    public function testSetStoredAsStringFalse(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setStoredAsString(false);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(NumberField::OPTION_STORED_AS_STRING));
+        self::assertSame('number', $fieldDto->getFormTypeOption('input'));
+    }
+
+    public function testSetNumberFormat(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(42.5);
+        $field->setNumberFormat('%.3f');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('%.3f', $fieldDto->getCustomOption(NumberField::OPTION_NUMBER_FORMAT));
+        self::assertSame('42.500', $fieldDto->getFormattedValue());
+    }
+
+    public function testSetThousandsSeparator(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(1234567.89);
+        $field->setThousandsSeparator(' ');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(' ', $fieldDto->getCustomOption(NumberField::OPTION_THOUSANDS_SEPARATOR));
+        self::assertStringContainsString('1 234 567', $fieldDto->getFormattedValue());
+    }
+
+    public function testSetDecimalSeparator(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(123.45);
+        $field->setDecimalSeparator(',');
+        $field->setNumDecimals(2);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(',', $fieldDto->getCustomOption(NumberField::OPTION_DECIMAL_SEPARATOR));
+        self::assertStringContainsString('123,45', $fieldDto->getFormattedValue());
+    }
+
+    public function testThousandsAndDecimalSeparatorsTogether(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(1234567.89);
+        $field->setThousandsSeparator('.');
+        $field->setDecimalSeparator(',');
+        $field->setNumDecimals(2);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('1.234.567,89', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldWithZeroValue(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(0);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(0, $fieldDto->getValue());
+    }
+
+    public function testFieldWithNegativeValue(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(-123.45);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(-123.45, $fieldDto->getValue());
+    }
+
+    public function testRoundingBehaviorHalfUp(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(123.455);
+        $field->setNumDecimals(2);
+        $field->setRoundingMode(\NumberFormatter::ROUND_HALFUP);
+        $fieldDto = $this->configure($field);
+
+        self::assertMatchesRegularExpression('/123[.,]46/', $fieldDto->getFormattedValue());
+    }
+
+    public function testRoundingBehaviorDown(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(123.459);
+        $field->setNumDecimals(2);
+        $field->setRoundingMode(\NumberFormatter::ROUND_DOWN);
+        $fieldDto = $this->configure($field);
+
+        self::assertMatchesRegularExpression('/123[.,]45/', $fieldDto->getFormattedValue());
+    }
+
+    public function testRoundingBehaviorUp(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(123.451);
+        $field->setNumDecimals(2);
+        $field->setRoundingMode(\NumberFormatter::ROUND_UP);
+        $fieldDto = $this->configure($field);
+
+        self::assertMatchesRegularExpression('/123[.,]46/', $fieldDto->getFormattedValue());
+    }
+
+    public function testNumberFormatTakesPrecedenceOverSeparators(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(1234.5);
+        $field->setNumberFormat('%08.2f');
+        $field->setThousandsSeparator(' ');
+        $field->setDecimalSeparator(',');
+        $fieldDto = $this->configure($field);
+
+        // when numberFormat is set, it takes precedence over separators
+        // sprintf('%08.2f', 1234.5) = '01234.50'
+        self::assertSame('01234.50', $fieldDto->getFormattedValue());
+    }
+
+    public function testFormattedValueWithLargeNumber(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(9876543210.12);
+        $field->setThousandsSeparator(',');
+        $field->setNumDecimals(2);
+        $fieldDto = $this->configure($field);
+
+        self::assertStringContainsString('9,876,543,210', $fieldDto->getFormattedValue());
+    }
+
+    public function testFormattedValueWithSmallDecimal(): void
+    {
+        $field = NumberField::new('foo');
+        $field->setValue(0.00123);
+        $field->setNumDecimals(5);
+        $fieldDto = $this->configure($field);
+
+        self::assertMatchesRegularExpression('/0[.,]00123/', $fieldDto->getFormattedValue());
+    }
+}

--- a/tests/Field/PercentFieldTest.php
+++ b/tests/Field/PercentFieldTest.php
@@ -15,7 +15,7 @@ class PercentFieldTest extends AbstractFieldTest
         $this->configurator = new PercentConfigurator(new IntlFormatter());
     }
 
-    public function testFieldWithNullValues()
+    public function testFieldWithNullValues(): void
     {
         $field = PercentField::new('foo')->setValue(null);
         $fieldDto = $this->configure($field);
@@ -24,29 +24,32 @@ class PercentFieldTest extends AbstractFieldTest
         self::assertSame('%', $fieldDto->getCustomOption(PercentField::OPTION_SYMBOL));
     }
 
-    public function testFieldDefaultDecimalsAndFractional()
+    public function testFieldDefaultDecimalsAndFractional(): void
     {
         $field = PercentField::new('foo')->setValue(100.9874)->setStoredAsFractional(false);
         $fieldDto = $this->configure($field);
+
         self::assertSame(0, $fieldDto->getCustomOption(PercentField::OPTION_NUM_DECIMALS));
         self::assertSame(0, $fieldDto->getFormTypeOption('scale'));
         self::assertSame('101%', $fieldDto->getFormattedValue());
     }
 
-    public function testFieldDecimalsAndFractional()
+    public function testFieldDecimalsAndFractional(): void
     {
         $field = PercentField::new('foo')->setValue(100.1345)->setStoredAsFractional(false)->setNumDecimals(3);
         $fieldDto = $this->configure($field);
+
         self::assertSame(3, $fieldDto->getCustomOption(PercentField::OPTION_NUM_DECIMALS));
         self::assertSame(3, $fieldDto->getFormTypeOption('scale'));
-        self::assertSame('100.135%', $fieldDto->getFormattedValue());
+        self::assertMatchesRegularExpression('/100[.,]135%/', $fieldDto->getFormattedValue());
     }
 
-    public function testFieldSynmbolAndFractional()
+    public function testFieldSymbolAndFractional(): void
     {
-        $field = PercentField::new('foo')->setValue(100)->setSymbol(' %')->setStoredAsFractional(false);
+        $field = PercentField::new('foo')->setValue(1.0)->setSymbol(' %')->setStoredAsFractional();
         $fieldDto = $this->configure($field);
+
         self::assertSame('100 %', $fieldDto->getFormattedValue());
-        self::assertSame('integer', $fieldDto->getFormTypeOption('type'));
+        self::assertSame('fractional', $fieldDto->getFormTypeOption('type'));
     }
 }

--- a/tests/Field/SlugFieldTest.php
+++ b/tests/Field/SlugFieldTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\SlugConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\SlugField;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\SlugType;
+use function Symfony\Component\Translation\t;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+class SlugFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new SlugConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = SlugField::new('slug');
+        // we need to set target field for the configurator to work
+        $field->setTargetFieldName('title');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(SlugType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-text', $fieldDto->getCssClass());
+        self::assertSame('crud/field/text', $fieldDto->getTemplateName());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = SlugField::new('slug');
+        $field->setTargetFieldName('title');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithStringValue(): void
+    {
+        $field = SlugField::new('slug');
+        $field->setTargetFieldName('title');
+        $field->setValue('my-slug-value');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('my-slug-value', $fieldDto->getValue());
+    }
+
+    public function testSetTargetFieldNameWithString(): void
+    {
+        $field = SlugField::new('slug');
+        $field->setTargetFieldName('title');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(['title'], $fieldDto->getCustomOption(SlugField::OPTION_TARGET_FIELD_NAME));
+        self::assertSame('title', $fieldDto->getFormTypeOption('target'));
+    }
+
+    public function testSetTargetFieldNameWithArray(): void
+    {
+        $field = SlugField::new('slug');
+        $field->setTargetFieldName(['title', 'subtitle']);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(['title', 'subtitle'], $fieldDto->getCustomOption(SlugField::OPTION_TARGET_FIELD_NAME));
+        self::assertSame('title|subtitle', $fieldDto->getFormTypeOption('target'));
+    }
+
+    public function testWithoutTargetFieldNameThrowsException(): void
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $field = SlugField::new('slug');
+        $this->configure($field);
+    }
+
+    public function testSetUnlockConfirmationMessage(): void
+    {
+        $field = SlugField::new('slug');
+        $field->setTargetFieldName('title');
+        $field->setUnlockConfirmationMessage('Are you sure?');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('Are you sure?', $fieldDto->getCustomOption(SlugField::OPTION_UNLOCK_CONFIRMATION_MESSAGE));
+    }
+
+    public function testUnlockConfirmationMessageInFormTypeOptions(): void
+    {
+        $field = SlugField::new('slug');
+        $field->setTargetFieldName('title');
+        $field->setUnlockConfirmationMessage('Unlock confirmation');
+        $fieldDto = $this->configure($field);
+
+        // the confirmation message should be set as a data attribute
+        $confirmText = $fieldDto->getFormTypeOption('attr.data-confirm-text');
+        self::assertNotNull($confirmText);
+    }
+
+    public function testSetUnlockConfirmationMessageWithTranslatableInterface(): void
+    {
+        $field = SlugField::new('slug');
+        $field->setTargetFieldName('title');
+        $field->setUnlockConfirmationMessage(t('unlock.confirmation'));
+        $fieldDto = $this->configure($field);
+
+        $customOption = $fieldDto->getCustomOption(SlugField::OPTION_UNLOCK_CONFIRMATION_MESSAGE);
+        self::assertInstanceOf(TranslatableInterface::class, $customOption);
+    }
+
+    public function testUnlockConfirmationMessageWithSpecialCharacters(): void
+    {
+        $message = 'Are you sure? This <b>cannot</b> be "undone" & will change the URL\'s permanently!';
+        $field = SlugField::new('slug');
+        $field->setTargetFieldName('title');
+        $field->setUnlockConfirmationMessage($message);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($message, $fieldDto->getCustomOption(SlugField::OPTION_UNLOCK_CONFIRMATION_MESSAGE));
+        // the configurator wraps the message in a TranslatableMessage
+        $formTypeOption = $fieldDto->getFormTypeOption('attr.data-confirm-text');
+        self::assertInstanceOf(TranslatableMessage::class, $formTypeOption);
+        self::assertSame($message, $formTypeOption->getMessage());
+    }
+}

--- a/tests/Field/TelephoneFieldTest.php
+++ b/tests/Field/TelephoneFieldTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\TelephoneConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TelephoneField;
+use Symfony\Component\Form\Extension\Core\Type\TelType;
+
+class TelephoneFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new TelephoneConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = TelephoneField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('tel', $fieldDto->getFormTypeOption('attr.inputmode'));
+        self::assertSame(TelType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-telephone', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithValue(): void
+    {
+        $field = TelephoneField::new('foo');
+        $field->setValue('+1234567890');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('+1234567890', $fieldDto->getValue());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = TelephoneField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testInputModeIsNotOverriddenIfAlreadySet(): void
+    {
+        $field = TelephoneField::new('foo');
+        $field->setFormTypeOption('attr.inputmode', 'text');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('text', $fieldDto->getFormTypeOption('attr.inputmode'));
+    }
+}

--- a/tests/Field/TextEditorFieldTest.php
+++ b/tests/Field/TextEditorFieldTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextEditorField;
+use EasyCorp\Bundle\EasyAdminBundle\Form\Type\TextEditorType;
+
+class TextEditorFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // TextEditorField has no dedicated configurator
+        $this->configurator = new class implements FieldConfiguratorInterface {
+            public function supports(FieldDto $field, EntityDto $entityDto): bool
+            {
+                return TextEditorField::class === $field->getFieldFqcn();
+            }
+
+            public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
+            {
+                // No-op: TextEditorField has no special configuration logic
+            }
+        };
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = TextEditorField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getCustomOption(TextEditorField::OPTION_NUM_OF_ROWS));
+        self::assertNull($fieldDto->getCustomOption(TextEditorField::OPTION_TRIX_EDITOR_CONFIG));
+        self::assertSame(TextEditorType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-text_editor', $fieldDto->getCssClass());
+        self::assertSame('crud/field/text_editor', $fieldDto->getTemplateName());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = TextEditorField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithHtmlValue(): void
+    {
+        $htmlContent = '<p>This is <strong>rich</strong> text content.</p>';
+        $field = TextEditorField::new('foo');
+        $field->setValue($htmlContent);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($htmlContent, $fieldDto->getValue());
+    }
+
+    public function testSetNumOfRows(): void
+    {
+        $field = TextEditorField::new('foo');
+        $field->setNumOfRows(15);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(15, $fieldDto->getCustomOption(TextEditorField::OPTION_NUM_OF_ROWS));
+    }
+
+    public function testSetNumOfRowsThrowsExceptionForZeroOrNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        TextEditorField::new('foo')->setNumOfRows(0);
+    }
+
+    public function testSetTrixEditorConfig(): void
+    {
+        $config = [
+            'blockAttributes' => [
+                'default' => ['tagName' => 'p'],
+            ],
+        ];
+        $field = TextEditorField::new('foo');
+        $field->setTrixEditorConfig($config);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($config, $fieldDto->getCustomOption(TextEditorField::OPTION_TRIX_EDITOR_CONFIG));
+    }
+
+    public function testSetTrixEditorConfigWithEmptyArray(): void
+    {
+        $field = TextEditorField::new('foo');
+        $field->setTrixEditorConfig([]);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame([], $fieldDto->getCustomOption(TextEditorField::OPTION_TRIX_EDITOR_CONFIG));
+    }
+}

--- a/tests/Field/TextFieldTest.php
+++ b/tests/Field/TextFieldTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\TextConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+
+class TextFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new TextConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = TextField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getCustomOption(TextField::OPTION_MAX_LENGTH));
+        self::assertFalse($fieldDto->getCustomOption(TextField::OPTION_RENDER_AS_HTML));
+        self::assertFalse($fieldDto->getCustomOption(TextField::OPTION_STRIP_TAGS));
+        self::assertSame(TextType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-text', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = TextField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithStringValue(): void
+    {
+        $field = TextField::new('foo');
+        $field->setValue('Hello World');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('Hello World', $fieldDto->getValue());
+    }
+
+    public function testFieldTruncatesOnIndexPage(): void
+    {
+        $longText = str_repeat('a', 100);
+        $field = TextField::new('foo');
+        $field->setValue($longText);
+        $fieldDto = $this->configure($field);
+
+        // default max length on index page is 64
+        self::assertStringEndsWith('…', $fieldDto->getFormattedValue());
+        self::assertLessThanOrEqual(64, mb_strlen($fieldDto->getFormattedValue()));
+    }
+
+    public function testFieldDoesNotTruncateOnDetailPage(): void
+    {
+        $longText = str_repeat('a', 100);
+        $field = TextField::new('foo');
+        $field->setValue($longText);
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        // on detail page, max length is PHP_INT_MAX (effectively no truncation)
+        self::assertSame($longText, $fieldDto->getFormattedValue());
+    }
+
+    public function testSetMaxLength(): void
+    {
+        $field = TextField::new('foo');
+        $field->setValue('123456789012345');
+        $field->setMaxLength(10);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(10, $fieldDto->getCustomOption(TextField::OPTION_MAX_LENGTH));
+        self::assertLessThanOrEqual(10, mb_strlen($fieldDto->getFormattedValue()));
+    }
+
+    public function testSetMaxLengthThrowsExceptionForZeroOrNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        TextField::new('foo')->setMaxLength(0);
+    }
+
+    public function testRenderAsHtml(): void
+    {
+        $htmlContent = '<strong>Bold</strong> and <em>italic</em>';
+        $field = TextField::new('foo');
+        $field->setValue($htmlContent);
+        $field->renderAsHtml();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(TextField::OPTION_RENDER_AS_HTML));
+        // HTML content should be preserved, not escaped
+        self::assertSame($htmlContent, $fieldDto->getFormattedValue());
+    }
+
+    public function testRenderAsHtmlIgnoresMaxLength(): void
+    {
+        $htmlContent = '<strong>'.str_repeat('a', 100).'</strong>';
+        $field = TextField::new('foo');
+        $field->setValue($htmlContent);
+        $field->renderAsHtml();
+        $field->setMaxLength(10);
+        $fieldDto = $this->configure($field);
+
+        // when renderAsHtml is true, maxLength is ignored
+        self::assertSame($htmlContent, $fieldDto->getFormattedValue());
+    }
+
+    public function testStripTags(): void
+    {
+        $htmlContent = '<strong>Bold</strong> and <em>italic</em>';
+        $field = TextField::new('foo');
+        $field->setValue($htmlContent);
+        $field->stripTags();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(TextField::OPTION_STRIP_TAGS));
+        self::assertSame('Bold and italic', $fieldDto->getFormattedValue());
+    }
+
+    public function testHtmlEntitiesAreEscapedByDefault(): void
+    {
+        $field = TextField::new('foo');
+        $field->setValue('<script>alert("xss")</script>');
+        $fieldDto = $this->configure($field);
+
+        // HTML should be escaped by default
+        self::assertStringContainsString('&lt;script&gt;', $fieldDto->getFormattedValue());
+    }
+
+    public function testBackedEnumValue(): void
+    {
+        if (\PHP_VERSION_ID < 80100) {
+            $this->markTestSkipped('PHP 8.1 or higher is required to run this test.');
+        }
+
+        // create a backed enum for testing
+        $enumValue = Fixtures\ChoiceField\StatusBackedEnum::Draft;
+        $field = TextField::new('foo');
+        $field->setValue($enumValue);
+        $fieldDto = $this->configure($field);
+
+        // BackedEnum should be converted to its value
+        self::assertSame('draft', $fieldDto->getFormattedValue());
+    }
+}

--- a/tests/Field/TextareaFieldTest.php
+++ b/tests/Field/TextareaFieldTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\TextConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+
+class TextareaFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new TextConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = TextareaField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getCustomOption(TextareaField::OPTION_MAX_LENGTH));
+        self::assertSame(5, $fieldDto->getCustomOption(TextareaField::OPTION_NUM_OF_ROWS));
+        self::assertFalse($fieldDto->getCustomOption(TextareaField::OPTION_RENDER_AS_HTML));
+        self::assertFalse($fieldDto->getCustomOption(TextareaField::OPTION_STRIP_TAGS));
+        self::assertSame(TextareaType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-textarea', $fieldDto->getCssClass());
+    }
+
+    public function testFormTypeOptionsForTextarea(): void
+    {
+        $field = TextareaField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        // TextConfigurator sets rows and data attribute for TextareaField via nested attr
+        $attr = $fieldDto->getFormTypeOption('attr');
+        self::assertIsArray($attr);
+        self::assertSame(5, $attr['rows'] ?? null);
+        self::assertTrue($attr['data-ea-textarea-field'] ?? false);
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = TextareaField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFieldWithStringValue(): void
+    {
+        $field = TextareaField::new('foo');
+        $field->setValue("Line 1\nLine 2\nLine 3");
+        $fieldDto = $this->configure($field);
+
+        self::assertSame("Line 1\nLine 2\nLine 3", $fieldDto->getValue());
+    }
+
+    public function testSetNumOfRows(): void
+    {
+        $field = TextareaField::new('foo');
+        $field->setNumOfRows(10);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(10, $fieldDto->getCustomOption(TextareaField::OPTION_NUM_OF_ROWS));
+        $attr = $fieldDto->getFormTypeOption('attr');
+        self::assertIsArray($attr);
+        self::assertSame(10, $attr['rows'] ?? null);
+    }
+
+    public function testSetNumOfRowsThrowsExceptionForZeroOrNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        TextareaField::new('foo')->setNumOfRows(0);
+    }
+
+    public function testSetMaxLength(): void
+    {
+        $field = TextareaField::new('foo');
+        $field->setValue('123456789012345');
+        $field->setMaxLength(10);
+        $fieldDto = $this->configure($field);
+
+        self::assertSame(10, $fieldDto->getCustomOption(TextareaField::OPTION_MAX_LENGTH));
+        self::assertLessThanOrEqual(10, mb_strlen($fieldDto->getFormattedValue()));
+    }
+
+    public function testSetMaxLengthThrowsExceptionForZeroOrNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        TextareaField::new('foo')->setMaxLength(0);
+    }
+
+    public function testRenderAsHtml(): void
+    {
+        $htmlContent = '<p>Paragraph 1</p><p>Paragraph 2</p>';
+        $field = TextareaField::new('foo');
+        $field->setValue($htmlContent);
+        $field->renderAsHtml();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(TextareaField::OPTION_RENDER_AS_HTML));
+        self::assertSame($htmlContent, $fieldDto->getFormattedValue());
+    }
+
+    public function testStripTags(): void
+    {
+        $htmlContent = '<p>Paragraph 1</p><p>Paragraph 2</p>';
+        $field = TextareaField::new('foo');
+        $field->setValue($htmlContent);
+        $field->stripTags();
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(TextareaField::OPTION_STRIP_TAGS));
+        self::assertSame('Paragraph 1Paragraph 2', $fieldDto->getFormattedValue());
+    }
+
+    public function testFieldTruncatesOnIndexPage(): void
+    {
+        $longText = str_repeat('a', 100);
+        $field = TextareaField::new('foo');
+        $field->setValue($longText);
+        $fieldDto = $this->configure($field);
+
+        // default max length on index page is 64
+        self::assertStringEndsWith('…', $fieldDto->getFormattedValue());
+        self::assertLessThanOrEqual(64, mb_strlen($fieldDto->getFormattedValue()));
+    }
+
+    public function testFieldDoesNotTruncateOnDetailPage(): void
+    {
+        $longText = str_repeat('a', 100);
+        $field = TextareaField::new('foo');
+        $field->setValue($longText);
+        $fieldDto = $this->configure($field, Crud::PAGE_DETAIL, 'en', Action::DETAIL);
+
+        self::assertSame($longText, $fieldDto->getFormattedValue());
+    }
+}

--- a/tests/Field/TimeFieldTest.php
+++ b/tests/Field/TimeFieldTest.php
@@ -16,7 +16,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->configurator = new DateTimeConfigurator(new IntlFormatter());
     }
 
-    public function testFieldWithWrongTimezone()
+    public function testFieldWithWrongTimezone(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -24,7 +24,7 @@ class TimeFieldTest extends AbstractFieldTest
         $field->setTimezone('this-timezone-does-not-exist');
     }
 
-    public function testFieldWithoutTimezone()
+    public function testFieldWithoutTimezone(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);
@@ -33,7 +33,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertNull($fieldDto->getCustomOption(DateTimeField::OPTION_TIMEZONE));
     }
 
-    public function testFieldWithTimezone()
+    public function testFieldWithTimezone(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);
@@ -43,7 +43,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertSame('Europe/Madrid', $fieldDto->getCustomOption(DateTimeField::OPTION_TIMEZONE));
     }
 
-    public function testFieldWithWrongFormat()
+    public function testFieldWithWrongFormat(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -52,7 +52,7 @@ class TimeFieldTest extends AbstractFieldTest
         $field->setFormat(DateTimeField::FORMAT_NONE);
     }
 
-    public function testFieldWithEmptyFormat()
+    public function testFieldWithEmptyFormat(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -61,7 +61,7 @@ class TimeFieldTest extends AbstractFieldTest
         $field->setFormat('');
     }
 
-    public function testFieldWithPredefinedFormat()
+    public function testFieldWithPredefinedFormat(): void
     {
         $field = TimeField::new('foo')->setValue(new \DateTime('2006-01-02 15:04:05'));
         $field->setFieldFqcn(TimeField::class);
@@ -72,7 +72,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertSame('3:04:05 PM UTC', $fieldDto->getFormattedValue());
     }
 
-    public function testFieldWithCustomPattern()
+    public function testFieldWithCustomPattern(): void
     {
         $field = TimeField::new('foo')->setValue(new \DateTime('2006-01-02 15:04:05'));
         $field->setFieldFqcn(TimeField::class);
@@ -84,7 +84,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertMatchesRegularExpression('/^15:04:05 GMT(\+00:00)? PM$/', $fieldDto->getFormattedValue());
     }
 
-    public function testFieldDefaultWidget()
+    public function testFieldDefaultWidget(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);
@@ -93,7 +93,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(TimeField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsNativeWidget()
+    public function testFieldRenderAsNativeWidget(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);
@@ -105,7 +105,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertTrue($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotNativeWidget()
+    public function testFieldRenderAsNotNativeWidget(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);
@@ -115,7 +115,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_CHOICE, $fieldDto->getCustomOption(TimeField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsChoice()
+    public function testFieldRenderAsChoice(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);
@@ -127,7 +127,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertTrue($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotChoice()
+    public function testFieldRenderAsNotChoice(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);
@@ -137,7 +137,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertSame(DateTimeField::WIDGET_NATIVE, $fieldDto->getCustomOption(TimeField::OPTION_WIDGET));
     }
 
-    public function testFieldRenderAsText()
+    public function testFieldRenderAsText(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);
@@ -149,7 +149,7 @@ class TimeFieldTest extends AbstractFieldTest
         $this->assertFalse($fieldDto->getFormTypeOption('html5'));
     }
 
-    public function testFieldRenderAsNotText()
+    public function testFieldRenderAsNotText(): void
     {
         $field = TimeField::new('foo');
         $field->setFieldFqcn(TimeField::class);

--- a/tests/Field/TimezoneFieldTest.php
+++ b/tests/Field/TimezoneFieldTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
+
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\TimezoneConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TimezoneField;
+use Symfony\Component\Form\Extension\Core\Type\TimezoneType;
+
+class TimezoneFieldTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new TimezoneConfigurator();
+    }
+
+    public function testDefaultOptions(): void
+    {
+        $field = TimezoneField::new('foo');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('ea-autocomplete', $fieldDto->getFormTypeOption('attr.data-ea-widget'));
+        self::assertTrue($fieldDto->getFormTypeOption('intl'));
+        self::assertFalse($fieldDto->getFormTypeOption('choice_translation_domain'));
+        self::assertSame(TimezoneType::class, $fieldDto->getFormType());
+        self::assertStringContainsString('field-timezone', $fieldDto->getCssClass());
+    }
+
+    public function testFieldWithValue(): void
+    {
+        $field = TimezoneField::new('foo');
+        $field->setValue('Europe/Madrid');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('Europe/Madrid', $fieldDto->getValue());
+    }
+
+    public function testFieldWithNullValue(): void
+    {
+        $field = TimezoneField::new('foo');
+        $field->setValue(null);
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getValue());
+    }
+
+    public function testFormTypeOptionsAreNotOverriddenIfAlreadySet(): void
+    {
+        $field = TimezoneField::new('foo');
+        $field->setFormTypeOption('attr.data-ea-widget', 'custom-widget');
+        $field->setFormTypeOption('intl', false);
+        $field->setFormTypeOption('choice_translation_domain', 'messages');
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('custom-widget', $fieldDto->getFormTypeOption('attr.data-ea-widget'));
+        self::assertFalse($fieldDto->getFormTypeOption('intl'));
+        self::assertSame('messages', $fieldDto->getFormTypeOption('choice_translation_domain'));
+    }
+}

--- a/tests/Field/UrlFieldTest.php
+++ b/tests/Field/UrlFieldTest.php
@@ -13,7 +13,7 @@ class UrlFieldTest extends AbstractFieldTest
         parent::setUp();
     }
 
-    public function testDefaultFieldOptions()
+    public function testDefaultFieldOptions(): void
     {
         $this->initializeConfigurator();
 
@@ -30,7 +30,7 @@ class UrlFieldTest extends AbstractFieldTest
      *           ["https"]
      *           ["ftp"]
      */
-    public function testDefaultProtocolOption(string $defaultProtocol)
+    public function testDefaultProtocolOption(string $defaultProtocol): void
     {
         $this->initializeConfigurator();
 
@@ -49,7 +49,7 @@ class UrlFieldTest extends AbstractFieldTest
      *           ["https://www.example.com", "example.com"]
      *           ["https://01234567890123456789012345678901234567890123456789.com", "0123456789012345678901234567890…"]
      */
-    public function testFormattedValuesOnIndexAction(string $url, string $expectedRenderedUrl)
+    public function testFormattedValuesOnIndexAction(string $url, string $expectedRenderedUrl): void
     {
         $this->initializeConfigurator();
 


### PR DESCRIPTION
This PR adds all the missing tests for field classes and adds new tests in existing field tests.

I know some of these tests are very simple and boring, but it's a good thing to have them to prevent changing any option or default behavior unawarely.