### PR TITLE
Ease upgrade to EasyAdmin 5.x by supporting entity IDs in query params

### DIFF
--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -22,7 +22,6 @@ use Twig\Environment;
 final readonly class ExceptionListener
 {
     public function __construct(
-
         private bool $kernelDebug,
         private AdminContextProviderInterface $adminContextProvider,
         private Environment $twig,

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -192,7 +192,7 @@ final readonly class AdminContextFactory
         if (null !== $crudDto) {
             $translationParameters['%entity_name%'] = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
             $translationParameters['%entity_as_string%'] = null === $entityDto ? '' : (string) $entityDto;
-            $translationParameters['%entity_id%'] = $entityId = $request->attributes->get(EA::ENTITY_ID);
+            $translationParameters['%entity_id%'] = $entityId = $request->attributes->get(EA::ENTITY_ID) ?? $request->query->get(EA::ENTITY_ID);
             $translationParameters['%entity_short_id%'] = null === $entityId ? null : u($entityId)->truncate(7)->toString();
 
             $entityInstance = null === $entityDto ? null : $entityDto->getInstance();
@@ -261,7 +261,7 @@ final readonly class AdminContextFactory
             return null;
         }
 
-        $entityId = $request->attributes->get(EA::ENTITY_ID);
+        $entityId = $request->attributes->get(EA::ENTITY_ID) ?? $request->query->get(EA::ENTITY_ID);
 
         return $this->entityFactory->create($crudDto->getEntityFqcn(), $entityId, $crudDto->getEntityPermission());
     }


### PR DESCRIPTION
As reported by a user on Symfony Slack, if a custom action of yours doesn't include the `entityId` as a route palceholder, the generated URL will include that as a query param. In 4.x that works but in 5.x it doesn't because it always expects the entit yID to be part of the route attributes.

We partially support entity IDs in query params in 5.x branch, but this PR ensures we support it in the other missing places.