### PR TITLE
Fix nested associations and embedded properties

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -378,6 +378,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(4, new Reference(FieldFactory::class))
             ->arg(5, new Reference(AuthorizationChecker::class))
             ->arg(6, service(AdminContextFactory::class))
+            ->arg(7, service(EntityRepository::class))
             ->tag('kernel.reset', ['method' => 'reset'])
 
         ->set(AvatarConfigurator::class)
@@ -446,6 +447,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, service(ControllerFactory::class))
             ->arg(3, new Reference(FieldFactory::class))
             ->arg(4, service(AdminContextProvider::class))
+            ->arg(5, service(EntityRepository::class))
 
         ->set(SlugConfigurator::class)
 

--- a/config/services.php
+++ b/config/services.php
@@ -334,6 +334,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set(EntityFilterConfigurator::class)
             ->arg(0, new Reference(AdminUrlGenerator::class))
+            ->arg(1, service(EntityRepository::class))
 
         ->set(LanguageFilterConfigurator::class)
 

--- a/src/Contracts/Factory/EntityFactoryInterface.php
+++ b/src/Contracts/Factory/EntityFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Factory;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use EasyCorp\Bundle\EasyAdminBundle\Collection\EntityCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use Symfony\Component\ExpressionLanguage\Expression;
+
+interface EntityFactoryInterface
+{
+    /**
+     * @param class-string $entityFqcn
+     */
+    public function create(string $entityFqcn, mixed $entityId = null, string|Expression|null $entityPermission = null): EntityDto;
+
+    public function createForEntityInstance(object $entityInstance): EntityDto;
+
+    /**
+     * @param iterable<object>|null $entityInstances
+     */
+    public function createCollection(EntityDto $entityDto, ?iterable $entityInstances): EntityCollection;
+
+    /**
+     * @template TEntity of object
+     *
+     * @param class-string<TEntity> $entityFqcn
+     *
+     * @return ClassMetadata<TEntity>
+     */
+    public function getEntityMetadata(string $entityFqcn): ClassMetadata;
+}

--- a/src/Contracts/Orm/EntityRepositoryInterface.php
+++ b/src/Contracts/Orm/EntityRepositoryInterface.php
@@ -14,4 +14,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 interface EntityRepositoryInterface
 {
     public function createQueryBuilder(SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields, FilterCollection $filters): QueryBuilder;
+
+    /**
+     * @return array{
+     * entity_dto: EntityDto,
+     * entity_alias: string,
+     * property_name: string,
+     * }
+     */
+    public function resolveNestedAssociations(?QueryBuilder $queryBuilder, EntityDto $rootEntityDto, string $propertyName, bool $mustEndWithAssociation = false): array;
 }

--- a/src/Dto/FilterDataDto.php
+++ b/src/Dto/FilterDataDto.php
@@ -8,7 +8,8 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 final class FilterDataDto
 {
     private int $index;
-    private string $entityAlias;
+    /** @var array{entity_dto: EntityDto, entity_alias: string, property_name: string} */
+    private array $resolvedProperty;
     private FilterDto $filterDto;
     /** @var string */
     private $comparison;
@@ -20,14 +21,15 @@ final class FilterDataDto
     }
 
     /**
-     * @param array{comparison: string, value: mixed, value2?: mixed} $formData
+     * @param array{comparison: string, value: mixed, value2?: mixed}                   $formData
+     * @param array{entity_dto: EntityDto, entity_alias: string, property_name: string} $resolvedProperty
      */
-    public static function new(int $index, FilterDto $filterDto, string $entityAlias, array $formData): self
+    public static function new(int $index, FilterDto $filterDto, array $resolvedProperty, array $formData): self
     {
         $filterData = new self();
         $filterData->index = $index;
         $filterData->filterDto = $filterDto;
-        $filterData->entityAlias = $entityAlias;
+        $filterData->resolvedProperty = $resolvedProperty;
         $filterData->comparison = $formData['comparison'];
         $filterData->value = $formData['value'];
         $filterData->value2 = $formData['value2'] ?? null;
@@ -37,12 +39,12 @@ final class FilterDataDto
 
     public function getEntityAlias(): string
     {
-        return $this->entityAlias;
+        return $this->resolvedProperty['entity_alias'];
     }
 
     public function getProperty(): string
     {
-        return $this->filterDto->getProperty();
+        return $this->resolvedProperty['property_name'];
     }
 
     public function getFormTypeOption(string $optionName): mixed
@@ -67,11 +69,11 @@ final class FilterDataDto
 
     public function getParameterName(): string
     {
-        return sprintf('%s_%d', str_replace('.', '_', $this->getProperty()), $this->index);
+        return sprintf('%s_%d', str_replace('.', '_', $this->filterDto->getProperty()), $this->index);
     }
 
     public function getParameter2Name(): string
     {
-        return sprintf('%s_%d', str_replace('.', '_', $this->getProperty()), $this->index + 1);
+        return sprintf('%s_%d', str_replace('.', '_', $this->filterDto->getProperty()), $this->index + 1);
     }
 }

--- a/src/Factory/EntityFactory.php
+++ b/src/Factory/EntityFactory.php
@@ -7,6 +7,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\Proxy;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\EntityCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Factory\EntityFactoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntityBuiltEvent;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\EntityNotFoundException;
@@ -18,7 +19,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final readonly class EntityFactory
+final readonly class EntityFactory implements EntityFactoryInterface
 {
     public function __construct(
         private AuthorizationCheckerInterface $authorizationChecker,

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -65,12 +65,11 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyName = $field->getProperty();
-        $resolvedProperty = $this->entityRepository->resolveNestedAssociations(null, $entityDto, $propertyName, true);
-        /** @var EntityDto $entityDtoResolved */
-        $entityDtoResolved = $resolvedProperty['entity_dto'];
-        /** @var string $resolvedProperty */
-        $resolvedProperty = $resolvedProperty['property_name'];
+        $rootPropertyName = $field->getProperty();
+        $resolvedProperty = $this->entityRepository->resolveNestedAssociations(null, $entityDto, $rootPropertyName, true);
+        $entityDto = $resolvedProperty['entity_dto'];
+        $propertyName = $resolvedProperty['property_name'];
+        $field->setProperty($propertyName);
 
         if (!$this->isAssociation($entityDto->getClassMetadata(), $propertyName)) {
             throw new \RuntimeException(sprintf('The "%s" field is not a Doctrine association, so it cannot be used as an association field.', $propertyName));
@@ -78,14 +77,14 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
         // the target CRUD controller can be NULL; in that case, field value doesn't link to the related entity
         $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER)
-            ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty));
+            ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($propertyName));
 
         if (true === $field->getCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM)) {
             if (false === $entityDto->getClassMetadata()->isSingleValuedAssociation($propertyName)) {
                 throw new \RuntimeException(
                     sprintf(
                         'The "%s" association field of "%s" is a to-many association but it\'s trying to use the "renderAsEmbeddedForm()" option, which is only available for to-one associations. If you want to use a CRUD form to render to-many associations, use a CollectionField instead of the AssociationField.',
-                        $field->getProperty(),
+                        $rootPropertyName,
                         $context->getCrud()?->getControllerFqcn(),
                     )
                 );
@@ -95,7 +94,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 throw new \RuntimeException(
                     sprintf(
                         'The "%s" association field of "%s" wants to render its contents using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "renderAsEmbeddedForm()" method.',
-                        $field->getProperty(),
+                        $rootPropertyName,
                         $context->getCrud()?->getControllerFqcn(),
                         $entityDto->getClassMetadata()->getAssociationTargetClass($propertyName)
                     )
@@ -177,7 +176,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         if (true === $field->getCustomOption(AssociationField::OPTION_AUTOCOMPLETE)) {
             $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER);
             if (null === $targetCrudControllerFqcn) {
-                throw new \RuntimeException(sprintf('The "%s" field cannot be autocompleted because it doesn\'t define the related CRUD controller FQCN with the "setCrudController()" method.', $field->getProperty()));
+                throw new \RuntimeException(sprintf('The "%s" field cannot be autocompleted because it doesn\'t define the related CRUD controller FQCN with the "setCrudController()" method.', $rootPropertyName));
             }
 
             $field->setFormType(CrudAutocompleteType::class);

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -109,6 +109,8 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 $targetCrudControllerFqcn,
             );
 
+            $field->setProperty($rootPropertyName);
+
             return;
         }
 
@@ -221,6 +223,8 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
                 return $queryBuilder;
             });
         }
+
+        $field->setProperty($rootPropertyName);
     }
 
     /**

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -22,6 +22,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
+use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository as EAEntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,6 +49,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         private readonly FieldFactory $fieldFactory,
         private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly AdminContextFactory $adminContextFactory,
+        private EAEntityRepository $entityRepository,
     ) {
     }
 
@@ -64,6 +66,11 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
         $propertyName = $field->getProperty();
+        $resolvedProperty = $this->entityRepository->resolveNestedAssociations(null, $entityDto, $propertyName, true);
+        /** @var EntityDto $entityDtoResolved */
+        $entityDtoResolved = $resolvedProperty['entity_dto'];
+        /** @var string $resolvedProperty */
+        $resolvedProperty = $resolvedProperty['property_name'];
 
         if (!$this->isAssociation($entityDto->getClassMetadata(), $propertyName)) {
             throw new \RuntimeException(sprintf('The "%s" field is not a Doctrine association, so it cannot be used as an association field.', $propertyName));
@@ -71,7 +78,7 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
 
         // the target CRUD controller can be NULL; in that case, field value doesn't link to the related entity
         $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER)
-            ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($propertyName));
+            ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty));
 
         if (true === $field->getCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM)) {
             if (false === $entityDto->getClassMetadata()->isSingleValuedAssociation($propertyName)) {

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -144,30 +144,29 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
             return;
         }
 
+        $rootPropertyName = $fieldDto->getProperty();
         $resolvedProperty = $this->entityRepository->resolveNestedAssociations(null, $entityDto, $fieldDto->getProperty(), true);
-        /** @var EntityDto $entityDtoResolved */
-        $entityDtoResolved = $resolvedProperty['entity_dto'];
-        /** @var string $resolvedProperty */
-        $resolvedProperty = $resolvedProperty['property_name'];
+        $entityDto = $resolvedProperty['entity_dto'];
+        $fieldDto->setProperty($resolvedProperty['property_name']);
 
         if (true === $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM)) {
-            if (!$entityDtoResolved->getClassMetadata()->hasAssociation($resolvedProperty)) {
-                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" cannot use the "useEntryCrudForm()" method because it is not a Doctrine association.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn()));
+            if (!$entityDto->getClassMetadata()->hasAssociation($fieldDto->getProperty())) {
+                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" cannot use the "useEntryCrudForm()" method because it is not a Doctrine association.', $rootPropertyName, $context->getCrud()?->getControllerFqcn()));
             }
 
             if (null !== $fieldDto->getCustomOptions()->get(CollectionField::OPTION_ENTRY_TYPE)) {
-                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" can render its entries using a Symfony Form (via the "setEntryType()" method) or using an EasyAdmin CRUD Form (via the "useEntryCrudForm()" method) but you cannot use both methods at the same time. Remove one of those two methods.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn()));
+                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" can render its entries using a Symfony Form (via the "setEntryType()" method) or using an EasyAdmin CRUD Form (via the "useEntryCrudForm()" method) but you cannot use both methods at the same time. Remove one of those two methods.', $rootPropertyName, $context->getCrud()?->getControllerFqcn()));
             }
 
             $targetCrudControllerFqcn = $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_CONTROLLER_FQCN)
-                ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty));
+                ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()));
 
             if (null === $targetCrudControllerFqcn) {
-                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" wants to render its entries using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "useEntryCrudForm()" method.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn(), $entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty)));
+                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" wants to render its entries using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "useEntryCrudForm()" method.', $rootPropertyName, $context->getCrud()?->getControllerFqcn(), $entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty())));
             }
         } elseif (null === $fieldDto->getFormTypeOption('entry_type')
-            && $entityDtoResolved->getClassMetadata()->hasAssociation($resolvedProperty)) {
-            $targetCrudControllerFqcn = $context->getAdminControllers()->findCrudControllerByEntity($entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty));
+            && $entityDto->getClassMetadata()->hasAssociation($fieldDto->getProperty())) {
+            $targetCrudControllerFqcn = $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()));
 
             if (null === $targetCrudControllerFqcn) {
                 return;
@@ -176,7 +175,7 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
             return;
         }
 
-        $targetEntityFqcn = $entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty);
+        $targetEntityFqcn = $entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty());
 
         $editEntityDto = $this->createEntityDto(
             $targetEntityFqcn,

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -9,6 +9,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityRepositoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
@@ -36,6 +37,7 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
         private ControllerFactory $controllerFactory,
         private FieldFactory $fieldFactory,
         private AdminContextProviderInterface $adminContextProvider,
+        private EntityRepositoryInterface $entityRepository,
     ) {
     }
 
@@ -142,8 +144,14 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
             return;
         }
 
+        $resolvedProperty = $this->entityRepository->resolveNestedAssociations(null, $entityDto, $fieldDto->getProperty(), true);
+        /** @var EntityDto $entityDtoResolved */
+        $entityDtoResolved = $resolvedProperty['entity_dto'];
+        /** @var string $resolvedProperty */
+        $resolvedProperty = $resolvedProperty['property_name'];
+
         if (true === $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM)) {
-            if (!$entityDto->getClassMetadata()->hasAssociation($fieldDto->getProperty())) {
+            if (!$entityDtoResolved->getClassMetadata()->hasAssociation($resolvedProperty)) {
                 throw new \RuntimeException(sprintf('The "%s" collection field of "%s" cannot use the "useEntryCrudForm()" method because it is not a Doctrine association.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn()));
             }
 
@@ -152,14 +160,14 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
             }
 
             $targetCrudControllerFqcn = $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_CONTROLLER_FQCN)
-                ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()));
+                ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty));
 
             if (null === $targetCrudControllerFqcn) {
-                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" wants to render its entries using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "useEntryCrudForm()" method.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn(), $entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty())));
+                throw new \RuntimeException(sprintf('The "%s" collection field of "%s" wants to render its entries using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "%s" or pass the CRUD controller to use as the first argument of the "useEntryCrudForm()" method.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn(), $entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty)));
             }
         } elseif (null === $fieldDto->getFormTypeOption('entry_type')
-            && $entityDto->getClassMetadata()->hasAssociation($fieldDto->getProperty())) {
-            $targetCrudControllerFqcn = $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()));
+            && $entityDtoResolved->getClassMetadata()->hasAssociation($resolvedProperty)) {
+            $targetCrudControllerFqcn = $context->getAdminControllers()->findCrudControllerByEntity($entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty));
 
             if (null === $targetCrudControllerFqcn) {
                 return;
@@ -168,7 +176,7 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
             return;
         }
 
-        $targetEntityFqcn = $entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty());
+        $targetEntityFqcn = $entityDtoResolved->getClassMetadata()->getAssociationTargetClass($resolvedProperty);
 
         $editEntityDto = $this->createEntityDto(
             $targetEntityFqcn,

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -48,6 +48,11 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
+        $rootPropertyName = $field->getProperty();
+        $resolvedProperty = $this->entityRepository->resolveNestedAssociations(null, $entityDto, $field->getProperty(), true);
+        $entityDto = $resolvedProperty['entity_dto'];
+        $field->setProperty($resolvedProperty['property_name']);
+
         if (null !== $entryTypeFqcn = $field->getCustomOptions()->get(CollectionField::OPTION_ENTRY_TYPE)) {
             $field->setFormTypeOption('entry_type', $entryTypeFqcn);
         }
@@ -83,7 +88,9 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
 
         $field->setFormattedValue($this->formatCollection($field, $context));
 
-        $this->configureEntryType($field, $entityDto, $context);
+        $this->configureEntryType($field, $entityDto, $context, $rootPropertyName);
+
+        $field->setProperty($rootPropertyName);
     }
 
     private function formatCollection(FieldDto $field, AdminContext $context): int|string
@@ -132,7 +139,7 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
         return 0;
     }
 
-    private function configureEntryType(FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
+    private function configureEntryType(FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context, string $rootPropertyName): void
     {
         // entry_type and prototype options are only consumed when the field is
         // rendered as a form (NEW/EDIT). On INDEX/DETAIL the field is rendered
@@ -143,11 +150,6 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
         if (!\in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_EDIT, Crud::PAGE_NEW], true)) {
             return;
         }
-
-        $rootPropertyName = $fieldDto->getProperty();
-        $resolvedProperty = $this->entityRepository->resolveNestedAssociations(null, $entityDto, $fieldDto->getProperty(), true);
-        $entityDto = $resolvedProperty['entity_dto'];
-        $fieldDto->setProperty($resolvedProperty['property_name']);
 
         if (true === $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM)) {
             if (!$entityDto->getClassMetadata()->hasAssociation($fieldDto->getProperty())) {

--- a/src/Filter/Configurator/EntityConfigurator.php
+++ b/src/Filter/Configurator/EntityConfigurator.php
@@ -10,6 +10,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
+use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 
 /**
@@ -20,6 +21,7 @@ final class EntityConfigurator implements FilterConfiguratorInterface
 {
     public function __construct(
         private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private EntityRepository $entityRepository,
     ) {
     }
 
@@ -30,10 +32,9 @@ final class EntityConfigurator implements FilterConfiguratorInterface
 
     public function configure(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
-        $propertyName = $filterDto->getProperty();
-        if (!$entityDto->getClassMetadata()->hasAssociation($propertyName)) {
-            return;
-        }
+        $resolvedProperty = $this->entityRepository->resolveNestedAssociations(null, $entityDto, $filterDto->getProperty(), true);
+        $entityDto = $resolvedProperty['entity_dto'];
+        $propertyName = $resolvedProperty['property_name'];
 
         // TODO: add the 'em' form type option too?
         $filterDto->setFormTypeOptionIfNotSet('value_type_options.class', $entityDto->getClassMetadata()->getAssociationTargetClass($propertyName));

--- a/src/Filter/Configurator/EntityConfigurator.php
+++ b/src/Filter/Configurator/EntityConfigurator.php
@@ -5,12 +5,12 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
 use Doctrine\ORM\Mapping\JoinColumnMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityRepositoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
-use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 
 /**
@@ -21,7 +21,7 @@ final class EntityConfigurator implements FilterConfiguratorInterface
 {
     public function __construct(
         private AdminUrlGeneratorInterface $adminUrlGenerator,
-        private EntityRepository $entityRepository,
+        private EntityRepositoryInterface $entityRepository,
     ) {
     }
 

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -22,6 +22,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntitySearchEvent;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\ComparisonType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\FiltersFormType;
 use Symfony\Component\Uid\Ulid;
@@ -31,14 +32,17 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final readonly class EntityRepository implements EntityRepositoryInterface
+final class EntityRepository implements EntityRepositoryInterface
 {
+    /** @var array<string, string> */
+    private array $associationAlreadyJoined = [];
+
     public function __construct(
-        private AdminContextProviderInterface $adminContextProvider,
-        private ManagerRegistry $doctrine,
-        private EntityFactory $entityFactory,
-        private FormFactory $formFactory,
-        private EventDispatcherInterface $eventDispatcher,
+        private readonly AdminContextProviderInterface $adminContextProvider,
+        private readonly ManagerRegistry $doctrine,
+        private readonly EntityFactory $entityFactory,
+        private readonly FormFactory $formFactory,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
@@ -249,10 +253,18 @@ final readonly class EntityRepository implements EntityRepositoryInterface
                 ];
             }
 
-            /** @var string $rootAlias */
-            $rootAlias = current($queryBuilder->getRootAliases());
+            try {
+                $resolvedProperty = $this->resolveNestedAssociations($queryBuilder, $entityDto, $originalPropertyName, EntityFilter::class === $filter->getFqcn());
+            } catch (\InvalidArgumentException) {
+                // Fallback to support custom filters with unmapped property names
+                $resolvedProperty = [
+                    'entity_dto' => $entityDto,
+                    'entity_alias' => current($queryBuilder->getRootAliases()),
+                    'property_name' => $originalPropertyName,
+                ];
+            }
 
-            $filterDataDto = FilterDataDto::new($i, $filter, $rootAlias, $submittedData);
+            $filterDataDto = FilterDataDto::new($i, $filter, $resolvedProperty, $submittedData);
             $filter->apply($queryBuilder, $filterDataDto, $fields->getByProperty($originalPropertyName), $entityDto);
 
             ++$i;
@@ -280,47 +292,11 @@ final readonly class EntityRepository implements EntityRepositoryInterface
         $configuredSearchableProperties = $searchDto->getSearchableProperties();
         $searchableProperties = (null === $configuredSearchableProperties || 0 === \count($configuredSearchableProperties)) ? $entityDto->getClassMetadata()->getFieldNames() : $configuredSearchableProperties;
 
-        $entitiesAlreadyJoined = [];
         foreach ($searchableProperties as $searchableProperty) {
-            // support arbitrarily nested associations (e.g. foo.bar.baz.qux)
-            $associatedProperties = explode('.', $searchableProperty);
-            $numAssociatedProperties = \count($associatedProperties);
-            $parentEntityDto = $entityDto;
-            $parentEntityAlias = 'entity';
-            $fullPropertyName = $parentPropertyName = $associatedPropertyName = '';
-
-            for ($i = 0; $i < $numAssociatedProperties; ++$i) {
-                $associatedPropertyName = $associatedProperties[$i];
-                $fullPropertyName = trim($fullPropertyName.'.'.$associatedPropertyName, '.');
-
-                if ($this->isAssociation($parentEntityDto, $associatedPropertyName)) {
-                    if ($i === $numAssociatedProperties - 1) {
-                        throw new \InvalidArgumentException(sprintf('The "%s" property included in the setSearchFields() method is not a valid search field. When using associated properties in search, you must also define the exact field used in the search (e.g. \'%s.id\', \'%s.name\', etc.)', $searchableProperty, $searchableProperty, $searchableProperty));
-                    }
-
-                    $associatedEntityDto = $this->entityFactory->create($parentEntityDto->getClassMetadata()->getAssociationTargetClass($associatedPropertyName));
-
-                    if (!isset($entitiesAlreadyJoined[$fullPropertyName])) {
-                        $aliasIndex = \count($entitiesAlreadyJoined);
-                        $entitiesAlreadyJoined[$fullPropertyName] ??= Escaper::escapeDqlAlias($associatedPropertyName.(0 === $aliasIndex ? '' : $aliasIndex));
-                        $queryBuilder->leftJoin(Escaper::escapeDqlAlias($parentEntityAlias).'.'.$associatedPropertyName, $entitiesAlreadyJoined[$fullPropertyName]);
-                    }
-
-                    $parentEntityDto = $associatedEntityDto;
-                    $parentEntityAlias = $entitiesAlreadyJoined[$fullPropertyName];
-                    $parentPropertyName = '';
-                } else {
-                    // Normal & Embedded class properties
-                    $associatedPropertyName = $parentPropertyName = trim($parentPropertyName.'.'.$associatedPropertyName, '.');
-                }
-            }
-
-            if (!isset($parentEntityDto->getClassMetadata()->fieldMappings[$associatedPropertyName])) {
-                throw new \InvalidArgumentException(sprintf('The "%s" property included in the setSearchFields() method is not a valid search field. The field "%s" does not exist in "%s".', $searchableProperty, $associatedPropertyName, $searchableProperty));
-            }
+            $resolvedProperty = $this->resolveNestedAssociations($queryBuilder, $entityDto, $searchableProperty);
 
             // In Doctrine ORM 3.x, FieldMapping implements \ArrayAccess; in 4.x it's an object with properties
-            $fieldMapping = $parentEntityDto->getClassMetadata()->getFieldMapping($associatedPropertyName);
+            $fieldMapping = $resolvedProperty['entity_dto']->getClassMetadata()->getFieldMapping($resolvedProperty['property_name']);
             // In Doctrine ORM 2.x, getFieldMapping() returns an array
             /** @phpstan-ignore-next-line function.impossibleType */
             if (\is_array($fieldMapping)) {
@@ -349,7 +325,7 @@ final readonly class EntityRepository implements EntityRepositoryInterface
                 && !$isUlidProperty
                 && !$isJsonProperty
             ) {
-                $entityFqcn = $parentEntityDto->getFqcn();
+                $entityFqcn = $resolvedProperty['entity_dto']->getFqcn();
 
                 /** @var \ReflectionNamedType|\ReflectionUnionType|null $idClassType */
                 $idClassType = null;
@@ -357,8 +333,8 @@ final readonly class EntityRepository implements EntityRepositoryInterface
 
                 // this is needed to handle inherited properties
                 while (false !== $reflectionClass) {
-                    if ($reflectionClass->hasProperty($associatedPropertyName)) {
-                        $reflection = $reflectionClass->getProperty($associatedPropertyName);
+                    if ($reflectionClass->hasProperty($resolvedProperty['property_name'])) {
+                        $reflection = $reflectionClass->getProperty($resolvedProperty['property_name']);
                         $idClassType = $reflection->getType();
                         break;
                     }
@@ -377,9 +353,9 @@ final readonly class EntityRepository implements EntityRepositoryInterface
             }
 
             $searchablePropertiesConfig[] = [
-                'entity_name' => $parentEntityAlias,
+                'entity_name' => $resolvedProperty['entity_alias'],
                 'property_data_type' => $propertyDataType,
-                'property_name' => $associatedPropertyName,
+                'property_name' => $resolvedProperty['property_name'],
                 'is_boolean' => $isBoolean,
                 'is_small_integer' => $isSmallIntegerProperty,
                 'is_integer' => $isIntegerProperty,
@@ -392,6 +368,63 @@ final readonly class EntityRepository implements EntityRepositoryInterface
         }
 
         return $searchablePropertiesConfig;
+    }
+
+    /**
+     * Support arbitrarily nested associations (e.g. foo.bar.baz.qux).
+     *
+     * @return array{
+     *      entity_dto: EntityDto,
+     *      entity_alias: string,
+     *      property_name: string,
+     *  }
+     */
+    public function resolveNestedAssociations(?QueryBuilder $queryBuilder, EntityDto $rootEntityDto, string $propertyName, bool $mustEndWithAssociation = false): array
+    {
+        $associatedProperties = explode('.', $propertyName);
+        $numAssociatedProperties = \count($associatedProperties);
+        $resolvedEntityDto = $rootEntityDto;
+        $parentEntityAlias = 'entity';
+        $fullPropertyName = $compoundPropertyName = $resolvedPropertyName = '';
+
+        for ($i = 0; $i < $numAssociatedProperties; ++$i) {
+            $resolvedPropertyName = trim($compoundPropertyName.'.'.$associatedProperties[$i], '.');
+            $fullPropertyName = trim($fullPropertyName.'.'.$resolvedPropertyName, '.');
+
+            if ($this->isAssociation($resolvedEntityDto, $resolvedPropertyName)) {
+                if ($i === $numAssociatedProperties - 1) {
+                    if (!$mustEndWithAssociation) {
+                        throw new \InvalidArgumentException(sprintf('The "%s" property is not valid. When using associated properties, you must also define the exact field to target (e.g. "%s.id", "%s.name", etc.)', $propertyName, $propertyName, $propertyName));
+                    }
+
+                    // Skip join when the last property is an association
+                    continue;
+                }
+
+                if (isset($queryBuilder) && !isset($this->associationAlreadyJoined[$fullPropertyName])) {
+                    $aliasIndex = \count($this->associationAlreadyJoined);
+                    $this->associationAlreadyJoined[$fullPropertyName] ??= Escaper::escapeDqlAlias($resolvedPropertyName.(0 === $aliasIndex ? '' : $aliasIndex));
+                    $queryBuilder->leftJoin(Escaper::escapeDqlAlias($parentEntityAlias).'.'.$resolvedPropertyName, $this->associationAlreadyJoined[$fullPropertyName]);
+                }
+
+                $parentEntityAlias = $this->associationAlreadyJoined[$fullPropertyName] ?? null;
+                $resolvedEntityDto = $this->entityFactory->create($resolvedEntityDto->getClassMetadata()->getAssociationTargetClass($resolvedPropertyName));
+                $compoundPropertyName = '';
+            } else {
+                // Normal & Embedded class properties
+                $compoundPropertyName = $resolvedPropertyName;
+            }
+        }
+
+        if (!$mustEndWithAssociation && !isset($resolvedEntityDto->getClassMetadata()->fieldMappings[$resolvedPropertyName])) {
+            throw new \InvalidArgumentException(sprintf('The "%s" property is not valid. The field "%s" does not exist in "%s".', $propertyName, $resolvedPropertyName, $propertyName));
+        }
+
+        return [
+            'entity_dto' => $resolvedEntityDto,
+            'entity_alias' => $parentEntityAlias,
+            'property_name' => $resolvedPropertyName,
+        ];
     }
 
     private function isAssociation(EntityDto $entityDto, string $propertyName): bool

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -5,7 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Orm;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Query\Expr\Orx;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -13,13 +12,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SearchMode;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Factory\EntityFactoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityRepositoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Event\AfterEntitySearchEvent;
-use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
@@ -40,7 +39,7 @@ final class EntityRepository implements EntityRepositoryInterface
     public function __construct(
         private readonly AdminContextProviderInterface $adminContextProvider,
         private readonly ManagerRegistry $doctrine,
-        private readonly EntityFactory $entityFactory,
+        private readonly EntityFactoryInterface $entityFactory,
         private readonly FormFactory $formFactory,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {

--- a/tests/Functional/Apps/AdminRouteApp/config/reference.php
+++ b/tests/Functional/Apps/AdminRouteApp/config/reference.php
@@ -127,7 +127,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
- *     _instanceof?: InstanceofType,
+ *     _instanceof?: array<class-string, InstanceofType>,
  *     ...<string, DefinitionType|AliasType|PrototypeType|StackType|ArgumentsType|null>
  * }
  * @psalm-type ExtensionType = array<string, mixed>
@@ -1227,7 +1227,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  * }
  * @psalm-type TwigComponentConfig = array{
- *     defaults?: array<string, string|array{ // Default: ["__deprecated__use_old_naming_behavior"]
+ *     defaults?: array<string, string|array{ // Default: []
  *         template_directory?: scalar|Param|null, // Default: "components"
  *         name_prefix?: scalar|Param|null, // Default: ""
  *     }>,
@@ -1236,7 +1236,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: "%kernel.debug%"
  *         collect_components?: bool|Param, // Collect components instances // Default: true
  *     },
- *     controllers_json?: scalar|Param|null, // Deprecated: The "twig_component.controllers_json" config option is deprecated, and will be removed in 3.0. // Default: null
  * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,

--- a/tests/Functional/Apps/DefaultApp/src/Entity/ProjectDomain/Developer.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/ProjectDomain/Developer.php
@@ -2,6 +2,8 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
@@ -17,6 +19,14 @@ class Developer implements \Stringable
 
     #[ORM\ManyToOne(inversedBy: 'favouriteProjectOf')]
     private ?Project $favouriteProject = null;
+
+    #[ORM\OneToMany(targetEntity: ProjectIssue::class, mappedBy: 'assignedDeveloper')]
+    private Collection $issues;
+
+    public function __construct()
+    {
+        $this->issues = new ArrayCollection();
+    }
 
     public function __toString(): string
     {
@@ -50,5 +60,15 @@ class Developer implements \Stringable
         $this->favouriteProject = $favouriteProject;
 
         return $this;
+    }
+
+    public function getIssues(): Collection
+    {
+        return $this->issues;
+    }
+
+    public function setIssues(Collection $issues): void
+    {
+        $this->issues = $issues;
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Entity/ProjectDomain/ProjectIssue.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/ProjectDomain/ProjectIssue.php
@@ -19,6 +19,9 @@ class ProjectIssue implements \Stringable
     #[ORM\JoinColumn(nullable: false)]
     private ?Project $project = null;
 
+    #[ORM\ManyToOne(targetEntity: Developer::class, inversedBy: 'issues')]
+    private ?Developer $assignedDeveloper = null;
+
     public function __toString(): string
     {
         return $this->name;
@@ -51,5 +54,15 @@ class ProjectIssue implements \Stringable
         $this->project = $project;
 
         return $this;
+    }
+
+    public function getAssignedDeveloper(): ?Developer
+    {
+        return $this->assignedDeveloper;
+    }
+
+    public function setAssignedDeveloper(?Developer $assignedDeveloper): void
+    {
+        $this->assignedDeveloper = $assignedDeveloper;
     }
 }

--- a/tests/Unit/Field/Configurator/AssociationConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/AssociationConfiguratorTest.php
@@ -18,6 +18,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\AssociationConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\ProjectDomain\DeveloperCrudController;
@@ -55,6 +56,7 @@ class AssociationConfiguratorTest extends AbstractFieldTest
             static::getContainer()->get(FieldFactory::class),
             static::getContainer()->get(AuthorizationCheckerInterface::class),
             static::getContainer()->get(AdminContextFactory::class),
+            static::getContainer()->get(EntityRepository::class),
         );
     }
 
@@ -104,6 +106,16 @@ class AssociationConfiguratorTest extends AbstractFieldTest
         $field = AssociationField::new('latestRelease.category')
             ->setCrudController(ProjectReleaseCategoryCrudController::class)
         ;
+
+        $fieldDto = $this->configure($field);
+
+        $this->assertSame(EntityType::class, $fieldDto->getFormType());
+        $this->assertSame(ProjectReleaseCategory::class, $fieldDto->getFormTypeOption('class'));
+    }
+
+    public function testNestedAssociationWithAutoConfiguration(): void
+    {
+        $field = AssociationField::new('latestRelease.category');
 
         $fieldDto = $this->configure($field);
 
@@ -266,6 +278,7 @@ class AssociationConfiguratorTest extends AbstractFieldTest
             static::getContainer()->get(FieldFactory::class),
             $authChecker,
             static::getContainer()->get(AdminContextFactory::class),
+            static::getContainer()->get(EntityRepository::class),
         );
     }
 

--- a/tests/Unit/Field/Configurator/CollectionConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/CollectionConfiguratorTest.php
@@ -48,6 +48,20 @@ class CollectionConfiguratorTest extends AbstractFieldTest
         yield [CollectionField::new('projectIssues')];
         yield [CollectionField::new('favouriteProjectOf')];
         yield [CollectionField::new('projectTags')];
+        yield [CollectionField::new('metaData')];
+    }
+
+    public function testNestedCollections(): void
+    {
+        $field = CollectionField::new('leadDeveloper.issues');
+        $field->setCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM, true);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'The "leadDeveloper.issues" collection field of "EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\ProjectDomain\ProjectCrudController" wants to render its entries using an EasyAdmin CRUD form. However, no CRUD form was found related to this field. You can either create a CRUD controller for the entity "EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\ProjectIssue" or pass the CRUD controller to use as the first argument of the "useEntryCrudForm()" method.'
+        );
+
+        $this->configure($field, pageName: Crud::PAGE_EDIT, controllerFqcn: ProjectCrudController::class);
     }
 
     /**

--- a/tests/Unit/Filter/Configurator/EntityConfiguratorTest.php
+++ b/tests/Unit/Filter/Configurator/EntityConfiguratorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Filter\Configurator;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\CrudContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\DashboardContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\I18nContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\RequestContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityRepositoryInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\EntityConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use PHPUnit\Framework\TestCase;
+
+final class EntityConfiguratorTest extends TestCase
+{
+    private EntityRepositoryInterface $entityRepository;
+
+    protected function setUp(): void
+    {
+        $this->entityRepository = $this->createMock(EntityRepositoryInterface::class);
+    }
+
+    public function testConfigureResolvesNestedAssociation(): void
+    {
+        $adminUrlGenerator = $this->createMock(AdminUrlGeneratorInterface::class);
+
+        $configurator = new EntityConfigurator($adminUrlGenerator, $this->entityRepository);
+
+        $filterDto = new FilterDto();
+        $filterDto->setProperty('parent.category');
+
+        $rootEntityDto = new EntityDto('App\Entity\Parent', $this->createMock(ClassMetadata::class));
+
+        $parentCategoryClassMetadata = $this->createMock(ClassMetadata::class);
+        $parentCategoryClassMetadata->expects(self::once())
+            ->method('getAssociationTargetClass')
+            ->with('category')
+            ->willReturn('App\Entity\Category');
+
+        $categoryEntityDto = new EntityDto('App\Entity\Category', $parentCategoryClassMetadata);
+
+        $this->entityRepository->expects(self::once())
+            ->method('resolveNestedAssociations')
+            ->with(null, $rootEntityDto, 'parent.category', true)
+            ->willReturn([
+                'entity_dto' => $categoryEntityDto,
+                'entity_alias' => 'category_parent',
+                'property_name' => 'category',
+            ]);
+
+        $configurator->configure($filterDto, null, $rootEntityDto, new AdminContext(
+            RequestContext::forTesting(),
+            CrudContext::forTesting(),
+            DashboardContext::forTesting(),
+            I18nContext::forTesting(),
+        ));
+
+        self::assertSame('App\Entity\Category', $filterDto->getFormTypeOption('value_type_options.class'));
+    }
+}

--- a/tests/Unit/Orm/EntityRepositoryTest.php
+++ b/tests/Unit/Orm/EntityRepositoryTest.php
@@ -8,11 +8,11 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Factory\EntityFactoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
-use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
@@ -26,22 +26,20 @@ class EntityRepositoryTest extends TestCase
     private ManagerRegistry $doctrine;
     private EventDispatcherInterface $eventDispatcher;
     private EntityRepository $entityRepository;
+    private EntityFactoryInterface $entityFactory;
 
     protected function setUp(): void
     {
         $this->adminContextProvider = $this->createMock(AdminContextProviderInterface::class);
         $this->doctrine = $this->createMock(ManagerRegistry::class);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-
-        // use reflection to create EntityRepository without needing to mock final classes
-        // entityFactory and FormFactory are only used in specific scenarios
-        $entityFactory = $this->createEntityFactoryStub();
+        $this->entityFactory = $this->createMock(EntityFactoryInterface::class);
         $formFactory = $this->createFormFactoryStub();
 
         $this->entityRepository = new EntityRepository(
             $this->adminContextProvider,
             $this->doctrine,
-            $entityFactory,
+            $this->entityFactory,
             $formFactory,
             $this->eventDispatcher
         );
@@ -229,7 +227,7 @@ class EntityRepositoryTest extends TestCase
 
     public function testCustomSortByExposedSortableFieldIsApplied(): void
     {
-        $entityDto = $this->createEntityDto(['displayedField']);
+        $entityDto = $this->createEntityDto(['displayedField' => ['type' => 'string']]);
         $fields = new FieldCollection([$this->createField('displayedField', true)]);
         $searchDto = $this->createSearchDtoForSort(customSort: ['displayedField' => 'ASC']);
 
@@ -247,7 +245,7 @@ class EntityRepositoryTest extends TestCase
     {
         // simulates ?sort[hiddenField]=ASC against a controller whose
         // configureFields(INDEX) doesn't expose `hiddenField`
-        $entityDto = $this->createEntityDto(['hiddenField']);
+        $entityDto = $this->createEntityDto(['hiddenField' => ['type' => 'string']]);
         $fields = new FieldCollection([]);
         $searchDto = $this->createSearchDtoForSort(customSort: ['hiddenField' => 'ASC']);
 
@@ -261,7 +259,7 @@ class EntityRepositoryTest extends TestCase
 
     public function testCustomSortByExplicitlyNonSortableFieldIsIgnored(): void
     {
-        $entityDto = $this->createEntityDto(['displayedField']);
+        $entityDto = $this->createEntityDto(['displayedField' => ['type' => 'string']]);
         $fields = new FieldCollection([$this->createField('displayedField', false)]);
         $searchDto = $this->createSearchDtoForSort(customSort: ['displayedField' => 'ASC']);
 
@@ -276,7 +274,7 @@ class EntityRepositoryTest extends TestCase
     public function testCustomSortKeyContainingCommaIsIgnored(): void
     {
         // ?sort[name,entity.email]=ASC — comma would smuggle an extra ORDER BY column
-        $entityDto = $this->createEntityDto(['displayedField']);
+        $entityDto = $this->createEntityDto(['displayedField' => ['type' => 'string']]);
         $fields = new FieldCollection([$this->createField('displayedField', true)]);
         $searchDto = $this->createSearchDtoForSort(customSort: ['displayedField,entity.hiddenField' => 'ASC']);
 
@@ -293,7 +291,7 @@ class EntityRepositoryTest extends TestCase
         // ?sort[customer.secretField]=ASC — multi-segment keys reach the unfiltered
         // multi-segment branch of applyOrderClause; URL-based association sort is
         // supported via single-segment keys + AssociationField::setSortProperty()
-        $entityDto = $this->createEntityDto([], ['customer']);
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
         $fields = new FieldCollection([$this->createField('customer', true)]);
         $searchDto = $this->createSearchDtoForSort(customSort: ['customer.secretField' => 'ASC']);
 
@@ -311,7 +309,7 @@ class EntityRepositoryTest extends TestCase
         // ?sort[displayedField]=ASC,%20entity.hiddenField%20DESC — Expr\OrderBy
         // concatenates "$property $direction", so an unvalidated direction smuggles
         // a second OrderByItem that the DQL parser happily accepts
-        $entityDto = $this->createEntityDto(['displayedField']);
+        $entityDto = $this->createEntityDto(['displayedField' => ['type' => 'string']]);
         $fields = new FieldCollection([$this->createField('displayedField', true)]);
         $searchDto = $this->createSearchDtoForSort(customSort: ['displayedField' => 'ASC, entity.hiddenField DESC']);
 
@@ -327,7 +325,7 @@ class EntityRepositoryTest extends TestCase
     {
         // ?sort[hiddenField]=ASC must not suppress setDefaultSort(['hiddenField' => 'DESC']):
         // the customSort entry is rejected, the defaultSort entry still applies
-        $entityDto = $this->createEntityDto(['hiddenField']);
+        $entityDto = $this->createEntityDto(['hiddenField' => ['type' => 'string']]);
         $fields = new FieldCollection([]);
         $searchDto = $this->createSearchDtoForSort(
             customSort: ['hiddenField' => 'ASC'],
@@ -347,7 +345,7 @@ class EntityRepositoryTest extends TestCase
     public function testDefaultSortByFieldAbsentFromFieldCollectionIsStillApplied(): void
     {
         // developer-supplied default sort is trusted unconditionally
-        $entityDto = $this->createEntityDto(['createdAt']);
+        $entityDto = $this->createEntityDto(['createdAt' => ['type' => 'date_time']]);
         $fields = new FieldCollection([]);
         $searchDto = $this->createSearchDtoForSort(defaultSort: ['createdAt' => 'DESC']);
 
@@ -363,7 +361,7 @@ class EntityRepositoryTest extends TestCase
 
     public function testValidCustomSortOverridesDefaultSortForSameKey(): void
     {
-        $entityDto = $this->createEntityDto(['displayedField']);
+        $entityDto = $this->createEntityDto(['displayedField' => ['type' => 'string']]);
         $fields = new FieldCollection([$this->createField('displayedField', true)]);
         $searchDto = $this->createSearchDtoForSort(
             customSort: ['displayedField' => 'ASC'],
@@ -378,6 +376,91 @@ class EntityRepositoryTest extends TestCase
         $this->stubEntityManager($queryBuilder);
 
         $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testResolveNestedAssociationsWithSimpleProperty(): void
+    {
+        $rootEntityDto = $this->createEntityDto(['title' => ['type' => 'string']], [], 'App\Entity\Post');
+
+        $resolved = $this->entityRepository->resolveNestedAssociations(null, $rootEntityDto, 'title');
+
+        self::assertSame($rootEntityDto, $resolved['entity_dto']);
+        self::assertSame('entity', $resolved['entity_alias']);
+        self::assertSame('title', $resolved['property_name']);
+    }
+
+    public function testResolveNestedAssociationsWithNestedProperty(): void
+    {
+        $authorEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\User');
+        $rootEntityDto = $this->createEntityDto([], ['author' => 'App\Entity\User'], 'App\Entity\Post');
+
+        $this->entityFactory->expects(self::once())
+            ->method('create')
+            ->with('App\Entity\User')
+            ->willReturn($authorEntityDto);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->expects(self::once())
+            ->method('leftJoin')
+            ->with('entity.author', 'author');
+
+        $resolved = $this->entityRepository->resolveNestedAssociations($queryBuilder, $rootEntityDto, 'author.name');
+
+        self::assertSame($authorEntityDto, $resolved['entity_dto']);
+        self::assertSame('author', $resolved['entity_alias']);
+        self::assertSame('name', $resolved['property_name']);
+    }
+
+    public function testResolveNestedAssociationsEndingWithAssociation(): void
+    {
+        $categoryEntityDto = $this->createEntityDto([], ['parent' => 'App\Entity\Category'], 'App\Entity\Category');
+        $rootEntityDto = $this->createEntityDto([], ['category' => 'App\Entity\Category'], 'App\Entity\Post');
+
+        $this->entityFactory->expects(self::once())
+            ->method('create')
+            ->with('App\Entity\Category')
+            ->willReturn($categoryEntityDto);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->expects(self::once())
+            ->method('leftJoin')
+            ->with('entity.category', 'category');
+
+        $resolved = $this->entityRepository->resolveNestedAssociations(
+            $queryBuilder,
+            $rootEntityDto,
+            'category.parent',
+            true
+        );
+
+        self::assertSame($categoryEntityDto, $resolved['entity_dto']);
+        self::assertSame('category', $resolved['entity_alias']);
+        self::assertSame('parent', $resolved['property_name']);
+    }
+
+    public function testResolveNestedAssociationsDoesNotDuplicateJoins(): void
+    {
+        $authorEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\User');
+        $rootEntityDto = $this->createEntityDto([], ['author' => 'App\Entity\User'], 'App\Entity\Post');
+
+        $this->entityFactory->method('create')->willReturn($authorEntityDto);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->expects(self::once())->method('leftJoin');
+
+        // This is called 2 times with the same parameters on purpose to verify it's only joined once.
+        $this->entityRepository->resolveNestedAssociations($queryBuilder, $rootEntityDto, 'author.name');
+        $this->entityRepository->resolveNestedAssociations($queryBuilder, $rootEntityDto, 'author.name');
+    }
+
+    public function testResolveNestedAssociationsThrowsOnInvalidProperty(): void
+    {
+        $rootEntityDto = $this->createEntityDto(['title' => ['type' => 'string']], [], 'App\Entity\Post');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "invalid" property is not valid');
+
+        $this->entityRepository->resolveNestedAssociations(null, $rootEntityDto, 'invalid');
     }
 
     private function createSearchDto(string $query = '', array $sort = [], ?array $appliedFilters = []): SearchDto
@@ -401,20 +484,22 @@ class EntityRepositoryTest extends TestCase
         return new SearchDto(new Request(), null, '', $defaultSort, $customSort, []);
     }
 
-    /**
-     * @param list<string> $mappedFields
-     * @param list<string> $mappedAssociations
-     */
-    private function createEntityDto(array $mappedFields = [], array $mappedAssociations = []): EntityDto
+    private function createEntityDto(array $mappedFields = [], array $mappedAssociations = [], string $fqcn = 'App\Entity\Product'): EntityDto
     {
         $metadata = $this->createMock(ClassMetadata::class);
         $metadata->method('getSingleIdentifierFieldName')->willReturn('id');
-        $metadata->method('hasField')->willReturnCallback(static fn (string $name): bool => \in_array($name, $mappedFields, true));
-        $metadata->method('hasAssociation')->willReturnCallback(static fn (string $name): bool => \in_array($name, $mappedAssociations, true));
-        $metadata->method('getFieldNames')->willReturn($mappedFields);
-        $metadata->fieldMappings = array_fill_keys($mappedFields, []);
+        $metadata->method('hasField')->willReturnCallback(static fn (string $name): bool => isset($mappedFields[$name]));
+        $metadata->method('hasAssociation')->willReturnCallback(static fn (string $name): bool => isset($mappedAssociations[$name]));
+        $metadata->method('getFieldNames')->willReturn(array_keys($mappedFields));
+        $metadata->method('getFieldMapping')->willReturnCallback(
+            static fn (string $name): array => $mappedFields[$name] ?? throw new \InvalidArgumentException()
+        );
+        $metadata->method('getAssociationTargetClass')->willReturnCallback(
+            static fn (string $name): string => $mappedAssociations[$name] ?? throw new \InvalidArgumentException()
+        );
+        $metadata->fieldMappings = $mappedFields;
 
-        return new EntityDto('App\Entity\Product', $metadata);
+        return new EntityDto($fqcn, $metadata);
     }
 
     private function createField(string $property, bool $sortable): FieldInterface
@@ -444,15 +529,6 @@ class EntityRepositoryTest extends TestCase
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->method('createQueryBuilder')->willReturn($queryBuilder);
         $this->doctrine->method('getManagerForClass')->willReturn($entityManager);
-    }
-
-    /**
-     * Creates a stub for EntityFactory using reflection since it's a final class.
-     */
-    private function createEntityFactoryStub(): EntityFactory
-    {
-        return (new \ReflectionClass(EntityFactory::class))
-            ->newInstanceWithoutConstructor();
     }
 
     /**


### PR DESCRIPTION
Same as https://github.com/EasyCorp/EasyAdminBundle/pull/7295 with a different approach.

Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/7452, https://github.com/EasyCorp/EasyAdminBundle/issues/6664 and https://github.com/EasyCorp/EasyAdminBundle/issues/7514

In `resolveNestedAssociations()` I have extracted the logic handling nested associations from search to make it reusable.
It also properly handles doctrine embeddables.

It's now possible to use associations in filters using the dot syntax:

```php
    public function configureFilters(Filters $filters): Filters
    {
        return $filters
            // author is an association
            ->add(TextFilter::new('author.fullName', 'Author name'))
            // address is an Embeddable
            ->add(TextFilter::new('author.address.country', 'Author country'));
    }
```

This PR also includes contributions from @KDederichs to reuse `resolveNestedAssociations()` and fix usage of nested associations in `AssociationField` and `CollectionField`