### PR TITLE
Allow to customize the default row action click trigger

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -515,8 +515,10 @@ class App {
         };
 
         clickableRows.forEach((row) => {
+            const clickTrigger = row.getAttribute('data-default-action-click-trigger') || 'single';
+
             // handle mouse clicks
-            row.addEventListener('click', (event) => {
+            row.addEventListener(clickTrigger === 'double' ? 'dblclick' : 'click', (event) => {
                 if (isInteractiveElement(event.target)) {
                     return;
                 }

--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -636,6 +636,22 @@ and you can configure it with the ``setDefaultRowAction()`` method::
             ;
         }
 
+.. tip::
+
+    The default row action supports either single or double clicks to trigger its behavior.
+    You can configure this with the ``setDefaultRowActionClickTrigger()`` method::
+
+        public function configureCrud(Crud $crud): Crud
+        {
+            return $crud
+                // this is the default behavior: single click triggers the default row action
+                ->setDefaultRowActionClickTrigger(ClickTrigger::SINGLE)
+
+                // use double click to trigger the default row action
+                ->setDefaultRowActionClickTrigger(ClickTrigger::DOUBLE)
+            ;
+        }
+
 The row click behavior is fully accessible via keyboard (using Enter or Space keys).
 Clicks on checkboxes, buttons, links, or any action elements within the row won't
 trigger the navigation to preserve the expected behavior of those elements.

--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Config;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ClickTrigger;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SearchMode;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
@@ -493,6 +494,20 @@ class Crud
         }
 
         $this->dto->setDefaultRowAction($actionName);
+
+        return $this;
+    }
+
+    /**
+     * Sets the click trigger for the default row action in the index page.
+     */
+    public function setDefaultRowActionClickTrigger(string $trigger): self
+    {
+        if (!\in_array($trigger, [ClickTrigger::SINGLE, ClickTrigger::DOUBLE], true)) {
+            throw new \InvalidArgumentException(sprintf('The default row action click trigger can be only "%s" or "%s", "%s" given.', ClickTrigger::SINGLE, ClickTrigger::DOUBLE, $trigger));
+        }
+
+        $this->dto->setDefaultRowActionClickTrigger($trigger);
 
         return $this;
     }

--- a/src/Config/Option/ClickTrigger.php
+++ b/src/Config/Option/ClickTrigger.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Config\Option;
+
+/**
+ * @author Nathan Page (https://github.com/natepage)
+ */
+final class ClickTrigger
+{
+    public const SINGLE = 'single';
+    public const DOUBLE = 'double';
+}

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ClickTrigger;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SearchMode;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
@@ -82,6 +83,7 @@ final class CrudDto
     private bool|string|TranslatableInterface $askConfirmationOnBatchActions = true;
     /** @var string|string[]|null Action name(s) to try when clicking a row. Array = fallback chain, null = disabled */
     private string|array|null $defaultRowAction = [Action::EDIT, Action::DETAIL];
+    private string $defaultRowActionClickTrigger = ClickTrigger::SINGLE;
     /** @var callable|null */
     private $autocompleteCallback;
     private ?string $autocompleteTemplate = null;
@@ -630,6 +632,16 @@ final class CrudDto
     public function setDefaultRowAction(string|array|null $actionName): void
     {
         $this->defaultRowAction = $actionName;
+    }
+
+    public function getDefaultRowActionClickTrigger(): string
+    {
+        return $this->defaultRowActionClickTrigger;
+    }
+
+    public function setDefaultRowActionClickTrigger(string $clickTrigger): void
+    {
+        $this->defaultRowActionClickTrigger = $clickTrigger;
     }
 
     public function getAutocompleteCallback(): ?callable

--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\ActionCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ClickTrigger;
 use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -26,6 +27,7 @@ final class EntityDto implements \Stringable
     private ?FieldCollection $fields = null;
     private ?ActionCollection $actions = null;
     private ?string $defaultActionUrl = null;
+    private string $defaultActionClickTrigger = ClickTrigger::SINGLE;
 
     /**
      * @param class-string<TEntity>  $fqcn
@@ -175,6 +177,16 @@ final class EntityDto implements \Stringable
     public function setDefaultActionUrl(?string $url): void
     {
         $this->defaultActionUrl = $url;
+    }
+
+    public function getDefaultActionClickTrigger(): string
+    {
+        return $this->defaultActionClickTrigger;
+    }
+
+    public function setDefaultActionClickTrigger(string $clickTrigger): void
+    {
+        $this->defaultActionClickTrigger = $clickTrigger;
     }
 
     public function getClassMetadata(): ClassMetadata

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -101,6 +101,7 @@ final class ActionFactory
 
         $entityDto->setActions(new ActionCollection($processedItems));
         $entityDto->setDefaultActionUrl($this->resolveDefaultActionUrl($processedItems));
+        $entityDto->setDefaultActionClickTrigger($this->adminContextProvider->getContext()->getCrud()->getDefaultRowActionClickTrigger());
     }
 
     /**

--- a/templates/crud/index.html.twig
+++ b/templates/crud/index.html.twig
@@ -146,7 +146,7 @@
             {% for entity in entities %}
                 {% block table_body_row %}
                 {% if entity.isAccessible %}
-                    <tr data-id="{{ entity.primaryKeyValueAsString }}" {% if entity.defaultActionUrl %}data-default-action-url="{{ entity.defaultActionUrl }}" class="ea-clickable-row" role="link" tabindex="0"{% endif %} {% block entity_row_attributes %}{% endblock %}>
+                    <tr data-id="{{ entity.primaryKeyValueAsString }}" {% if entity.defaultActionUrl %}data-default-action-url="{{ entity.defaultActionUrl }}" data-default-action-click-trigger="{{ entity.defaultActionClickTrigger }}" class="ea-clickable-row" role="link" tabindex="0"{% endif %} {% block entity_row_attributes %}{% endblock %}>
                         {% if has_batch_actions %}
                             <td class="batch-actions-selector">
                                 <div class="form-check">

--- a/tests/Functional/Apps/AdminRouteApp/config/reference.php
+++ b/tests/Functional/Apps/AdminRouteApp/config/reference.php
@@ -188,7 +188,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         only_exceptions?: bool|Param, // Default: false
  *         only_main_requests?: bool|Param, // Default: false
  *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
- *         collect_serializer_data?: bool|Param, // Enables the serializer data collector and profiler panel. // Default: false
+ *         collect_serializer_data?: true|Param, // Default: true
  *     },
  *     workflows?: bool|array{
  *         enabled?: bool|Param, // Default: false
@@ -232,7 +232,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: false
  *         resource: scalar|Param|null,
  *         type?: scalar|Param|null,
- *         cache_dir?: scalar|Param|null, // Deprecated: Setting the "framework.router.cache_dir.cache_dir" configuration option is deprecated. It will be removed in version 8.0. // Default: "%kernel.build_dir%"
  *         default_uri?: scalar|Param|null, // The default URI used to generate URLs in a non-HTTP context. // Default: null
  *         http_port?: scalar|Param|null, // Default: 80
  *         https_port?: scalar|Param|null, // Default: 443
@@ -256,8 +255,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         gc_maxlifetime?: scalar|Param|null,
  *         save_path?: scalar|Param|null, // Defaults to "%kernel.cache_dir%/sessions" if the "handler_id" option is not null.
  *         metadata_update_threshold?: int|Param, // Seconds to wait between 2 session metadata updates. // Default: 0
- *         sid_length?: int|Param, // Deprecated: Setting the "framework.session.sid_length.sid_length" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
- *         sid_bits_per_character?: int|Param, // Deprecated: Setting the "framework.session.sid_bits_per_character.sid_bits_per_character" configuration option is deprecated. It will be removed in version 8.0. No alternative is provided as PHP 8.4 has deprecated the related option.
  *     },
  *     request?: bool|array{ // Request configuration
  *         enabled?: bool|Param, // Default: false
@@ -331,11 +328,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     validation?: bool|array{ // Validation configuration
  *         enabled?: bool|Param, // Default: true
- *         cache?: scalar|Param|null, // Deprecated: Setting the "framework.validation.cache.cache" configuration option is deprecated. It will be removed in version 8.0.
  *         enable_attributes?: bool|Param, // Default: true
  *         static_method?: list<scalar|Param|null>,
  *         translation_domain?: scalar|Param|null, // Default: "validators"
- *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|"loose"|Param, // Default: "html5"
+ *         email_validation_mode?: "html5"|"html5-allow-no-tld"|"strict"|Param, // Default: "html5"
  *         mapping?: array{
  *             paths?: list<scalar|Param|null>,
  *         },
@@ -347,9 +343,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         auto_mapping?: array<string, array{ // Default: []
  *             services?: list<scalar|Param|null>,
  *         }>,
- *     },
- *     annotations?: bool|array{
- *         enabled?: bool|Param, // Default: false
  *     },
  *     serializer?: bool|array{ // Serializer configuration
  *         enabled?: bool|Param, // Default: false
@@ -382,7 +375,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     property_info?: bool|array{ // Property info configuration
  *         enabled?: bool|Param, // Default: true
- *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor.
+ *         with_constructor_extractor?: bool|Param, // Registers the constructor extractor. // Default: true
  *     },
  *     cache?: array{ // Cache configuration
  *         prefix_seed?: scalar|Param|null, // Used to namespace cache keys when using several apps with the same shared backend. // Default: "_%kernel.project_dir%.%kernel.container_class%"
@@ -877,7 +870,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * @psalm-type SecurityConfig = array{
  *     access_denied_url?: scalar|Param|null, // Default: null
  *     session_fixation_strategy?: "none"|"migrate"|"invalidate"|Param, // Default: "migrate"
- *     hide_user_not_found?: bool|Param, // Deprecated: The "hide_user_not_found" option is deprecated and will be removed in 8.0. Use the "expose_security_errors" option instead.
  *     expose_security_errors?: \Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::None|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::AccountStatus|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::All|Param, // Default: "none"
  *     erase_credentials?: bool|Param, // Default: true
  *     access_decision_manager?: array{
@@ -1113,9 +1105,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
  *                     audience: scalar|Param|null, // Audience set in the token, for validation purpose.
  *                     issuers: list<scalar|Param|null>,
- *                     algorithm?: array<mixed>,
  *                     algorithms: list<scalar|Param|null>,
- *                     key?: scalar|Param|null, // Deprecated: The "key" option is deprecated and will be removed in 8.0. Use the "keyset" option instead. // JSON-encoded JWK used to sign the token (must contain a "kty" key).
  *                     keyset?: scalar|Param|null, // JSON-encoded JWKSet used to sign the token (must contain a list of valid public keys).
  *                     encryption?: bool|array{
  *                         enabled?: bool|Param, // Default: false
@@ -1194,7 +1184,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     }>,
  *     autoescape_service?: scalar|Param|null, // Default: null
  *     autoescape_service_method?: scalar|Param|null, // Default: null
- *     base_template_class?: scalar|Param|null, // Deprecated: The child node "base_template_class" at path "twig.base_template_class" is deprecated.
  *     cache?: scalar|Param|null, // Default: true
  *     charset?: scalar|Param|null, // Default: "%kernel.charset%"
  *     debug?: bool|Param, // Default: "%kernel.debug%"

--- a/tests/Functional/Apps/DefaultApp/src/Controller/DefaultRowAction/DefaultRowActionClickTriggerDoubleCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/DefaultRowAction/DefaultRowActionClickTriggerDoubleCrudController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DefaultRowAction;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ClickTrigger;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+
+/**
+ * Tests the setDefaultRowActionClickTrigger() method with ClickTrigger::DOUBLE.
+ *
+ * @extends AbstractCrudController<Category>
+ */
+class DefaultRowActionClickTriggerDoubleCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Category::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('name'),
+        ];
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud->setDefaultRowActionClickTrigger(ClickTrigger::DOUBLE);
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions
+            ->add(Crud::PAGE_INDEX, Action::DETAIL)
+        ;
+    }
+}

--- a/tests/Functional/Default/DefaultRowActionCrudControllerTest.php
+++ b/tests/Functional/Default/DefaultRowActionCrudControllerTest.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Default;
 use Doctrine\ORM\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DefaultRowAction\DefaultRowActionClickTriggerDoubleCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DefaultRowAction\DefaultRowActionCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DefaultRowAction\DefaultRowActionDetailCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DefaultRowAction\DefaultRowActionDisabledCrudController;
@@ -46,8 +47,10 @@ class DefaultRowActionCrudControllerTest extends AbstractCrudTestCase
 
         $firstRow = $rows->first();
         static::assertNotNull($firstRow->attr('data-default-action-url'), 'Row should have data-default-action-url attribute');
+        static::assertNotNull($firstRow->attr('data-default-action-click-trigger'), 'Row should have data-default-action-click-trigger attribute');
         static::assertStringContainsString('ea-clickable-row', $firstRow->attr('class'), 'Row should have ea-clickable-row class');
         static::assertStringContainsString('/edit', $firstRow->attr('data-default-action-url'), 'URL should contain edit action');
+        static::assertEquals('single', $firstRow->attr('data-default-action-click-trigger'), 'Click trigger should be single by default');
     }
 
     public function testDefaultRowActionWithDetailAction(): void
@@ -127,5 +130,21 @@ class DefaultRowActionCrudControllerTest extends AbstractCrudTestCase
 
         // verify all entity IDs are unique
         static::assertCount(\count(array_unique($entityIds)), $entityIds, 'Each row should have a unique entity ID');
+    }
+
+    public function testDefaultRowActionWithDoubleClickTrigger(): void
+    {
+        // use a different controller that sets Action::DETAIL as default
+        $crawler = $this->client->request('GET', $this->generateIndexUrl(null, null, DefaultRowActionClickTriggerDoubleCrudController::class));
+
+        $rows = $crawler->filter('table.datagrid tbody tr[data-id]');
+        static::assertGreaterThan(0, $rows->count(), 'There should be at least one row in the table');
+
+        $firstRow = $rows->first();
+        static::assertNotNull($firstRow->attr('data-default-action-url'), 'Row should have data-default-action-url attribute');
+        static::assertNotNull($firstRow->attr('data-default-action-click-trigger'), 'Row should have data-default-action-click-trigger attribute');
+        static::assertStringContainsString('ea-clickable-row', $firstRow->attr('class'), 'Row should have ea-clickable-row class');
+        static::assertStringContainsString('/edit', $firstRow->attr('data-default-action-url'), 'URL should contain edit action');
+        static::assertEquals('double', $firstRow->attr('data-default-action-click-trigger'), 'Click trigger should be single by default');
     }
 }

--- a/tests/Unit/Config/CrudTest.php
+++ b/tests/Unit/Config/CrudTest.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Config;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ClickTrigger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\TranslatableMessage;
 
@@ -273,5 +274,38 @@ class CrudTest extends TestCase
 
         $crudConfig = Crud::new();
         $crudConfig->setDefaultRowAction($actionNames);
+    }
+
+    public function testDefaultRowActionDefaultClickTrigger(): void
+    {
+        $crudConfig = Crud::new();
+
+        $this->assertSame(ClickTrigger::SINGLE, $crudConfig->getAsDto()->getDefaultRowActionClickTrigger());
+    }
+
+    /**
+     * @testWith ["single"]
+     *           ["double"]
+     */
+    public function testSetDefaultRowActionDefaultClickTrigger(string $clickTrigger): void
+    {
+        $crudConfig = Crud::new();
+        $crudConfig->setDefaultRowActionClickTrigger($clickTrigger);
+
+        $this->assertSame($clickTrigger, $crudConfig->getAsDto()->getDefaultRowActionClickTrigger());
+    }
+
+    /**
+     * @testWith [""]
+     *           ["   "]
+     *           ["invalid"]
+     */
+    public function testSetDefaultRowActionDefaultClickTriggerWithInvalidString(string $clickTrigger): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The default row action click trigger can be only "single" or "double", "%s" given.', $clickTrigger));
+
+        $crudConfig = Crud::new();
+        $crudConfig->setDefaultRowActionClickTrigger($clickTrigger);
     }
 }


### PR DESCRIPTION
Hi @javiereguiluz 

Thank you for implementing the default row action feature, this was something we have been looking forward to for a little while 😄 
Unfortunately, it did break our current admins as we had an implementation in place which relies on double click instead of single one...

Here is a PR which allows to configure the "click trigger" for the default row action, it would be much appreciated if it can be release so we could get rid of our custom implementation and fix our admins for our users!

Thank you!
