### PR TITLE
Introduce an AdminControllerRegistry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ make checks-before-pr
 - Braces required for all control structures
 - Trailing commas in multi-line arrays
 - Blank line before `return` (unless only statement in block)
+- Don't add comments in classes as separators (e.g. `// === Methods for dashboards ===`)
 
 ### Naming
 - Variables/methods: `camelCase`

--- a/config/services.php
+++ b/config/services.php
@@ -81,8 +81,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityUpdater;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\FieldProvider;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
-use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteLoader;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
@@ -181,7 +181,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(5, service('cache.easyadmin'))
             ->arg(6, service(AdminRouteGenerator::class))
             ->arg(7, '%kernel.build_dir%')
-            ->arg(8, service(CrudControllerRegistry::class))
+            ->arg(8, service(AdminControllerRegistry::class))
             ->tag('kernel.event_subscriber')
 
         ->set(ControllerFactory::class)
@@ -196,11 +196,12 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, '%kernel.build_dir%')
             ->arg(1, new Reference('security.token_storage', ContainerInterface::NULL_ON_INVALID_REFERENCE))
             ->arg(2, new Reference(MenuFactory::class))
-            ->arg(3, new Reference(CrudControllerRegistry::class))
+            ->arg(3, new Reference(AdminControllerRegistry::class))
             ->arg(4, new Reference(EntityFactory::class))
             ->arg(5, service(AdminRouteGenerator::class))
             ->arg(6, service(ActionFactory::class))
             ->arg(7, service(EntityTranslationIdGeneratorInterface::class))
+            ->arg(8, new Reference(CrudControllerRegistry::class))
 
         ->set(AdminUrlGenerator::class)
             // I don't know if we truly need the share() method to get a new instance of the
@@ -209,7 +210,7 @@ return static function (ContainerConfigurator $container) {
             ->share(false)
             ->arg(0, service(AdminContextProvider::class))
             ->arg(1, service('router'))
-            ->arg(2, service(DashboardControllerRegistry::class))
+            ->arg(2, service(AdminControllerRegistry::class))
             ->arg(3, service(AdminRouteGenerator::class))
             ->arg(4, service('cache.easyadmin'))
 
@@ -220,6 +221,11 @@ return static function (ContainerConfigurator $container) {
         ->set('cache.easyadmin')
             ->parent('cache.system')
             ->tag('cache.pool')
+
+        ->set(AdminControllerRegistry::class)
+            ->arg(0, '%kernel.build_dir%')
+            ->arg(1, abstract_arg('CRUD controller FQCN to Entity FQCN map'))
+            ->arg(2, abstract_arg('Dashboard controller FQCNs'))
 
         ->set(AdminRouteGenerator::class)
             ->arg(0, tagged_iterator(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER))

--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -12,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\LocaleDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -85,8 +86,23 @@ final class AdminContext implements AdminContextInterface
         return $this->crudContext->getSearch();
     }
 
+    public function getAdminControllers(): AdminControllerRegistry
+    {
+        return $this->crudContext->getAdminControllers();
+    }
+
+    /**
+     * @deprecated since 4.28.1, use getAdminControllers() instead
+     */
     public function getCrudControllers(): CrudControllerRegistry
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "getAdminControllers()" instead.',
+            __METHOD__
+        );
+
         return $this->crudContext->getCrudControllers();
     }
 
@@ -202,7 +218,7 @@ final class AdminContext implements AdminContextInterface
                 $this->crudContext->getCrud(),
                 $entityDto,
                 $this->crudContext->getSearch(),
-                $this->crudContext->getCrudControllers()
+                $this->crudContext->getAdminControllers(),
             ),
             $this->dashboardContext,
             $this->i18nContext,

--- a/src/Context/CrudContext.php
+++ b/src/Context/CrudContext.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Context;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 
 /**
@@ -19,7 +20,8 @@ final class CrudContext
         private readonly ?CrudDto $crudDto,
         private readonly ?EntityDto $entityDto,
         private readonly ?SearchDto $searchDto,
-        private readonly CrudControllerRegistry $crudControllers,
+        private readonly AdminControllerRegistry $adminControllers,
+        private readonly ?CrudControllerRegistry $crudControllers = null,
     ) {
     }
 
@@ -40,7 +42,16 @@ final class CrudContext
 
     public function getCrudControllers(): CrudControllerRegistry
     {
+        if (null === $this->crudControllers) {
+            throw new \LogicException('The CrudControllerRegistry is not available. This method requires the registry to be injected in the constructor.');
+        }
+
         return $this->crudControllers;
+    }
+
+    public function getAdminControllers(): AdminControllerRegistry
+    {
+        return $this->adminControllers;
     }
 
     /**
@@ -50,13 +61,17 @@ final class CrudContext
         ?CrudDto $crudDto = null,
         ?EntityDto $entityDto = null,
         ?SearchDto $searchDto = null,
+        ?AdminControllerRegistry $adminControllers = null,
         ?CrudControllerRegistry $crudControllers = null,
     ): self {
+        $adminControllers ??= new AdminControllerRegistry('', [], []);
+
         return new self(
             $crudDto ?? new CrudDto(),
             $entityDto,
             $searchDto,
-            $crudControllers ?? new CrudControllerRegistry([], [], [], [])
+            $adminControllers,
+            $crudControllers ?? new CrudControllerRegistry([], [], [], []),
         );
     }
 }

--- a/src/Contracts/Context/AdminContextInterface.php
+++ b/src/Contracts/Context/AdminContextInterface.php
@@ -10,6 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\LocaleDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -28,6 +29,13 @@ interface AdminContextInterface
 
     public function getI18n(): I18nDto;
 
+    // this method will be introduced in 5.0.0, but the class that implements
+    // this interface already implements it, so you can use it to smooth upgrade
+    // public function getAdminControllers(): AdminControllerRegistry;
+
+    /**
+     * @deprecated since 4.28.1, use getAdminControllers() instead
+     */
     public function getCrudControllers(): CrudControllerRegistry;
 
     /**

--- a/src/Contracts/Registry/AdminControllerRegistryInterface.php
+++ b/src/Contracts/Registry/AdminControllerRegistryInterface.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Registry;
+
+/**
+ * Unified registry for Dashboard and CRUD controllers.
+ * Replaces the deprecated DashboardControllerRegistry and CrudControllerRegistry.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+interface AdminControllerRegistryInterface
+{
+    /**
+     * Returns the route name for the given Dashboard controller FQCN.
+     *
+     * @param class-string $dashboardFqcn
+     */
+    public function getDashboardRoute(string $dashboardFqcn): ?string;
+
+    /**
+     * Returns the Dashboard controller FQCN for the given route name.
+     *
+     * @return class-string|null
+     */
+    public function getDashboardByRoute(string $routeName): ?string;
+
+    /**
+     * Returns the number of registered Dashboard controllers.
+     */
+    public function getDashboardCount(): int;
+
+    /**
+     * Returns the FQCN of the first registered Dashboard controller.
+     *
+     * @return class-string|null
+     */
+    public function getFirstDashboard(): ?string;
+
+    /**
+     * Returns the route name of the first registered Dashboard controller.
+     */
+    public function getFirstDashboardRoute(): ?string;
+
+    /**
+     * Returns all registered Dashboard controller FQCNs.
+     *
+     * @return array<class-string>
+     */
+    public function getAllDashboards(): array;
+
+    /**
+     * Returns the CRUD controller FQCN that manages the given entity.
+     *
+     * Note: If multiple CRUD controllers manage the same entity, only the
+     * last one registered will be returned. Use explicit controller references
+     * when multiple controllers manage the same entity.
+     *
+     * @param class-string $entityFqcn
+     *
+     * @return class-string|null
+     */
+    public function findCrudControllerByEntity(string $entityFqcn): ?string;
+
+    /**
+     * Returns the entity FQCN managed by the given CRUD controller.
+     *
+     * @param class-string $crudControllerFqcn
+     *
+     * @return class-string|null
+     */
+    public function findEntityByCrudController(string $crudControllerFqcn): ?string;
+
+    /**
+     * Returns all registered CRUD controller FQCNs.
+     *
+     * @return array<class-string>
+     */
+    public function getAllCrudControllers(): array;
+}

--- a/src/DependencyInjection/CreateControllerRegistriesPass.php
+++ b/src/DependencyInjection/CreateControllerRegistriesPass.php
@@ -2,14 +2,15 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\DependencyInjection;
 
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * Creates the services of the Dashboard and CRUD controller registries. They can't
- * be defined as normal services because they cause circular dependencies.
+ * Creates the services of the controller registries. They can't be defined as
+ * normal services because they cause circular dependencies.
  * See https://github.com/EasyCorp/EasyAdminBundle/issues/3541.
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -18,10 +19,31 @@ class CreateControllerRegistriesPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        $this->createAdminControllerRegistryService($container);
         $this->createDashboardControllerRegistryService($container);
         $this->createCrudControllerRegistryService($container);
     }
 
+    private function createAdminControllerRegistryService(ContainerBuilder $container): void
+    {
+        $dashboardControllersFqcn = array_keys($container->findTaggedServiceIds(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER, true));
+        $crudControllersFqcn = array_keys($container->findTaggedServiceIds(EasyAdminExtension::TAG_CRUD_CONTROLLER, true));
+
+        $crudFqcnToEntityFqcnMap = [];
+        foreach ($crudControllersFqcn as $controllerFqcn) {
+            $crudFqcnToEntityFqcnMap[$controllerFqcn] = $controllerFqcn::getEntityFqcn();
+        }
+
+        // the service is defined with abstract_arg() placeholders:
+        // here we only replace the dynamic arguments built from tagged services.
+        $container->getDefinition(AdminControllerRegistry::class)
+            ->replaceArgument(1, $crudFqcnToEntityFqcnMap)
+            ->replaceArgument(2, $dashboardControllersFqcn);
+    }
+
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry instead
+     */
     private function createDashboardControllerRegistryService(ContainerBuilder $container): void
     {
         $dashboardControllersFqcn = array_keys($container->findTaggedServiceIds(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER, true));
@@ -44,6 +66,9 @@ class CreateControllerRegistriesPass implements CompilerPassInterface
             ]);
     }
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry instead
+     */
     private function createCrudControllerRegistryService(ContainerBuilder $container): void
     {
         $crudControllersFqcn = array_keys($container->findTaggedServiceIds(EasyAdminExtension::TAG_CRUD_CONTROLLER, true));

--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -9,7 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInte
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\AdminContextFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
-use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminRouteGenerator;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -47,7 +47,7 @@ class AdminRouterSubscriber implements EventSubscriberInterface
         private readonly CacheItemPoolInterface $cache,
         private readonly AdminRouteGeneratorInterface $adminRouteGenerator,
         private readonly string $buildDir,
-        private readonly CrudControllerRegistry $crudControllerRegistry,
+        private readonly AdminControllerRegistry $adminControllers,
     ) {
     }
 
@@ -158,7 +158,7 @@ class AdminRouterSubscriber implements EventSubscriberInterface
             if (is_subclass_of($entityFqcnOrCrudControllerFqcn, CrudControllerInterface::class)) {
                 $crudControllerFqcn = $entityFqcnOrCrudControllerFqcn;
             } else {
-                $crudControllerFqcn = $this->crudControllerRegistry->findCrudFqcnByEntityFqcn($entityFqcnOrCrudControllerFqcn);
+                $crudControllerFqcn = $this->adminControllers->findCrudControllerByEntity($entityFqcnOrCrudControllerFqcn);
             }
 
             $prettyUrlRoute = $this->adminRouteGenerator->findRouteName($dashboardControllerFqcn, $crudControllerFqcn, $request->query->get(EA::CRUD_ACTION, ''));

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -25,6 +25,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterConfigDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\TemplateRegistry;
 use Symfony\Component\HttpFoundation\Request;
@@ -43,11 +44,12 @@ final class AdminContextFactory
         private readonly string $buildDir,
         private readonly ?TokenStorageInterface $tokenStorage,
         private readonly MenuFactoryInterface $menuFactory,
-        private readonly CrudControllerRegistry $crudControllers,
+        private readonly AdminControllerRegistry $adminControllers,
         private readonly EntityFactory $entityFactory,
         private readonly AdminRouteGeneratorInterface $adminRouteGenerator,
         private readonly ActionFactory $actionFactory,
         private readonly ?EntityTranslationIdGeneratorInterface $entityTranslationIdGenerator = null,
+        private readonly ?CrudControllerRegistry $crudControllers = null,
     ) {
         if (null === $this->entityTranslationIdGenerator) {
             trigger_deprecation(
@@ -72,7 +74,7 @@ final class AdminContextFactory
 
         // build a first version of CrudDto without actions so we can create AdminContext, which is
         // needed for action extensions; later, we'll update the CrudDto object with the full action config
-        $crudDto = $this->getCrudDto($this->crudControllers, $dashboardController, $crudController, new ActionConfigDto(), $filters, $crudAction, $pageName);
+        $crudDto = $this->getCrudDto($this->adminControllers, $dashboardController, $crudController, new ActionConfigDto(), $filters, $crudAction, $pageName);
         $entityDto = $this->getEntityDto($request, $crudDto);
         $searchDto = $this->getSearchDto($request, $crudDto);
         $i18nDto = $this->getI18nDto($request, $dashboardDto, $crudDto, $entityDto);
@@ -81,7 +83,7 @@ final class AdminContextFactory
 
         // build sub-contexts
         $requestContext = new RequestContext($request, $user);
-        $crudContext = new CrudContext($crudDto, $entityDto, $searchDto, $this->crudControllers);
+        $crudContext = new CrudContext($crudDto, $entityDto, $searchDto, $this->adminControllers, $this->crudControllers);
         $dashboardContext = new DashboardContext($dashboardDto, $dashboardController::class, $assetDto, $usePrettyUrls);
         $i18nContext = new I18nContext($i18nDto, $templateRegistry);
 
@@ -150,7 +152,7 @@ final class AdminContextFactory
         return $crudController->configureAssets($defaultAssets)->getAsDto()->loadedOn($pageName);
     }
 
-    private function getCrudDto(CrudControllerRegistry $crudControllers, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ActionConfigDto $actionConfigDto, FilterConfigDto $filters, ?string $crudAction, ?string $pageName): ?CrudDto
+    private function getCrudDto(AdminControllerRegistry $adminControllers, DashboardControllerInterface $dashboardController, ?CrudControllerInterface $crudController, ActionConfigDto $actionConfigDto, FilterConfigDto $filters, ?string $crudAction, ?string $pageName): ?CrudDto
     {
         if (null === $crudController) {
             return null;
@@ -159,7 +161,7 @@ final class AdminContextFactory
         $defaultCrud = $dashboardController->configureCrud();
         $crudDto = $crudController->configureCrud($defaultCrud)->getAsDto();
 
-        $entityFqcn = $crudControllers->findEntityFqcnByCrudFqcn($crudController::class);
+        $entityFqcn = $adminControllers->findEntityByCrudController($crudController::class);
 
         $crudDto->setControllerFqcn($crudController::class);
         $crudDto->setActionsConfig($actionConfigDto);

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -158,8 +158,8 @@ final class MenuFactory implements MenuFactoryInterface
                 $this->adminUrlGenerator->setController($crudControllerFqcn);
             // 2. ...otherwise, find the CRUD controller from the entityFqcn
             } else {
-                $crudControllers = $this->adminContextProvider->getContext()?->getCrudControllers();
-                if (null === $controllerFqcn = $crudControllers->findCrudFqcnByEntityFqcn($entityFqcn)) {
+                $adminControllers = $this->adminContextProvider->getContext()?->getAdminControllers(); // @phpstan-ignore method.notFound (method will be added to the interface in 5.0)
+                if (null === $controllerFqcn = $adminControllers->findCrudControllerByEntity($entityFqcn)) {
                     throw new \RuntimeException(sprintf('Unable to find the controller related to the "%s" Entity; did you forget to extend "%s"?', $entityFqcn, AbstractCrudController::class));
                 }
 

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -64,7 +64,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
         // the target CRUD controller can be NULL; in that case, field value doesn't link to the related entity
         $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER)
-            ?? $context->getCrudControllers()->findCrudFqcnByEntityFqcn($entityDto->getClassMetadata()->getAssociationTargetClass($propertyName));
+            ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($propertyName));
 
         if (true === $field->getCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM)) {
             if (false === $entityDto->getClassMetadata()->isSingleValuedAssociation($propertyName)) {

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -144,14 +144,14 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             }
 
             $targetCrudControllerFqcn = $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_CONTROLLER_FQCN)
-                ?? $context->getCrudControllers()->findCrudFqcnByEntityFqcn($entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()));
+                ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()));
 
             if (null === $targetCrudControllerFqcn) {
                 throw new \RuntimeException(sprintf('The "%s" collection field of "%s" wants to render its entries using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "useEntryCrudForm()" method.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn(), $entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty())));
             }
         } elseif (null === $fieldDto->getFormTypeOption('entry_type')
             && $entityDto->getClassMetadata()->hasAssociation($fieldDto->getProperty())) {
-            $targetCrudControllerFqcn = $context->getCrudControllers()->findCrudFqcnByEntityFqcn($entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()));
+            $targetCrudControllerFqcn = $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()));
 
             if (null === $targetCrudControllerFqcn) {
                 return;

--- a/src/Filter/Configurator/EntityConfigurator.php
+++ b/src/Filter/Configurator/EntityConfigurator.php
@@ -69,7 +69,7 @@ final class EntityConfigurator implements FilterConfiguratorInterface
         if ($supportsAutocomplete) {
             $associationMapping = $entityDto->getClassMetadata()->associationMappings[$propertyName];
             $targetEntityFqcn = $associationMapping['targetEntity'];
-            if (null === $targetCrudControllerFqcn = $context->getCrudControllers()->findCrudFqcnByEntityFqcn($targetEntityFqcn)) {
+            if (null === $targetCrudControllerFqcn = $context->getAdminControllers()->findCrudControllerByEntity($targetEntityFqcn)) {
                 throw new \LogicException('The target CRUD controller for the entity '.$targetEntityFqcn.' is not defined.');
             }
             $autocompleteEndpointUrl = $this->adminUrlGenerator

--- a/src/Provider/AdminContextProvider.php
+++ b/src/Provider/AdminContextProvider.php
@@ -12,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\MainMenuDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\UserMenuDto;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -94,12 +95,27 @@ final class AdminContextProvider implements AdminContextProviderInterface
         return $this->getContext(true)->getI18n();
     }
 
-    public function getCrudControllers(): CrudControllerRegistry
+    public function getAdminControllers(): AdminControllerRegistry
     {
         trigger_deprecation(
             'easycorp/easyadmin-bundle',
             '4.25.0',
             'The "%s" method is deprecated and will be removed in EasyAdmin 5.0.0. Use the method with the same name from the "EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext" class instead. This deprecation may have been triggered by the usage of the global "ea" variable in a Twig template, which is also deprecated. Use the equivalent "ea()" Twig function instead.',
+            __METHOD__
+        );
+
+        return $this->getContext(true)->getAdminControllers(); // @phpstan-ignore method.notFound (method will be added to the interface in 5.0)
+    }
+
+    /**
+     * @deprecated since 4.28.1, use getAdminControllers() instead
+     */
+    public function getCrudControllers(): CrudControllerRegistry
+    {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s" method is deprecated and will be removed in EasyAdmin 5.0.0. Use "AdminContext::getAdminControllers()" instead.',
             __METHOD__
         );
 

--- a/src/Registry/AdminControllerRegistry.php
+++ b/src/Registry/AdminControllerRegistry.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
+
+use EasyCorp\Bundle\EasyAdminBundle\Cache\CacheWarmer;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Registry\AdminControllerRegistryInterface;
+use function Symfony\Component\String\u;
+
+/**
+ * Unified registry for Dashboard and CRUD controllers.
+ * Replaces the deprecated DashboardControllerRegistry and CrudControllerRegistry.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class AdminControllerRegistry implements AdminControllerRegistryInterface
+{
+    /** @var array<string, string>|null */
+    private ?array $controllerFqcnToRouteMap = null;
+    /** @var array<string, string>|null */
+    private ?array $routeToControllerFqcnMap = null;
+
+    /** @var array<class-string, class-string> */
+    private readonly array $entityFqcnToCrudFqcnMap;
+
+    /**
+     * @param array<class-string, class-string> $crudFqcnToEntityFqcnMap CRUD controller FQCN => Entity FQCN
+     * @param array<class-string>               $dashboardControllers    List of Dashboard controller FQCNs
+     */
+    public function __construct(
+        private readonly string $buildDir,
+        private readonly array $crudFqcnToEntityFqcnMap,
+        private readonly array $dashboardControllers,
+    ) {
+        $this->entityFqcnToCrudFqcnMap = array_flip($crudFqcnToEntityFqcnMap);
+    }
+
+    public function getDashboardRoute(string $dashboardFqcn): ?string
+    {
+        return $this->getControllerFqcnToRouteMap()[$dashboardFqcn] ?? null;
+    }
+
+    public function getDashboardByRoute(string $routeName): ?string
+    {
+        return $this->getRouteToControllerFqcnMap()[$routeName] ?? null;
+    }
+
+    public function getDashboardCount(): int
+    {
+        return \count($this->dashboardControllers);
+    }
+
+    public function getFirstDashboard(): ?string
+    {
+        $map = $this->getControllerFqcnToRouteMap();
+
+        return \count($map) < 1 ? null : array_key_first($map);
+    }
+
+    public function getFirstDashboardRoute(): ?string
+    {
+        $map = $this->getControllerFqcnToRouteMap();
+
+        return \count($map) < 1 ? null : $map[array_key_first($map)];
+    }
+
+    public function getAllDashboards(): array
+    {
+        return $this->dashboardControllers;
+    }
+
+    public function findCrudControllerByEntity(string $entityFqcn): ?string
+    {
+        return $this->entityFqcnToCrudFqcnMap[$entityFqcn] ?? null;
+    }
+
+    public function findEntityByCrudController(string $crudControllerFqcn): ?string
+    {
+        return $this->crudFqcnToEntityFqcnMap[$crudControllerFqcn] ?? null;
+    }
+
+    public function getAllCrudControllers(): array
+    {
+        return array_keys($this->crudFqcnToEntityFqcnMap);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getControllerFqcnToRouteMap(): array
+    {
+        if (null === $this->controllerFqcnToRouteMap) {
+            $this->loadDashboardRoutesCache();
+        }
+
+        return $this->controllerFqcnToRouteMap;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function getRouteToControllerFqcnMap(): array
+    {
+        if (null === $this->routeToControllerFqcnMap) {
+            $this->loadDashboardRoutesCache();
+        }
+
+        return $this->routeToControllerFqcnMap;
+    }
+
+    private function loadDashboardRoutesCache(): void
+    {
+        $this->controllerFqcnToRouteMap = [];
+
+        $dashboardRoutesCachePath = $this->buildDir.'/'.CacheWarmer::DASHBOARD_ROUTES_CACHE;
+        $dashboardControllerRoutes = file_exists($dashboardRoutesCachePath) ? require $dashboardRoutesCachePath : [];
+
+        foreach ($dashboardControllerRoutes as $routeName => $controller) {
+            $this->controllerFqcnToRouteMap[u($controller)->before('::')->toString()] = $routeName;
+        }
+
+        $this->routeToControllerFqcnMap = array_flip($this->controllerFqcnToRouteMap);
+    }
+}

--- a/src/Registry/CrudControllerRegistry.php
+++ b/src/Registry/CrudControllerRegistry.php
@@ -3,6 +3,8 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 
 /**
+ * @deprecated since 4.28.1, use AdminControllerRegistry instead
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
 final class CrudControllerRegistry
@@ -10,8 +12,8 @@ final class CrudControllerRegistry
     /**
      * @param array<class-string, class-string> $crudFqcnToEntityFqcnMap
      * @param array<class-string, string>       $crudFqcnToCrudIdMap
-     * @param array<string, class-string>       $crudIdToCrudFqcnMap
      * @param array<class-string, class-string> $entityFqcnToCrudFqcnMap
+     * @param array<string, class-string>       $crudIdToCrudFqcnMap
      */
     public function __construct(
         private readonly array $crudFqcnToEntityFqcnMap,
@@ -22,46 +24,91 @@ final class CrudControllerRegistry
     }
 
     /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::findCrudControllerByEntity() instead
+     *
      * @param class-string $entityFqcn
      *
      * @return class-string|null
      */
     public function findCrudFqcnByEntityFqcn(string $entityFqcn): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::findCrudControllerByEntity()" instead.',
+            __METHOD__
+        );
+
         return $this->entityFqcnToCrudFqcnMap[$entityFqcn] ?? null;
     }
 
     /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::findEntityByCrudController() instead
+     *
      * @param class-string $controllerFqcn
      *
      * @return class-string|null
      */
     public function findEntityFqcnByCrudFqcn(string $controllerFqcn): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::findEntityByCrudController()" instead.',
+            __METHOD__
+        );
+
         return $this->crudFqcnToEntityFqcnMap[$controllerFqcn] ?? null;
     }
 
     /**
+     * @deprecated since 4.28.1, this concept (crudId) no longer exists in modern EasyAdmin
+     *
      * @return class-string|null
      */
     public function findCrudFqcnByCrudId(string $crudId): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated and will be removed in EasyAdmin 5.x. The "crudId" concept no longer exists in modern EasyAdmin with pretty URLs.',
+            __METHOD__
+        );
+
         return $this->crudIdToCrudFqcnMap[$crudId] ?? null;
     }
 
     /**
+     * @deprecated since 4.28.1, this concept (crudId) no longer exists in modern EasyAdmin
+     *
      * @param class-string $controllerFqcn
      */
     public function findCrudIdByCrudFqcn(string $controllerFqcn): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated and will be removed in EasyAdmin 5.x. The "crudId" concept no longer exists in modern EasyAdmin with pretty URLs.',
+            __METHOD__
+        );
+
         return $this->crudFqcnToCrudIdMap[$controllerFqcn] ?? null;
     }
 
     /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getAllCrudControllers() instead
+     *
      * @return array<int, class-string>
      */
     public function getAll(): array
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::getAllCrudControllers()" instead.',
+            __METHOD__
+        );
+
         return array_values($this->entityFqcnToCrudFqcnMap);
     }
 }

--- a/src/Registry/DashboardControllerRegistry.php
+++ b/src/Registry/DashboardControllerRegistry.php
@@ -5,6 +5,9 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 use EasyCorp\Bundle\EasyAdminBundle\Cache\CacheWarmer;
 use function Symfony\Component\String\u;
 
+/**
+ * @deprecated since 4.28.1, use AdminControllerRegistry instead
+ */
 final class DashboardControllerRegistry implements DashboardControllerRegistryInterface
 {
     /** @var array<string, string>|null */
@@ -23,47 +26,127 @@ final class DashboardControllerRegistry implements DashboardControllerRegistryIn
     ) {
     }
 
+    /**
+     * @deprecated since 4.28.1, this concept (contextId) no longer exists in modern EasyAdmin
+     */
     public function getControllerFqcnByContextId(string $contextId): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated and will be removed in EasyAdmin 5.x. The "contextId" concept no longer exists in modern EasyAdmin with pretty URLs.',
+            __METHOD__
+        );
+
         return $this->contextIdToControllerFqcnMap[$contextId] ?? null;
     }
 
+    /**
+     * @deprecated since 4.28.1, this concept (contextId) no longer exists in modern EasyAdmin
+     */
     public function getContextIdByControllerFqcn(string $controllerFqcn): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated and will be removed in EasyAdmin 5.x. The "contextId" concept no longer exists in modern EasyAdmin with pretty URLs.',
+            __METHOD__
+        );
+
         return $this->controllerFqcnToContextIdMap[$controllerFqcn] ?? null;
     }
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getDashboardByRoute() instead
+     */
     public function getControllerFqcnByRoute(string $routeName): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::getDashboardByRoute()" instead.',
+            __METHOD__
+        );
+
         return $this->getRouteToControllerFqcnMap()[$routeName] ?? null;
     }
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getDashboardRoute() instead
+     */
     public function getRouteByControllerFqcn(string $controllerFqcn): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::getDashboardRoute()" instead.',
+            __METHOD__
+        );
+
         return $this->getControllerFqcnToRouteMap()[$controllerFqcn] ?? null;
     }
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getDashboardCount() instead
+     */
     public function getNumberOfDashboards(): int
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::getDashboardCount()" instead.',
+            __METHOD__
+        );
+
         return \count($this->controllerFqcnToContextIdMap);
     }
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getFirstDashboardRoute() instead
+     */
     public function getFirstDashboardRoute(): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::getFirstDashboardRoute()" instead.',
+            __METHOD__
+        );
+
         $map = $this->getControllerFqcnToRouteMap();
 
         return \count($map) < 1 ? null : $map[array_key_first($map)];
     }
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getFirstDashboard() instead
+     */
     public function getFirstDashboardFqcn(): ?string
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::getFirstDashboard()" instead.',
+            __METHOD__
+        );
+
         $map = $this->getControllerFqcnToRouteMap();
 
         return \count($map) < 1 ? null : array_key_first($map);
     }
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getAllDashboards() instead
+     */
     public function getAll(): array
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.28.1',
+            'The "%s()" method is deprecated. Use "AdminControllerRegistry::getAllDashboards()" instead. Note: the return format is different (the new method returns a simple array of dashboard FQCNs).',
+            __METHOD__
+        );
+
         $dashboards = [];
         foreach ($this->controllerFqcnToContextIdMap as $controllerFqcn => $contextId) {
             $dashboards[] = [

--- a/src/Registry/DashboardControllerRegistryInterface.php
+++ b/src/Registry/DashboardControllerRegistryInterface.php
@@ -2,23 +2,49 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Registry;
 
+/**
+ * @deprecated since 4.28.1, use AdminControllerRegistryInterface instead
+ */
 interface DashboardControllerRegistryInterface
 {
+    /**
+     * @deprecated since 4.28.1, this concept (contextId) no longer exists in modern EasyAdmin
+     */
     public function getControllerFqcnByContextId(string $contextId): ?string;
 
+    /**
+     * @deprecated since 4.28.1, this concept (contextId) no longer exists in modern EasyAdmin
+     */
     public function getContextIdByControllerFqcn(string $controllerFqcn): ?string;
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getDashboardByRoute() instead
+     */
     public function getControllerFqcnByRoute(string $routeName): ?string;
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getDashboardRoute() instead
+     */
     public function getRouteByControllerFqcn(string $controllerFqcn): ?string;
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getDashboardCount() instead
+     */
     public function getNumberOfDashboards(): int;
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getFirstDashboardRoute() instead
+     */
     public function getFirstDashboardRoute(): ?string;
 
+    /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getFirstDashboard() instead
+     */
     public function getFirstDashboardFqcn(): ?string;
 
     /**
+     * @deprecated since 4.28.1, use AdminControllerRegistry::getAllDashboards() instead
+     *
      * @return array<int, array{controller: string, route: string, context: string}>
      */
     public function getAll(): array;

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -9,7 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInte
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistryInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -29,7 +29,7 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
     public function __construct(
         private readonly AdminContextProviderInterface $adminContextProvider,
         private readonly UrlGeneratorInterface $urlGenerator,
-        private readonly DashboardControllerRegistryInterface $dashboardControllerRegistry,
+        private readonly AdminControllerRegistry $adminControllers,
         private readonly AdminRouteGeneratorInterface $adminRouteGenerator,
         private readonly CacheItemPoolInterface $cache,
     ) {
@@ -245,7 +245,7 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
         // if the Dashboard FQCN is defined, find its route and use it to override
         // the current route (this is needed to allow generating links to different dashboards)
         if (null !== $dashboardControllerFqcn = $this->get(EA::DASHBOARD_CONTROLLER_FQCN)) {
-            if (null === $dashboardRoute = $this->dashboardControllerRegistry->getRouteByControllerFqcn($dashboardControllerFqcn)) {
+            if (null === $dashboardRoute = $this->adminControllers->getDashboardRoute($dashboardControllerFqcn)) {
                 throw new \InvalidArgumentException(sprintf('The given "%s" class is not a valid Dashboard controller. Make sure it extends from "%s" or implements "%s".', $dashboardControllerFqcn, AbstractDashboardController::class, DashboardControllerInterface::class));
             }
 
@@ -263,12 +263,12 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
         // this happens when generating URLs from outside EasyAdmin (AdminContext is null) and
         // no Dashboard FQCN has been defined explicitly
         if (null === $this->dashboardRoute) {
-            if ($this->dashboardControllerRegistry->getNumberOfDashboards() > 1) {
+            if ($this->adminControllers->getDashboardCount() > 1) {
                 throw new \RuntimeException('When generating admin URLs from outside EasyAdmin or without a related HTTP request (e.g. in tests, console commands, etc.), if your application has more than one Dashboard, you must associate the URL to a specific Dashboard using the "setDashboard()" method.');
             }
 
-            $this->setDashboard($this->dashboardControllerRegistry->getFirstDashboardFqcn());
-            $this->dashboardRoute = $this->dashboardControllerRegistry->getFirstDashboardRoute();
+            $this->setDashboard($this->adminControllers->getFirstDashboard());
+            $this->dashboardRoute = $this->adminControllers->getFirstDashboardRoute();
         }
 
         // if present, remove the suffix of i18n route names (it's the content after the last dot
@@ -301,7 +301,7 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
         }
 
         if ($usePrettyUrls) {
-            $dashboardControllerFqcn = $this->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $context?->getRequest()->attributes->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $context?->getDashboardControllerFqcn() ?? $this->dashboardControllerRegistry->getFirstDashboardFqcn();
+            $dashboardControllerFqcn = $this->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $context?->getRequest()->attributes->get(EA::DASHBOARD_CONTROLLER_FQCN) ?? $context?->getDashboardControllerFqcn() ?? $this->adminControllers->getFirstDashboard();
             $crudControllerFqcn = $this->get(EA::CRUD_CONTROLLER_FQCN) ?? $context?->getRequest()->attributes->get(EA::CRUD_CONTROLLER_FQCN);
             $actionName = $this->get(EA::CRUD_ACTION) ?? $context?->getRequest()->attributes->get(EA::CRUD_ACTION);
 

--- a/tests/Unit/Field/Configurator/CommonPreConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/CommonPreConfiguratorTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Configurator;
 
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CommonPreConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
@@ -19,7 +20,8 @@ class CommonPreConfiguratorTest extends AbstractFieldTest
         $container = self::$kernel->getContainer()->get('test.service_container');
         $propertyAccessor = $container->get(PropertyAccessorInterface::class);
         $entityFactory = $container->get(EntityFactory::class);
-        $this->configurator = new CommonPreConfigurator($propertyAccessor, $entityFactory);
+        $entityTranslationIdGenerator = $container->get(EntityTranslationIdGeneratorInterface::class);
+        $this->configurator = new CommonPreConfigurator($propertyAccessor, $entityFactory, $entityTranslationIdGenerator);
     }
 
     public function testShouldKeepExistingValue(): void

--- a/tests/Unit/Registry/AdminControllerRegistryTest.php
+++ b/tests/Unit/Registry/AdminControllerRegistryTest.php
@@ -1,0 +1,306 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Registry;
+
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
+use PHPUnit\Framework\TestCase;
+
+class AdminControllerRegistryTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir().'/easyadmin_test_'.uniqid(more_entropy: true);
+        mkdir($this->tempDir.'/easyadmin', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->tempDir.'/easyadmin/routes-dashboard.php')) {
+            unlink($this->tempDir.'/easyadmin/routes-dashboard.php');
+        }
+        if (is_dir($this->tempDir.'/easyadmin')) {
+            rmdir($this->tempDir.'/easyadmin');
+        }
+        if (is_dir($this->tempDir)) {
+            rmdir($this->tempDir);
+        }
+    }
+
+    public function testGetDashboardRouteReturnsRouteWhenExists(): void
+    {
+        $this->createCacheFile([
+            'admin_dashboard' => 'App\Controller\Admin\DashboardController::index',
+        ]);
+
+        $registry = $this->createRegistry();
+
+        $result = $registry->getDashboardRoute('App\Controller\Admin\DashboardController');
+
+        $this->assertSame('admin_dashboard', $result);
+    }
+
+    public function testGetDashboardRouteReturnsNullWhenNotExists(): void
+    {
+        $this->createCacheFile([
+            'admin_dashboard' => 'App\Controller\Admin\DashboardController::index',
+        ]);
+
+        $registry = $this->createRegistry();
+
+        $result = $registry->getDashboardRoute('App\Controller\NonExistentController');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetDashboardByRouteReturnsControllerWhenExists(): void
+    {
+        $this->createCacheFile([
+            'admin_dashboard' => 'App\Controller\Admin\DashboardController::index',
+            'reports_dashboard' => 'App\Controller\Reports\DashboardController::index',
+        ]);
+
+        $registry = $this->createRegistry();
+
+        $result = $registry->getDashboardByRoute('admin_dashboard');
+
+        $this->assertSame('App\Controller\Admin\DashboardController', $result);
+    }
+
+    public function testGetDashboardByRouteReturnsNullWhenNotExists(): void
+    {
+        $this->createCacheFile([
+            'admin_dashboard' => 'App\Controller\Admin\DashboardController::index',
+        ]);
+
+        $registry = $this->createRegistry();
+
+        $result = $registry->getDashboardByRoute('nonexistent_route');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetDashboardCountReturnsCorrectCount(): void
+    {
+        $registry = $this->createRegistry();
+
+        $result = $registry->getDashboardCount();
+
+        $this->assertSame(2, $result);
+    }
+
+    public function testGetDashboardCountReturnsZeroWhenEmpty(): void
+    {
+        $registry = new AdminControllerRegistry($this->tempDir, [], []);
+
+        $result = $registry->getDashboardCount();
+
+        $this->assertSame(0, $result);
+    }
+
+    public function testGetFirstDashboardReturnsFirstControllerWhenExists(): void
+    {
+        $this->createCacheFile([
+            'admin_dashboard' => 'App\Controller\Admin\DashboardController::index',
+            'reports_dashboard' => 'App\Controller\Reports\DashboardController::index',
+        ]);
+
+        $registry = $this->createRegistry();
+
+        $result = $registry->getFirstDashboard();
+
+        $this->assertSame('App\Controller\Admin\DashboardController', $result);
+    }
+
+    public function testGetFirstDashboardReturnsNullWhenNoDashboards(): void
+    {
+        $this->createCacheFile([]);
+
+        $registry = new AdminControllerRegistry($this->tempDir, [], []);
+
+        $result = $registry->getFirstDashboard();
+
+        $this->assertNull($result);
+    }
+
+    public function testGetFirstDashboardRouteReturnsFirstRouteWhenExists(): void
+    {
+        $this->createCacheFile([
+            'admin_dashboard' => 'App\Controller\Admin\DashboardController::index',
+            'reports_dashboard' => 'App\Controller\Reports\DashboardController::index',
+        ]);
+
+        $registry = $this->createRegistry();
+
+        $result = $registry->getFirstDashboardRoute();
+
+        $this->assertSame('admin_dashboard', $result);
+    }
+
+    public function testGetFirstDashboardRouteReturnsNullWhenNoDashboards(): void
+    {
+        $this->createCacheFile([]);
+
+        $registry = new AdminControllerRegistry($this->tempDir, [], []);
+
+        $result = $registry->getFirstDashboardRoute();
+
+        $this->assertNull($result);
+    }
+
+    public function testGetAllDashboardsReturnsAllDashboardControllers(): void
+    {
+        $registry = $this->createRegistry();
+
+        $result = $registry->getAllDashboards();
+
+        $this->assertCount(2, $result);
+        $this->assertContains('App\Controller\Admin\DashboardController', $result);
+        $this->assertContains('App\Controller\Reports\DashboardController', $result);
+    }
+
+    public function testGetAllDashboardsReturnsEmptyArrayWhenNoDashboards(): void
+    {
+        $registry = new AdminControllerRegistry($this->tempDir, [], []);
+
+        $result = $registry->getAllDashboards();
+
+        $this->assertSame([], $result);
+    }
+
+    public function testFindCrudControllerByEntityReturnsControllerWhenExists(): void
+    {
+        $registry = $this->createRegistry();
+
+        $result = $registry->findCrudControllerByEntity('App\Entity\Product');
+
+        $this->assertSame('App\Controller\ProductCrudController', $result);
+    }
+
+    public function testFindCrudControllerByEntityReturnsNullWhenNotExists(): void
+    {
+        $registry = $this->createRegistry();
+
+        $result = $registry->findCrudControllerByEntity('App\Entity\NonExistent');
+
+        $this->assertNull($result);
+    }
+
+    public function testFindEntityByCrudControllerReturnsEntityWhenExists(): void
+    {
+        $registry = $this->createRegistry();
+
+        $result = $registry->findEntityByCrudController('App\Controller\CategoryCrudController');
+
+        $this->assertSame('App\Entity\Category', $result);
+    }
+
+    public function testFindEntityByCrudControllerReturnsNullWhenNotExists(): void
+    {
+        $registry = $this->createRegistry();
+
+        $result = $registry->findEntityByCrudController('App\Controller\NonExistentCrudController');
+
+        $this->assertNull($result);
+    }
+
+    public function testGetAllCrudControllersReturnsAllControllers(): void
+    {
+        $registry = $this->createRegistry();
+
+        $result = $registry->getAllCrudControllers();
+
+        $this->assertCount(3, $result);
+        $this->assertContains('App\Controller\ProductCrudController', $result);
+        $this->assertContains('App\Controller\CategoryCrudController', $result);
+        $this->assertContains('App\Controller\UserCrudController', $result);
+    }
+
+    public function testGetAllCrudControllersReturnsEmptyArrayWhenNoControllers(): void
+    {
+        $registry = new AdminControllerRegistry($this->tempDir, [], []);
+
+        $result = $registry->getAllCrudControllers();
+
+        $this->assertSame([], $result);
+    }
+
+    public function testBidirectionalEntityCrudMapping(): void
+    {
+        $registry = $this->createRegistry();
+
+        $entityFqcn = 'App\Entity\Category';
+        $crudFqcn = $registry->findCrudControllerByEntity($entityFqcn);
+
+        $this->assertNotNull($crudFqcn);
+
+        $resolvedEntityFqcn = $registry->findEntityByCrudController($crudFqcn);
+        $this->assertSame($entityFqcn, $resolvedEntityFqcn);
+    }
+
+    public function testRouteMapsAreLazilyLoaded(): void
+    {
+        // create registry before cache file exists
+        $registry = $this->createRegistry();
+
+        // now create the cache file
+        $this->createCacheFile([
+            'admin_dashboard' => 'App\Controller\Admin\DashboardController::index',
+        ]);
+
+        // the route should be found because maps are loaded lazily
+        $result = $registry->getDashboardRoute('App\Controller\Admin\DashboardController');
+
+        $this->assertSame('admin_dashboard', $result);
+    }
+
+    public function testRouteMapsHandleMissingCacheFile(): void
+    {
+        // don't create cache file
+        $registry = $this->createRegistry();
+
+        $result = $registry->getDashboardRoute('App\Controller\Admin\DashboardController');
+
+        $this->assertNull($result);
+    }
+
+    public function testEmptyRegistry(): void
+    {
+        $emptyRegistry = new AdminControllerRegistry($this->tempDir, [], []);
+
+        $this->assertSame(0, $emptyRegistry->getDashboardCount());
+        $this->assertNull($emptyRegistry->getFirstDashboard());
+        $this->assertNull($emptyRegistry->getFirstDashboardRoute());
+        $this->assertSame([], $emptyRegistry->getAllDashboards());
+        $this->assertSame([], $emptyRegistry->getAllCrudControllers());
+        $this->assertNull($emptyRegistry->findCrudControllerByEntity('App\Entity\Product'));
+        $this->assertNull($emptyRegistry->findEntityByCrudController('App\Controller\ProductCrudController'));
+    }
+
+    private function createRegistry(): AdminControllerRegistry
+    {
+        $crudFqcnToEntityFqcnMap = [
+            'App\Controller\ProductCrudController' => 'App\Entity\Product',
+            'App\Controller\CategoryCrudController' => 'App\Entity\Category',
+            'App\Controller\UserCrudController' => 'App\Entity\User',
+        ];
+
+        $dashboardControllers = [
+            'App\Controller\Admin\DashboardController',
+            'App\Controller\Reports\DashboardController',
+        ];
+
+        return new AdminControllerRegistry(
+            $this->tempDir,
+            $crudFqcnToEntityFqcnMap,
+            $dashboardControllers
+        );
+    }
+
+    private function createCacheFile(array $routes): void
+    {
+        $content = '<?php return '.var_export($routes, true).';';
+        file_put_contents($this->tempDir.'/easyadmin/routes-dashboard.php', $content);
+    }
+}

--- a/tests/Unit/Registry/CrudControllerRegistryTest.php
+++ b/tests/Unit/Registry/CrudControllerRegistryTest.php
@@ -5,6 +5,9 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Registry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\CrudControllerRegistry;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class CrudControllerRegistryTest extends TestCase
 {
     private CrudControllerRegistry $registry;
@@ -39,7 +42,7 @@ class CrudControllerRegistryTest extends TestCase
             $crudFqcnToEntityFqcnMap,
             $crudFqcnToCrudIdMap,
             $entityFqcnToCrudFqcnMap,
-            $crudIdToCrudFqcnMap
+            $crudIdToCrudFqcnMap,
         );
     }
 

--- a/tests/Unit/Registry/DashboardControllerRegistryTest.php
+++ b/tests/Unit/Registry/DashboardControllerRegistryTest.php
@@ -5,6 +5,9 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Registry;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistry;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @group legacy
+ */
 class DashboardControllerRegistryTest extends TestCase
 {
     private string $tempDir;
@@ -276,7 +279,7 @@ class DashboardControllerRegistryTest extends TestCase
             [
                 'admin' => 'App\Controller\Admin\DashboardController',
                 'reports' => 'App\Controller\Reports\DashboardController',
-            ]
+            ],
         );
     }
 

--- a/tests/Unit/Router/AdminUrlGeneratorTest.php
+++ b/tests/Unit/Router/AdminUrlGeneratorTest.php
@@ -10,7 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\DashboardContext;
 use EasyCorp\Bundle\EasyAdminBundle\Context\RequestContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Router\AdminRouteGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
-use EasyCorp\Bundle\EasyAdminBundle\Registry\DashboardControllerRegistryInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Registry\AdminControllerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -293,12 +293,20 @@ class AdminUrlGeneratorTest extends KernelTestCase
 
         $adminContextProvider = new AdminContextProvider($requestStack);
 
-        $dashboardControllerRegistry = $this->getMockBuilder(DashboardControllerRegistryInterface::class)->disableOriginalConstructor()->getMock();
-        $dashboardControllerRegistry->method('getRouteByControllerFqcn')->willReturnMap([
-            ['App\Controller\Admin\CustomHtmlAttributeDashboardController', 'custom_html_attribute_admin'],
-        ]);
-        $dashboardControllerRegistry->method('getNumberOfDashboards')->willReturn(2);
-        $dashboardControllerRegistry->method('getFirstDashboardRoute')->willReturn('admin');
+        // create a minimal temp directory and cache file for testing
+        $tempDir = sys_get_temp_dir().'/easyadmin_test_url_gen_'.uniqid();
+        @mkdir($tempDir.'/easyadmin', 0777, true);
+        $cacheContent = '<?php return '.var_export([
+            'admin' => 'App\Controller\Admin\DashboardController::index',
+            'custom_html_attribute_admin' => 'App\Controller\Admin\CustomHtmlAttributeDashboardController::index',
+        ], true).';';
+        file_put_contents($tempDir.'/easyadmin/routes-dashboard.php', $cacheContent);
+
+        $adminControllers = new AdminControllerRegistry(
+            $tempDir,
+            [], // crudFqcnToEntityFqcnMap
+            ['App\Controller\Admin\DashboardController', 'App\Controller\Admin\CustomHtmlAttributeDashboardController']
+        );
 
         $router = self::getContainer()->get('router');
 
@@ -316,6 +324,6 @@ class AdminUrlGeneratorTest extends KernelTestCase
         $cacheMock->method('getItem')->willReturn($cacheItem);
         $cacheMock->method('save')->willReturn(true);
 
-        return new AdminUrlGenerator($adminContextProvider, $router, $dashboardControllerRegistry, $adminRouteGenerator, $cacheMock);
+        return new AdminUrlGenerator($adminContextProvider, $router, $adminControllers, $adminRouteGenerator, $cacheMock);
     }
 }


### PR DESCRIPTION
This is the last piece we need to be able to release the 5.x version.

`CrudControllerRegistry` and `DashboardControllerRegistry` are mostly internal classes that holds a registry of all the controllers that define a CRUD controller or a Dashboard controller. Some of their features are outdated and make no sense when using pretty URLs.

Since 5.x requires pretty URLs and deep Symfony controller integrations via `#[AdminRoute]` we can simplify many things. So, let's merge both registries into a new single `AdminControllerRegistry` that stores everything and provides useful methods that still must be used.