### PR TITLE
Fix getting entityId when using mapped route attributes

### DIFF
--- a/src/Factory/ControllerFactory.php
+++ b/src/Factory/ControllerFactory.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -39,6 +40,10 @@ final readonly class ControllerFactory
 
     private function getCrudController(?string $crudControllerFqcn, ?string $crudAction, Request $request): ?CrudControllerInterface
     {
+        if (isset($request->attributes->get('_route_params')[EA::ENTITY_ID]) && !$request->attributes->has(EA::ENTITY_ID)) {
+            $request->attributes->set(EA::ENTITY_ID, $request->attributes->get('_route_params')[EA::ENTITY_ID]);
+        }
+
         return $this->getController(CrudControllerInterface::class, $crudControllerFqcn, $crudAction, $request);
     }
 


### PR DESCRIPTION
When using mapped attributes (i.e. `entityId` becoming `order.id` like in the example below) entity instance is not properly set inside AdminContext.

```
        #[AdminRoute('/{entityId:order.id}/invoice')]
        public function renderInvoice(Order $order, AdminContext $context): Response {
            $context->getEntity()->getInstance(); // is null!
        }
```

This is because `entityId` is no longer a route attribute, `order.id` is.

Fix this by trying to fetch original `entityId` value from `_route_params`.

Related to https://github.com/EasyCorp/EasyAdminBundle/issues/7488