### PR TITLE
Adding space above the header on the login page

### DIFF
--- a/assets/css/easyadmin-theme/pages.css
+++ b/assets/css/easyadmin-theme/pages.css
@@ -26,12 +26,13 @@ body.page-login #flash-messages {
     align-items: center;
     display: flex;
     flex-direction: column;
-    margin: 0 auto;
+    margin: 2rem auto;
     max-inline-size: 28rem;
     inline-size: 94%;
 }
 @media (min-width: 992px) {
     .login-wrapper {
+        margin: 0 auto;
         margin-block-start: -225px;
         inline-size: 100%;
     }


### PR DESCRIPTION
The changes apply to the mobile view (below 992px).

before:
<img width="851" height="435" alt="Zrzut ekranu z 2026-02-20 20-00-46" src="https://github.com/user-attachments/assets/3e77028e-5402-4628-847d-04b3336624ab" />


after:
<img width="824" height="466" alt="Zrzut ekranu z 2026-02-20 20-02-06" src="https://github.com/user-attachments/assets/be79dd3c-3ead-4048-9b0e-15ccb72f08b4" />

