### PR TITLE
chore: remove ext-json dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
     ],
     "require": {
         "php": ">=8.2",
-        "ext-json": "*",
         "doctrine/doctrine-bundle": "^2.18|^3.2",
         "doctrine/dbal": "^3.10|^4.4",
         "doctrine/orm": "^2.20|^3.6",


### PR DESCRIPTION
> For composer.json file that had ext-json in the require section, this requirement is no longer necessary if already requires php ^8.0.

https://php.watch/versions/8.0/ext-json