### PR TITLE
Allow to set a custom response in all AfterEntity events

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -276,7 +276,11 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
             $this->updateEntity($this->container->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
 
-            $this->container->get('event_dispatcher')->dispatch(new AfterEntityUpdatedEvent($entityInstance));
+            $event = new AfterEntityUpdatedEvent($entityInstance);
+            $this->container->get('event_dispatcher')->dispatch($event);
+            if ($event->isPropagationStopped()) {
+                return $event->getResponse();
+            }
 
             return $this->getRedirectResponseAfterSave($context, Action::EDIT);
         }
@@ -336,8 +340,12 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
             $this->persistEntity($this->container->get('doctrine')->getManagerForClass($context->getEntity()->getFqcn()), $entityInstance);
 
-            $this->container->get('event_dispatcher')->dispatch(new AfterEntityPersistedEvent($entityInstance));
+            $event = new AfterEntityPersistedEvent($entityInstance);
+            $this->container->get('event_dispatcher')->dispatch($event);
             $context->getEntity()->setInstance($entityInstance);
+            if ($event->isPropagationStopped()) {
+                return $event->getResponse();
+            }
 
             return $this->getRedirectResponseAfterSave($context, Action::NEW);
         }
@@ -397,7 +405,11 @@ abstract class AbstractCrudController extends AbstractController implements Crud
             throw new EntityRemoveException(['entity_name' => $context->getEntity()->getName(), 'message' => $e->getMessage()], $e);
         }
 
-        $this->container->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));
+        $event = new AfterEntityDeletedEvent($entityInstance);
+        $this->container->get('event_dispatcher')->dispatch($event);
+        if ($event->isPropagationStopped()) {
+            return $event->getResponse();
+        }
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([
             'entity' => $context->getEntity(),
@@ -458,7 +470,11 @@ abstract class AbstractCrudController extends AbstractController implements Crud
                 throw new EntityRemoveException(['entity_name' => (string) $entityDto, 'message' => $e->getMessage()], $e);
             }
 
-            $this->container->get('event_dispatcher')->dispatch(new AfterEntityDeletedEvent($entityInstance));
+            $event = new AfterEntityDeletedEvent($entityInstance);
+            $this->container->get('event_dispatcher')->dispatch($event);
+            if ($event->isPropagationStopped()) {
+                return $event->getResponse();
+            }
         }
 
         $responseParameters = $this->configureResponseParameters(KeyValueStore::new([

--- a/src/Event/AfterEntityDeletedEvent.php
+++ b/src/Event/AfterEntityDeletedEvent.php
@@ -11,4 +11,5 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
  */
 final class AfterEntityDeletedEvent extends AbstractLifecycleEvent
 {
+    use StoppableEventTrait;
 }

--- a/src/Event/AfterEntityPersistedEvent.php
+++ b/src/Event/AfterEntityPersistedEvent.php
@@ -11,4 +11,5 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
  */
 final class AfterEntityPersistedEvent extends AbstractLifecycleEvent
 {
+    use StoppableEventTrait;
 }

--- a/src/Event/AfterEntityUpdatedEvent.php
+++ b/src/Event/AfterEntityUpdatedEvent.php
@@ -17,4 +17,5 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Event;
  */
 final class AfterEntityUpdatedEvent extends AbstractLifecycleEvent
 {
+    use StoppableEventTrait;
 }


### PR DESCRIPTION
We no longer add new features in 4.x branch. But, this one is tiny and ask asled a long time ago, so we can me an exception here.

Fixes #4247.