### PR TITLE
Fix field processing

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -372,8 +372,6 @@ return static function (ContainerConfigurator $container) {
             ->arg(1, new Reference(AuthorizationChecker::class))
             ->arg(2, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
 
-        ->set(CollectionConfigurator::class)
-
         ->set(CommonPostConfigurator::class)
             ->arg(0, service(AdminContextProvider::class))
             ->arg(1, '%kernel.charset%')
@@ -424,7 +422,8 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, service('request_stack'))
             ->arg(1, service(EntityFactory::class))
             ->arg(2, service(ControllerFactory::class))
-            ->arg(3, new Reference(FieldFactory::class))
+            ->arg(3, service(AdminContextProvider::class))
+            ->arg(4, new Reference(FieldFactory::class))
 
         ->set(SlugConfigurator::class)
 

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -191,6 +191,25 @@ final class AdminContext implements AdminContextInterface
     }
 
     /**
+     * Returns a new AdminContext with a different EntityDto.
+     * Useful for nested CRUD operations (e.g., CollectionField).
+     */
+    public function withEntity(EntityDto $entityDto): self
+    {
+        return new self(
+            $this->requestContext,
+            new CrudContext(
+                $this->crudContext->getCrud(),
+                $entityDto,
+                $this->crudContext->getSearch(),
+                $this->crudContext->getCrudControllers()
+            ),
+            $this->dashboardContext,
+            $this->i18nContext,
+        );
+    }
+
+    /**
      * Creates an AdminContext instance suitable for testing.
      *
      * This method provides sensible defaults for all sub-contexts, making it easy

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\PersistentCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -15,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
 use Symfony\Component\Form\Extension\Core\Type\LanguageType;
@@ -33,6 +35,7 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
         private readonly RequestStack $requestStack,
         private readonly EntityFactory $entityFactory,
         private readonly ControllerFactory $controllerFactory,
+        private readonly AdminContextProvider $adminContextProvider,
         private readonly ?FieldFactory $fieldFactory = null,
     ) {
         if (null === $this->fieldFactory) {
@@ -188,19 +191,36 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
     private function createEntityDto(string $targetEntityFqcn, string $targetCrudControllerFqcn, string $crudAction, string $crudControllerPageName, string $crudPageName): EntityDto
     {
         $entityDto = $this->entityFactory->create($targetEntityFqcn);
+        $request = $this->requestStack->getMainRequest();
 
         $crudController = $this->controllerFactory->getCrudControllerInstance(
             $targetCrudControllerFqcn,
             $crudAction,
-            $this->requestStack->getMainRequest()
+            $request
         );
 
-        $fields = $crudController->configureFields($crudControllerPageName);
+        $originalContext = $this->adminContextProvider->getContext();
 
-        if (null === $this->fieldFactory) {
-            $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
-        } else {
-            $this->fieldFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+        // temporarily swap AdminContext with the collection's EntityDto
+        // (this allows e.g. the CRUD controller of the collection entry to get the correct entity instance)
+        if ($originalContext instanceof AdminContext && null !== $request) {
+            $collectionContext = $originalContext->withEntity($entityDto);
+            $request->attributes->set(EA::CONTEXT_REQUEST_ATTRIBUTE, $collectionContext);
+        }
+
+        try {
+            $fields = $crudController->configureFields($crudControllerPageName);
+
+            if (null === $this->fieldFactory) {
+                $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+            } else {
+                $this->fieldFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+            }
+        } finally {
+            // restore the original context
+            if ($originalContext instanceof AdminContext && null !== $request) {
+                $request->attributes->set(EA::CONTEXT_REQUEST_ATTRIBUTE, $originalContext);
+            }
         }
 
         return $entityDto;

--- a/src/Form/EventListener/CrudAutocompleteSubscriber.php
+++ b/src/Form/EventListener/CrudAutocompleteSubscriber.php
@@ -106,7 +106,6 @@ class CrudAutocompleteSubscriber implements EventSubscriberInterface
                                 // Use RFC4122 format for platforms with native GUID type (e.g., PostgreSQL),
                                 // and binary format for platforms without native GUID type (e.g., MySQL, SQLite)
                                 $platform = $options['em']->getConnection()->getDatabasePlatform();
-
                                 $hasNativeGuidType = $platform->getGuidTypeDeclarationSQL([]) !== $platform->getStringTypeDeclarationSQL(['fixed' => true, 'length' => 36]);
 
                                 return $hasNativeGuidType

--- a/tests/Functional/Apps/DefaultApp/src/Controller/NestedCrudForm/ProjectIssueNestedCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/NestedCrudForm/ProjectIssueNestedCrudController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\NestedCrudForm;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\ProjectIssue;
+
+/**
+ * CRUD controller for ProjectIssue that accesses $context->getEntity() in configureFields().
+ * This is used to test that nested CRUD forms receive the correct entity in the context.
+ *
+ * @extends AbstractCrudController<ProjectIssue>
+ */
+class ProjectIssueNestedCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return ProjectIssue::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Project Issue')
+            ->setEntityLabelInPlural('Project Issues');
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        // before the fix, this would return the parent entity (Project) instead of ProjectIssue,
+        // causing errors when trying to access ProjectIssue-specific methods.
+        $context = $this->getContext();
+        if (null !== $context) {
+            $entity = $context->getEntity();
+            $entityFqcn = $entity->getFqcn();
+
+            if (ProjectIssue::class !== $entityFqcn) {
+                throw new \LogicException(sprintf(
+                    'Expected entity FQCN to be "%s", but got "%s". The AdminContext is not being swapped correctly for nested CRUD forms.',
+                    ProjectIssue::class,
+                    $entityFqcn
+                ));
+            }
+        }
+
+        yield TextField::new('name', 'Issue Name');
+    }
+}

--- a/tests/Functional/Apps/DefaultApp/src/Controller/NestedCrudForm/ProjectWithNestedIssuesCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/NestedCrudForm/ProjectWithNestedIssuesCrudController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\NestedCrudForm;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+
+/**
+ * CRUD controller for Project that uses CollectionField with useEntryCrudForm().
+ * This is used to test that nested CRUD forms work correctly with the AdminContext fix.
+ *
+ * @extends AbstractCrudController<Project>
+ */
+class ProjectWithNestedIssuesCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Project::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Project')
+            ->setEntityLabelInPlural('Projects');
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield TextField::new('name', 'Project Name');
+
+        // use useEntryCrudForm() to render nested ProjectIssue entities using the
+        // ProjectIssueNestedCrudController. This controller accesses $context->getEntity()
+        // in its configureFields(), which tests the bug fix
+        yield CollectionField::new('projectIssues', 'Issues')
+            ->useEntryCrudForm(ProjectIssueNestedCrudController::class);
+    }
+}

--- a/tests/Functional/Fields/Collection/NestedCrudFormTest.php
+++ b/tests/Functional/Fields/Collection/NestedCrudFormTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Fields\Collection;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\NestedCrudForm\ProjectWithNestedIssuesCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\ProjectIssue;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Tests that CollectionField with useEntryCrudForm() works correctly when the nested
+ * CRUD controller accesses $context->getEntity() in configureFields().
+ */
+class NestedCrudFormTest extends AbstractCrudTestCase
+{
+    /** @var EntityRepository<Project> */
+    private EntityRepository $projectRepository;
+
+    protected function setUp(): void
+    {
+        // useEntryCrudForm() requires the 'prototype_options' option, added in Symfony 6.1
+        if (Kernel::MAJOR_VERSION < 6 || (6 === Kernel::MAJOR_VERSION && Kernel::MINOR_VERSION < 1)) {
+            $this->markTestSkipped('useEntryCrudForm() requires Symfony 6.1 or newer.');
+        }
+
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->projectRepository = $this->entityManager->getRepository(Project::class);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->projectRepository);
+        parent::tearDown();
+    }
+
+    protected function getControllerFqcn(): string
+    {
+        return ProjectWithNestedIssuesCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    /**
+     * Tests that the NEW form page loads correctly with nested CRUD forms.
+     *
+     * The nested ProjectIssueNestedCrudController accesses $context->getEntity() in
+     * configureFields(). Before the fix, this would fail because the context would
+     * contain the parent entity (Project) instead of the nested entity (ProjectIssue).
+     */
+    public function testNewFormLoadsWithNestedCrudForm(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateNewFormUrl());
+
+        static::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form[name="Project"]');
+        static::assertCount(1, $form, 'The Project form should exist');
+
+        $collectionField = $crawler->filter('.field-collection');
+        static::assertGreaterThanOrEqual(1, $collectionField->count(), 'The collection field should exist');
+    }
+
+    /**
+     * Tests that the EDIT form page loads correctly with nested CRUD forms.
+     */
+    public function testEditFormLoadsWithNestedCrudForm(): void
+    {
+        $project = $this->createProjectWithIssues();
+
+        $crawler = $this->client->request('GET', $this->generateEditFormUrl($project->getId()));
+
+        static::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form[name="Project"]');
+        static::assertCount(1, $form, 'The Project form should exist');
+
+        $html = $crawler->html();
+        static::assertStringContainsString('Test Issue 1', $html, 'First issue should be visible');
+        static::assertStringContainsString('Test Issue 2', $html, 'Second issue should be visible');
+    }
+
+    /**
+     * Creates a Project with ProjectIssue entities for testing.
+     */
+    private function createProjectWithIssues(): Project
+    {
+        $project = new Project();
+        $project->setName('Test Project');
+        $project->setDescription('Test project for nested CRUD form testing');
+        $project->setInternal(false);
+        $project->setCountInteger(1);
+        $project->setCountSmallint(1);
+        $project->setPriceDecimal('100');
+        $project->setPriceFloat(100.0);
+        $project->setStartDateMutable(new \DateTime());
+        $project->setStartDateImmutable(new \DateTimeImmutable());
+        $project->setStartDateTimeMutable(new \DateTime());
+        $project->setStartDateTimeImmutable(new \DateTimeImmutable());
+        $project->setStartDateTimeTzMutable(new \DateTime());
+        $project->setStartDateTimeTzImmutable(new \DateTimeImmutable());
+        $project->setStartTimeMutable(new \DateTime());
+        $project->setStartTimeImmutable(new \DateTimeImmutable());
+        $project->setStatesSimpleArray(['active']);
+        $project->setRolesJson(['ROLE_USER']);
+
+        $issue1 = new ProjectIssue();
+        $issue1->setName('Test Issue 1');
+        $project->addProjectIssue($issue1);
+
+        $issue2 = new ProjectIssue();
+        $issue2->setName('Test Issue 2');
+        $project->addProjectIssue($issue2);
+
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+
+        return $project;
+    }
+}


### PR DESCRIPTION
This fixes a bug I faced this morning.

In a CRUD controller, you have something like this:

```php
public function configureFields(string $pageName): iterable
{
    yield CollectionField::new('some_field');
}
```

In the CRUD controller associated to `some_field`, you have something like this:

```php
$myEntity = $this->adminContextProvider->getContext()?->getEntity()->getInstance();
```

This code works perfectly when this second CRUD controller is run directly. But, when using a `CollectionField`, you get the entity associated to the first CRUD controller, not the entity associated to this one.

This is because the following stack of calls happens:

```
SecondCrudController.php:168, App\Controller\Admin\SecondCrudController->configureFields()
CollectionConfigurator.php:198, EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CollectionConfigurator->createEntityDto()
CollectionConfigurator.php:160, EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CollectionConfigurator->configureEntryType()
CollectionConfigurator.php:90, EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CollectionConfigurator->configure()
FieldFactory.php:115, EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory->processFields()
AbstractCrudController.php:189, EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController->detail()
HttpKernel.php:183, Symfony\Component\HttpKernel\HttpKernel->handleRaw()
HttpKernel.php:76, Symfony\Component\HttpKernel\HttpKernel->handle()
Kernel.php:191, Symfony\Component\HttpKernel\Kernel->handle()
HttpKernelRunner.php:35, Symfony\Component\Runtime\Runner\Symfony\HttpKernelRunner->run()
autoload_runtime.php:32, require_once()
index.php:5, {main}()
```

So, the second CRUD controller runs `configureFields()` and the line shown above:

```php
$myEntity = $this->adminContextProvider->getContext()?->getEntity()->getInstance();
```

This returns the entity related to the first CRUD controller (the one with the `CollectionField`) instead of the entity of the second CRUD controller. This PR updates the admin context while processing the collection of fields (so you have access to the right entity data) and restores it afterwards.