### PR TITLE
Introduce a new type of menu item to link to any controller

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -564,10 +564,10 @@ The main menu is a collection of objects implementing
 ``EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface`` that configure
 the look and behavior of each menu item::
 
-    use App\Entity\BlogPost;
-    use App\Entity\Category;
-    use App\Entity\Comment;
-    use App\Entity\User;
+    use App\Controller\Admin\BlogPostCrudController;
+    use App\Controller\Admin\CategoryCrudController;
+    use App\Controller\Admin\CommentCrudController;
+    use App\Controller\Admin\UserCrudController;
     use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
     use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
     use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
@@ -583,12 +583,12 @@ the look and behavior of each menu item::
                 MenuItem::linkToDashboard('Dashboard', 'fa fa-home'),
 
                 MenuItem::section('Blog'),
-                MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class),
-                MenuItem::linkToCrud('Blog Posts', 'fa fa-file-text', BlogPost::class),
+                MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fa fa-tags'),
+                MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts', 'fa fa-file-text'),
 
                 MenuItem::section('Users'),
-                MenuItem::linkToCrud('Comments', 'fa fa-comment', Comment::class),
-                MenuItem::linkToCrud('Users', 'fa fa-user', User::class),
+                MenuItem::linkTo(CommentCrudController::class, 'Comments', 'fa fa-comment'),
+                MenuItem::linkTo(UserCrudController::class, 'Users', 'fa fa-user'),
             ];
         }
     }
@@ -635,13 +635,73 @@ The rest of options depend on each menu item type, as explained in the next sect
 Menu Item Types
 ~~~~~~~~~~~~~~~
 
+Controller Menu Item
+....................
+
+This is the most common menu item type. Use ``MenuItem::linkTo()`` to link to
+any admin controller: CRUD controllers, Dashboard controllers, or custom
+controllers with the ``#[AdminRoute]`` attribute.
+
+The first argument is the FQCN *(fully-qualified class name)* of the controller.
+The label and icon are optional (when linking to a CRUD controller without a
+label, EasyAdmin derives it automatically from the entity name)::
+
+    use App\Controller\Admin\CategoryCrudController;
+    use App\Controller\Admin\LegacyCategoryCrudController;
+    use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+    use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+
+    public function configureMenuItems(): iterable
+    {
+        return [
+            // ...
+
+            // links to the 'index' action of the Category CRUD controller
+            // the label is auto-derived from the entity name (e.g. "Categories")
+            MenuItem::linkTo(CategoryCrudController::class),
+
+            // you can pass an explicit label and icon
+            MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fa fa-tags'),
+
+            // links to a different CRUD action
+            MenuItem::linkTo(CategoryCrudController::class, 'Add Category', 'fa fa-tags')
+                ->setAction(Action::NEW),
+
+            MenuItem::linkTo(CategoryCrudController::class, 'Show Main Category', 'fa fa-tags')
+                ->setAction(Action::DETAIL)
+                ->setEntityId(40585),
+
+            // uses custom sorting options for the listing
+            MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fa fa-tags')
+                ->setDefaultSort(['createdAt' => 'DESC']),
+        ];
+    }
+
+You can also link to your own Symfony controllers if they use the
+``#[AdminRoute]`` attribute to integrate them in EasyAdmin::
+
+    use App\Controller\Admin\AnalyticsDashboardController;
+
+    MenuItem::linkTo(AnalyticsDashboardController::class, 'Analytics', 'fa fa-chart-line');
+
+If the controller is invokable (has a ``__invoke()`` method), the action is
+detected automatically. Otherwise, call ``->setAction('theActionName')`` to
+specify which action to link to.
+
 CRUD Menu Item
 ..............
 
-This is the most common menu item type and it links to some action of some
-:doc:`CRUD controller </crud>`. Instead of passing the FQCN *(fully-qualified
-class name)* of the CRUD controller, you must pass the FQCN of the Doctrine
-entity associated to the CRUD controller::
+.. note::
+
+    ``MenuItem::linkToCrud()`` is still fully supported, but ``MenuItem::linkTo()``
+    (explained above) is now the recommended way to create menu items that link to
+    CRUD controllers. ``linkTo()`` provides a unified API that works with any type
+    of admin controller and puts the controller class first, making the code
+    easier to navigate and refactor.
+
+``MenuItem::linkToCrud()`` links to some action of some :doc:`CRUD controller </crud>`.
+Instead of passing the FQCN of the CRUD controller, you pass the FQCN of the
+Doctrine entity associated to the CRUD controller::
 
     use App\Entity\Category;
     use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
@@ -690,6 +750,16 @@ have to specify the route name (it's found automatically)::
             // ...
         ];
     }
+
+.. tip::
+
+    You can also use ``MenuItem::linkTo()`` to link to a dashboard. This is
+    especially useful when you have multiple dashboards and want to link to a
+    *different* one::
+
+        use App\Controller\Admin\AnalyticsDashboardController;
+
+        MenuItem::linkTo(AnalyticsDashboardController::class, 'Analytics', 'fa fa-chart-line');
 
 Route Menu Item
 ...............
@@ -803,15 +873,18 @@ Submenus
 The main menu can display up to two level nested menus. Submenus are defined
 using the ``subMenu()`` item type::
 
+    use App\Controller\Admin\BlogPostCrudController;
+    use App\Controller\Admin\CategoryCrudController;
+    use App\Controller\Admin\CommentCrudController;
     use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 
     public function configureMenuItems(): iterable
     {
         return [
             MenuItem::subMenu('Blog', 'fa fa-article')->setSubItems([
-                MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class),
-                MenuItem::linkToCrud('Posts', 'fa fa-file-text', BlogPost::class),
-                MenuItem::linkToCrud('Comments', 'fa fa-comment', Comment::class),
+                MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fa fa-tags'),
+                MenuItem::linkTo(BlogPostCrudController::class, 'Posts', 'fa fa-file-text'),
+                MenuItem::linkTo(CommentCrudController::class, 'Comments', 'fa fa-comment'),
             ]),
             // ...
         ];
@@ -836,8 +909,8 @@ generator to return the menu items::
 
         if ('... some complex expression ...') {
             yield MenuItem::section('Blog');
-            yield MenuItem::linkToCrud('Categories', 'fa fa-tags', Category::class);
-            yield MenuItem::linkToCrud('Blog Posts', 'fa fa-file-text', BlogPost::class);
+            yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fa fa-tags');
+            yield MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts', 'fa fa-file-text');
         }
 
         // ...

--- a/doc/security.rst
+++ b/doc/security.rst
@@ -111,7 +111,7 @@ user must have to see the menu item::
         return [
             // ...
 
-            MenuItem::linkToCrud('Blog Posts', null, BlogPost::class)
+            MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts')
                 ->setPermission('ROLE_EDITOR'),
         ];
     }
@@ -133,7 +133,7 @@ menu item definition to not have to deal with array merges::
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
 
         if ($this->isGranted('ROLE_EDITOR') && '...') {
-            yield MenuItem::linkToCrud('Blog Posts', null, BlogPost::class);
+            yield MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts');
         }
 
         // ...

--- a/src/Config/Menu/ControllerMenuItem.php
+++ b/src/Config/Menu/ControllerMenuItem.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Config\Menu;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\MenuItemDto;
+use Symfony\Component\Uid\AbstractUid;
+use Symfony\Contracts\Translation\TranslatableInterface;
+
+/**
+ * @see \EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem::linkTo()
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class ControllerMenuItem implements MenuItemInterface
+{
+    use MenuItemTrait;
+
+    public function __construct(string $controllerFqcn, TranslatableInterface|string|null $label, ?string $icon)
+    {
+        $this->dto = new MenuItemDto();
+
+        $this->dto->setType(MenuItemDto::TYPE_CONTROLLER);
+        $this->dto->setLabel($label);
+        $this->dto->setIcon($icon);
+        $this->dto->setRouteParameters([
+            EA::CRUD_CONTROLLER_FQCN => $controllerFqcn,
+            EA::CRUD_ACTION => null,
+            EA::ENTITY_ID => null,
+        ]);
+    }
+
+    public function setHtmlAttribute(string $name, mixed $value): self
+    {
+        $this->dto->setHtmlAttribute($name, $value);
+
+        return $this;
+    }
+
+    public function setAction(string $actionName): self
+    {
+        $this->dto->setRouteParameters(array_merge(
+            $this->dto->getRouteParameters(),
+            [EA::CRUD_ACTION => $actionName]
+        ));
+
+        return $this;
+    }
+
+    public function setEntityId(AbstractUid|int|string $entityId): self
+    {
+        $this->dto->setRouteParameters(array_merge(
+            $this->dto->getRouteParameters(),
+            [EA::ENTITY_ID => $entityId]
+        ));
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, 'ASC'|'DESC'> $sortFieldsAndOrder ['fieldName' => 'ASC|DESC', ...]
+     */
+    public function setDefaultSort(array $sortFieldsAndOrder): self
+    {
+        $sortFieldsAndOrder = array_map('strtoupper', $sortFieldsAndOrder);
+        foreach ($sortFieldsAndOrder as $sortField => $sortOrder) {
+            if (!\in_array($sortOrder, [SortOrder::ASC, SortOrder::DESC], true)) {
+                throw new \InvalidArgumentException(sprintf('The sort order can be only "ASC" or "DESC", "%s" given.', $sortOrder));
+            }
+
+            if (!\is_string($sortField)) {
+                throw new \InvalidArgumentException(sprintf('The keys of the array that defines the default sort must be strings with the field names, but the given "%s" value is a "%s".', $sortField, \gettype($sortField)));
+            }
+        }
+
+        $this->dto->setRouteParameters(array_merge(
+            $this->dto->getRouteParameters(),
+            [EA::SORT => $sortFieldsAndOrder]
+        ));
+
+        return $this;
+    }
+}

--- a/src/Config/MenuItem.php
+++ b/src/Config/MenuItem.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\ControllerMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\CrudMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\DashboardMenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\ExitImpersonationMenuItem;
@@ -22,10 +23,30 @@ final class MenuItem
     }
 
     /**
+     * Creates a menu item that links to any admin controller: CRUD controllers,
+     * Dashboard controllers, or custom controllers with the #[AdminRoute] attribute.
+     *
+     * @param string      $controllerFqcn The FQCN of the admin controller to link to
+     * @param string|null $icon           The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
+     */
+    public static function linkTo(string $controllerFqcn, TranslatableInterface|string|null $label = null, ?string $icon = null): ControllerMenuItem
+    {
+        return new ControllerMenuItem($controllerFqcn, $label, $icon);
+    }
+
+    /**
+     * @deprecated since 4.29.0, use MenuItem::linkTo() instead.
+     *
      * @param string|null $icon The full CSS classes of the FontAwesome icon to render (see https://fontawesome.com/v6/search?m=free)
      */
     public static function linkToCrud(TranslatableInterface|string|null $label, ?string $icon, string $entityFqcn): CrudMenuItem
     {
+        trigger_deprecation(
+            'easycorp/easyadmin-bundle',
+            '4.29.0',
+            'The "MenuItem::linkToCrud()" method is deprecated, use "MenuItem::linkTo()" instead.',
+        );
+
         return new CrudMenuItem($label, $icon, $entityFqcn);
     }
 

--- a/src/Dto/MenuItemDto.php
+++ b/src/Dto/MenuItemDto.php
@@ -17,6 +17,7 @@ final class MenuItemDto
     public const TYPE_DASHBOARD = 'dashboard';
     public const TYPE_LOGOUT = 'logout';
     public const TYPE_SUBMENU = 'submenu';
+    public const TYPE_CONTROLLER = 'controller';
     public const TYPE_ROUTE = 'route';
 
     private ?string $type = null;

--- a/src/Factory/MenuFactory.php
+++ b/src/Factory/MenuFactory.php
@@ -6,6 +6,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Factory\MenuFactoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
@@ -117,6 +119,18 @@ final class MenuFactory implements MenuFactoryInterface
                 } else {
                     $label = basename(str_replace('\\', '/', $menuItemDto->getRouteParameters()[EA::ENTITY_FQCN]));
                 }
+            } elseif (null === $label && MenuItemDto::TYPE_CONTROLLER === $menuItemDto->getType()) {
+                $controllerFqcn = $menuItemDto->getRouteParameters()[EA::CRUD_CONTROLLER_FQCN];
+                if ($isUseEntityTranslations && is_a($controllerFqcn, CrudControllerInterface::class, true)) {
+                    $entityFqcn = $controllerFqcn::getEntityFqcn();
+                    $action = $menuItemDto->getRouteParameters()[EA::CRUD_ACTION] ?? Action::INDEX;
+                    $label = Action::INDEX === $action
+                        ? $this->entityTranslationIdGenerator->generateForEntity($entityFqcn, false)
+                        : $this->entityTranslationIdGenerator->generateForEntity($entityFqcn, true);
+                } else {
+                    $label = basename(str_replace('\\', '/', $controllerFqcn));
+                    $label = preg_replace('/(Crud)?Controller$/', '', $label);
+                }
             } else {
                 $label = '' === $label ? $label : t($label, $menuItemDto->getTranslationParameters(), $translationDomain);
             }
@@ -169,6 +183,42 @@ final class MenuFactory implements MenuFactoryInterface
 
                 $this->adminUrlGenerator->setController($controllerFqcn);
                 $this->adminUrlGenerator->unset(EA::ENTITY_FQCN);
+            }
+
+            return $this->adminUrlGenerator->generateUrl();
+        }
+
+        if (MenuItemDto::TYPE_CONTROLLER === $menuItemType) {
+            $routeParameters = $menuItemDto->getRouteParameters();
+            $controllerFqcn = $routeParameters[EA::CRUD_CONTROLLER_FQCN];
+
+            $this->adminUrlGenerator->unsetAll();
+
+            if (is_a($controllerFqcn, DashboardControllerInterface::class, true)) {
+                return $this->adminUrlGenerator
+                    ->setDashboard($controllerFqcn)
+                    ->generateUrl();
+            }
+
+            $action = $routeParameters[EA::CRUD_ACTION] ?? null;
+            if (null === $action) {
+                if (is_a($controllerFqcn, CrudControllerInterface::class, true)) {
+                    $action = Action::INDEX;
+                } elseif (method_exists($controllerFqcn, '__invoke')) {
+                    $action = '__invoke';
+                } else {
+                    throw new \RuntimeException(sprintf('The menu item that links to the "%s" controller must call "->setAction()" to specify which action to link to, because the controller defines multiple actions and is not invokable.', $controllerFqcn));
+                }
+            }
+
+            $this->adminUrlGenerator->setController($controllerFqcn);
+            $this->adminUrlGenerator->setAction($action);
+
+            if (null !== ($routeParameters[EA::ENTITY_ID] ?? null)) {
+                $this->adminUrlGenerator->setEntityId($routeParameters[EA::ENTITY_ID]);
+            }
+            if (isset($routeParameters[EA::SORT])) {
+                $this->adminUrlGenerator->set(EA::SORT, $routeParameters[EA::SORT]);
             }
 
             return $this->adminUrlGenerator->generateUrl();

--- a/tests/Functional/AdminRoute/AdminRouteTest.php
+++ b/tests/Functional/AdminRoute/AdminRouteTest.php
@@ -2,7 +2,10 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\AdminRoute;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Menu\CrudMenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Entity\Product;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Kernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\Filesystem\Filesystem;
@@ -600,6 +603,13 @@ class AdminRouteTest extends WebTestCase
         $client->request('GET', '/admin/legacy-crud/export');
         $this->assertResponseIsSuccessful();
         $this->assertSame('Legacy export action', $client->getResponse()->getContent());
+    }
+
+    public function testLegacyLinkToCrudMenuItemStillWorks(): void
+    {
+        $menuItem = MenuItem::linkToCrud('Products', 'fas fa-box', Product::class);
+
+        $this->assertInstanceOf(CrudMenuItem::class, $menuItem);
     }
 
     public function testAdminDashboardAdvancedRouteOptions(): void

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/AssetsTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/AssetsTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\BlogPost;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\Crud\BlogPostCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -29,6 +29,6 @@ class AssetsTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-list', BlogPost::class);
+        yield MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/ColorSchemeTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/ColorSchemeTestDashboardController.php
@@ -9,7 +9,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ColorScheme;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -37,6 +36,6 @@ class ColorSchemeTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/ContentMaximizedTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/ContentMaximizedTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class ContentMaximizedTestDashboardController extends AbstractDashboardControlle
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/CustomHtmlAttributeTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/CustomHtmlAttributeTestDashboardController.php
@@ -6,8 +6,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\BlogPost;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\Crud\BlogPostCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\Crud\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 #[AdminDashboard(
@@ -30,10 +30,10 @@ class CustomHtmlAttributeTestDashboardController extends AbstractDashboardContro
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)->setHtmlAttribute(
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags')->setHtmlAttribute(
             'test-attribute', 'test'
         );
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class)
+        yield MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts', 'fas fa-tags')
             ->setHtmlAttribute('multi-test-one', 'test1')
             ->setHtmlAttribute('multi-test-two', 'test2')
             ->setBadge('0', 'secondary', [

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/DarkModeTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/DarkModeTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class DarkModeTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/FaviconTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/FaviconTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class FaviconTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/LocalesTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/LocalesTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class LocalesTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/RelativeUrlsTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/RelativeUrlsTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class RelativeUrlsTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/SidebarMinimizedTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/SidebarMinimizedTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class SidebarMinimizedTestDashboardController extends AbstractDashboardControlle
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TextDirectionTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TextDirectionTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class TextDirectionTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TitleTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TitleTestDashboardController.php
@@ -8,7 +8,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -35,6 +34,6 @@ class TitleTestDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TranslationDomainTestDashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/Dashboard/TranslationDomainTestDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Controller\DemoEntityCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class TranslationDomainTestDashboardController extends AbstractDashboardControll
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/CustomizationApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/CustomizationApp/src/Controller/DashboardController.php
@@ -6,7 +6,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\CustomizationApp\Entity\DemoEntity;
 use Symfony\Component\HttpFoundation\Response;
 
 #[AdminDashboard(routePath: '/admin', routeName: 'customization_admin')]
@@ -26,6 +25,6 @@ class DashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Demo', 'fas fa-list', DemoEntity::class);
+        yield MenuItem::linkTo(DemoEntityCrudController::class, 'Demo', 'fas fa-list');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/CustomHtmlAttributeDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/CustomHtmlAttributeDashboardController.php
@@ -6,8 +6,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\BlogPost;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
 
 #[AdminDashboard(
@@ -30,10 +28,10 @@ class CustomHtmlAttributeDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)->setHtmlAttribute(
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags')->setHtmlAttribute(
             'test-attribute', 'test'
         );
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class)
+        yield MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts', 'fas fa-tags')
             ->setHtmlAttribute('multi-test-one', 'test1')
             ->setHtmlAttribute('multi-test-two', 'test2')
             ->setBadge('0', 'secondary', [

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/ColorSchemeDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/ColorSchemeDashboardController.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ColorScheme;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -31,6 +31,6 @@ class ColorSchemeDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/DisabledDarkModeDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/DisabledDarkModeDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -30,6 +30,6 @@ class DisabledDarkModeDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/EntityTranslationsDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/EntityTranslationsDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -32,6 +32,6 @@ class EntityTranslationsDashboardController extends AbstractDashboardController
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
         // use null label to test that entity translations are used for menu items
-        yield MenuItem::linkToCrud(null, 'fas fa-tags', Category::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, null, 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/LayoutDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/LayoutDashboardController.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextDirection;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -38,6 +38,6 @@ class LayoutDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/LocaleDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/LocaleDashboardController.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Locale;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -37,6 +37,6 @@ class LocaleDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/MenuDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/MenuDashboardController.php
@@ -6,8 +6,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\BlogPost;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\BlogPostCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -40,12 +40,17 @@ class MenuDashboardController extends AbstractDashboardController
         // section header
         yield MenuItem::section('Content Management');
 
-        // regular CRUD links
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-newspaper', BlogPost::class)
+        // regular CRUD link using linkTo()
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
+
+        // CRUD link using linkTo() with explicit label and icon
+        yield MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts', 'fas fa-newspaper')
             ->setBadge('New', 'success');
 
-        // section with submenu
+        // CRUD link using linkTo() with auto-derived label (no label/icon)
+        yield MenuItem::linkTo(CategoryCrudController::class);
+
+        // section with submenu, including a linkTo() submenu item
         yield MenuItem::section('Advanced');
 
         // submenu with nested items

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/SecondDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/SecondDashboardController.php
@@ -6,7 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -37,7 +37,7 @@ class SecondDashboardController extends AbstractDashboardController
         yield MenuItem::section('Second Dashboard Content');
 
         // only Categories, not Blog Posts
-        yield MenuItem::linkToCrud('Manage Categories', 'fas fa-folder', Category::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Manage Categories', 'fas fa-folder');
 
         // different external links
         yield MenuItem::section('Links');

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/UserMenuDashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Dashboard/UserMenuDashboardController.php
@@ -7,7 +7,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -45,6 +45,6 @@ class UserMenuDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
@@ -6,17 +6,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\BlogPost;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\ActionTestEntity;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\BatchActionTestEntity;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\DefaultCrudTestEntity;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\FieldRelatedEntity;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\FieldTestEntity;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\FilterRelatedEntity;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\FilterTestEntity;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\FormTestEntity;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SearchTestEntity;
 
 #[AdminDashboard(routePath: '/admin', routeName: 'admin')]
 class DashboardController extends AbstractDashboardController
@@ -30,19 +19,19 @@ class DashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
+        yield MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts', 'fas fa-tags');
 
         // synthetic test entities
         yield MenuItem::section('Synthetic Tests');
-        yield MenuItem::linkToCrud('Field Tests', 'fas fa-flask', FieldTestEntity::class);
-        yield MenuItem::linkToCrud('Field Related Entities', 'fas fa-link', FieldRelatedEntity::class);
-        yield MenuItem::linkToCrud('Filter Tests', 'fas fa-filter', FilterTestEntity::class);
-        yield MenuItem::linkToCrud('Filter Related Entities', 'fas fa-link', FilterRelatedEntity::class);
-        yield MenuItem::linkToCrud('Form Layout Tests', 'fas fa-th-large', FormTestEntity::class);
-        yield MenuItem::linkToCrud('Batch Action Tests', 'fas fa-tasks', BatchActionTestEntity::class);
-        yield MenuItem::linkToCrud('Default CRUD Tests', 'fas fa-cog', DefaultCrudTestEntity::class);
-        yield MenuItem::linkToCrud('Search Tests', 'fas fa-search', SearchTestEntity::class);
-        yield MenuItem::linkToCrud('Action Tests', 'fas fa-mouse-pointer', ActionTestEntity::class);
+        yield MenuItem::linkTo(Synthetic\FieldTestEntityCrudController::class, 'Field Tests', 'fas fa-flask');
+        yield MenuItem::linkTo(Synthetic\FieldRelatedEntityCrudController::class, 'Field Related Entities', 'fas fa-link');
+        yield MenuItem::linkTo(Synthetic\FilterTestEntityCrudController::class, 'Filter Tests', 'fas fa-filter');
+        yield MenuItem::linkTo(Synthetic\FilterRelatedEntityCrudController::class, 'Filter Related Entities', 'fas fa-link');
+        yield MenuItem::linkTo(Synthetic\FormLayoutFieldsetsCrudController::class, 'Form Layout Tests', 'fas fa-th-large');
+        yield MenuItem::linkTo(Synthetic\BatchActionTestEntityCrudController::class, 'Batch Action Tests', 'fas fa-tasks');
+        yield MenuItem::linkTo(Synthetic\DefaultCrudTestEntityCrudController::class, 'Default CRUD Tests', 'fas fa-cog');
+        yield MenuItem::linkTo(Synthetic\SearchAllTermsCrudController::class, 'Search Tests', 'fas fa-search');
+        yield MenuItem::linkTo(Synthetic\ActionTestEntityCrudController::class, 'Action Tests', 'fas fa-mouse-pointer');
     }
 }

--- a/tests/Functional/Apps/SecuredApp/src/Controller/SecuredDashboardController.php
+++ b/tests/Functional/Apps/SecuredApp/src/Controller/SecuredDashboardController.php
@@ -6,7 +6,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
 
 #[AdminDashboard('/admin', 'secured_admin')]
@@ -26,7 +25,6 @@ class SecuredDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)
-            ->setController(CategoryCrudController::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/SecuredApp/src/Controller/UserMenuDashboardController.php
+++ b/tests/Functional/Apps/SecuredApp/src/Controller/UserMenuDashboardController.php
@@ -7,7 +7,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -45,7 +44,6 @@ class UserMenuDashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class)
-            ->setController(CategoryCrudController::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/UglyUrlsApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/UglyUrlsApp/src/Controller/DashboardController.php
@@ -5,8 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\UglyUrlsApp\Cont
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\BlogPost;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -27,7 +25,7 @@ class DashboardController extends AbstractDashboardController
     public function configureMenuItems(): iterable
     {
         yield MenuItem::linktoDashboard('Dashboard', 'fa fa-home');
-        yield MenuItem::linkToCrud('Categories', 'fas fa-tags', Category::class);
-        yield MenuItem::linkToCrud('Blog Posts', 'fas fa-tags', BlogPost::class);
+        yield MenuItem::linkTo(CategoryCrudController::class, 'Categories', 'fas fa-tags');
+        yield MenuItem::linkTo(BlogPostCrudController::class, 'Blog Posts', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Default/Dashboard/MenuTest.php
+++ b/tests/Functional/Default/Dashboard/MenuTest.php
@@ -91,10 +91,47 @@ class MenuTest extends AbstractCrudTestCase
 
         static::assertResponseIsSuccessful();
 
-        // cRUD menu items should be present
         $html = $crawler->html();
         static::assertStringContainsString('Categories', $html);
         static::assertStringContainsString('Blog Posts', $html);
+    }
+
+    public function testLinkToMenuItemsAreRendered(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        static::assertResponseIsSuccessful();
+
+        // the linkTo(BlogPostCrudController::class, 'Blog Posts', ...) item should render
+        $html = $crawler->html();
+        static::assertStringContainsString('Blog Posts', $html);
+
+        // the linkTo(CategoryCrudController::class) item (auto-derived label) should also render
+        // and its link should be clickable (have an href)
+        $menuLinks = $crawler->filter('.menu-item a.menu-item-contents:not(.submenu-toggle)');
+        $hasLinkToItem = false;
+        foreach ($menuLinks as $link) {
+            $href = $link->getAttribute('href');
+            if ('' !== $href && '#' !== $href) {
+                $hasLinkToItem = true;
+                break;
+            }
+        }
+        static::assertTrue($hasLinkToItem, 'linkTo() menu items should generate valid URLs');
+    }
+
+    public function testLinkToMenuItemBadgeIsRendered(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        static::assertResponseIsSuccessful();
+
+        // the linkTo() Blog Posts item has a badge with 'New'
+        $badges = $crawler->filter('.menu-item-badge');
+        static::assertGreaterThan(0, $badges->count());
+
+        $html = $crawler->html();
+        static::assertStringContainsString('New', $html);
     }
 
     public function testMenuItemBadgesAreRendered(): void

--- a/tests/Unit/Factory/MenuFactoryTest.php
+++ b/tests/Unit/Factory/MenuFactoryTest.php
@@ -2,7 +2,9 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Factory;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\UserMenu;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Context\I18nContext;
@@ -241,6 +243,112 @@ class MenuFactoryTest extends TestCase
         $this->assertTrue($result->isNameDisplayed());
     }
 
+    public function testCreateMainMenuGeneratesUrlsForControllerTypeCrud(): void
+    {
+        $this->setupAdminContext();
+        $this->authChecker->method('isGranted')->willReturn(true);
+        $this->adminUrlGenerator->method('unsetAll')->willReturnSelf();
+        $this->adminUrlGenerator->method('setController')->willReturnSelf();
+        $this->adminUrlGenerator->method('setAction')->willReturnSelf();
+        $this->adminUrlGenerator->method('generateUrl')->willReturn('/admin/category');
+        $this->menuItemMatcher->method('markSelectedMenuItem')->willReturnArgument(0);
+
+        $menuItem = $this->createControllerMenuItem(
+            'EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController',
+            'Categories',
+        );
+
+        $result = $this->menuFactory->createMainMenu([$menuItem]);
+
+        $items = $result->getItems();
+        $this->assertSame('/admin/category', $items[0]->getLinkUrl());
+    }
+
+    public function testCreateMainMenuGeneratesUrlsForControllerTypeDashboard(): void
+    {
+        $this->setupAdminContext();
+        $this->authChecker->method('isGranted')->willReturn(true);
+        $this->adminUrlGenerator->method('unsetAll')->willReturnSelf();
+        $this->adminUrlGenerator->method('setDashboard')->willReturnSelf();
+        $this->adminUrlGenerator->method('generateUrl')->willReturn('/admin');
+        $this->menuItemMatcher->method('markSelectedMenuItem')->willReturnArgument(0);
+
+        $menuItem = $this->createControllerMenuItem(
+            'EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController',
+            'Dashboard',
+        );
+
+        $result = $this->menuFactory->createMainMenu([$menuItem]);
+
+        $items = $result->getItems();
+        $this->assertSame('/admin', $items[0]->getLinkUrl());
+    }
+
+    public function testCreateMainMenuGeneratesUrlsForControllerTypeWithExplicitAction(): void
+    {
+        $this->setupAdminContext();
+        $this->authChecker->method('isGranted')->willReturn(true);
+        $this->adminUrlGenerator->method('unsetAll')->willReturnSelf();
+        $this->adminUrlGenerator->method('setController')->willReturnSelf();
+        $this->adminUrlGenerator->method('setAction')->willReturnSelf();
+        $this->adminUrlGenerator->method('generateUrl')->willReturn('/admin/category/new');
+        $this->menuItemMatcher->method('markSelectedMenuItem')->willReturnArgument(0);
+
+        $menuItem = $this->createControllerMenuItem(
+            'EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController',
+            'New Category',
+            Action::NEW,
+        );
+
+        $result = $this->menuFactory->createMainMenu([$menuItem]);
+
+        $items = $result->getItems();
+        $this->assertSame('/admin/category/new', $items[0]->getLinkUrl());
+    }
+
+    public function testCreateMainMenuGeneratesUrlsForControllerTypeWithEntityId(): void
+    {
+        $this->setupAdminContext();
+        $this->authChecker->method('isGranted')->willReturn(true);
+        $this->adminUrlGenerator->method('unsetAll')->willReturnSelf();
+        $this->adminUrlGenerator->method('setController')->willReturnSelf();
+        $this->adminUrlGenerator->method('setAction')->willReturnSelf();
+        $this->adminUrlGenerator->method('setEntityId')->willReturnSelf();
+        $this->adminUrlGenerator->method('generateUrl')->willReturn('/admin/category/42/edit');
+        $this->menuItemMatcher->method('markSelectedMenuItem')->willReturnArgument(0);
+
+        $menuItem = $this->createControllerMenuItemWithEntityId(
+            'EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController',
+            'Edit Category',
+            Action::EDIT,
+            42,
+        );
+
+        $result = $this->menuFactory->createMainMenu([$menuItem]);
+
+        $items = $result->getItems();
+        $this->assertSame('/admin/category/42/edit', $items[0]->getLinkUrl());
+    }
+
+    public function testControllerTypeThrowsForMultiActionNonInvokableController(): void
+    {
+        $this->setupAdminContext();
+        $this->authChecker->method('isGranted')->willReturn(true);
+        $this->adminUrlGenerator->method('unsetAll')->willReturnSelf();
+        $this->menuItemMatcher->method('markSelectedMenuItem')->willReturnArgument(0);
+
+        // Use a class that is not a CRUD controller, not a Dashboard, and not invokable
+        $menuItem = $this->createControllerMenuItem(
+            self::class,
+            'Bad Item',
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('must call "->setAction()"');
+
+        $this->menuFactory->createMainMenu([$menuItem]);
+    }
+
     private function setupAdminContext(): void
     {
         $request = new Request();
@@ -319,6 +427,34 @@ class MenuFactoryTest extends TestCase
         $item->setType(MenuItemDto::TYPE_SUBMENU);
         $item->setLabel($label);
         $item->setSubItems($subItems);
+
+        return $item;
+    }
+
+    private function createControllerMenuItem(string $controllerFqcn, string $label, ?string $action = null): MenuItemDto
+    {
+        $item = new MenuItemDto();
+        $item->setType(MenuItemDto::TYPE_CONTROLLER);
+        $item->setLabel($label);
+        $item->setRouteParameters([
+            EA::CRUD_CONTROLLER_FQCN => $controllerFqcn,
+            EA::CRUD_ACTION => $action,
+            EA::ENTITY_ID => null,
+        ]);
+
+        return $item;
+    }
+
+    private function createControllerMenuItemWithEntityId(string $controllerFqcn, string $label, string $action, int|string $entityId): MenuItemDto
+    {
+        $item = new MenuItemDto();
+        $item->setType(MenuItemDto::TYPE_CONTROLLER);
+        $item->setLabel($label);
+        $item->setRouteParameters([
+            EA::CRUD_CONTROLLER_FQCN => $controllerFqcn,
+            EA::CRUD_ACTION => $action,
+            EA::ENTITY_ID => $entityId,
+        ]);
 
         return $item;
     }


### PR DESCRIPTION
This introduces `linkTo()` as a better replacement of `linkToCrud()`.

As explained in the docs, we now link to controllers instead of entities and swap the argument order. Read the examples to see how it works in practice.

**I have a question**: I haven't deprecated the `linkToCrud()` method because it might be a pain for some folks (just "busy work" for no real gain). Should we deprecate it? Or is it enough to only show the new method in docs and encourage folks to not use the old one?
