### PR TITLE
Refactor/dto collections

### DIFF
--- a/src/Collection/ActionCollection.php
+++ b/src/Collection/ActionCollection.php
@@ -2,21 +2,18 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Collection;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Collection\CollectionInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionGroupDto;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- *
- * @implements CollectionInterface<string, ActionDto|ActionGroupDto>
  */
-final class ActionCollection implements CollectionInterface
+final class ActionCollection implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
      * @param array<string, ActionDto|ActionGroupDto> $actions
      */
-    private function __construct(private array $actions)
+    public function __construct(private array $actions = [])
     {
     }
 
@@ -28,6 +25,8 @@ final class ActionCollection implements CollectionInterface
     }
 
     /**
+     * @deprecated since 4.28.2 and removed in 5.0.0, use FilterCollection::__construct() instead.
+     *
      * @param array<string, ActionDto|ActionGroupDto> $actions
      */
     public static function new(array $actions): self
@@ -94,7 +93,7 @@ final class ActionCollection implements CollectionInterface
 
     public function getGlobalActions(): self
     {
-        return self::new(array_filter(
+        return new self(array_filter(
             $this->actions,
             static fn (ActionDto|ActionGroupDto $action): bool => $action->isGlobalAction()
         ));
@@ -102,7 +101,7 @@ final class ActionCollection implements CollectionInterface
 
     public function getBatchActions(): self
     {
-        return self::new(array_filter(
+        return new self(array_filter(
             $this->actions,
             static fn (ActionDto|ActionGroupDto $action): bool => $action instanceof ActionDto && $action->isBatchAction()
         ));

--- a/src/Collection/EntityCollection.php
+++ b/src/Collection/EntityCollection.php
@@ -2,24 +2,23 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Collection;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Collection\CollectionInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- *
- * @implements CollectionInterface<string, EntityDto>
  */
-final class EntityCollection implements CollectionInterface
+final class EntityCollection implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
      * @param array<string, EntityDto> $entities
      */
-    private function __construct(private array $entities)
+    public function __construct(private array $entities = [])
     {
     }
 
     /**
+     * @deprecated since 4.28.2 and removed in 5.0.0, use FilterCollection::__construct() instead.
+     *
      * @param array<string, EntityDto> $entities
      */
     public static function new(array $entities): self

--- a/src/Collection/FieldCollection.php
+++ b/src/Collection/FieldCollection.php
@@ -2,17 +2,14 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Collection;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Collection\CollectionInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- *
- * @implements CollectionInterface<string, FieldDto>
  */
-final class FieldCollection implements CollectionInterface
+final class FieldCollection implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /** @var array<string, FieldDto> */
     private array $fields;
@@ -20,7 +17,7 @@ final class FieldCollection implements CollectionInterface
     /**
      * @param array<FieldInterface|string> $fields
      */
-    private function __construct(iterable $fields)
+    public function __construct(iterable $fields)
     {
         $this->fields = $this->processFields($fields);
     }
@@ -37,6 +34,8 @@ final class FieldCollection implements CollectionInterface
     }
 
     /**
+     * @deprecated since 4.28.2 and removed in 5.0.0, use FilterCollection::__construct() instead.
+     *
      * @param array<FieldInterface|string> $fields
      */
     public static function new(iterable $fields): self

--- a/src/Collection/FilterCollection.php
+++ b/src/Collection/FilterCollection.php
@@ -2,24 +2,23 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Collection;
 
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Collection\CollectionInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
- *
- * @implements CollectionInterface<string, FilterDto>
  */
-final class FilterCollection implements CollectionInterface
+final class FilterCollection implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
      * @param array<string, FilterDto> $filters
      */
-    private function __construct(private array $filters)
+    public function __construct(private array $filters = [])
     {
     }
 
     /**
+     * @deprecated since 4.28.2 and removed in 5.0.0, use FilterCollection::__construct() instead.
+     *
      * @param array<string, FilterDto> $filters
      */
     public static function new(array $filters = []): self

--- a/src/Contracts/Collection/CollectionInterface.php
+++ b/src/Contracts/Collection/CollectionInterface.php
@@ -3,6 +3,8 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Collection;
 
 /**
+ * @deprecated since 4.28.2 and removed in 5.0.0 without a replacement.
+ *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  *
  * @template TKey

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -132,7 +132,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             throw new ForbiddenActionException($context);
         }
 
-        $fields = FieldCollection::new($this->configureFields(Crud::PAGE_INDEX));
+        $fields = new FieldCollection($this->configureFields(Crud::PAGE_INDEX));
         $filters = $this->container->get(FilterFactory::class)->create($context->getCrud()->getFiltersConfig(), $fields, $context->getEntity());
         $queryBuilder = $this->createIndexQueryBuilder($context->getSearch(), $context->getEntity(), $fields, $filters);
         $paginator = $this->container->get(PaginatorFactory::class)->create($queryBuilder);
@@ -147,7 +147,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
         $entities = $this->container->get(EntityFactory::class)->createCollection($context->getEntity(), $paginator->getResults());
         $this->container->get(FieldFactory::class)->processFieldsForAll($entities, $fields, Crud::PAGE_INDEX);
-        $processedFields = $entities->first()?->getFields() ?? FieldCollection::new([]);
+        $processedFields = $entities->first()?->getFields() ?? new FieldCollection([]);
         $context->getCrud()->setFieldAssets($this->getFieldAssets($processedFields));
         $actions = $this->container->get(ActionFactory::class)->processGlobalActionsAndEntityActionsForAll($entities, $context->getCrud()->getActionsConfig());
 
@@ -186,7 +186,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             throw new InsufficientEntityPermissionException($context);
         }
 
-        $this->container->get(FieldFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_DETAIL)), Crud::PAGE_DETAIL);
+        $this->container->get(FieldFactory::class)->processFields($context->getEntity(), new FieldCollection($this->configureFields(Crud::PAGE_DETAIL)), Crud::PAGE_DETAIL);
         $context->getCrud()->setFieldAssets($this->getFieldAssets($context->getEntity()->getFields()));
         $this->container->get(ActionFactory::class)->processEntityActions($context->getEntity(), $context->getCrud()->getActionsConfig());
 
@@ -221,7 +221,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             throw new InsufficientEntityPermissionException($context);
         }
 
-        $this->container->get(FieldFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_EDIT)), Crud::PAGE_EDIT);
+        $this->container->get(FieldFactory::class)->processFields($context->getEntity(), new FieldCollection($this->configureFields(Crud::PAGE_EDIT)), Crud::PAGE_EDIT);
         $context->getCrud()->setFieldAssets($this->getFieldAssets($context->getEntity()->getFields()));
         $this->container->get(ActionFactory::class)->processEntityActions($context->getEntity(), $context->getCrud()->getActionsConfig());
         /** @var TEntity $entityInstance */
@@ -307,7 +307,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         /** @var class-string<TEntity> $entityFqcn */
         $entityFqcn = $context->getEntity()->getFqcn();
         $context->getEntity()->setInstance($this->createEntity($entityFqcn));
-        $this->container->get(FieldFactory::class)->processFields($context->getEntity(), FieldCollection::new($this->configureFields(Crud::PAGE_NEW)), Crud::PAGE_NEW);
+        $this->container->get(FieldFactory::class)->processFields($context->getEntity(), new FieldCollection($this->configureFields(Crud::PAGE_NEW)), Crud::PAGE_NEW);
         $context->getCrud()->setFieldAssets($this->getFieldAssets($context->getEntity()->getFields()));
         $this->container->get(ActionFactory::class)->processEntityActions($context->getEntity(), $context->getCrud()->getActionsConfig());
 
@@ -469,7 +469,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function autocomplete(AdminContext $context): JsonResponse
     {
-        $queryBuilder = $this->createIndexQueryBuilder($context->getSearch(), $context->getEntity(), FieldCollection::new([]), FilterCollection::new());
+        $queryBuilder = $this->createIndexQueryBuilder($context->getSearch(), $context->getEntity(), new FieldCollection([]), new FilterCollection());
 
         $autocompleteContext = $context->getRequest()->query->all(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT);
 
@@ -482,7 +482,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $controller = $this->container->get(ControllerFactory::class)->getCrudControllerInstance($crudControllerFqcn, Action::INDEX, $context->getRequest());
         $originatingPage = $autocompleteContext['originatingPage'];
         $propertyName = $autocompleteContext['propertyName'];
-        $fields = FieldCollection::new($controller->configureFields($originatingPage));
+        $fields = new FieldCollection($controller->configureFields($originatingPage));
 
         // find the first field with matching property that is displayed on the originating page;
         // this ensures we get the correct field when a controller defines more than one field for the
@@ -526,7 +526,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function renderFilters(AdminContext $context): KeyValueStore
     {
-        $fields = FieldCollection::new($this->configureFields(Crud::PAGE_INDEX));
+        $fields = new FieldCollection($this->configureFields(Crud::PAGE_INDEX));
         $this->container->get(FieldFactory::class)->processFields($context->getEntity(), $fields, Crud::PAGE_INDEX);
         $filters = $this->container->get(FilterFactory::class)->create($context->getCrud()->getFiltersConfig(), $context->getEntity()->getFields(), $context->getEntity());
 

--- a/src/Dto/ActionConfigDto.php
+++ b/src/Dto/ActionConfigDto.php
@@ -113,7 +113,7 @@ final class ActionConfigDto
      */
     public function getActions(): ActionCollection|array
     {
-        return null === $this->pageName ? $this->actions : ActionCollection::new($this->actions[$this->pageName]);
+        return null === $this->pageName ? $this->actions : new ActionCollection($this->actions[$this->pageName]);
     }
 
     /**

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -99,7 +99,7 @@ final class ActionFactory
             $processedItems = $this->sortActionsByPriority($processedItems);
         }
 
-        $entityDto->setActions(ActionCollection::new($processedItems));
+        $entityDto->setActions(new ActionCollection($processedItems));
         $entityDto->setDefaultActionUrl($this->resolveDefaultActionUrl($processedItems));
     }
 
@@ -223,7 +223,7 @@ final class ActionFactory
             $processedItems = $this->sortActionsByPriority($processedItems);
         }
 
-        return ActionCollection::new($processedItems);
+        return new ActionCollection($processedItems);
     }
 
     public function processGlobalActionsAndEntityActionsForAll(EntityCollection $entityDtos, ActionConfigDto $actionConfigDto): ActionCollection

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -120,7 +120,7 @@ final class EntityFactory
             $entityDtos[$newEntityId] = $newEntityDto;
         }
 
-        return EntityCollection::new($entityDtos);
+        return new EntityCollection($entityDtos);
     }
 
     /**

--- a/src/Factory/FilterFactory.php
+++ b/src/Factory/FilterFactory.php
@@ -91,7 +91,7 @@ final class FilterFactory
             $builtFilters[$property] = $filterDto;
         }
 
-        return FilterCollection::new($builtFilters);
+        return new FilterCollection($builtFilters);
     }
 
     private function guessFilterClass(EntityDto $entityDto, string $propertyName): string

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -386,9 +386,9 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         $fields = $crudController->configureFields($crudControllerPageName);
 
         if (null === $this->fieldFactory) {
-            $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+            $this->entityFactory->processFields($entityDto, new FieldCollection($fields), $crudPageName);
         } else {
-            $this->fieldFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+            $this->fieldFactory->processFields($entityDto, new FieldCollection($fields), $crudPageName);
         }
 
         return $entityDto;

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -212,9 +212,9 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             $fields = $crudController->configureFields($crudControllerPageName);
 
             if (null === $this->fieldFactory) {
-                $this->entityFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+                $this->entityFactory->processFields($entityDto, new FieldCollection($fields), $crudPageName);
             } else {
-                $this->fieldFactory->processFields($entityDto, FieldCollection::new($fields), $crudPageName);
+                $this->fieldFactory->processFields($entityDto, new FieldCollection($fields), $crudPageName);
             }
         } finally {
             // restore the original context

--- a/src/Form/Type/FiltersFormType.php
+++ b/src/Form/Type/FiltersFormType.php
@@ -29,7 +29,7 @@ class FiltersFormType extends AbstractType
         $resolver->setDefaults([
             'allow_extra_fields' => true,
             'csrf_protection' => false,
-            'ea_filters' => FilterCollection::new(),
+            'ea_filters' => new FilterCollection(),
         ]);
     }
 

--- a/tests/Unit/Factory/FieldFactoryTest.php
+++ b/tests/Unit/Factory/FieldFactoryTest.php
@@ -41,7 +41,7 @@ class FieldFactoryTest extends KernelTestCase
 
     public function testEmpty(): void
     {
-        $fieldCollection = FieldCollection::new([]);
+        $fieldCollection = new FieldCollection([]);
 
         $this->fieldFactory->processFields($this->projectDto, $fieldCollection, Crud::PAGE_INDEX);
 
@@ -53,7 +53,7 @@ class FieldFactoryTest extends KernelTestCase
      */
     public function testRemovesFieldsOnPage(string $pageName, FieldInterface $field): void
     {
-        $fieldCollection = FieldCollection::new([$field]);
+        $fieldCollection = new FieldCollection([$field]);
 
         $this->fieldFactory->processFields($this->projectDto, $fieldCollection, $pageName);
 
@@ -89,7 +89,7 @@ class FieldFactoryTest extends KernelTestCase
      */
     public function testKeepsFieldsOnPage(string $pageName, FieldInterface $field): void
     {
-        $fieldCollection = FieldCollection::new([$field]);
+        $fieldCollection = new FieldCollection([$field]);
 
         $this->fieldFactory->processFields($this->projectDto, $fieldCollection, $pageName);
 
@@ -136,7 +136,7 @@ class FieldFactoryTest extends KernelTestCase
      */
     public function testStringNamesAreTurnedIntoFields(string $property, string $expectedField): void
     {
-        $fieldCollection = FieldCollection::new([$property]);
+        $fieldCollection = new FieldCollection([$property]);
 
         $this->fieldFactory->processFields($this->projectDto, $fieldCollection, Crud::PAGE_INDEX);
 

--- a/tests/Unit/Factory/FilterFactoryTest.php
+++ b/tests/Unit/Factory/FilterFactoryTest.php
@@ -39,7 +39,7 @@ class FilterFactoryTest extends TestCase
         $filterConfig->addFilter(TextFilter::new('name'));
 
         $entityDto = $this->createEntityDto(['name' => Types::STRING]);
-        $fields = FieldCollection::new([]);
+        $fields = new FieldCollection([]);
 
         $result = $this->filterFactory->create($filterConfig, $fields, $entityDto);
 
@@ -59,7 +59,7 @@ class FilterFactoryTest extends TestCase
         $filterConfig->addFilter($propertyName);
 
         $entityDto = $this->createEntityDto([$propertyName => $doctrineType]);
-        $fields = FieldCollection::new([]);
+        $fields = new FieldCollection([]);
 
         $result = $this->filterFactory->create($filterConfig, $fields, $entityDto);
 
@@ -105,7 +105,7 @@ class FilterFactoryTest extends TestCase
         $filterConfig->addFilter('category');
 
         $entityDto = $this->createEntityDtoWithAssociation('category', 'App\Entity\Category');
-        $fields = FieldCollection::new([]);
+        $fields = new FieldCollection([]);
 
         $result = $this->filterFactory->create($filterConfig, $fields, $entityDto);
 
@@ -127,7 +127,7 @@ class FilterFactoryTest extends TestCase
             'isActive' => Types::BOOLEAN,
             'createdAt' => Types::DATETIME_MUTABLE,
         ]);
-        $fields = FieldCollection::new([]);
+        $fields = new FieldCollection([]);
 
         $result = $this->filterFactory->create($filterConfig, $fields, $entityDto);
 
@@ -149,7 +149,7 @@ class FilterFactoryTest extends TestCase
         $filterConfig->addFilter(TextFilter::new('name'));
 
         $entityDto = $this->createEntityDto(['name' => Types::STRING]);
-        $fields = FieldCollection::new([]);
+        $fields = new FieldCollection([]);
 
         $this->filterFactory->create($filterConfig, $fields, $entityDto);
     }
@@ -166,7 +166,7 @@ class FilterFactoryTest extends TestCase
         $filterConfig->addFilter(TextFilter::new('name'));
 
         $entityDto = $this->createEntityDto(['name' => Types::STRING]);
-        $fields = FieldCollection::new([]);
+        $fields = new FieldCollection([]);
 
         $this->filterFactory->create($filterConfig, $fields, $entityDto);
     }
@@ -177,7 +177,7 @@ class FilterFactoryTest extends TestCase
 
         $filterConfig = new FilterConfigDto();
         $entityDto = $this->createEntityDto([]);
-        $fields = FieldCollection::new([]);
+        $fields = new FieldCollection([]);
 
         $result = $this->filterFactory->create($filterConfig, $fields, $entityDto);
 
@@ -192,7 +192,7 @@ class FilterFactoryTest extends TestCase
         $filterConfig->addFilter('address');
 
         $entityDto = $this->createEntityDtoWithEmbedded('address');
-        $fields = FieldCollection::new([]);
+        $fields = new FieldCollection([]);
 
         $result = $this->filterFactory->create($filterConfig, $fields, $entityDto);
 

--- a/tests/Unit/Factory/FormFactoryTest.php
+++ b/tests/Unit/Factory/FormFactoryTest.php
@@ -174,7 +174,7 @@ class FormFactoryTest extends TestCase
 
     public function testCreateFiltersFormReturnsHandledForm(): void
     {
-        $filters = FilterCollection::new();
+        $filters = new FilterCollection();
         $request = new Request(['filters' => ['name' => 'test']]);
 
         $form = $this->createMock(FormInterface::class);
@@ -204,7 +204,7 @@ class FormFactoryTest extends TestCase
 
     public function testCreateFiltersFormPreservesQueryParameters(): void
     {
-        $filters = FilterCollection::new();
+        $filters = new FilterCollection();
         $request = new Request(['crudAction' => 'index', 'page' => 2]);
 
         $form = $this->createMock(FormInterface::class);

--- a/tests/Unit/Factory/FormLayoutFactoryTest.php
+++ b/tests/Unit/Factory/FormLayoutFactoryTest.php
@@ -300,7 +300,7 @@ class FormLayoutFactoryTest extends TestCase
      */
     public function testTabLabelTranslation(TranslatableInterface|string $label, string $expectedTabId): void
     {
-        $fields = FieldCollection::new([
+        $fields = new FieldCollection([
             FormField::addTab($label),
             TextField::new('some_field'),
         ]);
@@ -362,7 +362,7 @@ class FormLayoutFactoryTest extends TestCase
 
     private function createFormFieldsFromConfig(array $fieldDefinition): FieldCollection
     {
-        return FieldCollection::new($this->doCreateFormFields($fieldDefinition));
+        return new FieldCollection($this->doCreateFormFields($fieldDefinition));
     }
 
     private function createFormFieldsFromLayout(string $layoutDescription): FieldCollection

--- a/tests/Unit/Field/Configurator/AssociationConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/AssociationConfiguratorTest.php
@@ -55,7 +55,7 @@ class AssociationConfiguratorTest extends AbstractFieldTest
     {
         $field = AssociationField::new('leadDeveloper');
         $entityDto = new EntityDto(Project::class, $this->createStub(ClassMetadata::class));
-        $entityDto->setFields(FieldCollection::new([$field]));
+        $entityDto->setFields(new FieldCollection([$field]));
 
         $field->getAsDto()->setDoctrineMetadata((array) $this->projectDto->getClassMetadata()->getAssociationMapping($field->getAsDto()->getProperty()));
         $field->setCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER, DeveloperCrudController::class);

--- a/tests/Unit/Filter/CrudFormTypeTest.php
+++ b/tests/Unit/Filter/CrudFormTypeTest.php
@@ -36,11 +36,11 @@ class CrudFormTypeTest extends TypeTestCase
 
         if ($useLayout) {
             $fieldCollection = (new FormLayoutFactory(new IdentityTranslator()))->createLayout(
-                FieldCollection::new([$field]),
+                new FieldCollection([$field]),
                 Crud::PAGE_NEW,
             );
         } else {
-            $fieldCollection = FieldCollection::new([$field]);
+            $fieldCollection = new FieldCollection([$field]);
         }
 
         $form = $this->factory->create(CrudFormType::class, null, [
@@ -73,11 +73,11 @@ class CrudFormTypeTest extends TypeTestCase
     {
         if ($useLayout) {
             $fieldCollection = (new FormLayoutFactory(new IdentityTranslator()))->createLayout(
-                FieldCollection::new([$field]),
+                new FieldCollection([$field]),
                 Crud::PAGE_NEW,
             );
         } else {
-            $fieldCollection = FieldCollection::new([$field]);
+            $fieldCollection = new FieldCollection([$field]);
         }
 
         $form = $this->factory->create(CrudFormType::class, null, [

--- a/tests/Unit/Orm/EntityRepositoryTest.php
+++ b/tests/Unit/Orm/EntityRepositoryTest.php
@@ -49,8 +49,8 @@ class EntityRepositoryTest extends TestCase
     {
         $searchDto = $this->createSearchDto();
         $entityDto = $this->createEntityDto();
-        $fields = FieldCollection::new([]);
-        $filters = FilterCollection::new();
+        $fields = new FieldCollection([]);
+        $filters = new FilterCollection();
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('select')->willReturnSelf();
@@ -76,8 +76,8 @@ class EntityRepositoryTest extends TestCase
     {
         $searchDto = $this->createSearchDto();
         $entityDto = $this->createEntityDto();
-        $fields = FieldCollection::new([]);
-        $filters = FilterCollection::new();
+        $fields = new FieldCollection([]);
+        $filters = new FilterCollection();
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('select')->willReturnSelf();
@@ -100,8 +100,8 @@ class EntityRepositoryTest extends TestCase
     {
         $searchDto = $this->createSearchDto('', ['name' => 'ASC']);
         $entityDto = $this->createEntityDto();
-        $fields = FieldCollection::new([]);
-        $filters = FilterCollection::new();
+        $fields = new FieldCollection([]);
+        $filters = new FilterCollection();
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('select')->willReturnSelf();
@@ -126,8 +126,8 @@ class EntityRepositoryTest extends TestCase
     {
         $searchDto = $this->createSearchDto('', ['name' => 'ASC', 'createdAt' => 'DESC']);
         $entityDto = $this->createEntityDto();
-        $fields = FieldCollection::new([]);
-        $filters = FilterCollection::new();
+        $fields = new FieldCollection([]);
+        $filters = new FilterCollection();
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('select')->willReturnSelf();
@@ -152,8 +152,8 @@ class EntityRepositoryTest extends TestCase
     {
         $searchDto = $this->createSearchDto('', [], null);
         $entityDto = $this->createEntityDto();
-        $fields = FieldCollection::new([]);
-        $filters = FilterCollection::new();
+        $fields = new FieldCollection([]);
+        $filters = new FilterCollection();
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('select')->willReturnSelf();
@@ -176,8 +176,8 @@ class EntityRepositoryTest extends TestCase
     {
         $searchDto = $this->createSearchDto();
         $entityDto = $this->createEntityDto();
-        $fields = FieldCollection::new([]);
-        $filters = FilterCollection::new();
+        $fields = new FieldCollection([]);
+        $filters = new FilterCollection();
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('select')->willReturnSelf();
@@ -199,8 +199,8 @@ class EntityRepositoryTest extends TestCase
     {
         $searchDto = $this->createSearchDto('test search');
         $entityDto = $this->createEntityDto();
-        $fields = FieldCollection::new([]);
-        $filters = FilterCollection::new();
+        $fields = new FieldCollection([]);
+        $filters = new FilterCollection();
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('select')->willReturnSelf();


### PR DESCRIPTION
Mini refactor. For easier review I did two commits.

Please feel free to decline it, it is really a minor thing.. 

Notes:
- Contains a minor BC break. If someone uses `CollectionInterface` as a type hint and for example an object of `FilterCollection` is passed as an argument it will throw an error. I guess this is an absolute edge case (and if it exists somewhere it can be fixed easily).
- Deprecates `CollectionInterface` because it is not used nor needed. I checked in Symfony core, here I only found collections, bags, lists etc. that directly implement SPL interfaces.
- Deprecates the static factory methods just because I found no reason why the constructor is private and an extra factory method is needed. (I understand that  DTO collections are no services and they do not use service injection in the constructor via the container but in Symfony these collections, bags, lists, etc. all have a public constructor and no static factory method).