### PR TITLE
Issue #7456 PHPDoc in Action::setHtmlAttributes

### DIFF
--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -228,7 +228,7 @@ final class Action implements \Stringable
     }
 
     /**
-     * @param array<string, string> $attributes
+     * @param array<string, string|TranslatableInterface> $attributes
      */
     public function setHtmlAttributes(array $attributes): self
     {


### PR DESCRIPTION
Fixing PHPDocs for Config\Action::setHtmlAttributes to match ActionDto::setHtmlAttributes.