### PR TITLE
Allow to set translations for entities and their properties

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -12,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityPaginatorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\EasyAdminExtension;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\AdminRouterSubscriber;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\CrudResponseListener;
@@ -87,6 +88,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\UrlSigner;
 use EasyCorp\Bundle\EasyAdminBundle\Security\AuthorizationChecker;
 use EasyCorp\Bundle\EasyAdminBundle\Security\SecurityVoter;
+use EasyCorp\Bundle\EasyAdminBundle\Translation\EntityTranslationIdGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Alert;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Flag;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Icon;
@@ -197,6 +199,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(4, new Reference(EntityFactory::class))
             ->arg(5, service(AdminRouteGenerator::class))
             ->arg(6, service(ActionFactory::class))
+            ->arg(7, service(EntityTranslationIdGeneratorInterface::class))
 
         ->set(AdminUrlGenerator::class)
             // I don't know if we truly need the share() method to get a new instance of the
@@ -373,6 +376,7 @@ return static function (ContainerConfigurator $container) {
         ->set(CommonPreConfigurator::class)
             ->arg(0, new Reference('property_accessor'))
             ->arg(1, service(EntityFactory::class))
+            ->arg(2, service(EntityTranslationIdGeneratorInterface::class))
             ->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR, ['priority' => 9999])
 
         ->set(CountryConfigurator::class)
@@ -425,6 +429,10 @@ return static function (ContainerConfigurator $container) {
         ->set(TimezoneConfigurator::class)
 
         ->set(UrlConfigurator::class)
+
+        ->set(EntityTranslationIdGenerator::class)
+
+        ->alias(EntityTranslationIdGeneratorInterface::class, EntityTranslationIdGenerator::class)
 
         ->set(AssetPackage::class)
             ->arg(0, service('request_stack'))

--- a/src/Config/Dashboard.php
+++ b/src/Config/Dashboard.php
@@ -131,6 +131,13 @@ final class Dashboard
         return $this;
     }
 
+    public function useEntityTranslations(bool $useEntityTranslations): self
+    {
+        $this->dto->setUseEntityTranslations($useEntityTranslations);
+
+        return $this;
+    }
+
     public function getAsDto(): DashboardDto
     {
         return $this->dto;

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
@@ -10,7 +11,7 @@ use Symfony\Component\Uid\AbstractUid;
 use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
- * @see EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToCrud()
+ * @see \EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToCrud()
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
@@ -18,7 +19,7 @@ final class CrudMenuItem implements MenuItemInterface
 {
     use MenuItemTrait;
 
-    public function __construct(TranslatableInterface|string $label, ?string $icon, string $entityFqcn)
+    public function __construct(TranslatableInterface|string|null $label, ?string $icon, string $entityFqcn)
     {
         $this->dto = new MenuItemDto();
 
@@ -26,7 +27,7 @@ final class CrudMenuItem implements MenuItemInterface
         $this->dto->setLabel($label);
         $this->dto->setIcon($icon);
         $this->dto->setRouteParameters([
-            EA::CRUD_ACTION => 'index',
+            EA::CRUD_ACTION => Action::INDEX,
             EA::CRUD_CONTROLLER_FQCN => null,
             EA::ENTITY_FQCN => $entityFqcn,
             EA::ENTITY_ID => null,

--- a/src/Config/MenuItem.php
+++ b/src/Config/MenuItem.php
@@ -24,7 +24,7 @@ final class MenuItem
     /**
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
-    public static function linkToCrud(TranslatableInterface|string $label, ?string $icon, string $entityFqcn): CrudMenuItem
+    public static function linkToCrud(TranslatableInterface|string|null $label, ?string $icon, string $entityFqcn): CrudMenuItem
     {
         return new CrudMenuItem($label, $icon, $entityFqcn);
     }

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -185,6 +185,11 @@ final class AdminContext implements AdminContextInterface
         return $this->i18nContext->getTemplatePath($templateName);
     }
 
+    public function isUseEntityTranslations(): bool
+    {
+        return $this->dashboardContext->getDashboardDto()->isUseEntityTranslations();
+    }
+
     /**
      * Creates an AdminContext instance suitable for testing.
      *

--- a/src/Contracts/Translation/EntityTranslationIdGeneratorInterface.php
+++ b/src/Contracts/Translation/EntityTranslationIdGeneratorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation;
+
+interface EntityTranslationIdGeneratorInterface
+{
+    /**
+     * @param class-string $entity
+     */
+    public function generateForEntity(string $entity, bool $singular): string;
+
+    /**
+     * @param class-string $entity
+     */
+    public function generateForProperty(string $entity, string $property): string;
+}

--- a/src/Dto/DashboardDto.php
+++ b/src/Dto/DashboardDto.php
@@ -25,6 +25,7 @@ final class DashboardDto
     private string $defaultColorScheme = ColorScheme::AUTO;
     /** @var LocaleDto[] */
     private array $locales = [];
+    private bool $useEntityTranslations = false;
 
     public function getRouteName(): string
     {
@@ -203,5 +204,17 @@ final class DashboardDto
     public function setLocales(array $locales): void
     {
         $this->locales = $locales;
+    }
+
+    public function isUseEntityTranslations(): bool
+    {
+        return $this->useEntityTranslations;
+    }
+
+    public function setUseEntityTranslations(bool $useEntityTranslations): self
+    {
+        $this->useEntityTranslations = $useEntityTranslations;
+
+        return $this;
     }
 }

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -108,12 +108,12 @@ final class MenuItemDto
         $this->expanded = $isExpanded;
     }
 
-    public function getLabel(): TranslatableInterface|string
+    public function getLabel(): TranslatableInterface|string|null
     {
         return $this->label;
     }
 
-    public function setLabel(TranslatableInterface|string $label): void
+    public function setLabel(TranslatableInterface|string|null $label): void
     {
         $this->label = $label;
     }

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -16,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Factory\MenuFactoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionConfigDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetsDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
@@ -46,7 +47,16 @@ final class AdminContextFactory
         private readonly EntityFactory $entityFactory,
         private readonly AdminRouteGeneratorInterface $adminRouteGenerator,
         private readonly ActionFactory $actionFactory,
+        private readonly ?EntityTranslationIdGeneratorInterface $entityTranslationIdGenerator = null,
     ) {
+        if (null === $this->entityTranslationIdGenerator) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.27',
+                'Not passing argument "$entityTranslationIdGenerator" will cause an error in 5.0.0.',
+                '$entityTranslationIdGenerator',
+            );
+        }
     }
 
     public function create(Request $request, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ?string $actionName = null): AdminContext
@@ -199,7 +209,7 @@ final class AdminContextFactory
 
         $translationParameters = [];
         if (null !== $crudDto) {
-            $translationParameters['%entity_name%'] = $entityName = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
+            $translationParameters['%entity_name%'] = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
             $translationParameters['%entity_as_string%'] = null === $entityDto ? '' : (string) $entityDto;
             // when using pretty URLs, the entity ID is passed as a request attribute (it's part of the route path);
             // in legacy URLs, the entity ID is passed as a regular query parameter
@@ -209,14 +219,22 @@ final class AdminContextFactory
             $entityInstance = null === $entityDto ? null : $entityDto->getInstance();
             $pageName = $crudDto->getCurrentPage();
 
-            $singularLabel = $crudDto->getEntityLabelInSingular($entityInstance, $pageName);
+            $singularLabel = $crudDto->getEntityLabelInSingular($entityInstance, $pageName)
+                ?? ($dashboardDto->isUseEntityTranslations() && null !== $this->entityTranslationIdGenerator
+                    ? $this->entityTranslationIdGenerator->generateForEntity($crudDto->getEntityFqcn(), true)
+                    : $translationParameters['%entity_name%']
+                );
             if (!$singularLabel instanceof TranslatableInterface) {
-                $singularLabel = t($singularLabel ?? $entityName, $translationParameters, $translationDomain);
+                $singularLabel = t($singularLabel, $translationParameters, $translationDomain);
             }
 
-            $pluralLabel = $crudDto->getEntityLabelInPlural($entityInstance, $pageName);
+            $pluralLabel = $crudDto->getEntityLabelInPlural($entityInstance, $pageName)
+                ?? ($dashboardDto->isUseEntityTranslations() && null !== $this->entityTranslationIdGenerator
+                    ? $this->entityTranslationIdGenerator->generateForEntity($crudDto->getEntityFqcn(), false)
+                    : $translationParameters['%entity_name%']
+                );
             if (!$pluralLabel instanceof TranslatableInterface) {
-                $pluralLabel = t($pluralLabel ?? $entityName, $translationParameters, $translationDomain);
+                $pluralLabel = t($pluralLabel, $translationParameters, $translationDomain);
             }
 
             $crudDto->setEntityLabelInSingular($singularLabel);

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
@@ -10,6 +11,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
@@ -80,10 +82,10 @@ final class MenuFactory implements MenuFactoryInterface
                     continue;
                 }
 
-                $subItems[] = $this->buildMenuItem($menuSubItemDto, [], $translationDomain);
+                $subItems[] = $this->buildMenuItem($menuSubItemDto, [], $translationDomain, $adminContext->getCrud());
             }
 
-            $builtItems[] = $this->buildMenuItem($menuItemDto, $subItems, $translationDomain);
+            $builtItems[] = $this->buildMenuItem($menuItemDto, $subItems, $translationDomain, $adminContext->getCrud());
         }
 
         $builtItems = $this->menuItemMatcher->markSelectedMenuItem($builtItems, $adminContext->getRequest());
@@ -94,13 +96,18 @@ final class MenuFactory implements MenuFactoryInterface
     /**
      * @param MenuItemDto[] $subItems
      */
-    private function buildMenuItem(MenuItemDto $menuItemDto, array $subItems, string $translationDomain): MenuItemDto
+    private function buildMenuItem(MenuItemDto $menuItemDto, array $subItems, string $translationDomain, CrudDto $crudDto): MenuItemDto
     {
         if (!$menuItemDto->getLabel() instanceof TranslatableInterface) {
             $label = $menuItemDto->getLabel();
-            $menuItemDto->setLabel(
-                '' === $label ? $label : t($label, $menuItemDto->getTranslationParameters(), $translationDomain)
-            );
+            if (null === $label && MenuItemDto::TYPE_CRUD === $menuItemDto->getType()) {
+                $label = Action::INDEX === $menuItemDto->getRouteParameters()[EA::CRUD_ACTION]
+                    ? $crudDto->getEntityLabelInPlural()
+                    : $crudDto->getEntityLabelInSingular();
+            } else {
+                $label = '' === $label ? $label : t($label, $menuItemDto->getTranslationParameters(), $translationDomain);
+            }
+            $menuItemDto->setLabel($label);
         }
 
         $url = $this->generateMenuItemUrl($menuItemDto);

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -9,6 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
@@ -26,8 +27,19 @@ use function Symfony\Component\Translation\t;
  */
 final class CommonPreConfigurator implements FieldConfiguratorInterface
 {
-    public function __construct(private readonly PropertyAccessorInterface $propertyAccessor, private readonly EntityFactory $entityFactory)
-    {
+    public function __construct(
+        private readonly PropertyAccessorInterface $propertyAccessor,
+        private readonly EntityFactory $entityFactory,
+        private readonly ?EntityTranslationIdGeneratorInterface $entityTranslationIdGenerator = null,
+    ) {
+        if (null === $this->entityTranslationIdGenerator) {
+            trigger_deprecation(
+                'easycorp/easyadmin-bundle',
+                '4.27',
+                'Not passing argument "$entityTranslationIdGenerator" will cause an error in 5.0.0.',
+                '$entityTranslationIdGenerator',
+            );
+        }
     }
 
     public function supports(FieldDto $field, EntityDto $entityDto): bool
@@ -56,7 +68,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
             }
         }
 
-        $label = $this->buildLabelOption($field, $translationDomain, $context->getCrud()->getCurrentPage());
+        $label = $this->buildLabelOption($entityDto, $field, $translationDomain, $context->getCrud()->getCurrentPage(), $context->isUseEntityTranslations());
         $field->setLabel($label);
 
         $isRequired = $this->buildRequiredOption($field, $entityDto);
@@ -109,10 +121,7 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         return '' === $help ? null : t($help, $field->getTranslationParameters(), $translationDomain);
     }
 
-    /**
-     * @return TranslatableInterface|string|false|null
-     */
-    private function buildLabelOption(FieldDto $field, string $translationDomain, ?string $currentPage)
+    private function buildLabelOption(EntityDto $entityDto, FieldDto $field, string $translationDomain, ?string $currentPage, bool $useEntityTranslations): TranslatableInterface|string|false|null
     {
         // don't autogenerate a label for these special fields (there's a dedicated configurator for them)
         if (FormField::class === $field->getFieldFqcn()) {
@@ -134,7 +143,9 @@ final class CommonPreConfigurator implements FieldConfiguratorInterface
         // it field doesn't define its label explicitly, generate an automatic
         // label based on the field's field name
         if (null === $label = $field->getLabel()) {
-            $label = $this->humanizeString($field->getProperty());
+            $label = $useEntityTranslations
+                ? $this->entityTranslationIdGenerator->generateForProperty($entityDto->getFqcn(), $field->getProperty())
+                : $this->humanizeString($field->getProperty());
         }
 
         if ('' === $label || false === $label) {

--- a/src/Translation/EntityTranslationIdGenerator.php
+++ b/src/Translation/EntityTranslationIdGenerator.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Translation;
+
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
+
+class EntityTranslationIdGenerator implements EntityTranslationIdGeneratorInterface
+{
+    public function generateForEntity(string $entity, bool $singular): string
+    {
+        return sprintf('entities.%s.%s', $entity, $singular ? 'singular' : 'plural');
+    }
+
+    public function generateForProperty(string $entity, string $property): string
+    {
+        return sprintf('entities.%s.properties.%s', $entity, $property);
+    }
+}


### PR DESCRIPTION
Replaces https://github.com/EasyCorp/EasyAdminBundle/pull/7383.

There are no BC breaks and the behaviour of existing apps does not change at all.

I will add docs if the PR is ready to be merged.

Allows to enable entity translations in dashboard controllers:
```php
    public function configureDashboard(): Dashboard
    {
        return Dashboard::new()->useEntityTranslations(true);
    }
```

Example:
```php
// translations/messages.en.php
return [
    'entities' => [
        App\Entity\Developer::class => [
            'singular' => 'Dev',
            'plural' => 'Devs',
            'properties' => [
                'favouriteProject' => 'Favorite proj',
            ],
        ],
    ],
];
```

Notes:
- The translation domain can be configured as before, for example with `Dashboard::new()->setTranslationDomain('Foo')` or in Twig. If no domain is configured the `messages` domain is used (as it was before this PR).
- The translation ID (eg `entities.App\Entity\Developer.singular`) can be customized by implementing `EntityTranslationIdGeneratorInterface`:
```php
class EntityTranslationIdGenerator implements EntityTranslationIdGeneratorInterface
{
    public function generateForEntity(string $entity, bool $singular): string
    {
        return sprintf('entities.%s.%s', basename(str_replace('\\', '/', entity)), $singular ? 'singular' : 'plural');
    }

    public function generateForProperty(string $entity, string $property): string
    {
        return sprintf('entities.%s.properties.%s', basename(str_replace('\\', '/', entity)), $property);
    }
}
```