### PR TITLE
Move Inspector\DataCollector to DataCollector\EasyAdminDataCollector

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -13,6 +13,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityPaginatorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\DataCollector\EasyAdminDataCollector;
 use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\EasyAdminExtension;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\AdminRouterSubscriber;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\CrudResponseListener;
@@ -72,7 +73,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FileUploadType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType;
-use EasyCorp\Bundle\EasyAdminBundle\Inspector\DataCollector;
 use EasyCorp\Bundle\EasyAdminBundle\Intl\IntlFormatter;
 use EasyCorp\Bundle\EasyAdminBundle\Maker\ClassMaker;
 use EasyCorp\Bundle\EasyAdminBundle\Menu\MenuItemMatcher;
@@ -126,7 +126,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, service('router'))
             ->tag('kernel.cache_warmer')
 
-        ->set(DataCollector::class)
+        ->set(EasyAdminDataCollector::class)
             ->arg(0, service(AdminContextProvider::class))
             ->tag('data_collector', ['id' => 'easyadmin', 'template' => '@EasyAdmin/inspector/data_collector.html.twig'])
 

--- a/src/DataCollector/EasyAdminDataCollector.php
+++ b/src/DataCollector/EasyAdminDataCollector.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\DataCollector;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector as BaseDataCollector;
+use Symfony\Component\VarDumper\Cloner\Data;
+
+/**
+ * Collects information about the requests related to EasyAdmin and displays
+ * it both in the web debug toolbar and in the profiler.
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+class EasyAdminDataCollector extends BaseDataCollector
+{
+    public function __construct(private readonly AdminContextProviderInterface $adminContextProvider)
+    {
+    }
+
+    public function reset(): void
+    {
+        $this->data = [];
+    }
+
+    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
+    {
+        if (null === $context = $this->adminContextProvider->getContext()) {
+            return;
+        }
+
+        $collectedData = [];
+        foreach ($this->collectData($context) as $key => $value) {
+            $collectedData[$key] = $this->cloneVar($value);
+        }
+
+        $this->data = $collectedData;
+    }
+
+    public function isEasyAdminRequest(): bool
+    {
+        return 0 !== \count($this->data);
+    }
+
+    /**
+     * @return array<mixed>|Data
+     */
+    public function getData(): array|Data
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function collectData(AdminContextInterface $context): array
+    {
+        $attributes = $context->getRequest()->attributes->all();
+        $query = $context->getRequest()->query->all();
+
+        return [
+            'CRUD Controller FQCN' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
+            'CRUD Action' => $attributes[EA::CRUD_ACTION] ?? $query[EA::CRUD_ACTION] ?? null,
+            'Entity ID' => $attributes[EA::ENTITY_ID] ?? $query[EA::ENTITY_ID] ?? null,
+            'Sort' => $attributes[EA::SORT] ?? $query[EA::SORT] ?? null,
+        ];
+    }
+
+    public function getName(): string
+    {
+        return 'easyadmin';
+    }
+}

--- a/src/Inspector/DataCollector.php
+++ b/src/Inspector/DataCollector.php
@@ -2,77 +2,16 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Inspector;
 
-use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\DataCollector\DataCollector as BaseDataCollector;
-use Symfony\Component\VarDumper\Cloner\Data;
+use EasyCorp\Bundle\EasyAdminBundle\DataCollector\EasyAdminDataCollector;
 
 /**
+ * @deprecated since 4.28.1 and will be removed in 5.0.0. Use \EasyCorp\Bundle\EasyAdminBundle\DataCollector\EasyAdminDataCollector instead.
+ *
  * Collects information about the requests related to EasyAdmin and displays
  * it both in the web debug toolbar and in the profiler.
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-class DataCollector extends BaseDataCollector
+class DataCollector extends EasyAdminDataCollector
 {
-    public function __construct(
-        private readonly AdminContextProviderInterface $adminContextProvider,
-    ) {
-    }
-
-    public function reset(): void
-    {
-        $this->data = [];
-    }
-
-    public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
-    {
-        if (null === $context = $this->adminContextProvider->getContext()) {
-            return;
-        }
-
-        $collectedData = [];
-        foreach ($this->collectData($context) as $key => $value) {
-            $collectedData[$key] = $this->cloneVar($value);
-        }
-
-        $this->data = $collectedData;
-    }
-
-    public function isEasyAdminRequest(): bool
-    {
-        return 0 !== \count($this->data);
-    }
-
-    /**
-     * @return array<mixed>|Data
-     */
-    public function getData(): array|Data
-    {
-        return $this->data;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function collectData(AdminContextInterface $context): array
-    {
-        $attributes = $context->getRequest()->attributes->all();
-        $query = $context->getRequest()->query->all();
-
-        return [
-            'CRUD Controller FQCN' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
-            'CRUD Action' => $attributes[EA::CRUD_ACTION] ?? $query[EA::CRUD_ACTION] ?? null,
-            'Entity ID' => $attributes[EA::ENTITY_ID] ?? $query[EA::ENTITY_ID] ?? null,
-            'Sort' => $attributes[EA::SORT] ?? $query[EA::SORT] ?? null,
-        ];
-    }
-
-    public function getName(): string
-    {
-        return 'easyadmin';
-    }
 }

--- a/tests/Functional/DataCollector/EasyAdminDataCollectorTest.php
+++ b/tests/Functional/DataCollector/EasyAdminDataCollectorTest.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Inspector;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\DataCollector;
 
 use Doctrine\ORM\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
-use EasyCorp\Bundle\EasyAdminBundle\Inspector\DataCollector;
+use EasyCorp\Bundle\EasyAdminBundle\DataCollector\EasyAdminDataCollector;
 use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\CategoryCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
 use Symfony\Component\VarDumper\Cloner\Data;
 
-class DataCollectorTest extends AbstractCrudTestCase
+class EasyAdminDataCollectorTest extends AbstractCrudTestCase
 {
     protected EntityRepository $categories;
 
@@ -40,7 +40,7 @@ class DataCollectorTest extends AbstractCrudTestCase
         $sort = ['name' => 'DESC', 'slug' => 'ASC'];
         $this->client->request('GET', $this->generateIndexUrl().'?'.http_build_query([EA::SORT => $sort]));
 
-        /** @var DataCollector $collector */
+        /** @var EasyAdminDataCollector $collector */
         $collector = $this->client->getProfile()->getCollector('easyadmin');
 
         $this->assertTrue($collector->isEasyAdminRequest());
@@ -63,7 +63,7 @@ class DataCollectorTest extends AbstractCrudTestCase
 
         $this->client->request('GET', $this->generateEditFormUrl($category->getId()));
 
-        /** @var DataCollector $collector */
+        /** @var EasyAdminDataCollector $collector */
         $collector = $this->client->getProfile()->getCollector('easyadmin');
 
         $this->assertTrue($collector->isEasyAdminRequest());
@@ -83,7 +83,7 @@ class DataCollectorTest extends AbstractCrudTestCase
     {
         $this->client->request('GET', $this->generateIndexUrl());
 
-        /** @var DataCollector $collector */
+        /** @var EasyAdminDataCollector $collector */
         $collector = $this->client->getProfile()->getCollector('easyadmin');
 
         $this->assertSame(


### PR DESCRIPTION
Changes nothing, only moves one class.

Reason is that it seems to be the usual namespace for DataCollectors, examples:

- https://github.com/symfony/symfony/blob/6ce530c5e90397d88e3a76a56db266c74d651584/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
- https://github.com/symfony/symfony/blob/7080b83f4e45db451d607cbc94c76340fd33e926/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
- https://github.com/symfony/symfony/blob/806224eb1a07bcec600d7a5c42c170e6a6903ce5/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
