### PR TITLE
Fix action confirmation messages in action groups

### DIFF
--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -276,9 +276,35 @@ final class ActionFactory
                 'data-action-variant' => $actionDto->getVariant()->value,
             ]);
 
-            // if a custom message is provided (string or TranslatableInterface), store it for Twig to translate
+            // add confirmation message attribute
             if (true !== $confirmationMessage) {
-                $actionDto->setDisplayableConfirmationMessage($confirmationMessage);
+                $actionDto->setHtmlAttribute(
+                    'data-action-confirmation-message',
+                    $confirmationMessage instanceof TranslatableInterface
+                        ? $confirmationMessage
+                        : t($confirmationMessage, $defaultTranslationParameters, $translationDomain)
+                );
+            }
+
+            // add confirmation button label attribute
+            $buttonLabel = $actionDto->getConfirmationButtonLabel();
+            if (null !== $buttonLabel) {
+                $actionDto->setHtmlAttribute(
+                    'data-action-confirmation-button',
+                    $buttonLabel instanceof TranslatableInterface
+                        ? $buttonLabel
+                        : t($buttonLabel, $defaultTranslationParameters, $translationDomain)
+                );
+            }
+
+            // add entity context attributes (only for entity actions)
+            if (null !== $entityDto) {
+                $entityLabel = $adminContext->getCrud()->getEntityLabelInSingular();
+                $actionDto->setHtmlAttribute(
+                    'data-action-entity-name',
+                    \is_string($entityLabel) ? t($entityLabel, $defaultTranslationParameters, $translationDomain) : $entityLabel
+                );
+                $actionDto->setHtmlAttribute('data-action-entity-id', $entityDto->getPrimaryKeyValueAsString());
             }
         }
 

--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -64,6 +64,7 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
             new TwigFilter('ea_flatten_array', [$this, 'flattenArray']),
             new TwigFilter('ea_filesize', [$this, 'fileSize']),
             new TwigFilter('ea_as_string', [$this, 'representAsString']),
+            new TwigFilter('ea_html_attrs', [$this, 'processHtmlAttributes']),
             // deprecated filters
             new TwigFilter('ea_apply_filter_if_exists', [$this, 'applyFilterIfExists'], ['needs_environment' => true, 'deprecation_info' => new DeprecatedCallableInfo('easycorp/easyadmin-bundle', '4.21.0', 'No alternative is provided because it\'s no longer needed thanks to the Twig guard tag.')]),
         ];
@@ -126,6 +127,26 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
         }
 
         return $flattenedArray;
+    }
+
+    /**
+     * Processes an array of HTML attributes, translating any TranslatableInterface values.
+     * This is needed because Twig Components don't accept non-scalar attribute values.
+     *
+     * @param array<string, mixed> $attributes
+     *
+     * @return array<string, mixed>
+     */
+    public function processHtmlAttributes(array $attributes): array
+    {
+        $processed = [];
+        foreach ($attributes as $name => $value) {
+            $processed[$name] = $value instanceof TranslatableInterface
+                ? $value->trans($this->translator)
+                : $value;
+        }
+
+        return $processed;
     }
 
     public function fileSize(int $bytes): string

--- a/templates/components/ActionMenu/ActionList/ItemGroup.html.twig
+++ b/templates/components/ActionMenu/ActionList/ItemGroup.html.twig
@@ -20,7 +20,7 @@
                 {% else %}
                     href="{{ group.mainAction.linkUrl }}"
                 {% endif %}
-                {% for attr, value in group.mainAction.htmlAttributes %}{{ attr }}="{{ value }}" {% endfor %}>
+                {% for attr, value in group.mainAction.htmlAttributes|ea_html_attrs %}{{ attr }}="{{ value }}" {% endfor %}>
                 {% if group.icon %}
                     <twig:ea:Icon name="{{ group.icon }}" />
                 {% elseif showBlankIcons or group.hasAnyActionWithIcon %}
@@ -60,7 +60,7 @@
                 <twig:ea:ActionMenu:ActionList:Item
                     class="{{ subItem.cssClass }} dropdown-item-variant-{{ subItem.variant.value }}"
                     label="{{ subItem.label|trans }}" icon="{{ subItem.icon }}"
-                    htmlAttributes="{{ subItem.htmlAttributes }}"
+                    htmlAttributes="{{ subItem.htmlAttributes|ea_html_attrs }}"
                     url="{{ subItem.linkUrl }}" renderLabelRaw="true"
                     renderAsForm="{{ subItem.isRenderedAsForm }}"
                     showBlankIcons="{{ group.hasAnyActionWithIcon }}" />

--- a/templates/crud/action.html.twig
+++ b/templates/crud/action.html.twig
@@ -2,29 +2,11 @@
 {# @var action \EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto #}
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 
-{% set html_attributes = action.htmlAttributes %}
-{% if action.displayableConfirmationMessage is not null %}
-    {% set html_attributes = html_attributes|merge({
-        'data-action-confirmation-message': action.displayableConfirmationMessage|trans,
-    }) %}
-{% endif %}
-{% if action.hasConfirmation %}
-    {% set html_attributes = html_attributes|merge({
-        'data-action-entity-name': ea().crud.entityLabelInSingular|default('')|trans,
-        'data-action-entity-id': entity.primaryKeyValueAsString|default(''),
-    }) %}
-    {% if action.confirmationButtonLabel is not null %}
-        {% set html_attributes = html_attributes|merge({
-            'data-action-confirmation-button': action.confirmationButtonLabel|trans,
-        }) %}
-    {% endif %}
-{% endif %}
-
 <twig:ea:Button
     variant="{{ action.variant }}"
     isInvisible="{{ action.usesTextStyle }}"
     class="{{ action.htmlElement.isLink and isIncludedInDropdown|default(false) ? 'dropdown-item' }} {{ action.cssClass }}"
-    htmlAttributes="{{ html_attributes }}"
+    htmlAttributes="{{ action.htmlAttributes|ea_html_attrs }}"
     htmlElement="{{ action.htmlElement }}"
     type="{{ action.buttonType.value }}"
     icon="{{ action.icon }}"

--- a/templates/crud/action_group.html.twig
+++ b/templates/crud/action_group.html.twig
@@ -13,7 +13,7 @@
             action="{{ main_action.htmlElement.isForm ? main_action.linkUrl : null }}"
             method="{{ main_action.htmlElement.isForm ? 'POST' : null }}"
             icon="{{ main_action.icon ?: group.icon }}"
-            htmlAttributes="{{ main_action.htmlAttributes|merge({'data-action-group-name-main-action': true, 'data-ea-action-url': main_action.htmlElement.isButton ? main_action.linkUrl : null})|filter((v) => v is not null) }}"
+            htmlAttributes="{{ main_action.htmlAttributes|ea_html_attrs|merge({'data-action-group-name-main-action': true, 'data-ea-action-url': main_action.htmlElement.isButton ? main_action.linkUrl : null})|filter((v) => v is not null) }}"
         >
             {% set main_action_label = main_action.label|trans %}
             {%- if main_action_label is not same as(false) -%}{{ main_action_label|raw }}{%- endif -%}
@@ -56,7 +56,7 @@
                 {# item is an ActionDto #}
                 <twig:ea:ActionMenu:ActionList:Item
                     label="{{ item.label|trans }}" icon="{{ item.icon }}" class="{{ item.cssClass }} dropdown-item-variant-{{ item.variant.value }}"
-                    htmlAttributes="{{ item.htmlAttributes }}"
+                    htmlAttributes="{{ item.htmlAttributes|ea_html_attrs }}"
                     renderAsForm="{{ item.isRenderedAsForm }}"
                     url="{{ item.linkUrl }}" renderLabelRaw="true"
                     showBlankIcons="{{ group.hasAnyActionWithIcon }}"

--- a/templates/crud/index.html.twig
+++ b/templates/crud/index.html.twig
@@ -182,28 +182,10 @@
                                                                 showBlankIcons="{{ hasAnyActionWithIcon }}"
                                                                 entity="{{ entity }}" />
                                                         {% else %}
-                                                            {# add confirmation-related attributes if needed #}
-                                                            {% set item_html_attributes = item.htmlAttributes %}
-                                                            {% if item.displayableConfirmationMessage is not null %}
-                                                                {% set item_html_attributes = item_html_attributes|merge({
-                                                                    'data-action-confirmation-message': item.displayableConfirmationMessage|trans,
-                                                                }) %}
-                                                            {% endif %}
-                                                            {% if item.hasConfirmation %}
-                                                                {% set item_html_attributes = item_html_attributes|merge({
-                                                                    'data-action-entity-name': ea.crud.entityLabelInSingular|default('')|trans,
-                                                                    'data-action-entity-id': entity.primaryKeyValueAsString|default(''),
-                                                                }) %}
-                                                                {% if item.confirmationButtonLabel is not null %}
-                                                                    {% set item_html_attributes = item_html_attributes|merge({
-                                                                        'data-action-confirmation-button': item.confirmationButtonLabel|trans,
-                                                                    }) %}
-                                                                {% endif %}
-                                                            {% endif %}
                                                             <twig:ea:ActionMenu:ActionList:Item
                                                                 class="{{ item.cssClass }} dropdown-item-variant-{{ item.variant.value }}" url="{{ item.linkUrl }}"
                                                                 icon="{{ item.icon }}" icon:class="action-icon"
-                                                                htmlAttributes="{{ item_html_attributes }}"
+                                                                htmlAttributes="{{ item.htmlAttributes|ea_html_attrs }}"
                                                                 renderAsForm="{{ item.isRenderedAsForm }}"
                                                                 label="{{ item.label|trans }}" label:class="action-label" renderLabelRaw
                                                                 showBlankIcons="{{ hasAnyActionWithIcon }}" />


### PR DESCRIPTION
Fixes #7399.

The fix was trivial, but this PR is more complex because it also removes the repeated code on Twig templates, moves logic to PHP and even adds a Twig filter to deal with HTML attributes on Twig components.