### PR TITLE
Fix some filter conditions when using null values

### DIFF
--- a/src/Filter/DateTimeFilter.php
+++ b/src/Filter/DateTimeFilter.php
@@ -42,17 +42,13 @@ final class DateTimeFilter implements FilterInterface
         $value = $filterDataDto->getValue();
         $value2 = $filterDataDto->getValue2();
 
-        if (ComparisonType::BETWEEN === $comparison) {
+        if (null === $value) {
+            $queryBuilder->andWhere(sprintf('%s.%s %s', $alias, $property, $comparison));
+        } elseif (ComparisonType::BETWEEN === $comparison) {
             $queryBuilder->andWhere(sprintf('%s.%s BETWEEN :%s and :%s', $alias, $property, $parameterName, $parameter2Name))
                 ->setParameter($parameterName, $value)
                 ->setParameter($parameter2Name, $value2);
         } else {
-            if (null === $value && ComparisonType::EQ === $comparison) {
-                $queryBuilder->andWhere(sprintf('%s.%s is null', $alias, $property));
-
-                return;
-            }
-
             $queryBuilder->andWhere(sprintf('%s.%s %s :%s', $alias, $property, $comparison, $parameterName))
                 ->setParameter($parameterName, $value);
         }

--- a/src/Filter/NumericFilter.php
+++ b/src/Filter/NumericFilter.php
@@ -50,7 +50,9 @@ final class NumericFilter implements FilterInterface
             $value2 *= $divisor;
         }
 
-        if (ComparisonType::BETWEEN === $comparison) {
+        if (null === $value) {
+            $queryBuilder->andWhere(sprintf('%s.%s %s', $alias, $property, $comparison));
+        } elseif (ComparisonType::BETWEEN === $comparison) {
             $queryBuilder->andWhere(sprintf('%s.%s BETWEEN :%s and :%s', $alias, $property, $parameterName, $parameter2Name))
                 ->setParameter($parameterName, $value)
                 ->setParameter($parameter2Name, $value2);

--- a/src/Form/Filter/Type/DateTimeFilterType.php
+++ b/src/Form/Filter/Type/DateTimeFilterType.php
@@ -37,6 +37,12 @@ class DateTimeFilterType extends AbstractType
                 $data['value'] ??= null;
                 $data['value2'] ??= null;
 
+                if (null === $data['value'] && ComparisonType::BETWEEN !== $data['comparison']) {
+                    $data['comparison'] = ComparisonType::EQ === $data['comparison'] ? 'IS NULL' : 'IS NOT NULL';
+
+                    return $data;
+                }
+
                 if (ComparisonType::BETWEEN === $data['comparison']) {
                     if (null === $data['value'] || '' === $data['value'] || null === $data['value2'] || '' === $data['value2']) {
                         throw new TransformationFailedException('Two values must be provided when "BETWEEN" comparison is selected.');

--- a/src/Form/Filter/Type/NumericFilterType.php
+++ b/src/Form/Filter/Type/NumericFilterType.php
@@ -34,6 +34,14 @@ class NumericFilterType extends AbstractType
         $builder->addModelTransformer(new CallbackTransformer(
             static fn ($data) => $data,
             static function ($data) {
+                $data['value'] ??= null;
+
+                if (null === $data['value'] && ComparisonType::BETWEEN !== $data['comparison']) {
+                    $data['comparison'] = ComparisonType::EQ === $data['comparison'] ? 'IS NULL' : 'IS NOT NULL';
+
+                    return $data;
+                }
+
                 if (ComparisonType::BETWEEN === $data['comparison']) {
                     if (null === $data['value'] || '' === $data['value'] || null === $data['value2'] || '' === $data['value2']) {
                         throw new TransformationFailedException('Two values must be provided when "BETWEEN" comparison is selected.');

--- a/src/Test/AbstractCrudTestCase.php
+++ b/src/Test/AbstractCrudTestCase.php
@@ -49,6 +49,7 @@ abstract class AbstractCrudTestCase extends WebTestCase
             $this->entityManager->getConnection()->close();
         }
 
+        // @phpstan-ignore-next-line unset.possiblyHookedProperty
         unset($this->client, $this->entityManager, $this->adminUrlGenerator);
 
         parent::tearDown();

--- a/tests/Unit/Filter/DateTimeFilterTypeTest.php
+++ b/tests/Unit/Filter/DateTimeFilterTypeTest.php
@@ -61,5 +61,20 @@ class DateTimeFilterTypeTest extends TypeTestCase
             ['comparison' => 'between', 'value' => '15:00:00', 'value2' => null],
             'Unable to reverse value for property path "ea_datetime_filter": Two values must be provided when "BETWEEN" comparison is selected.',
         ];
+        yield [
+            [],
+            ['comparison' => ComparisonType::EQ, 'value' => null, 'value2' => null],
+            ['comparison' => 'IS NULL', 'value' => null, 'value2' => null],
+        ];
+        yield [
+            [],
+            ['comparison' => ComparisonType::NEQ, 'value' => null, 'value2' => null],
+            ['comparison' => 'IS NOT NULL', 'value' => null, 'value2' => null],
+        ];
+        yield [
+            [],
+            ['comparison' => ComparisonType::GT, 'value' => null, 'value2' => null],
+            ['comparison' => 'IS NOT NULL', 'value' => null, 'value2' => null],
+        ];
     }
 }

--- a/tests/Unit/Filter/NumericFilterTypeTest.php
+++ b/tests/Unit/Filter/NumericFilterTypeTest.php
@@ -55,5 +55,20 @@ class NumericFilterTypeTest extends TypeTestCase
             ['comparison' => 'between', 'value' => '23.32', 'value2' => null],
             'Unable to reverse value for property path "ea_numeric_filter": Two values must be provided when "BETWEEN" comparison is selected.',
         ];
+        yield [
+            [],
+            ['comparison' => ComparisonType::EQ, 'value' => null, 'value2' => null],
+            ['comparison' => 'IS NULL', 'value' => null, 'value2' => null],
+        ];
+        yield [
+            [],
+            ['comparison' => ComparisonType::NEQ, 'value' => null, 'value2' => null],
+            ['comparison' => 'IS NOT NULL', 'value' => null, 'value2' => null],
+        ];
+        yield [
+            [],
+            ['comparison' => ComparisonType::GT, 'value' => null, 'value2' => null],
+            ['comparison' => 'IS NOT NULL', 'value' => null, 'value2' => null],
+        ];
     }
 }


### PR DESCRIPTION
This continues #7454 to fix other null-related issues in the datetime and other filters. It also adds some tests.