### PR TITLE
Fix search on nested embedded properties

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -262,69 +262,54 @@ final class EntityRepository implements EntityRepositoryInterface
         $searchableProperties = (null === $configuredSearchableProperties || 0 === \count($configuredSearchableProperties)) ? $entityDto->getClassMetadata()->getFieldNames() : $configuredSearchableProperties;
 
         $entitiesAlreadyJoined = [];
-        foreach ($searchableProperties as $propertyName) {
-            if ($this->isAssociation($entityDto, $propertyName)) {
-                // support arbitrarily nested associations (e.g. foo.bar.baz.qux)
-                $associatedProperties = explode('.', $propertyName);
-                $numAssociatedProperties = \count($associatedProperties);
+        foreach ($searchableProperties as $searchableProperty) {
+            // support arbitrarily nested associations (e.g. foo.bar.baz.qux)
+            $associatedProperties = explode('.', $searchableProperty);
+            $numAssociatedProperties = \count($associatedProperties);
+            $parentEntityDto = $entityDto;
+            $parentEntityAlias = 'entity';
+            $fullPropertyName = $parentPropertyName = $associatedPropertyName = '';
 
-                if (1 === $numAssociatedProperties) {
-                    throw new \InvalidArgumentException(sprintf('The "%s" property included in the setSearchFields() method is not a valid search field. When using associated properties in search, you must also define the exact field used in the search (e.g. \'%s.id\', \'%s.name\', etc.)', $propertyName, $propertyName, $propertyName));
-                }
+            for ($i = 0; $i < $numAssociatedProperties; ++$i) {
+                $associatedPropertyName = $associatedProperties[$i];
+                $fullPropertyName = trim($fullPropertyName.'.'.$associatedPropertyName, '.');
 
-                $associatedEntityDto = $this->entityFactory->create($entityDto->getClassMetadata()->getAssociationTargetClass($associatedProperties[0]));
-
-                $associatedEntityAlias = $associatedPropertyName = '';
-                for ($i = 0; $i < $numAssociatedProperties - 1; ++$i) {
-                    $associatedEntityName = $associatedProperties[$i];
-                    $associatedEntityAlias = $entitiesAlreadyJoined[$associatedEntityName] ?? Escaper::escapeDqlAlias($associatedEntityName).(0 === $i ? '' : $i);
-                    $associatedPropertyName = $associatedProperties[$i + 1];
-
-                    if (!\in_array($associatedEntityAlias, $entitiesAlreadyJoined, true)) {
-                        $parentEntityName = 0 === $i ? 'entity' : $entitiesAlreadyJoined[$associatedProperties[$i - 1]];
-                        $queryBuilder->leftJoin(Escaper::escapeDqlAlias($parentEntityName).'.'.$associatedEntityName, $associatedEntityAlias);
-                        $entitiesAlreadyJoined[$associatedEntityName] = $associatedEntityAlias;
+                if ($this->isAssociation($parentEntityDto, $associatedPropertyName)) {
+                    if ($i === $numAssociatedProperties - 1) {
+                        throw new \InvalidArgumentException(sprintf('The "%s" property included in the setSearchFields() method is not a valid search field. When using associated properties in search, you must also define the exact field used in the search (e.g. \'%s.id\', \'%s.name\', etc.)', $searchableProperty, $searchableProperty, $searchableProperty));
                     }
 
-                    if ($i < $numAssociatedProperties - 2) {
-                        $targetEntity = $associatedEntityDto->getClassMetadata()->getAssociationTargetClass($associatedPropertyName);
-                        $associatedEntityDto = $this->entityFactory->create($targetEntity);
+                    $associatedEntityDto = $this->entityFactory->create($parentEntityDto->getClassMetadata()->getAssociationTargetClass($associatedPropertyName));
+
+                    if (!isset($entitiesAlreadyJoined[$fullPropertyName])) {
+                        $aliasIndex = \count($entitiesAlreadyJoined);
+                        $entitiesAlreadyJoined[$fullPropertyName] ??= Escaper::escapeDqlAlias($associatedPropertyName.(0 === $aliasIndex ? '' : $aliasIndex));
+                        $queryBuilder->leftJoin(Escaper::escapeDqlAlias($parentEntityAlias).'.'.$associatedPropertyName, $entitiesAlreadyJoined[$fullPropertyName]);
                     }
-                }
 
-                $entityName = $associatedEntityAlias;
-                $propertyName = $associatedPropertyName;
-                if (!isset($associatedEntityDto->getClassMetadata()->fieldMappings[$propertyName])) {
-                    throw new \InvalidArgumentException(sprintf('The "%s" property included in the setSearchFields() method is not a valid search field. When using associated properties in search, you must also define the exact field used in the search (e.g. \'%s.id\', \'%s.name\', etc.)', $propertyName, $propertyName, $propertyName));
+                    $parentEntityDto = $associatedEntityDto;
+                    $parentEntityAlias = $entitiesAlreadyJoined[$fullPropertyName];
+                    $parentPropertyName = '';
+                } else {
+                    // Normal & Embedded class properties
+                    $associatedPropertyName = $parentPropertyName = trim($parentPropertyName.'.'.$associatedPropertyName, '.');
                 }
-
-                // In Doctrine ORM 3.x, FieldMapping implements \ArrayAccess; in 4.x it's an object with properties
-                $fieldMapping = $associatedEntityDto->getClassMetadata()->getFieldMapping($propertyName);
-                // In Doctrine ORM 2.x, getFieldMapping() returns an array
-                /** @phpstan-ignore-next-line function.impossibleType */
-                if (\is_array($fieldMapping)) {
-                    /** @phpstan-ignore-next-line cast.useless */
-                    $fieldMapping = (object) $fieldMapping;
-                }
-                /** @phpstan-ignore-next-line function.alreadyNarrowedType */
-                $propertyDataType = property_exists($fieldMapping, 'type') ? $fieldMapping->type : $fieldMapping['type'];
-            } else {
-                $entityName = 'entity';
-                if (!isset($entityDto->getClassMetadata()->fieldMappings[$propertyName])) {
-                    throw new \InvalidArgumentException(sprintf('The "%s" property included in the setSearchFields() method is not a valid search field. When using associated properties in search, you must also define the exact field used in the search (e.g. \'%s.id\', \'%s.name\', etc.)', $propertyName, $propertyName, $propertyName));
-                }
-
-                // In Doctrine ORM 3.x, FieldMapping implements \ArrayAccess; in 4.x it's an object with properties
-                $fieldMapping = $entityDto->getClassMetadata()->getFieldMapping($propertyName);
-                // In Doctrine ORM 2.x, getFieldMapping() returns an array
-                /** @phpstan-ignore-next-line function.impossibleType */
-                if (\is_array($fieldMapping)) {
-                    /** @phpstan-ignore-next-line cast.useless */
-                    $fieldMapping = (object) $fieldMapping;
-                }
-                /** @phpstan-ignore-next-line function.alreadyNarrowedType */
-                $propertyDataType = property_exists($fieldMapping, 'type') ? $fieldMapping->type : $fieldMapping['type'];
             }
+
+            if (!isset($parentEntityDto->getClassMetadata()->fieldMappings[$associatedPropertyName])) {
+                throw new \InvalidArgumentException(sprintf('The "%s" property included in the setSearchFields() method is not a valid search field. The field "%s" does not exist in "%s".', $searchableProperty, $associatedPropertyName, $searchableProperty));
+            }
+
+            // In Doctrine ORM 3.x, FieldMapping implements \ArrayAccess; in 4.x it's an object with properties
+            $fieldMapping = $parentEntityDto->getClassMetadata()->getFieldMapping($associatedPropertyName);
+            // In Doctrine ORM 2.x, getFieldMapping() returns an array
+            /** @phpstan-ignore-next-line function.impossibleType */
+            if (\is_array($fieldMapping)) {
+                /** @phpstan-ignore-next-line cast.useless */
+                $fieldMapping = (object) $fieldMapping;
+            }
+            /** @phpstan-ignore-next-line function.alreadyNarrowedType */
+            $propertyDataType = property_exists($fieldMapping, 'type') ? $fieldMapping->type : $fieldMapping['type'];
 
             $isBoolean = 'boolean' === $propertyDataType;
             $isSmallIntegerProperty = 'smallint' === $propertyDataType;
@@ -345,10 +330,7 @@ final class EntityRepository implements EntityRepositoryInterface
                 && !$isUlidProperty
                 && !$isJsonProperty
             ) {
-                $entityFqcn = 'entity' !== $entityName && isset($associatedEntityDto)
-                    ? $associatedEntityDto->getFqcn()
-                    : $entityDto->getFqcn()
-                ;
+                $entityFqcn = $parentEntityDto->getFqcn();
 
                 /** @var \ReflectionNamedType|\ReflectionUnionType|null $idClassType */
                 $idClassType = null;
@@ -356,8 +338,8 @@ final class EntityRepository implements EntityRepositoryInterface
 
                 // this is needed to handle inherited properties
                 while (false !== $reflectionClass) {
-                    if ($reflectionClass->hasProperty($propertyName)) {
-                        $reflection = $reflectionClass->getProperty($propertyName);
+                    if ($reflectionClass->hasProperty($associatedPropertyName)) {
+                        $reflection = $reflectionClass->getProperty($associatedPropertyName);
                         $idClassType = $reflection->getType();
                         break;
                     }
@@ -376,9 +358,9 @@ final class EntityRepository implements EntityRepositoryInterface
             }
 
             $searchablePropertiesConfig[] = [
-                'entity_name' => $entityName,
+                'entity_name' => $parentEntityAlias,
                 'property_data_type' => $propertyDataType,
-                'property_name' => $propertyName,
+                'property_name' => $associatedPropertyName,
                 'is_boolean' => $isBoolean,
                 'is_small_integer' => $isSmallIntegerProperty,
                 'is_integer' => $isIntegerProperty,
@@ -395,16 +377,8 @@ final class EntityRepository implements EntityRepositoryInterface
 
     private function isAssociation(EntityDto $entityDto, string $propertyName): bool
     {
-        if ($entityDto->getClassMetadata()->hasAssociation($propertyName)) {
-            return true;
-        }
-
-        if (!str_contains($propertyName, '.')) {
-            return false;
-        }
-
         $propertyNameParts = explode('.', $propertyName, 2);
 
-        return !isset($entityDto->getClassMetadata()->embeddedClasses[$propertyNameParts[0]]);
+        return $entityDto->getClassMetadata()->hasAssociation($propertyNameParts[0]);
     }
 }


### PR DESCRIPTION
Searching on Embedded properties is currently supported only if the embedded is on the root entity.

Eg, if I my entity `User` has a `user.address` embedded where `address` is an embedded with fields `address.city`, `address.country`...

The following code already works, in the `UserCrudController`, we can successfully search on `address.city`:
```php
    // UserCrudController.php

    public function configureCrud(Crud $crud): Crud
    {
        return $crud->setSearchFields(['address.city']);
    }
```

But searching on embedded was not supported if combined with association.
My PR is fixing that limitation.

For example with `PostCrudController`, we can now do this:

```php
    // PostCrudController.php

    public function configureCrud(Crud $crud): Crud
    {
        return $crud->setSearchFields(['author.address.city']);
    }
```
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/6854

It's also kind of related to https://github.com/EasyCorp/EasyAdminBundle/issues/7020, but I think filters and search are not sharing the same code, so searching embedded with filters may not be fixed yet.


