### PR TITLE
Display the main action icon in split buttons

### DIFF
--- a/templates/crud/action_group.html.twig
+++ b/templates/crud/action_group.html.twig
@@ -12,7 +12,7 @@
             href="{{ main_action.htmlElement.isLink ? main_action.linkUrl : null }}"
             action="{{ main_action.htmlElement.isForm ? main_action.linkUrl : null }}"
             method="{{ main_action.htmlElement.isForm ? 'POST' : null }}"
-            icon="{{ group.icon }}"
+            icon="{{ main_action.icon ?: group.icon }}"
             htmlAttributes="{{ main_action.htmlAttributes|merge({'data-action-group-name-main-action': true, onclick: main_action.htmlElement.isButton ? 'window.location=\'' ~ main_action.linkUrl ~ '\'' : null})|filter((v) => v is not null) }}"
         >
             {% set main_action_label = main_action.label|trans %}

--- a/tests/Controller/ActionGroupsCrudControllerTest.php
+++ b/tests/Controller/ActionGroupsCrudControllerTest.php
@@ -65,6 +65,22 @@ class ActionGroupsCrudControllerTest extends AbstractCrudTestCase
         static::assertGreaterThanOrEqual(2, $splitDropdown->filter('.dropdown-menu .dropdown-item')->count(), 'Split dropdown should have at least 2 actions');
     }
 
+    public function testSplitButtonMainActionIconInIndexPage(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        // find the split button for group2global which has an icon on the main action
+        $splitDropdown = $crawler->filter('.action-group[data-action-group-name="group2global"]');
+        static::assertCount(1, $splitDropdown, 'Should have group2global action group');
+
+        $mainAction = $splitDropdown->filter('[data-action-group-name-main-action]');
+        static::assertCount(1, $mainAction, 'Split dropdown should have a main action');
+
+        // verify the main action has the icon
+        $icon = $mainAction->filter('i.fa-star, .btn-icon i.fa-star');
+        static::assertCount(1, $icon, 'Main action in split button should display its icon');
+    }
+
     public function testActionGroupsWithHeadersAndDividersInIndexPage(): void
     {
         $crawler = $this->client->request('GET', $this->generateIndexUrl());

--- a/tests/TestApplication/src/Controller/ActionGroupsCrudController.php
+++ b/tests/TestApplication/src/Controller/ActionGroupsCrudController.php
@@ -50,7 +50,7 @@ class ActionGroupsCrudController extends AbstractCrudController
             ->addAction(Action::new('action2', 'Action 2')->linkToCrudAction('delete'));
         $group2Global = ActionGroup::new('group2global', 'Global Action Group 2')
             ->createAsGlobalActionGroup()
-            ->addMainAction(Action::new('main_action', 'Main Action')->linkToCrudAction('aGlobalAction'))
+            ->addMainAction(Action::new('main_action', 'Main Action')->setIcon('fa fa-star')->linkToCrudAction('aGlobalAction'))
             ->addAction(Action::new('action1', 'Action 1')->linkToCrudAction('aGlobalAction'))
             ->addAction(Action::new('action2', 'Action 2')->linkToCrudAction('aGlobalAction'));
 


### PR DESCRIPTION
When setting an action as the main action of an action group, its icon is lost. We now display it and fall back to the action group icon, which is also configurable.