### PR TITLE
Fix sidebar overscroll behavior on desktop (>992px)

### DIFF
--- a/assets/css/easyadmin-theme/base.css
+++ b/assets/css/easyadmin-theme/base.css
@@ -207,6 +207,7 @@ body:not(.ea-content-width-full) .content-wrapper {
         position: static;
         z-index: calc(var(--zindex-modal-backdrop) - 1);
         inline-size: initial;
+        overscroll-behavior: auto;
     }
 }
 body.ea-mobile-sidebar-visible .sidebar {


### PR DESCRIPTION
### Problem
`overscroll-behavior: contain` works well when the sidebar is in "overlay" mode,
but on desktop it prevents scrolling the whole page when hovering the scrollbar.

### Solution
Restore the default overscroll behavior for viewports wider than 992px,
keeping the current behavior only for the overlay/mobile sidebar.