### PR TITLE
Fix checkbox label condition to avoid rendering a label when explicitly set to `false`.

### DIFF
--- a/templates/symfony-form-themes/bootstrap_5_layout.html.twig
+++ b/templates/symfony-form-themes/bootstrap_5_layout.html.twig
@@ -285,7 +285,7 @@
         {%- endif -%}
         {# don't use 'label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
         {% set has_label = label is not same as(false) and label is not null and label is not same as('') %}
-        {%- if not has_label -%}
+        {%- if label is not same as(false) and not has_label -%}
             {%- if label_format is not empty -%}
                 {%- set label = label_format|replace({
                     '%name%': name,

--- a/templates/symfony-form-themes/form_div_layout.html.twig
+++ b/templates/symfony-form-themes/form_div_layout.html.twig
@@ -296,7 +296,7 @@
         {%- endif -%}
         {# don't use 'label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
         {% set has_label = label is not same as(false) and label is not null and label is not same as('') %}
-        {% if not has_label -%}
+        {% if label is not same as(false) and not has_label -%}
             {%- if label_format is not empty -%}
                 {% set label = label_format|replace({
                     '%name%': name,


### PR DESCRIPTION
During #7442 the label rendering has been changed to avoid deprecations, but now setting a form field label to `false` will still render the fallback label.
This is because before the fallback was rendered only if not `false`.