### PR TITLE
Allow setQueryBuilder() callable to return a custom QueryBuilder

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -203,7 +203,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 // it would then be identical to the one used in autocomplete action, but it is a bit complex getting it in here
                 $queryBuilder = $repository->createQueryBuilder('entity');
                 if (null !== $queryBuilderCallable = $field->getCustomOption(AssociationField::OPTION_QUERY_BUILDER_CALLABLE)) {
-                    $queryBuilderCallable($queryBuilder);
+                    $queryBuilder = $queryBuilderCallable($queryBuilder) ?? $queryBuilder;
                 }
 
                 return $queryBuilder;


### PR DESCRIPTION
Fixes #7434

## Summary

- The return value of the callable passed to `setQueryBuilder()` was ignored in `AssociationConfigurator`, making it impossible to replace the QueryBuilder with one that includes eager loading (`leftJoin` + `addSelect`)
- This caused N+1 queries when using `group_by` or `choice_label` that access related entities on each choice
- The fix uses the callable's return value if provided, falling back to the original QueryBuilder if it returns nothing (backward compatible)