### PR TITLE
Deprecate unused method ActionCollection::getEntityActions()

### DIFF
--- a/src/Collection/ActionCollection.php
+++ b/src/Collection/ActionCollection.php
@@ -81,6 +81,9 @@ final class ActionCollection implements CollectionInterface
         return new \ArrayIterator($this->actions);
     }
 
+    /**
+     * @deprecated since 4.28.1 and will be removed in 5.0.0 without replacement
+     */
     public function getEntityActions(): self
     {
         return self::new(array_filter(


### PR DESCRIPTION
The method is neither used in PHP files nor in Twig templates.