### PR TITLE
Replace CrudMenuItem with EntityMenuItem

### DIFF
--- a/.ddev/example/Controller/Admin/DashboardController.php
+++ b/.ddev/example/Controller/Admin/DashboardController.php
@@ -31,7 +31,7 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
 
         yield MenuItem::section('Entities');
-        yield MenuItem::linkToCrud('Articles', 'fas fa-list', BlogArticle::class);
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tag', Category::class);
+        yield MenuItem::linkToEntity(BlogArticle::class, 'Articles', 'fas fa-list');
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tag');
     }
 }

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -86,11 +86,11 @@ jobs:
                   expect eof
                   EOD
                   
-                  # Add MenuItem::linkToCrud() entry if missing
+                  # Add MenuItem::linkToEntity() entry if missing
                   file="src/Controller/Admin/DashboardController.php"
-                  if ! grep -q "linkToCrud" "$file"; then
+                  if ! grep -q "linkToEntity" "$file"; then
                     sed -i '/yield MenuItem::linkToDashboard/a\
-                        yield MenuItem::linkToCrud("Products", "fa fa-box", App\\Entity\\Product::class);' "$file"
+                        yield MenuItem::linkToEntity(App\\Entity\\Product::class, "Products", "fa fa-box");' "$file"
                   fi
 
             - name: Create factory and fixtures

--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -583,12 +583,12 @@ the look and behavior of each menu item::
                 MenuItem::linkToDashboard('Dashboard', 'fa fa-home'),
 
                 MenuItem::section('Blog'),
-                MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class),
-                MenuItem::linkToCrud('Blog Posts', 'fa fa-file-text', BlogPost::class),
+                MenuItem::linkToEntity(Category::class, 'Categories', 'fa fa-tags'),
+                MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', 'fa fa-file-text'),
 
                 MenuItem::section('Users'),
-                MenuItem::linkToCrud('Comments', 'fa fa-comment', Comment::class),
-                MenuItem::linkToCrud('Users', 'fa fa-user', User::class),
+                MenuItem::linkToEntity(Comment::class, 'Comments', 'fa fa-comment'),
+                MenuItem::linkToEntity(User::class, 'Users', 'fa fa-user'),
             ];
         }
     }
@@ -653,23 +653,23 @@ entity associated to the CRUD controller::
             // ...
 
             // links to the 'index' action of the Category CRUD controller
-            MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class),
+            MenuItem::linkToEntity(Category::class, 'Categories', 'fa fa-tags'),
 
             // links to a different CRUD action
-            MenuItem::linkToCrud('Add Category', 'fa fa-tags', Category::class)
+            MenuItem::linkToEntity(Category::class, 'Add Category', 'fa fa-tags')
                 ->setAction(Action::NEW),
 
-            MenuItem::linkToCrud('Show Main Category', 'fa fa-tags', Category::class)
+            MenuItem::linkToEntity(Category::class, 'Show Main Category', 'fa fa-tags')
                 ->setAction(Action::DETAIL)
                 ->setEntityId(1),
 
             // if the same Doctrine entity is associated to more than one CRUD controller,
             // use the 'setController()' method to specify which controller to use
-            MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class)
+            MenuItem::linkToEntity(Category::class, 'Categories', 'fa fa-tags')
                 ->setController(LegacyCategoryCrudController::class),
 
             // uses custom sorting options for the listing
-            MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class)
+            MenuItem::linkToEntity(Category::class, 'Categories', 'fa fa-tags')
                 ->setDefaultSort(['createdAt' => 'DESC']),
         ];
     }
@@ -809,9 +809,9 @@ using the ``subMenu()`` item type::
     {
         return [
             MenuItem::subMenu('Blog', 'fa fa-article')->setSubItems([
-                MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class),
-                MenuItem::linkToCrud('Posts', 'fa fa-file-text', BlogPost::class),
-                MenuItem::linkToCrud('Comments', 'fa fa-comment', Comment::class),
+                MenuItem::linkToEntity(Category::class, 'Categories', 'fa fa-tags'),
+                MenuItem::linkToEntity(BlogPost::class, 'Posts', 'fa fa-file-text'),
+                MenuItem::linkToEntity(Comment::class, 'Comments', 'fa fa-comment'),
             ]),
             // ...
         ];
@@ -836,8 +836,8 @@ generator to return the menu items::
 
         if ('... some complex expression ...') {
             yield MenuItem::section('Blog');
-            yield MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class);
-            yield MenuItem::linkToCrud('Blog Posts', 'fa fa-file-text', BlogPost::class);
+            yield MenuItem::linkToEntity(Category::class, 'Categories', 'fa fa-tags');
+            yield MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', 'fa fa-file-text');
         }
 
         // ...
@@ -1098,8 +1098,8 @@ When using this feature, you can omit the label when creating CRUD menu items:
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
 
         // no label needed: will use the translated plural label
-        yield MenuItem::linkToCrud(null, 'fa fa-file-text', BlogPost::class);
-        yield MenuItem::linkToCrud(null, 'fa fa-users', User::class);
+        yield MenuItem::linkToEntity(BlogPost::class, null, 'fa fa-file-text');
+        yield MenuItem::linkToEntity(User::class, null, 'fa fa-users');
     }
 
 .. note::

--- a/doc/security.rst
+++ b/doc/security.rst
@@ -111,7 +111,7 @@ user must have to see the menu item::
         return [
             // ...
 
-            MenuItem::linkToCrud('Blog Posts', null, BlogPost::class)
+            MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', null)
                 ->setPermission('ROLE_EDITOR'),
         ];
     }
@@ -133,7 +133,7 @@ menu item definition to not have to deal with array merges::
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
 
         if ($this->isGranted('ROLE_EDITOR') && '...') {
-            yield MenuItem::linkToCrud('Blog Posts', null, BlogPost::class);
+            yield MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', null);
         }
 
         // ...
@@ -250,7 +250,7 @@ like this::
 
     use Symfony\Component\ExpressionLanguage\Expression;
 
-    MenuItem::linkToCrud('Restricted menu-item', null, Example::class)
+    MenuItem::linkToEntity(Example::class, 'Restricted menu-item', null)
         ->setPermission(new Expression('"ROLE_DEVELOPER" in role_names and "ROLE_EXTERNAL" not in role_names'));
 
 Expressions enable the definition of much more detailed permissions, based on

--- a/src/Config/Menu/CrudMenuItem.php
+++ b/src/Config/Menu/CrudMenuItem.php
@@ -2,111 +2,16 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
 
-use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
-use Symfony\Component\Uid\AbstractUid;
-use Symfony\Contracts\Translation\TranslatableInterface;
 
 /**
+ * @deprecated Since 4.28.1 and will be removed in 5.0.0. Use EntityMenuItem instead.
  * @see \EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToCrud()
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @phpstan-ignore-next-line
  */
-final class CrudMenuItem implements MenuItemInterface
+final class CrudMenuItem extends EntityMenuItem implements MenuItemInterface
 {
-    use MenuItemTrait;
-
-    public function __construct(TranslatableInterface|string|null $label, ?string $icon, string $entityFqcn)
-    {
-        $this->dto = new MenuItemDto();
-
-        $this->dto->setType(MenuItemDto::TYPE_CRUD);
-        $this->dto->setLabel($label);
-        $this->dto->setIcon($icon);
-        $this->dto->setRouteParameters([
-            EA::CRUD_ACTION => Action::INDEX,
-            EA::CRUD_CONTROLLER_FQCN => null,
-            EA::ENTITY_FQCN => $entityFqcn,
-            EA::ENTITY_ID => null,
-        ]);
-    }
-
-    public function setHtmlAttribute(string $name, mixed $value): self
-    {
-        $this->dto->setHtmlAttribute($name, $value);
-
-        return $this;
-    }
-
-    public function setController(string $controllerFqcn): self
-    {
-        $this->dto->setRouteParameters(array_merge(
-            $this->dto->getRouteParameters(),
-            [EA::CRUD_CONTROLLER_FQCN => $controllerFqcn]
-        ));
-
-        return $this;
-    }
-
-    public function setAction(string $actionName): self
-    {
-        $this->dto->setRouteParameters(array_merge(
-            $this->dto->getRouteParameters(),
-            [EA::CRUD_ACTION => $actionName]
-        ));
-
-        return $this;
-    }
-
-    /**
-     * @param AbstractUid|int|string $entityId
-     */
-    public function setEntityId(/* AbstractUid|int|string */ $entityId): self
-    {
-        if (!\is_int($entityId) && !\is_string($entityId) && !$entityId instanceof AbstractUid) {
-            trigger_deprecation(
-                'easycorp/easyadmin-bundle',
-                '4.0.5',
-                'Argument "%s" for "%s" must be one of these types: %s. Passing type "%s" will cause an error in 5.0.0.',
-                '$entityId',
-                __METHOD__,
-                sprintf('"int", "string" or "%s"', AbstractUid::class),
-                \gettype($entityId)
-            );
-        }
-
-        $this->dto->setRouteParameters(array_merge(
-            $this->dto->getRouteParameters(),
-            [EA::ENTITY_ID => $entityId]
-        ));
-
-        return $this;
-    }
-
-    /**
-     * @param array<string, 'ASC'|'DESC'> $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
-     */
-    public function setDefaultSort(array $sortFieldsAndOrder): self
-    {
-        $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);
-        foreach ($sortFieldsAndOrder as $sortField => $sortOrder) {
-            if (!\in_array($sortOrder, [SortOrder::ASC, SortOrder::DESC], true)) {
-                throw new \InvalidArgumentException(sprintf('The sort order can be only "ASC" or "DESC", "%s" given.', $sortOrder));
-            }
-
-            if (!\is_string($sortField)) {
-                throw new \InvalidArgumentException(sprintf('The keys of the array that defines the default sort must be strings with the field names, but the given "%s" value is a "%s".', $sortField, \gettype($sortField)));
-            }
-        }
-
-        $this->dto->setRouteParameters(array_merge(
-            $this->dto->getRouteParameters(),
-            [EA::SORT => $sortFieldsAndOrder]
-        ));
-
-        return $this;
-    }
 }

--- a/src/Config/Menu/EntityMenuItem.php
+++ b/src/Config/Menu/EntityMenuItem.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+/**
+ * @see \EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkToEntity()
+ *
+ * @final Will be final in version 5.0.0.
+ */
+class EntityMenuItem implements MenuItemInterface
+{
+    use MenuItemTrait;
+
+    public function __construct(string $entityFqcn, TranslatableInterface|string|null $label = null, ?string $icon = null)
+    {
+        $this->dto = new MenuItemDto();
+
+        $this->dto->setType(MenuItemDto::TYPE_CRUD);
+        $this->dto->setLabel($label);
+        $this->dto->setIcon($icon);
+        $this->dto->setRouteParameters([
+            EA::CRUD_ACTION => Action::INDEX,
+            EA::CRUD_CONTROLLER_FQCN => null,
+            EA::ENTITY_FQCN => $entityFqcn,
+            EA::ENTITY_ID => null,
+        ]);
+    }
+
+    public function setHtmlAttribute(string $name, mixed $value): self
+    {
+        $this->dto->setHtmlAttribute($name, $value);
+
+        return $this;
+    }
+
+    public function setController(string $controllerFqcn): self
+    {
+        $this->dto->setRouteParameters(array_merge(
+            $this->dto->getRouteParameters(),
+            [EA::CRUD_CONTROLLER_FQCN => $controllerFqcn]
+        ));
+
+        return $this;
+    }
+
+    public function setAction(string $actionName): self
+    {
+        $this->dto->setRouteParameters(array_merge(
+            $this->dto->getRouteParameters(),
+            [EA::CRUD_ACTION => $actionName]
+        ));
+
+        return $this;
+    }
+
+    public function setEntityId(AbstractUid|int|string $entityId): self
+    {
+        $this->dto->setRouteParameters(array_merge(
+            $this->dto->getRouteParameters(),
+            [EA::ENTITY_ID => $entityId]
+        ));
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, 'ASC'|'DESC'> $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
+     */
+    public function setDefaultSort(array $sortFieldsAndOrder): self
+    {
+        $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);
+        foreach ($sortFieldsAndOrder as $sortField => $sortOrder) {
+            if (!\in_array($sortOrder, [SortOrder::ASC, SortOrder::DESC], true)) {
+                throw new \InvalidArgumentException(sprintf('The sort order can be only "ASC" or "DESC", "%s" given.', $sortOrder));
+            }
+
+            if (!\is_string($sortField)) {
+                throw new \InvalidArgumentException(sprintf('The keys of the array that defines the default sort must be strings with the field names, but the given "%s" value is a "%s".', $sortField, \gettype($sortField)));
+            }
+        }
+
+        $this->dto->setRouteParameters(array_merge(
+            $this->dto->getRouteParameters(),
+            [EA::SORT => $sortFieldsAndOrder]
+        ));
+
+        return $this;
+    }
+}

--- a/src/Config/MenuItem.php
+++ b/src/Config/MenuItem.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\CrudMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\DashboardMenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\EntityMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\ExitImpersonationMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\LogoutMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\RouteMenuItem;
@@ -22,11 +23,21 @@ final class MenuItem
     }
 
     /**
+     * @deprecated Since 4.28.1 and will be removed in 5.0.0. Use MenuItem::linkToEntity() instead.
+     *
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
     public static function linkToCrud(TranslatableInterface|string|null $label, ?string $icon, string $entityFqcn): CrudMenuItem
     {
         return new CrudMenuItem($label, $icon, $entityFqcn);
+    }
+
+    /**
+     * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
+     */
+    public static function linkToEntity(string $entityFqcn, TranslatableInterface|string|null $label = null, ?string $icon = null): EntityMenuItem
+    {
+        return new EntityMenuItem($entityFqcn, $label, $icon);
     }
 
     /**

--- a/src/Resources/skeleton/dashboard.tpl
+++ b/src/Resources/skeleton/dashboard.tpl
@@ -45,6 +45,6 @@ class <?= $class_name; ?> extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
-        // yield MenuItem::linkToCrud('The Label', 'fas fa-list', EntityClass::class);
+        // yield MenuItem::linkToEntity(EntityClass::class, 'The Label', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/AssetsTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/AssetsTestDashboardController.php
@@ -29,6 +29,6 @@ class AssetsTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-list', BlogPost::class);
+        yield MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/ColorSchemeTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/ColorSchemeTestDashboardController.php
@@ -37,6 +37,6 @@ class ColorSchemeTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/ContentMaximizedTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/ContentMaximizedTestDashboardController.php
@@ -30,6 +30,6 @@ class ContentMaximizedTestDashboardController extends AbstractDashboardControlle
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/CustomHtmlAttributeTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/CustomHtmlAttributeTestDashboardController.php
@@ -30,10 +30,10 @@ class CustomHtmlAttributeTestDashboardController extends AbstractDashboardContro
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)->setHtmlAttribute(
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags')->setHtmlAttribute(
             'test-attribute', 'test'
         );
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class)
+        yield MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', 'fas fa-tags')
             ->setHtmlAttribute('multi-test-one', 'test1')
             ->setHtmlAttribute('multi-test-two', 'test2')
             ->setBadge('0', 'secondary', [

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/DarkModeTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/DarkModeTestDashboardController.php
@@ -30,6 +30,6 @@ class DarkModeTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/FaviconTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/FaviconTestDashboardController.php
@@ -30,6 +30,6 @@ class FaviconTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/LocalesTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/LocalesTestDashboardController.php
@@ -30,6 +30,6 @@ class LocalesTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/RelativeUrlsTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/RelativeUrlsTestDashboardController.php
@@ -30,6 +30,6 @@ class RelativeUrlsTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/SidebarMinimizedTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/SidebarMinimizedTestDashboardController.php
@@ -30,6 +30,6 @@ class SidebarMinimizedTestDashboardController extends AbstractDashboardControlle
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TextDirectionTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TextDirectionTestDashboardController.php
@@ -30,6 +30,6 @@ class TextDirectionTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TitleTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TitleTestDashboardController.php
@@ -35,6 +35,6 @@ class TitleTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TranslationDomainTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TranslationDomainTestDashboardController.php
@@ -30,6 +30,6 @@ class TranslationDomainTestDashboardController extends AbstractDashboardControll
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/DashboardController.php
@@ -26,6 +26,6 @@ class DashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkToEntity(DemoEntity::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/CustomHtmlAttributeDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/CustomHtmlAttributeDashboardController.php
@@ -30,10 +30,10 @@ class CustomHtmlAttributeDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)->setHtmlAttribute(
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags')->setHtmlAttribute(
             'test-attribute', 'test'
         );
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class)
+        yield MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', 'fas fa-tags')
             ->setHtmlAttribute('multi-test-one', 'test1')
             ->setHtmlAttribute('multi-test-two', 'test2')
             ->setBadge('0', 'secondary', [

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/ColorSchemeDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/ColorSchemeDashboardController.php
@@ -31,6 +31,6 @@ class ColorSchemeDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/DisabledDarkModeDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/DisabledDarkModeDashboardController.php
@@ -30,6 +30,6 @@ class DisabledDarkModeDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/EntityTranslationsDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/EntityTranslationsDashboardController.php
@@ -32,6 +32,6 @@ class EntityTranslationsDashboardController extends AbstractDashboardController
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
         // use null label to test that entity translations are used for menu items
-        yield MenuItem::linkToCrud(null, 'fas fa-tags', Category::class);
+        yield MenuItem::linkToEntity(Category::class, null, 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/LayoutDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/LayoutDashboardController.php
@@ -38,6 +38,6 @@ class LayoutDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/LocaleDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/LocaleDashboardController.php
@@ -37,6 +37,6 @@ class LocaleDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/MenuDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/MenuDashboardController.php
@@ -41,8 +41,8 @@ class MenuDashboardController extends AbstractDashboardController
         yield MenuItem::section('Content Management');
 
         // regular CRUD links
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-newspaper', BlogPost::class)
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags');
+        yield MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', 'fas fa-newspaper')
             ->setBadge('New', 'success');
 
         // section with submenu

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/SecondDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/SecondDashboardController.php
@@ -37,7 +37,7 @@ class SecondDashboardController extends AbstractDashboardController
         yield MenuItem::section('Second Dashboard Content');
 
         // only Categories, not Blog Posts
-        yield MenuItem::linkToCrud('Manage Categories', 'fas fa-folder', Category::class);
+        yield MenuItem::linkToEntity(Category::class, 'Manage Categories', 'fas fa-folder');
 
         // different external links
         yield MenuItem::section('Links');

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/UserMenuDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/UserMenuDashboardController.php
@@ -45,6 +45,6 @@ class UserMenuDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
@@ -30,19 +30,19 @@ class DashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class);
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags');
+        yield MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', 'fas fa-tags');
 
         // synthetic test entities
         yield MenuItem::section('Synthetic Tests');
-        yield MenuItem::linkToCrud('Field Tests', 'fas fa-flask', FieldTestEntity::class);
-        yield MenuItem::linkToCrud('Field Related Entities', 'fas fa-link', FieldRelatedEntity::class);
-        yield MenuItem::linkToCrud('Filter Tests', 'fas fa-filter', FilterTestEntity::class);
-        yield MenuItem::linkToCrud('Filter Related Entities', 'fas fa-link', FilterRelatedEntity::class);
-        yield MenuItem::linkToCrud('Form Layout Tests', 'fas fa-th-large', FormTestEntity::class);
-        yield MenuItem::linkToCrud('Batch Action Tests', 'fas fa-tasks', BatchActionTestEntity::class);
-        yield MenuItem::linkToCrud('Default CRUD Tests', 'fas fa-cog', DefaultCrudTestEntity::class);
-        yield MenuItem::linkToCrud('Search Tests', 'fas fa-search', SearchTestEntity::class);
-        yield MenuItem::linkToCrud('Action Tests', 'fas fa-mouse-pointer', ActionTestEntity::class);
+        yield MenuItem::linkToEntity(FieldTestEntity::class, 'Field Tests', 'fas fa-flask');
+        yield MenuItem::linkToEntity(FieldRelatedEntity::class, 'Field Related Entities', 'fas fa-link');
+        yield MenuItem::linkToEntity(FilterTestEntity::class, 'Filter Tests', 'fas fa-filter');
+        yield MenuItem::linkToEntity(FilterRelatedEntity::class, 'Filter Related Entities', 'fas fa-link');
+        yield MenuItem::linkToEntity(FormTestEntity::class, 'Form Layout Tests', 'fas fa-th-large');
+        yield MenuItem::linkToEntity(BatchActionTestEntity::class, 'Batch Action Tests', 'fas fa-tasks');
+        yield MenuItem::linkToEntity(DefaultCrudTestEntity::class, 'Default CRUD Tests', 'fas fa-cog');
+        yield MenuItem::linkToEntity(SearchTestEntity::class, 'Search Tests', 'fas fa-search');
+        yield MenuItem::linkToEntity(ActionTestEntity::class, 'Action Tests', 'fas fa-mouse-pointer');
     }
 }

--- a/tests/Functional/Apps/SecuredApp/src/Controller/SecuredDashboardController.php
+++ b/tests/Functional/Apps/SecuredApp/src/Controller/SecuredDashboardController.php
@@ -26,7 +26,7 @@ class SecuredDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags')
             ->setController(CategoryCrudController::class);
     }
 }

--- a/tests/Functional/Apps/SecuredApp/src/Controller/UserMenuDashboardController.php
+++ b/tests/Functional/Apps/SecuredApp/src/Controller/UserMenuDashboardController.php
@@ -45,7 +45,7 @@ class UserMenuDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags')
             ->setController(CategoryCrudController::class);
     }
 }

--- a/tests/Functional/Apps/UglyUrlsApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/UglyUrlsApp/src/Controller/DashboardController.php
@@ -27,7 +27,7 @@ class DashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class);
+        yield MenuItem::linkToEntity(Category::class, 'Categories', 'fas fa-tags');
+        yield MenuItem::linkToEntity(BlogPost::class, 'Blog Posts', 'fas fa-tags');
     }
 }


### PR DESCRIPTION
I can understand if this PR is declined.

It only allows to use:

```php
    public function configureMenuItems(): iterable
    {
        yield MenuItem::linkToEntity(BlogPost::class);
    }
```

instead of:

```php
    public function configureMenuItems(): iterable
    {
        yield MenuItem::linkToCrud(null, null, BlogPost::class);
    }
```

Changing `CrudMenuItem` to `EntityMenuItem` is done only to be able to cleanly deprecate the old order of arguments (by the way at least for me the new name even fits better than the old one but I am not sure if everybody will agree).

Maybe it seems unimportant and a huge change for only a small improvement, so I understand if the PR is declined. But IMO it eases the first phase of developing a basic admin UI. The idea is that things like labels and icons still can be added later but links to entities will always be added in the first prototype of an admin UI.