### PR TITLE
Support custom variants in Alert component

### DIFF
--- a/src/Twig/Component/Alert.php
+++ b/src/Twig/Component/Alert.php
@@ -12,19 +12,27 @@ class Alert
 {
     public AlertVariant $variant = AlertVariant::Info;
     public bool $withDismissButton = false;
+    private ?string $customVariant = null;
 
     public function mount(string|AlertVariant $variant): void
     {
-        try {
-            $this->variant = \is_string($variant) ? AlertVariant::from($variant) : $variant;
-        } catch (\ValueError) {
-            throw new \InvalidArgumentException(sprintf('The alert variant "%s" is not valid. Valid values are: %s', $variant, implode(', ', array_map(static fn (AlertVariant $variant): string => $variant->value, AlertVariant::cases()))));
+        if (\is_string($variant)) {
+            $resolved = AlertVariant::tryFrom($variant);
+            $this->variant = $resolved ?? AlertVariant::Info;
+            if (null === $resolved) {
+                $this->customVariant = $variant;
+            }
+        } else {
+            $this->variant = $variant;
         }
     }
 
     public function getDefaultCssClass(): string
     {
         $cssClass = sprintf('alert %s', $this->variant->asBootstrapCssClass());
+        if (null !== $this->customVariant) {
+            $cssClass .= sprintf(' alert-%s', $this->customVariant);
+        }
         if ($this->withDismissButton) {
             $cssClass .= ' alert-dismissible';
         }

--- a/tests/Unit/Twig/Component/AlertTest.php
+++ b/tests/Unit/Twig/Component/AlertTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Twig\Component;
+
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Alert;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\AlertVariant;
+use PHPUnit\Framework\TestCase;
+
+class AlertTest extends TestCase
+{
+    /**
+     * @dataProvider provideKnownStringVariants
+     */
+    public function testMountWithKnownStringVariant(string $variantString, AlertVariant $expectedVariant): void
+    {
+        $alert = new Alert();
+        $alert->mount($variantString);
+
+        $this->assertSame($expectedVariant, $alert->variant);
+    }
+
+    public static function provideKnownStringVariants(): iterable
+    {
+        yield ['success', AlertVariant::Success];
+        yield ['danger', AlertVariant::Danger];
+        yield ['warning', AlertVariant::Warning];
+        yield ['info', AlertVariant::Info];
+        yield ['error', AlertVariant::Error];
+        yield ['notice', AlertVariant::Notice];
+    }
+
+    public function testMountWithEnumVariant(): void
+    {
+        $alert = new Alert();
+        $alert->mount(AlertVariant::Warning);
+
+        $this->assertSame(AlertVariant::Warning, $alert->variant);
+    }
+
+    public function testMountWithUnknownStringVariantFallsBackToInfo(): void
+    {
+        $alert = new Alert();
+        $alert->mount('attr_conf_activated');
+
+        $this->assertSame(AlertVariant::Info, $alert->variant);
+    }
+
+    /**
+     * @dataProvider provideGetDefaultCssClassData
+     */
+    public function testGetDefaultCssClass(string|AlertVariant $variant, bool $withDismissButton, string $expectedCssClass): void
+    {
+        $alert = new Alert();
+        $alert->mount($variant);
+        $alert->withDismissButton = $withDismissButton;
+
+        $this->assertSame($expectedCssClass, $alert->getDefaultCssClass());
+    }
+
+    public static function provideGetDefaultCssClassData(): iterable
+    {
+        yield 'known variant' => ['success', false, 'alert alert-success'];
+        yield 'error maps to danger' => ['error', false, 'alert alert-danger'];
+        yield 'notice maps to info' => ['notice', false, 'alert alert-info'];
+        yield 'enum variant' => [AlertVariant::Warning, false, 'alert alert-warning'];
+        yield 'with dismiss button' => ['success', true, 'alert alert-success alert-dismissible'];
+        yield 'unknown variant adds custom class' => ['attr_conf_activated', false, 'alert alert-info alert-attr_conf_activated'];
+        yield 'unknown variant with dismiss button' => ['attr_conf_activated', true, 'alert alert-info alert-attr_conf_activated alert-dismissible'];
+    }
+}


### PR DESCRIPTION
This fixes #7446.

For unknown variants, it shows the alert as "info" (because it's neutral) and applies a CSS class with the custom vairant name, so you can easily customize the styles.