### PR TITLE
Fix translations domain for VichUploadBundle #7415

### DIFF
--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -321,9 +321,9 @@
             <a class="ea-vich-file-name" href="{{ asset_helper is same as(true) ? asset(download_uri) : download_uri }}">
                 <twig:ea:Icon name="internal:file-lines" />
                 {%- if download_label|default(false) -%}
-                    {{ download_label|trans({}, 'VichUploaderBundle') }}
+                    {{ translation_domain is same as(false) ? download_label : download_label|trans({}, translation_domain) }}
                 {%- else -%}
-                    {{ download_uri|split('/')|last ?: 'download'|trans({}, 'VichUploaderBundle') }}
+                    {{ download_uri|split('/')|last ?: 'download'|trans({}, translation_domain) }}
                 {%- endif -%}
             </a>
         {% endif %}


### PR DESCRIPTION
EasyAdmin overrides VichUploadBundle widgets in `templates/crud/form_theme.html.twig`

But these overrides (probably based on an older version of VichUploadBundle) set a wrong translation domain on line
324

Updated them according to current VichUploadBundle codebase, fixing #7415 

https://github.com/EasyCorp/EasyAdminBundle/issues/7415

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
