### PR TITLE
Fix UUID format handling in autocomplete for native GUID platforms

### DIFF
--- a/src/Form/EventListener/CrudAutocompleteSubscriber.php
+++ b/src/Form/EventListener/CrudAutocompleteSubscriber.php
@@ -103,7 +103,15 @@ class CrudAutocompleteSubscriber implements EventSubscriberInterface
                             $idFieldType = property_exists($idFieldMapping, 'type') ? $idFieldMapping->type : $idFieldMapping['type'];
 
                             if (UuidType::NAME === $idFieldType) {
-                                return Uuid::fromString($v)->toBinary();
+                                // Use RFC4122 format for platforms with native GUID type (e.g., PostgreSQL),
+                                // and binary format for platforms without native GUID type (e.g., MySQL, SQLite)
+                                $platform = $options['em']->getConnection()->getDatabasePlatform();
+
+                                $hasNativeGuidType = $platform->getGuidTypeDeclarationSQL([]) !== $platform->getStringTypeDeclarationSQL(['fixed' => true, 'length' => 36]);
+
+                                return $hasNativeGuidType
+                                    ? Uuid::fromString($v)->toRfc4122()
+                                    : Uuid::fromString($v)->toBinary();
                             }
                         }
 


### PR DESCRIPTION
This PR fixes UUID conversion in the autocomplete field by detecting database platforms with native GUID type support.

```
An exception occurred while executing a query: SQLSTATE[22021]: Character not in repertoire: 7 ERROR: invalid byte sequence for encoding "UTF8": 0x92
CONTEXT: unnamed portal parameter $1
```

**How to reproduce**
- AssociationField to an Entity with uuid
- `autocomplete()` enabled
- On native uuid platforms like Postgres


**Changes:**
- Adds `hasNativeGuidType()` method to `CrudAutocompleteSubscriber` to detect platform capabilities
- Uses RFC4122 format for platforms with native GUID type (e.g., PostgreSQL)
- Uses binary format for platforms without native GUID type (e.g., MySQL, SQLite)

This ensures that UUID values are converted to the correct format based on the database platform, preventing issues with autocomplete fields when using UUID primary keys.
