### PR TITLE
PHP CS Fixer cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.php_cs.cache
 .php-cs-fixer.cache
 composer.lock
 .phpunit.result.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,7 +4,7 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->ignoreDotFiles(true)
     ->ignoreVCS(true)
-    ->exclude(array('build', 'vendor'))
+    ->exclude('vendor')
     ->files()
     ->name('*.php')
 ;
@@ -14,13 +14,11 @@ return (new PhpCsFixer\Config())
     ->setUsingCache(true)
     ->setRiskyAllowed(true)
     ->setFinder($finder)
-    ->setRules(array(
+    ->setRules([
         '@Symfony' => true,
         '@Symfony:risky' => true,
         '@PHPUnit48Migration:risky' => true,
-        'array_syntax' => ['syntax' => 'short'],
         'fopen_flags' => false,
-        'ordered_imports' => true,
         'protected_to_private' => false,
         'native_function_invocation' => ['exclude' => ['sprintf']],
         // Part of future @Symfony ruleset in PHP-CS-Fixer To be removed from the config file once upgrading
@@ -34,5 +32,5 @@ return (new PhpCsFixer\Config())
         'phpdoc_to_comment' => false,
         // Override @Symfony ruleset to keep mixed return type for PHPStan
         'no_superfluous_phpdoc_tags' => ['allow_hidden_params' => true, 'allow_mixed' => true, 'remove_inheritdoc' => true],
-    ))
+    ])
 ;

--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -7,8 +7,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonElement;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonStyle;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonType;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonVariant;
-use function Symfony\Component\String\u;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\String\u;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Config/ActionGroup.php
+++ b/src/Config/ActionGroup.php
@@ -4,8 +4,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionGroupDto;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonVariant;
-use function Symfony\Component\String\u;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\String\u;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -9,8 +9,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableMessageBuilder;
 use Symfony\Component\ExpressionLanguage\Expression;
-use function Symfony\Component\Translation\t;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -25,8 +25,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonVariant;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
-use function Symfony\Component\Translation\t;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -29,9 +29,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Registry\TemplateRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use function Symfony\Component\String\u;
 use function Symfony\Component\Translation\t;
-use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -17,8 +17,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
-use function Symfony\Component\Translation\t;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -12,10 +12,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableChoiceMessage;
 use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableChoiceMessageCollection;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EnumType;
-use function Symfony\Component\String\u;
-use function Symfony\Component\Translation\t;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\String\u;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Field/Configurator/CommonPostConfigurator.php
+++ b/src/Field/Configurator/CommonPostConfigurator.php
@@ -8,8 +8,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
-use function Symfony\Component\String\u;
 use Twig\Markup;
+use function Symfony\Component\String\u;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -17,9 +17,9 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Symfony\Contracts\Translation\TranslatableInterface;
 use function Symfony\Component\String\u;
 use function Symfony\Component\Translation\t;
-use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Field/Configurator/SlugConfigurator.php
+++ b/src/Field/Configurator/SlugConfigurator.php
@@ -7,8 +7,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\SlugField;
-use function Symfony\Component\Translation\t;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Filter/Configurator/CommonConfigurator.php
+++ b/src/Filter/Configurator/CommonConfigurator.php
@@ -7,8 +7,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
-use function Symfony\Component\String\u;
 use Symfony\Component\Translation\TranslatableMessage;
+use function Symfony\Component\String\u;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>

--- a/src/Translation/TranslatableMessageBuilder.php
+++ b/src/Translation/TranslatableMessageBuilder.php
@@ -2,9 +2,9 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Translation;
 
-use function Symfony\Component\Translation\t;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Jakub Caban <kuba.iluvatar@gmail.com>

--- a/tests/Field/SlugFieldTest.php
+++ b/tests/Field/SlugFieldTest.php
@@ -5,9 +5,9 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\SlugConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\SlugField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\SlugType;
-use function Symfony\Component\Translation\t;
 use Symfony\Component\Translation\TranslatableMessage;
 use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\Translation\t;
 
 class SlugFieldTest extends AbstractFieldTest
 {


### PR DESCRIPTION
I did multiple commits for easier review, please feel free to turn it into one commit.

See:
- for old cache file: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/9fdbf50f8640047d7a4f52da4953f5683404739e/UPGRADE-v3.md?plain=1#L13
- for old `build/` dir in EA I only found hints like here: https://github.com/EasyCorp/EasyAdminBundle/commit/793739dc9a845cfe576d0cde89ec2873ad55a858#diff-fb956de15e3155f7f2ad0c757a52896d4e56090736bb3b8b779167b4a58204aaR40 - I think it was used in the past as build dir for functional tests in EA
- array_syntax: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/src/RuleSet/Sets/PERCS2x0Set.php
- ordered_imports: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/9fdbf50f8640047d7a4f52da4953f5683404739e/src/RuleSet/Sets/SymfonySet.php#L147