### PR TITLE
Allow to customize rendered length of CollectionField

### DIFF
--- a/src/Field/CollectionField.php
+++ b/src/Field/CollectionField.php
@@ -25,6 +25,7 @@ final class CollectionField implements FieldInterface
     public const OPTION_ENTRY_CRUD_CONTROLLER_FQCN = 'entryCrudControllerFqcn';
     public const OPTION_ENTRY_CRUD_NEW_PAGE_NAME = 'entryCrudNewPageName';
     public const OPTION_ENTRY_CRUD_EDIT_PAGE_NAME = 'entryCrudEditPageName';
+    public const OPTION_MAX_LENGTH = 'maxLength';
 
     /**
      * @param TranslatableInterface|string|false|null $label
@@ -49,7 +50,8 @@ final class CollectionField implements FieldInterface
             ->setCustomOption(self::OPTION_ENTRY_USES_CRUD_FORM, false)
             ->setCustomOption(self::OPTION_ENTRY_CRUD_CONTROLLER_FQCN, null)
             ->setCustomOption(self::OPTION_ENTRY_CRUD_NEW_PAGE_NAME, null)
-            ->setCustomOption(self::OPTION_ENTRY_CRUD_EDIT_PAGE_NAME, null);
+            ->setCustomOption(self::OPTION_ENTRY_CRUD_EDIT_PAGE_NAME, null)
+            ->setCustomOption(self::OPTION_MAX_LENGTH, null);
     }
 
     public function allowAdd(bool $allow = true): self

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -107,8 +107,9 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
         }
 
         $isDetailAction = Action::DETAIL === $context->getCrud()->getCurrentAction();
+        $maxLength = $field->getCustomOption(CollectionField::OPTION_MAX_LENGTH) ?? ($isDetailAction ? 512 : 32);
 
-        return u(', ')->join($collectionItemsAsText)->truncate($isDetailAction ? 512 : 32, '…')->toString();
+        return u(', ')->join($collectionItemsAsText)->truncate($maxLength, '…')->toString();
     }
 
     private function countNumElements(mixed $collection): int


### PR DESCRIPTION
Right now it is fixed to 32 (or 512) characters. This commit add custom option 'maxLength' (similar to one in TextField) that allows to override the hard-coded value.
