### PR TITLE
Allow to set translations for entities and their properties

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,7 @@ Table of Contents
   permissions, conditional display)
 * :doc:`Security </security>` (access control, menu/action/field/entity permissions,
   custom voters)
+* :doc:`Translations </translations>`
 * :doc:`Events </events>` (entity events, CRUD events, JavaScript events)
 * :doc:`Tests </tests>` (functional testing, utilities, assertions)
 * :doc:`Upgrade </upgrade>` (from legacy versions)

--- a/doc/translations.rst
+++ b/doc/translations.rst
@@ -1,0 +1,25 @@
+Translations
+============
+
+EasyAdmin allows to set labels for menu items, fields, etc. If you omit
+the label or set it to ``null`` EasyAdmin will try to auto-generate a
+label in various places. For entities and their properties you can add
+project-wide translations which will be used by default:
+
+    // translations/EasyAdminBundle.en.php
+    return [
+        'entities' => [
+            App\Entity\Developer::class => [
+                'singular' => 'Dev',
+                'plural' => 'Devs',
+                'properties' => [
+                    'name' => 'Name :)'
+                    'favouriteProject' => 'Favorite project :)',
+                ],
+            ],
+            App\Entity\DeveloperCategory::class => [
+                'singular' => 'Category',
+                'plural' => 'Categories',
+            ],
+        ],
+    ];

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -2,15 +2,17 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableEntity;
 use Symfony\Component\Uid\AbstractUid;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
- * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToCrud()
+ * @see \EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToCrud()
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
@@ -18,15 +20,22 @@ final class CrudMenuItem implements MenuItemInterface
 {
     use MenuItemTrait;
 
-    public function __construct(TranslatableInterface|string $label, ?string $icon, string $entityFqcn)
+    private bool $autoTranslateEntity = false;
+
+    public function __construct(TranslatableInterface|string|null $label, ?string $icon, string $entityFqcn)
     {
+        if (null === $label) {
+            $this->autoTranslateEntity = true;
+            $label = new TranslatableEntity($entityFqcn, false);
+        }
+
         $this->dto = new MenuItemDto();
 
         $this->dto->setType(MenuItemDto::TYPE_CRUD);
         $this->dto->setLabel($label);
         $this->dto->setIcon($icon);
         $this->dto->setRouteParameters([
-            EA::CRUD_ACTION => 'index',
+            EA::CRUD_ACTION => Action::INDEX,
             EA::CRUD_CONTROLLER_FQCN => null,
             EA::ENTITY_FQCN => $entityFqcn,
             EA::ENTITY_ID => null,
@@ -52,6 +61,13 @@ final class CrudMenuItem implements MenuItemInterface
 
     public function setAction(string $actionName): self
     {
+        if ($this->autoTranslateEntity) {
+            $this->dto->setLabel(new TranslatableEntity(
+                $this->dto->getRouteParameters()[EA::ENTITY_FQCN],
+                Action::INDEX !== $actionName,
+            ));
+        }
+
         $this->dto->setRouteParameters(array_merge(
             $this->dto->getRouteParameters(),
             [EA::CRUD_ACTION => $actionName]

--- a/src/Config/MenuItem.php
+++ b/src/Config/MenuItem.php
@@ -24,7 +24,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function linkToCrud(TranslatableInterface|string $label, ?string $icon, string $entityFqcn): CrudMenuItem
+    public static function linkToCrud(TranslatableInterface|string|null $label, ?string $icon, string $entityFqcn): CrudMenuItem
     {
         return new CrudMenuItem($label, $icon, $entityFqcn);
     }

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -26,6 +26,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\TemplateRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableEntity;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -199,7 +200,7 @@ final class AdminContextFactory
 
         $translationParameters = [];
         if (null !== $crudDto) {
-            $translationParameters['%entity_name%'] = $entityName = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
+            $translationParameters['%entity_name%'] = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
             $translationParameters['%entity_as_string%'] = null === $entityDto ? '' : (string) $entityDto;
             // when using pretty URLs, the entity ID is passed as a request attribute (it's part of the route path);
             // in legacy URLs, the entity ID is passed as a regular query parameter
@@ -211,12 +212,20 @@ final class AdminContextFactory
 
             $singularLabel = $crudDto->getEntityLabelInSingular($entityInstance, $pageName);
             if (!$singularLabel instanceof TranslatableInterface) {
-                $singularLabel = t($singularLabel ?? $entityName, $translationParameters, $translationDomain);
+                if (null !== $singularLabel) {
+                    $singularLabel = t($singularLabel, $translationParameters, $translationDomain);
+                } else {
+                    $singularLabel = new TranslatableEntity($crudDto->getEntityFqcn(), true);
+                }
             }
 
             $pluralLabel = $crudDto->getEntityLabelInPlural($entityInstance, $pageName);
             if (!$pluralLabel instanceof TranslatableInterface) {
-                $pluralLabel = t($pluralLabel ?? $entityName, $translationParameters, $translationDomain);
+                if (null !== $pluralLabel) {
+                    $pluralLabel = t($pluralLabel, $translationParameters, $translationDomain);
+                } else {
+                    $pluralLabel = new TranslatableEntity($crudDto->getEntityFqcn(), false);
+                }
             }
 
             $crudDto->setEntityLabelInSingular($singularLabel);

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -14,11 +14,11 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AvatarField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
+use EasyCorp\Bundle\EasyAdminBundle\Translation\TranslatableProperty;
 use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Contracts\Translation\TranslatableInterface;
-use function Symfony\Component\String\u;
 use function Symfony\Component\Translation\t;
 
 /**
@@ -56,7 +56,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
             }
         }
 
-        $label = $this->buildLabelOption($field, $translationDomain, $context->getCrud()->getCurrentPage());
+        $label = $this->buildLabelOption($entityDto, $field, $translationDomain, $context->getCrud()->getCurrentPage());
         $field->setLabel($label);
 
         $isRequired = $this->buildRequiredOption($field, $entityDto);
@@ -109,10 +109,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         return '' === $help ? null : t($help, $field->getTranslationParameters(), $translationDomain);
     }
 
-    /**
-     * @return TranslatableInterface|string|false|null
-     */
-    private function buildLabelOption(FieldDto $field, string $translationDomain, ?string $currentPage)
+    private function buildLabelOption(EntityDto $entityDto, FieldDto $field, string $translationDomain, ?string $currentPage): TranslatableInterface|string|false|null
     {
         // don't autogenerate a label for these special fields (there's a dedicated configurator for them)
         if (FormField::class === $field->getFieldFqcn()) {
@@ -134,7 +131,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         // it field doesn't define its label explicitly, generate an automatic
         // label based on the field's field name
         if (null === $label = $field->getLabel()) {
-            $label = $this->humanizeString($field->getProperty());
+            return new TranslatableProperty($entityDto->getFqcn(), $field->getProperty());
         }
 
         if ('' === $label || false === $label) {
@@ -240,25 +237,5 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         $nullable = \is_array($fieldMapping) ? ($fieldMapping['nullable'] ?? null) : $fieldMapping->nullable;
 
         return false === $nullable || null === $nullable;
-    }
-
-    private function humanizeString(string $string): string
-    {
-        $uString = u($string);
-        $upperString = $uString->upper()->toString();
-
-        // this prevents humanizing all-uppercase labels (e.g. 'UUID' -> 'U u i d')
-        // and other special labels which look better in uppercase
-        if ($uString->toString() === $upperString || \in_array($upperString, ['ID', 'URL'], true)) {
-            return $upperString;
-        }
-
-        return $uString
-            ->replaceMatches('/([A-Z])/', '_$1')
-            ->replaceMatches('/[_\s]+/', ' ')
-            ->trim()
-            ->lower()
-            ->title(true)
-            ->toString();
     }
 }

--- a/src/Translation/TranslatableEntity.php
+++ b/src/Translation/TranslatableEntity.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Translation;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class TranslatableEntity implements TranslatableInterface
+{
+    public function __construct(
+        /** @var class-string */
+        private readonly string $entity,
+        private readonly bool $singular,
+    ) {
+    }
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        $translation = $translator->trans(
+            $id = sprintf('entities.%s.%s', $this->entity, $this->singular ? 'singular' : 'plural'),
+            [],
+            'EasyAdminBundle',
+            $locale,
+        );
+
+        return $id === $translation
+            ? (new \ReflectionClass($this->entity))->getShortName() // Fallback if no translation is found
+            : $translation;
+    }
+}

--- a/src/Translation/TranslatableProperty.php
+++ b/src/Translation/TranslatableProperty.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Translation;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use function Symfony\Component\String\u;
+
+class TranslatableProperty implements TranslatableInterface
+{
+    public function __construct(
+        /** @var class-string */
+        private readonly string $entity,
+        private readonly string $property,
+    ) {
+    }
+
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        $translation = $translator->trans(
+            $id = sprintf('entities.%s.properties.%s', $this->entity, $this->property),
+            [],
+            'EasyAdminBundle',
+            $locale,
+        );
+
+        if ($id !== $translation) {
+            return $translation;
+        }
+
+        // If no translation is found generate a label
+        $property = u($this->property);
+        $propertyUpper = u($this->property)->upper();
+
+        // Some labels look better in uppercase
+        if (\in_array($propertyUpper->toString(), ['ID', 'URL'], true)) {
+            return $propertyUpper->toString();
+        }
+
+        // Prevent changing all-uppercase labels (e.g. 'UUID' -> 'U u i d')
+        if ($propertyUpper->equalsTo($property)) {
+            return $propertyUpper->toString();
+        }
+
+        return $property
+            ->replaceMatches('/([A-Z])/', '_$1')
+            ->replaceMatches('/[_\s]+/', ' ')
+            ->trim()
+            ->lower()
+            ->title(true)
+            ->toString()
+        ;
+    }
+}

--- a/tests/Field/AbstractFieldTest.php
+++ b/tests/Field/AbstractFieldTest.php
@@ -34,6 +34,8 @@ abstract class AbstractFieldTest extends KernelTestCase
 
         $reflectedClass = new \ReflectionClass(EntityDto::class);
         $entityDto = $reflectedClass->newInstanceWithoutConstructor();
+        $metadataProperty = $reflectedClass->getProperty('fqcn');
+        $metadataProperty->setValue($entityDto, 'App\Entity\Foo');
         $instanceProperty = $reflectedClass->getProperty('instance');
         $instanceProperty->setValue($entityDto, new class {});
         $metadataProperty = $reflectedClass->getProperty('metadata');


### PR DESCRIPTION
There are no BC breaks and the behaviour of existing apps does not change at all.

- Allows to define translations for entities and entity properties. If no translation is configured the behaviour is exactly the same as before this PR. If found the translations are used in:
  - ``CrudMenuItem``
  - ``AdminContextFactory``
  - ``Field/Configurator/CommonPreConfigurator``
- Allows to omit the label for ``CrudMenuItem``
  - if omitted EA will search for a entity translation like ``entities.App\Entity\Developer.singular``
  - if no translation is found EA will use the short name of the class like ``Developer``



