### PR TITLE
Add linkToUrl method call in ActionDto::getAsConfigObject()

### DIFF
--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -399,6 +399,10 @@ final class ActionDto
             $action->linkToRoute($this->routeName, $this->routeParameters);
         }
 
+        if (null !== $this->url) {
+            $action->linkToUrl($this->url);
+        }
+
         if (null !== $this->displayCallable) {
             $action->displayIf($this->displayCallable);
         }


### PR DESCRIPTION
I have made a small implementation fixing an issue I was facing when :
- defining an action as a link
- but call `update()` which calls "ActionDto::getAsConfigObject()" and doesn't transfer the url to the resulting dto.

I would appreciate if this could be considered as a fix or any other alternative.