### PR TITLE
Add final keyword to Config/Crud and Config/Cache

### DIFF
--- a/src/Config/Cache.php
+++ b/src/Config/Cache.php
@@ -2,7 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
-class Cache
+final class Cache
 {
     public const ROUTE_NAME_TO_ATTRIBUTES = 'easyadmin.routes.route_to_fqcn';
     public const ROUTE_ATTRIBUTES_TO_NAME = 'easyadmin.routes.fqcn_to_route';

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -14,7 +14,7 @@ use Symfony\Contracts\Translation\TranslatableInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class Crud
+final class Crud
 {
     public const PAGE_DETAIL = 'detail';
     public const PAGE_EDIT = 'edit';


### PR DESCRIPTION
All other classes in `src/Config` are final. I guess it wasn't on purpose to omit `final` in these two classes. In 5.x it can be added I guess.