### PR TITLE
Add return types for CrudControllerInterface

### DIFF
--- a/src/Contracts/Controller/CrudControllerInterface.php
+++ b/src/Contracts/Controller/CrudControllerInterface.php
@@ -47,20 +47,15 @@ interface CrudControllerInterface
      */
     public function configureFields(string $pageName): iterable;
 
-    /** @return KeyValueStore|Response */
-    public function index(AdminContext $context);
+    public function index(AdminContext $context): KeyValueStore|Response;
 
-    /** @return KeyValueStore|Response */
-    public function detail(AdminContext $context);
+    public function detail(AdminContext $context): KeyValueStore|Response;
 
-    /** @return KeyValueStore|Response */
-    public function edit(AdminContext $context);
+    public function edit(AdminContext $context): KeyValueStore|Response;
 
-    /** @return KeyValueStore|Response */
-    public function new(AdminContext $context);
+    public function new(AdminContext $context): KeyValueStore|Response;
 
-    /** @return KeyValueStore|Response */
-    public function delete(AdminContext $context);
+    public function delete(AdminContext $context): KeyValueStore|Response;
 
     public function autocomplete(AdminContext $context): JsonResponse;
 
@@ -74,26 +69,24 @@ interface CrudControllerInterface
     /**
      * @param class-string<TEntity> $entityFqcn
      *
-     * @return object
-     *
      * @phpstan-return TEntity
      */
-    public function createEntity(string $entityFqcn);
+    public function createEntity(string $entityFqcn): object;
 
     /**
      * @param TEntity $entityInstance
      */
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void;
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void;
 
     /**
      * @param TEntity $entityInstance
      */
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void;
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void;
 
     /**
      * @param TEntity $entityInstance
      */
-    public function deleteEntity(EntityManagerInterface $entityManager, $entityInstance): void;
+    public function deleteEntity(EntityManagerInterface $entityManager, object $entityInstance): void;
 
     /**
      * @param EntityDto<TEntity> $entityDto

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -120,7 +120,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         ]);
     }
 
-    public function index(AdminContext $context)
+    public function index(AdminContext $context): KeyValueStore|Response
     {
         $event = new BeforeCrudActionEvent($context);
         $this->container->get('event_dispatcher')->dispatch($event);
@@ -170,7 +170,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $responseParameters;
     }
 
-    public function detail(AdminContext $context)
+    public function detail(AdminContext $context): KeyValueStore|Response
     {
         $event = new BeforeCrudActionEvent($context);
         $this->container->get('event_dispatcher')->dispatch($event);
@@ -205,7 +205,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $responseParameters;
     }
 
-    public function edit(AdminContext $context)
+    public function edit(AdminContext $context): KeyValueStore|Response
     {
         $event = new BeforeCrudActionEvent($context);
         $this->container->get('event_dispatcher')->dispatch($event);
@@ -288,7 +288,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $responseParameters;
     }
 
-    public function new(AdminContext $context)
+    public function new(AdminContext $context): KeyValueStore|Response
     {
         $event = new BeforeCrudActionEvent($context);
         $this->container->get('event_dispatcher')->dispatch($event);
@@ -349,7 +349,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $responseParameters;
     }
 
-    public function delete(AdminContext $context)
+    public function delete(AdminContext $context): KeyValueStore|Response
     {
         $event = new BeforeCrudActionEvent($context);
         $this->container->get('event_dispatcher')->dispatch($event);
@@ -524,24 +524,24 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $this->configureResponseParameters($responseParameters);
     }
 
-    public function createEntity(string $entityFqcn)
+    public function createEntity(string $entityFqcn): object
     {
         return new $entityFqcn();
     }
 
-    public function updateEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $entityManager->persist($entityInstance);
         $entityManager->flush();
     }
 
-    public function persistEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $entityManager->persist($entityInstance);
         $entityManager->flush();
     }
 
-    public function deleteEntity(EntityManagerInterface $entityManager, $entityInstance): void
+    public function deleteEntity(EntityManagerInterface $entityManager, object $entityInstance): void
     {
         $entityManager->remove($entityInstance);
         $entityManager->flush();

--- a/tests/AdminRouteTestApplication/src/Controller/BuiltInActionCrudController.php
+++ b/tests/AdminRouteTestApplication/src/Controller/BuiltInActionCrudController.php
@@ -3,9 +3,11 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Controller;
 
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\AdminRouteTestApplication\Entity\Product;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Test CRUD controller that overrides the route names and paths of built-in CRUD actions.
@@ -21,28 +23,28 @@ class BuiltInActionCrudController extends AbstractCrudController
 
     // override the 'index' action with a custom route name
     #[AdminRoute(name: 'list')]
-    public function index(AdminContext $context)
+    public function index(AdminContext $context): KeyValueStore|Response
     {
         return parent::index($context);
     }
 
     // override the 'new' action with a custom route name and path
     #[AdminRoute(path: '/create', name: 'create')]
-    public function new(AdminContext $context)
+    public function new(AdminContext $context): KeyValueStore|Response
     {
         return parent::new($context);
     }
 
     // override the 'edit' action with a custom route name
     #[AdminRoute(name: 'update')]
-    public function edit(AdminContext $context)
+    public function edit(AdminContext $context): KeyValueStore|Response
     {
         return parent::edit($context);
     }
 
     // override the 'detail' action with a custom route name
     #[AdminRoute(name: 'show')]
-    public function detail(AdminContext $context)
+    public function detail(AdminContext $context): KeyValueStore|Response
     {
         return parent::detail($context);
     }

--- a/tests/Functional/PrettyUrlsApp/src/Controller/UserCrudController.php
+++ b/tests/Functional/PrettyUrlsApp/src/Controller/UserCrudController.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\PrettyUrlsApp\Controller;
 
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
@@ -25,25 +26,25 @@ class UserCrudController extends AbstractCrudController
     }
 
     #[AdminRoute('/custom/path-for-index', 'custom_route_for_index')]
-    public function index(AdminContext $context)
+    public function index(AdminContext $context): KeyValueStore|Response
     {
         return parent::index($context);
     }
 
     #[AdminRoute('/custom/path-for-detail/{entityId}')]
-    public function detail(AdminContext $context)
+    public function detail(AdminContext $context): KeyValueStore|Response
     {
         return parent::detail($context);
     }
 
     #[AdminRoute(name: 'custom_route_for_new')]
-    public function new(AdminContext $context)
+    public function new(AdminContext $context): KeyValueStore|Response
     {
         return parent::new($context);
     }
 
     // this action doesn't use the #[AdminRoute] attribute on purpose to test default behavior
-    public function edit(AdminContext $context)
+    public function edit(AdminContext $context): KeyValueStore|Response
     {
         return parent::edit($context);
     }

--- a/tests/TestApplication/src/Controller/UserCrudController.php
+++ b/tests/TestApplication/src/Controller/UserCrudController.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\TestApplication\Controller;
 
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
@@ -40,25 +41,25 @@ class UserCrudController extends AbstractCrudController
     }
 
     #[AdminRoute('/custom/path-for-index', 'custom_route_for_index')]
-    public function index(AdminContext $context)
+    public function index(AdminContext $context): KeyValueStore|Response
     {
         return parent::index($context);
     }
 
     #[AdminRoute('/custom/path-for-detail/{entityId}')]
-    public function detail(AdminContext $context)
+    public function detail(AdminContext $context): KeyValueStore|Response
     {
         return parent::detail($context);
     }
 
     #[AdminRoute(name: 'custom_route_for_new')]
-    public function new(AdminContext $context)
+    public function new(AdminContext $context): KeyValueStore|Response
     {
         return parent::new($context);
     }
 
     // this action doesn't use the #[AdminRoute] attribute on purpose to test default behavior
-    public function edit(AdminContext $context)
+    public function edit(AdminContext $context): KeyValueStore|Response
     {
         return parent::edit($context);
     }


### PR DESCRIPTION
For a new major version it is maybe ok to add return types without adding a deprecation on 4.x.