### PR TITLE
Do not exclude AdminRouterSubscriberTest from test suite & rewrite un…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
         "symfony/web-link": "^5.4|^6.0|^7.0|^8.0",
         "vincentlanglet/twig-cs-fixer": "^3.10"
     },
+    "conflict": {
+        "symfony/error-handler": "<5.4.35"
+    },
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,7 +19,6 @@
         <testsuite name="EasyAdmin Test Suite">
             <directory>tests/</directory>
             <exclude>tests/Controller/PrettyUrls/</exclude>
-            <exclude>tests/EventListener/</exclude>
             <exclude>tests/Form/</exclude>
         </testsuite>
     </testsuites>

--- a/tests/EventListener/ExceptionListenerTest.php
+++ b/tests/EventListener/ExceptionListenerTest.php
@@ -2,81 +2,120 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\EventListener;
 
+use EasyCorp\Bundle\EasyAdminBundle\Context\ExceptionContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener;
-use EasyCorp\Bundle\EasyAdminBundle\Exception\EntityNotFoundException as EasyEntityNotFoundException;
+use EasyCorp\Bundle\EasyAdminBundle\Exception\BaseException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Twig\Environment;
+use Twig\Error\RuntimeError;
+use Twig\Loader\ArrayLoader;
 
 class ExceptionListenerTest extends TestCase
 {
-    private function getTwig()
+    /**
+     * @dataProvider unhandledException
+     */
+    public function testUnhandledException(bool $kernelDebug, bool $contextIsNull, \Exception $exception): void
     {
-        $twig = $this->getMockBuilder('\Twig_Environment')->disableOriginalConstructor()->getMock();
-        $twig->method('render')->willReturn('template content');
+        $contextProvider = $this->createMock(AdminContextProviderInterface::class);
+        if (!$contextIsNull) {
+            $context = $this->createMock(AdminContextInterface::class);
+            $context->method('getTemplatePath')->willReturn('foo');
+            $contextProvider->method('getContext')->willReturn($context);
+        }
 
-        return $twig;
+        $listener = new ExceptionListener(
+            $kernelDebug,
+            $contextProvider,
+            $this->createMock(Environment::class),
+        );
+
+        $expectedMessage = $exception->getMessage();
+
+        $listener->onKernelException($exceptionEvent = $this->createExceptionEvent($exception));
+
+        $this->assertSame($expectedMessage, $exceptionEvent->getThrowable()->getMessage());
+        $this->assertNull($exceptionEvent->getResponse());
     }
 
-    private function getEventExceptionThatShouldBeCalledOnce($exception)
+    public static function unhandledException(): \Generator
     {
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->method('getException')->willReturn($exception);
-        $event->method('getRequest')->willReturn(new Request());
-        $event->method('getKernel')->willReturn(new TestKernel());
-        $event->expects($this->once())->method('setResponse');
-
-        return $event;
+        yield [true, true, new \Exception()];
+        yield [true, false, new \Exception()];
+        yield [false, true, new \Exception()];
+        yield [false, false, new \Exception()];
+        yield [true, true, new RuntimeError('foo')];
+        yield [true, false, new RuntimeError('foo')];
+        yield [false, true, new RuntimeError('foo')];
+        yield [false, false, new RuntimeError('foo')];
+        yield [true, true, new class(new ExceptionContext('foo')) extends BaseException {}];
+        yield [true, false, new class(new ExceptionContext('foo')) extends BaseException {}];
+        yield [false, true, new class(new ExceptionContext('foo')) extends BaseException {}];
     }
 
-    public function testCatchBaseExceptions(): void
+    public function testAppendMessage(): void
     {
-        $exception = new EasyEntityNotFoundException([
-            'entity_name' => 'Test',
-            'entity_id_name' => 'Test key',
-            'entity_id_value' => 2,
-        ]);
-        $event = $this->getEventExceptionThatShouldBeCalledOnce($exception);
-        $twig = $this->getTwig();
+        $listener = new ExceptionListener(
+            true,
+            $this->createMock(AdminContextProviderInterface::class),
+            $this->createMock(Environment::class),
+        );
 
-        $listener = new ExceptionListener($twig, []);
-        $listener->onKernelException($event);
+        $exception = new RuntimeError('Variable "ea" does not exist.');
+        $listener->onKernelException($exceptionEvent = $this->createExceptionEvent($exception));
+
+        $expectedMessage = <<<MESSAGE
+Variable "ea" does not exist.
+
+The "ea" variable stores the admin context (menu items, actions, fields, etc.) and it's created automatically for requests served by EasyAdmin.
+
+If you are seeing this error, you are trying to use some EasyAdmin features in a request not served by EasyAdmin. For example, some of your custom actions may be trying to render or extend from one of the templates provided EasyAdmin.
+
+Your request must meet one of these conditions to be served by EasyAdmin (and to have the "ea" variable defined):
+
+1) It must be run by a controller that implements DashboardControllerInterface. This is done automatically for all actions and CRUD controllers associated to your dashboard.
+
+2) It must contain an "eaContext" query string parameter that identifies the Dashboard associated to this request (this parameter is automatically added by EasyAdmin when creating menu items that link to custom Symfony routes).
+MESSAGE;
+
+        $this->assertSame($expectedMessage, $exceptionEvent->getThrowable()->getMessage());
+        $this->assertNull($exceptionEvent->getResponse());
     }
 
-    private function getEventExceptionThatShouldNotBeCalled($exception)
+    public function testResponse(): void
     {
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $event->method('getException')->willReturn($exception);
-        $event->method('getRequest')->willReturn(new Request());
-        $event->expects($this->never())->method('setResponse');
+        $contextProvider = $this->createMock(AdminContextProviderInterface::class);
+        $context = $this->createMock(AdminContextInterface::class);
+        $context->method('getTemplatePath')->willReturn('@EasyAdmin/exception.html.twig');
+        $contextProvider->method('getContext')->willReturn($context);
+        $listener = new ExceptionListener(
+            false,
+            $contextProvider,
+            new Environment(new ArrayLoader(['@EasyAdmin/exception.html.twig' => '{{ exception.publicMessage }}'])),
+        );
 
-        return $event;
+        $exception = new class(new ExceptionContext('foo')) extends BaseException {};
+
+        $expectedStatusCode = $exception->getStatusCode();
+
+        $listener->onKernelException($exceptionEvent = $this->createExceptionEvent($exception));
+
+        $this->assertSame($expectedStatusCode, $exceptionEvent->getResponse()->getStatusCode());
+        $this->assertSame('foo', $exceptionEvent->getResponse()->getContent());
     }
 
-    public function testShouldNotCatchExceptionsWithSameName(): void
+    private function createExceptionEvent(\Exception $exception): ExceptionEvent
     {
-        $exception = new EntityNotFoundException();
-        $event = $this->getEventExceptionThatShouldNotBeCalled($exception);
-        $twig = $this->getTwig();
-
-        $listener = new ExceptionListener($twig, []);
-        $listener->onKernelException($event);
-    }
-}
-
-class EntityNotFoundException extends \Exception
-{
-}
-
-class TestKernel implements HttpKernelInterface
-{
-    public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
-    {
-        return new Response('foo');
+        return new ExceptionEvent(
+            $this->createStub(HttpKernelInterface::class),
+            Request::create('/'),
+            HttpKernelInterface::MAIN_REQUEST,
+            $exception,
+        );
     }
 }


### PR DESCRIPTION
…used ExceptionListenerTest which would not work anymore & add a conflict to composer.json to fix method signature missmatch

Note on the conflict in `composer.json`: the following method signature is not compatible with `symfony/error-handler` lower than `5.4.35` and throws a fatal error if a lower version is used:

```php
final class FlattenException extends BaseFlattenException
{
    public static function create(\Exception $exception, ?int $statusCode = null, array $headers = []): static
```

