### PR TITLE
Fix fieldset margins

### DIFF
--- a/assets/css/easyadmin-theme/forms.css
+++ b/assets/css/easyadmin-theme/forms.css
@@ -256,6 +256,11 @@ label.form-check-label {
 }
 
 /* Form columns */
+.form-column {
+    display: flex;
+    flex-direction: column;
+    gap: var(--bs-gutter-x);
+}
 .form-column .form-column-title {
     display: flex;
     flex-direction: column;
@@ -279,9 +284,6 @@ label.form-check-label {
     color: var(--form-column-help-color);
     flex: 1;
     margin: 0;
-}
-.form-column .field-form_fieldset {
-    margin-block-end: var(--bs-gutter-x);
 }
 
 .form-column .form-fieldset {
@@ -311,10 +313,6 @@ label.form-check-label {
 }
 
 /* Form fieldsets */
-.field-form_fieldset {
-    margin-block-end: calc(1.5 * var(--bs-gutter-x)); /* not a typo; don't use --bs-gutter-y here */
-}
-
 .form-section-empty {
     padding: var(--ea-sp-6) var(--ea-sp-2-5) var(--ea-sp-6);
 }

--- a/templates/crud/detail/column_group_open.html.twig
+++ b/templates/crud/detail/column_group_open.html.twig
@@ -3,5 +3,5 @@
    the 'detail' page; the closing tags are rendered by 'crud/detail/column_group_close' #}
 {# if columns are inside tabs, don't add a '.row' element because the tab pane already opens it #}
 {% if not field.getFormTypeOption('ea_is_inside_tab')|default(false) %}
-    <div class="row">
+    <div class="row g-4">
 {% endif %}

--- a/templates/crud/detail/tab_open.html.twig
+++ b/templates/crud/detail/tab_open.html.twig
@@ -11,4 +11,4 @@
         </div>
     {% endif %}
 
-    <div class="row">
+    <div class="row g-4">

--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -464,7 +464,7 @@
 {% block ea_form_column_group_open_row %}
     {# if columns are inside tabs, don't add a '.row' element because the tab pane already opens it #}
     {% if not form.vars.ea_is_inside_tab|default(false) %}
-        <div class="row">
+        <div class="row g-4">
     {% endif %}
 {% endblock ea_form_column_group_open_row %}
 
@@ -599,7 +599,7 @@
             </div>
         {% endif %}
 
-        <div class="row">
+        <div class="row g-4">
 {% endblock ea_form_tabpane_open_row %}
 
 {% block ea_form_tabpane_close_row %}


### PR DESCRIPTION
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/7044

After these changes, we should be able to apply the `h-100` class to our fieldsets to render them with equal heights.

```php
return [
    FormField::addColumn(6),
    FormField::addFieldset('Fieldset 1')->setCssClass('h-100'),
    // ...
    FormField::addColumn(6),
    FormField::addFieldset('Fieldset 2')->setCssClass('h-100'),
    // ...
    FormField::addColumn(12),
    FormField::addFieldset('Fieldset 3'),
    // ...
]
```

This was not easy to test, so I hope I didn't miss anything.