### PR TITLE
Fix filter on embedded properties

### DIFF
--- a/src/Config/KeyValueStore.php
+++ b/src/Config/KeyValueStore.php
@@ -13,16 +13,18 @@ final class KeyValueStore
     /**
      * @param array<string, mixed> $map
      */
-    private function __construct(private array $map)
-    {
+    private function __construct(
+        private array $map,
+        private ?string $delimiter,
+    ) {
     }
 
     /**
      * @param array<string, mixed> $keyValuePairs
      */
-    public static function new(array $keyValuePairs = []): self
+    public static function new(array $keyValuePairs = [], ?string $delimiter = '.'): self
     {
-        return new self($keyValuePairs);
+        return new self($keyValuePairs, $delimiter);
     }
 
     public function isEmpty(): bool
@@ -41,7 +43,7 @@ final class KeyValueStore
             return true;
         }
 
-        foreach (explode('.', $key) as $segment) {
+        foreach ($this->segments($key) as $segment) {
             if (!\is_array($items) || !\array_key_exists($segment, $items)) {
                 return false;
             }
@@ -63,7 +65,7 @@ final class KeyValueStore
         }
 
         $items = $this->map;
-        foreach (explode('.', $key) as $segment) {
+        foreach ($this->segments($key) as $segment) {
             if (!\is_array($items) || !\array_key_exists($segment, $items)) {
                 return $default;
             }
@@ -77,7 +79,7 @@ final class KeyValueStore
     public function set(string $key, mixed $value): void
     {
         $items = &$this->map;
-        foreach (explode('.', $key) as $segment) {
+        foreach ($this->segments($key) as $segment) {
             if (!isset($items[$segment]) || !\is_array($items[$segment])) {
                 $items[$segment] = [];
             }
@@ -114,7 +116,7 @@ final class KeyValueStore
         }
 
         $items = &$this->map;
-        $segments = explode('.', $key);
+        $segments = $this->segments($key);
         $lastSegment = array_pop($segments);
 
         foreach ($segments as $segment) {
@@ -134,5 +136,17 @@ final class KeyValueStore
     public function all(): array
     {
         return $this->map;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function segments(string $key): array
+    {
+        if (null === $this->delimiter || '' === $this->delimiter) {
+            return [$key];
+        }
+
+        return explode($this->delimiter, $key);
     }
 }

--- a/src/Dto/FilterConfigDto.php
+++ b/src/Dto/FilterConfigDto.php
@@ -14,7 +14,7 @@ final class FilterConfigDto
 
     public function __construct()
     {
-        $this->filters = KeyValueStore::new();
+        $this->filters = KeyValueStore::new(delimiter: null);
     }
 
     /**

--- a/src/Form/Type/FiltersFormType.php
+++ b/src/Form/Type/FiltersFormType.php
@@ -17,7 +17,8 @@ class FiltersFormType extends AbstractType
     {
         /** @var FilterDto $filter */
         foreach ($options['ea_filters'] as $filter) {
-            $builder->add($filter->getProperty(), $filter->getFormType(), $filter->getFormTypeOptions());
+            $name = str_replace('.', ':', $filter->getProperty());
+            $builder->add($name, $filter->getFormType(), $filter->getFormTypeOptions());
         }
     }
 

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -211,7 +211,7 @@ final class EntityRepository implements EntityRepositoryInterface
         foreach ($filtersForm as $filterForm) {
             $propertyName = $filterForm->getName();
 
-            $filter = $configuredFilters->get($propertyName);
+            $filter = $configuredFilters->get(str_replace(':', '.', $propertyName));
             // this filter is not defined or not applied
             if (null === $filter || !isset($appliedFilters[$propertyName])) {
                 continue;


### PR DESCRIPTION
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/7020 and https://github.com/EasyCorp/EasyAdminBundle/issues/6379

Complementary to https://github.com/EasyCorp/EasyAdminBundle/pull/7427

In order to fix this issue I had to :
1. filter config: allow storing properties with dot: by default `KeyValueStore` convert keys with dot to array.
2. in the form: automatically replace `.` by `:` because [we can't use dot in input names](https://github.com/symfony/symfony/blob/89a33b499afb0e708b9e7f9336f328890c5b2738/src/Symfony/Component/Form/FormConfigBuilder.php#L635)