### PR TITLE
Add configurable confirmation for actions

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -30,6 +30,7 @@ class App {
         this.#createAutoCompleteFields();
         this.#createBatchActions();
         this.#createModalWindowsForDeleteActions();
+        this.#createActionConfirmations();
         this.#createPopovers();
         this.#createTooltips();
 
@@ -328,7 +329,9 @@ class App {
         });
 
         const modalTitle = document.querySelector('#batch-action-confirmation-title');
+        const modalContent = document.querySelector('#batch-action-confirmation-content');
         const titleContentWithPlaceholders = modalTitle?.textContent;
+        const contentTextWithPlaceholders = modalContent?.textContent;
 
         document.querySelectorAll('[data-action-batch]').forEach((dataActionBatch) => {
             dataActionBatch.addEventListener('click', (event) => {
@@ -381,6 +384,16 @@ class App {
                         .replace('%action_name%', actionName)
                         .replace('%num_items%', selectedItems.length.toString());
 
+                    if (modalContent) {
+                        const customContent = actionElement.getAttribute('data-batch-action-confirm-content');
+                        const contentTemplate = null !== customContent ? customContent : contentTextWithPlaceholders;
+                        if (null !== contentTemplate) {
+                            modalContent.textContent = contentTemplate
+                                .replace('%action_name%', actionName)
+                                .replace('%num_items%', selectedItems.length.toString());
+                        }
+                    }
+
                     document.querySelector('#modal-batch-action-button').addEventListener('click', submitBatchAction);
                 }
             });
@@ -405,6 +418,96 @@ class App {
                     deleteForm.setAttribute('action', deleteFormAction);
                     deleteForm.submit();
                 });
+            });
+        });
+    }
+
+    #createActionConfirmations() {
+        const modalElement = document.querySelector('#modal-batch-action');
+        const modalTitle = document.querySelector('#batch-action-confirmation-title');
+        const modalContent = document.querySelector('#batch-action-confirmation-content');
+        const modalButton = document.querySelector('#modal-batch-action-button');
+
+        if (null === modalElement || null === modalTitle || null === modalButton) {
+            return;
+        }
+
+        const modalInstance = new bootstrap.Modal(modalElement);
+        let confirmHandler = null;
+
+        const submitAction = (actionElement) => {
+            const formId = actionElement.getAttribute('form');
+            if (formId) {
+                const form = document.getElementById(formId);
+                if (form) {
+                    form.submit();
+                    return;
+                }
+            }
+
+            const closestForm = actionElement.closest('form');
+            if (closestForm) {
+                closestForm.submit();
+                return;
+            }
+
+            if ('A' === actionElement.tagName) {
+                const url = actionElement.getAttribute('href');
+                if (url) {
+                    window.location.href = url;
+                }
+
+                return;
+            }
+
+            const formAction = actionElement.getAttribute('formaction');
+            if (formAction) {
+                const formMethod = actionElement.getAttribute('formmethod') || 'post';
+                const tempForm = document.createElement('form');
+                tempForm.setAttribute('method', formMethod);
+                tempForm.setAttribute('action', formAction);
+                document.body.appendChild(tempForm);
+                tempForm.submit();
+            }
+        };
+
+        document.querySelectorAll('[data-action-confirm]:not([data-action-batch])').forEach((actionElement) => {
+            actionElement.addEventListener('click', (event) => {
+                if (actionElement.hasAttribute('data-action-confirm-skip')) {
+                    actionElement.removeAttribute('data-action-confirm-skip');
+                    return;
+                }
+
+                const rawMessage = actionElement.getAttribute('data-action-confirm');
+                if (!rawMessage) {
+                    return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+
+                const actionName = actionElement.textContent.trim() || actionElement.getAttribute('title') || '';
+                const message = rawMessage.replace('%action_name%', actionName);
+
+                modalTitle.textContent = message;
+                if (modalContent) {
+                    const rawContent = actionElement.getAttribute('data-action-confirm-content');
+                    if (null !== rawContent) {
+                        modalContent.textContent = rawContent.replace('%action_name%', actionName);
+                    } else {
+                        modalContent.textContent = '';
+                    }
+                }
+
+                if (confirmHandler) {
+                    modalButton.removeEventListener('click', confirmHandler);
+                }
+
+                confirmHandler = () => {
+                    submitAction(actionElement);
+                };
+                modalButton.addEventListener('click', confirmHandler);
+                modalInstance.show();
             });
         });
     }

--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -825,6 +825,111 @@ For translatable messages, you can pass a ``TranslatableInterface`` object::
         ;
     }
 
+If you need to change the default confirmation content shown under the title,
+use ``Crud::setBatchActionConfirmationContent()``. Set it to ``false`` to clear
+the content. The content supports the ``%action_name%`` and ``%num_items%``
+placeholders::
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setBatchActionConfirmationContent(
+                'You can undo "%action_name%" later.'
+            )
+        ;
+    }
+
+You can override the confirmation behavior for a single batch action with
+``Action::setConfirmationMessage()`` and ``Action::setConfirmationContent()``.
+Use ``false`` as parameter of ``setConfirmationMessage``` to disable the confirmation. The message and content
+support the ``%action_name%`` and ``%num_items%`` placeholders::
+
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $publish = Action::new('publish')
+            ->linkToCrudAction('publish')
+            ->createAsBatchAction()
+            ->setConfirmationMessage(
+                'Are you sure you want to publish %num_items% items?'
+            )
+            ->setConfirmationContent(
+                'You can undo "%action_name%" later.'
+            )
+        ;
+
+        $archive = Action::new('archive')
+            ->linkToCrudAction('archive')
+            ->createAsBatchAction()
+            // skip confirmation just for this action
+            ->setConfirmationMessage(false)
+        ;
+
+        $restore = Action::new('restore')
+            ->linkToCrudAction('restore')
+            ->createAsBatchAction()
+            ->setConfirmationMessage(
+                'Are you sure you want to restore %num_items% items?'
+            )
+            // clear the content while keeping the title
+            ->setConfirmationContent(false)
+        ;
+
+        return $actions
+            ->addBatchAction($publish)
+            ->addBatchAction($archive)
+            ->addBatchAction($restore)
+        ;
+    }
+
+Confirmation for Custom Actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, custom actions don't display a confirmation dialog. If you want one,
+set a confirmation message on the action. The message can use the
+``%action_name%`` placeholder::
+
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $action = Action::new('publish')
+            ->linkToCrudAction('publish')
+            ->setConfirmationMessage(
+                'Are you sure you want to run "%action_name%"?'
+            )
+        ;
+
+        return $actions->add(Crud::PAGE_INDEX, $action);
+    }
+
+For custom actions, you can combine ``Action::setConfirmationMessage()`` and
+``Action::setConfirmationContent()`` in the same way. Use ``false`` to clear
+the content while keeping the title. The content supports the
+``%action_name%`` placeholder::
+
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+
+    public function configureActions(Actions $actions): Actions
+    {
+        $action = Action::new('publish')
+            ->linkToCrudAction('publish')
+            ->setConfirmationMessage('Confirm publish')
+            ->setConfirmationContent('You can undo "%action_name%".')
+        ;
+
+        return $actions->add(Crud::PAGE_INDEX, $action);
+    }
+
+The delete action keeps its own confirmation modal and is not affected by
+``setConfirmationMessage()``.
+
 .. _actions-integrating-symfony:
 
 Integrating Symfony Actions

--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -237,6 +237,28 @@ final class Action implements \Stringable
         return $this;
     }
 
+    /**
+     * Add a confirmation dialog before executing the action.
+     * Pass false to disable confirmation for batch actions even if enabled globally.
+     */
+    public function setConfirmationMessage(TranslatableInterface|string|false $message): self
+    {
+        $this->dto->setConfirmationMessage($message);
+
+        return $this;
+    }
+
+    /**
+     * Customize the content shown under the confirmation title for batch actions.
+     * Pass false to clear the content text.
+     */
+    public function setConfirmationContent(TranslatableInterface|string|false $content): self
+    {
+        $this->dto->setConfirmationContent($content);
+
+        return $this;
+    }
+
     public function setTemplatePath(string $templatePath): self
     {
         $this->dto->setTemplatePath($templatePath);

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -450,6 +450,18 @@ class Crud
         return $this;
     }
 
+    /**
+     * Customize the confirmation content shown under the title for batch actions.
+     * Set to false to clear the content text.
+     * The message can use placeholders: %action_name% and %num_items%.
+     */
+    public function setBatchActionConfirmationContent(bool|string|TranslatableInterface|null $content): self
+    {
+        $this->dto->setBatchActionConfirmationContent($content);
+
+        return $this;
+    }
+
     public function getAsDto(): CrudDto
     {
         $this->dto->setPaginator(new PaginatorDto($this->paginatorPageSize, $this->paginatorRangeSize, 1, $this->paginatorFetchJoinCollection, $this->paginatorUseOutputWalkers));

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -23,6 +23,10 @@ final class ActionDto
     private string $addedCssClass = '';
     /** @var array<string, string|TranslatableInterface> */
     private array $htmlAttributes = [];
+    /** @var TranslatableInterface|string|false|null */
+    private mixed $confirmationMessage = null;
+    /** @var TranslatableInterface|string|false|null */
+    private mixed $confirmationContent = null;
     private ?string $linkUrl = null;
     private ?string $templatePath = null;
     private ?string $crudActionName = null;
@@ -195,6 +199,26 @@ final class ActionDto
         $this->htmlAttributes[$attributeName] = $attributeValue;
     }
 
+    public function getConfirmationMessage(): TranslatableInterface|string|false|null
+    {
+        return $this->confirmationMessage;
+    }
+
+    public function setConfirmationMessage(TranslatableInterface|string|false $confirmationMessage): void
+    {
+        $this->confirmationMessage = $confirmationMessage;
+    }
+
+    public function getConfirmationContent(): TranslatableInterface|string|false|null
+    {
+        return $this->confirmationContent;
+    }
+
+    public function setConfirmationContent(TranslatableInterface|string|false $confirmationContent): void
+    {
+        $this->confirmationContent = $confirmationContent;
+    }
+
     public function getTemplatePath(): ?string
     {
         return $this->templatePath;
@@ -364,6 +388,12 @@ final class ActionDto
         $action->addCssClass($this->addedCssClass);
         $action->setHtmlAttributes($this->htmlAttributes);
         $action->setTranslationParameters($this->translationParameters);
+        if (null !== $this->confirmationMessage) {
+            $action->setConfirmationMessage($this->confirmationMessage);
+        }
+        if (null !== $this->confirmationContent) {
+            $action->setConfirmationContent($this->confirmationContent);
+        }
 
         if (null !== $this->templatePath) {
             $action->setTemplatePath($this->templatePath);

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -79,6 +79,7 @@ final class CrudDto
     private ?string $sidebarWidth = null;
     private bool $hideNullValues = false;
     private bool|string|TranslatableInterface $askConfirmationOnBatchActions = true;
+    private bool|string|TranslatableInterface|null $batchActionConfirmationContent = null;
 
     public function __construct()
     {
@@ -607,5 +608,15 @@ final class CrudDto
     public function setAskConfirmationOnBatchActions(bool|string|TranslatableInterface $askConfirmation): void
     {
         $this->askConfirmationOnBatchActions = $askConfirmation;
+    }
+
+    public function getBatchActionConfirmationContent(): bool|string|TranslatableInterface|null
+    {
+        return $this->batchActionConfirmationContent;
+    }
+
+    public function setBatchActionConfirmationContent(bool|string|TranslatableInterface|null $content): void
+    {
+        $this->batchActionConfirmationContent = $content;
     }
 }

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -211,6 +211,9 @@ final class ActionFactory
             ]);
         }
 
+        $actionConfirmationConfig = $actionDto->getConfirmationMessage();
+        $actionConfirmationContent = $actionDto->getConfirmationContent();
+
         if ($actionDto->isBatchAction()) {
             $batchActionAttributes = [
                 'data-action-csrf-token' => $this->csrfTokenManager?->getToken('ea-batch-action-'.$actionDto->getName()),
@@ -219,7 +222,7 @@ final class ActionFactory
                 'data-action-url' => $actionDto->getLinkUrl(),
             ];
 
-            $confirmationConfig = $adminContext->getCrud()->askConfirmationOnBatchActions();
+            $confirmationConfig = $actionConfirmationConfig ?? $adminContext->getCrud()->askConfirmationOnBatchActions();
 
             if (false === $confirmationConfig) {
                 $batchActionAttributes['data-action-batch-no-confirm'] = 'true';
@@ -229,13 +232,44 @@ final class ActionFactory
 
                 // if the confirmation config is not a boolean, it's a string or TranslatableInterface with the custom confirmation message
                 if (true !== $confirmationConfig) {
+                    $translationParameters = null !== $actionConfirmationConfig
+                        ? array_merge($defaultTranslationParameters, $actionDto->getTranslationParameters())
+                        : $defaultTranslationParameters;
                     $batchActionAttributes['data-batch-action-confirm-message'] = $confirmationConfig instanceof TranslatableInterface
-                        ? $confirmationConfig
-                        : t($confirmationConfig, $defaultTranslationParameters, $translationDomain);
+                        ? TranslatableMessageBuilder::withParameters($confirmationConfig, $translationParameters)
+                        : t($confirmationConfig, $translationParameters, $translationDomain);
+                }
+            }
+
+            $confirmationContentConfig = $actionConfirmationContent ?? $adminContext->getCrud()->getBatchActionConfirmationContent();
+            if (null !== $confirmationContentConfig) {
+                if (false === $confirmationContentConfig) {
+                    $batchActionAttributes['data-batch-action-confirm-content'] = '';
+                } else {
+                    $translationParameters = array_merge($defaultTranslationParameters, $actionDto->getTranslationParameters());
+                    $batchActionAttributes['data-batch-action-confirm-content'] = $confirmationContentConfig instanceof TranslatableInterface
+                        ? TranslatableMessageBuilder::withParameters($confirmationContentConfig, $translationParameters)
+                        : t($confirmationContentConfig, $translationParameters, $translationDomain);
                 }
             }
 
             $actionDto->addHtmlAttributes($batchActionAttributes);
+        } elseif (null !== $actionConfirmationConfig && false !== $actionConfirmationConfig && Action::DELETE !== $actionDto->getName()) {
+            $translationParameters = array_merge($defaultTranslationParameters, $actionDto->getTranslationParameters());
+            $confirmationMessage = $actionConfirmationConfig instanceof TranslatableInterface
+                ? TranslatableMessageBuilder::withParameters($actionConfirmationConfig, $translationParameters)
+                : t($actionConfirmationConfig, $translationParameters, $translationDomain);
+            $actionDto->setHtmlAttribute('data-action-confirm', $confirmationMessage);
+            if (null !== $actionConfirmationContent) {
+                if (false === $actionConfirmationContent) {
+                    $actionDto->setHtmlAttribute('data-action-confirm-content', '');
+                } else {
+                    $confirmationContent = $actionConfirmationContent instanceof TranslatableInterface
+                        ? TranslatableMessageBuilder::withParameters($actionConfirmationContent, $translationParameters)
+                        : t($actionConfirmationContent, $translationParameters, $translationDomain);
+                    $actionDto->setHtmlAttribute('data-action-confirm-content', $confirmationContent);
+                }
+            }
         }
 
         return $actionDto;

--- a/templates/crud/includes/_batch_action_modal.html.twig
+++ b/templates/crud/includes/_batch_action_modal.html.twig
@@ -3,7 +3,7 @@
         <div class="modal-content">
             <div class="modal-body">
                 <h4 id="batch-action-confirmation-title">{{ 'batch_action_modal.title'|trans(domain: 'EasyAdminBundle') }}</h4>
-                <p>{{ 'batch_action_modal.content'|trans(domain: 'EasyAdminBundle') }}</p>
+                <p id="batch-action-confirmation-content">{{ 'batch_action_modal.content'|trans(domain: 'EasyAdminBundle') }}</p>
             </div>
             <div class="modal-footer">
                 <twig:ea:Button type="button" data-bs-dismiss="modal">

--- a/templates/crud/index.html.twig
+++ b/templates/crud/index.html.twig
@@ -265,7 +265,5 @@
         {{ include('@EasyAdmin/crud/includes/_filters_modal.html.twig') }}
     {% endif %}
 
-    {% if has_batch_actions %}
-        {{ include('@EasyAdmin/crud/includes/_batch_action_modal.html.twig', {}, with_context: false) }}
-    {% endif %}
+    {# batch action modal is included in the base layout #}
 {% endblock main %}

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -393,6 +393,8 @@
         </div>
     {% endblock wrapper_wrapper %}
 
+    {{ include('@EasyAdmin/crud/includes/_batch_action_modal.html.twig', {}, with_context: false) }}
+
     {% block body_javascript %}{% endblock body_javascript %}
 
     {% block configured_body_contents %}

--- a/tests/Factory/ActionFactoryTest.php
+++ b/tests/Factory/ActionFactoryTest.php
@@ -4,8 +4,19 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Factory;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\CrudContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\I18nContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\RequestContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ActionFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Contracts\Translation\TranslatableInterface;
 
 class ActionFactoryTest extends TestCase
 {
@@ -76,5 +87,218 @@ class ActionFactoryTest extends TestCase
         $actionNames = array_keys($allActions);
         $expectedOrder = ['action_3', 'action_1', 'action_2'];
         $this->assertSame($expectedOrder, $actionNames);
+    }
+
+    public function testBatchActionConfirmationOverridesGlobalSetting(): void
+    {
+        $actionFactory = $this->createActionFactory(false);
+
+        $actions = Actions::new();
+        $actions->addBatchAction(
+            Action::new('publish')
+                ->linkToUrl('/admin/publish')
+                ->setConfirmationMessage('Confirm publish')
+        );
+
+        $processedActions = $actionFactory->processGlobalActions($actions->getAsDto(Crud::PAGE_INDEX));
+        $action = $processedActions->get('publish');
+
+        $this->assertNotNull($action);
+        $attributes = $action->getHtmlAttributes();
+        $this->assertArrayNotHasKey('data-action-batch-no-confirm', $attributes);
+        $this->assertSame('modal', $attributes['data-bs-toggle']);
+        $this->assertSame('#modal-batch-action', $attributes['data-bs-target']);
+        $message = $attributes['data-batch-action-confirm-message'] ?? null;
+        $this->assertInstanceOf(TranslatableInterface::class, $message);
+        $this->assertSame('Confirm publish', $message->getMessage());
+    }
+
+    public function testBatchActionConfirmationContentCanBeCustomized(): void
+    {
+        $actionFactory = $this->createActionFactory(true);
+
+        $actions = Actions::new();
+        $actions->addBatchAction(
+            Action::new('archive')
+                ->linkToUrl('/admin/archive')
+                ->setConfirmationContent('Archive content')
+        );
+
+        $processedActions = $actionFactory->processGlobalActions($actions->getAsDto(Crud::PAGE_INDEX));
+        $action = $processedActions->get('archive');
+
+        $this->assertNotNull($action);
+        $attributes = $action->getHtmlAttributes();
+        $content = $attributes['data-batch-action-confirm-content'] ?? null;
+        $this->assertInstanceOf(TranslatableInterface::class, $content);
+        $this->assertSame('Archive content', $content->getMessage());
+    }
+
+    public function testBatchActionConfirmationContentCanBeCleared(): void
+    {
+        $actionFactory = $this->createActionFactory(true);
+
+        $actions = Actions::new();
+        $actions->addBatchAction(
+            Action::new('archive')
+                ->linkToUrl('/admin/archive')
+                ->setConfirmationContent(false)
+        );
+
+        $processedActions = $actionFactory->processGlobalActions($actions->getAsDto(Crud::PAGE_INDEX));
+        $action = $processedActions->get('archive');
+
+        $this->assertNotNull($action);
+        $attributes = $action->getHtmlAttributes();
+        $this->assertSame('', $attributes['data-batch-action-confirm-content']);
+    }
+
+    public function testBatchActionConfirmationContentUsesCrudDefault(): void
+    {
+        $actionFactory = $this->createActionFactoryWithContent(true, 'Default content');
+
+        $actions = Actions::new();
+        $actions->addBatchAction(
+            Action::new('archive')
+                ->linkToUrl('/admin/archive')
+        );
+
+        $processedActions = $actionFactory->processGlobalActions($actions->getAsDto(Crud::PAGE_INDEX));
+        $action = $processedActions->get('archive');
+
+        $this->assertNotNull($action);
+        $attributes = $action->getHtmlAttributes();
+        $content = $attributes['data-batch-action-confirm-content'] ?? null;
+        $this->assertInstanceOf(TranslatableInterface::class, $content);
+        $this->assertSame('Default content', $content->getMessage());
+    }
+
+    public function testBatchActionConfirmationContentOverridesCrudDefault(): void
+    {
+        $actionFactory = $this->createActionFactoryWithContent(true, 'Default content');
+
+        $actions = Actions::new();
+        $actions->addBatchAction(
+            Action::new('archive')
+                ->linkToUrl('/admin/archive')
+                ->setConfirmationContent('Custom content')
+        );
+
+        $processedActions = $actionFactory->processGlobalActions($actions->getAsDto(Crud::PAGE_INDEX));
+        $action = $processedActions->get('archive');
+
+        $this->assertNotNull($action);
+        $attributes = $action->getHtmlAttributes();
+        $content = $attributes['data-batch-action-confirm-content'] ?? null;
+        $this->assertInstanceOf(TranslatableInterface::class, $content);
+        $this->assertSame('Custom content', $content->getMessage());
+    }
+
+    public function testBatchActionConfirmationCanBeDisabledPerAction(): void
+    {
+        $actionFactory = $this->createActionFactory(true);
+
+        $actions = Actions::new();
+        $actions->addBatchAction(
+            Action::new('archive')
+                ->linkToUrl('/admin/archive')
+                ->setConfirmationMessage(false)
+        );
+
+        $processedActions = $actionFactory->processGlobalActions($actions->getAsDto(Crud::PAGE_INDEX));
+        $action = $processedActions->get('archive');
+
+        $this->assertNotNull($action);
+        $attributes = $action->getHtmlAttributes();
+        $this->assertSame('true', $attributes['data-action-batch-no-confirm']);
+        $this->assertArrayNotHasKey('data-bs-toggle', $attributes);
+        $this->assertArrayNotHasKey('data-batch-action-confirm-message', $attributes);
+    }
+
+    public function testActionConfirmationAddsConfirmationAttribute(): void
+    {
+        $actionFactory = $this->createActionFactory(true);
+
+        $actions = Actions::new();
+        $actions->add(
+            Crud::PAGE_INDEX,
+            Action::new('publish')
+                ->createAsGlobalAction()
+                ->linkToUrl('/admin/publish')
+                ->setConfirmationMessage('Confirm publish')
+        );
+
+        $processedActions = $actionFactory->processGlobalActions($actions->getAsDto(Crud::PAGE_INDEX));
+        $action = $processedActions->get('publish');
+
+        $this->assertNotNull($action);
+        $attributes = $action->getHtmlAttributes();
+        $message = $attributes['data-action-confirm'] ?? null;
+        $this->assertInstanceOf(TranslatableInterface::class, $message);
+        $this->assertSame('Confirm publish', $message->getMessage());
+        $this->assertArrayNotHasKey('data-bs-toggle', $attributes);
+    }
+
+    public function testActionConfirmationContentAddsContentAttribute(): void
+    {
+        $actionFactory = $this->createActionFactory(true);
+
+        $actions = Actions::new();
+        $actions->add(
+            Crud::PAGE_INDEX,
+            Action::new('publish')
+                ->createAsGlobalAction()
+                ->linkToUrl('/admin/publish')
+                ->setConfirmationMessage('Confirm publish')
+                ->setConfirmationContent('Confirm content')
+        );
+
+        $processedActions = $actionFactory->processGlobalActions($actions->getAsDto(Crud::PAGE_INDEX));
+        $action = $processedActions->get('publish');
+
+        $this->assertNotNull($action);
+        $attributes = $action->getHtmlAttributes();
+        $content = $attributes['data-action-confirm-content'] ?? null;
+        $this->assertInstanceOf(TranslatableInterface::class, $content);
+        $this->assertSame('Confirm content', $content->getMessage());
+    }
+
+    private function createActionFactory(bool|string|TranslatableInterface $askConfirmationOnBatchActions): ActionFactory
+    {
+        return $this->createActionFactoryWithContent($askConfirmationOnBatchActions, null);
+    }
+
+    private function createActionFactoryWithContent(bool|string|TranslatableInterface $askConfirmationOnBatchActions, bool|string|TranslatableInterface|null $batchActionConfirmationContent): ActionFactory
+    {
+        $adminContextProvider = $this->createMock(AdminContextProviderInterface::class);
+        $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $adminUrlGenerator = $this->createMock(AdminUrlGeneratorInterface::class);
+
+        $authChecker->method('isGranted')->willReturn(true);
+        $adminUrlGenerator->method('unsetAllExcept')->willReturnSelf();
+        $adminUrlGenerator->method('setAll')->willReturnSelf();
+        $adminUrlGenerator->method('generateUrl')->willReturn('/admin');
+        $adminUrlGenerator->method('setController')->willReturnSelf();
+        $adminUrlGenerator->method('setAction')->willReturnSelf();
+        $adminUrlGenerator->method('setEntityId')->willReturnSelf();
+        $adminUrlGenerator->method('setRoute')->willReturnSelf();
+
+        $crudDto = new CrudDto();
+        $crudDto->setPageName(Crud::PAGE_INDEX);
+        $crudDto->setEntityFqcn('App\\Entity\\Dummy');
+        $crudDto->setAskConfirmationOnBatchActions($askConfirmationOnBatchActions);
+        $crudDto->setBatchActionConfirmationContent($batchActionConfirmationContent);
+        $crudDto->setControllerFqcn('App\\Controller\\DummyCrudController');
+
+        $adminContext = AdminContext::forTesting(
+            RequestContext::forTesting(new Request()),
+            CrudContext::forTesting($crudDto),
+            null,
+            I18nContext::forTesting('en', 'ltr')
+        );
+
+        $adminContextProvider->method('getContext')->willReturn($adminContext);
+
+        return new ActionFactory($adminContextProvider, $authChecker, $adminUrlGenerator);
     }
 }


### PR DESCRIPTION
Addressing
https://github.com/EasyCorp/EasyAdminBundle/issues/6674

Description
  - Add per-action confirmation title/content for batch and non‑batch actions
  - Add CRUD‑level default batch confirmation content override
  - Confirmation on non-batch actions applied on the index and detail pages

Notes:
1. Did not rename "EasyAdmin/crud/includes/_batch_action_modal.html.twig" to avoid a breaking change
2. I think it would make sense to configure the confirmation messages for Delete and Batch Delete separately from the other actions.
Ideally, confirmation would not be enabled by default for batch actions other than Delete, but that would break backward compatibility.
I would also show different content—or no content at all. The message “There is no undo for this operation.” is only accurate for the default Delete actions.
Since there is currently a default confirmation message for all batch actions, we could keep this behavior for backward compatibility by preserving the standard title (“You are going to apply the "%action_name%" action to %num_items% item(s).”), but remove the default content (“There is no undo for this operation.”) for non-delete actions.
