### PR TITLE
[Docs] Use named argument `icon` for `Action::new()`

### DIFF
--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -193,7 +193,7 @@ to users::
 
     public function configureActions(Actions $actions): Actions
     {
-        $viewInvoice = Action::new('View Invoice', 'fas fa-file-invoice')
+        $viewInvoice = Action::new('View Invoice', icon: 'fas fa-file-invoice')
             ->displayIf(static fn (Invoice $invoice): bool => $invoice->isPaid())
 
         return $actions


### PR DESCRIPTION
I'm tweaking my admin interface a little, and I needed to add a new custom action with an icon.

Without `icon:`, `fas fa-file-invoice` is used as the button text. 

Thanks!

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
