### PR TITLE
Fix subsection title in choice field documentation

### DIFF
--- a/doc/fields/ChoiceField.rst
+++ b/doc/fields/ChoiceField.rst
@@ -145,7 +145,7 @@ for the field. These options are defined in the same way as Symfony Forms:
     );
 
 PHP Enums Support
-·················
+.................
 
 The ``setChoices`` option supports PHP enums too, both UnitEnum and BackedEnum.
 Suppose you have this backed enum defined somewhere in your project::


### PR DESCRIPTION
The PHP Enums Support subsection title was not rendering properly.

<img width="226" height="41" alt="image" src="https://github.com/user-attachments/assets/eb04bce1-c2bc-4edc-be90-f8b8414d4013" />