### PR TITLE
Fix test bootstrap crash on PHP < 8.4 due to enable_native_lazy_objects

### DIFF
--- a/tests/Functional/Apps/AdminRouteApp/config/packages/doctrine.php
+++ b/tests/Functional/Apps/AdminRouteApp/config/packages/doctrine.php
@@ -30,7 +30,7 @@ return static function (ContainerConfigurator $container) {
             ];
 
             $doctrineOrmVersion = Composer\InstalledVersions::getVersion('doctrine/orm');
-            if (null !== $doctrineOrmVersion && version_compare($doctrineOrmVersion, '3.4.0', '>=')) {
+            if (null !== $doctrineOrmVersion && version_compare($doctrineOrmVersion, '3.4.0', '>=') && \PHP_VERSION_ID >= 80400) {
                 $config['orm']['enable_native_lazy_objects'] = true;
             }
         }

--- a/tests/Functional/Apps/CustomizationApp/config/packages/doctrine.php
+++ b/tests/Functional/Apps/CustomizationApp/config/packages/doctrine.php
@@ -30,7 +30,7 @@ if (class_exists(Composer\InstalledVersions::class)) {
         ];
 
         $doctrineOrmVersion = Composer\InstalledVersions::getVersion('doctrine/orm');
-        if (null !== $doctrineOrmVersion && version_compare($doctrineOrmVersion, '3.4.0', '>=')) {
+        if (null !== $doctrineOrmVersion && version_compare($doctrineOrmVersion, '3.4.0', '>=') && \PHP_VERSION_ID >= 80400) {
             $config['orm']['enable_native_lazy_objects'] = true;
         }
     }

--- a/tests/Functional/Apps/DefaultApp/config/packages/doctrine.php
+++ b/tests/Functional/Apps/DefaultApp/config/packages/doctrine.php
@@ -30,7 +30,7 @@ if (class_exists(Composer\InstalledVersions::class)) {
         ];
 
         $doctrineOrmVersion = Composer\InstalledVersions::getVersion('doctrine/orm');
-        if (null !== $doctrineOrmVersion && version_compare($doctrineOrmVersion, '3.4.0', '>=')) {
+        if (null !== $doctrineOrmVersion && version_compare($doctrineOrmVersion, '3.4.0', '>=') && \PHP_VERSION_ID >= 80400) {
             $config['orm']['enable_native_lazy_objects'] = true;
         }
     }

--- a/tests/Functional/Apps/SecuredApp/config/packages/doctrine.php
+++ b/tests/Functional/Apps/SecuredApp/config/packages/doctrine.php
@@ -30,7 +30,7 @@ if (class_exists(Composer\InstalledVersions::class)) {
         ];
 
         $doctrineOrmVersion = Composer\InstalledVersions::getVersion('doctrine/orm');
-        if (null !== $doctrineOrmVersion && version_compare($doctrineOrmVersion, '3.4.0', '>=')) {
+        if (null !== $doctrineOrmVersion && version_compare($doctrineOrmVersion, '3.4.0', '>=') && \PHP_VERSION_ID >= 80400) {
             $config['orm']['enable_native_lazy_objects'] = true;
         }
     }


### PR DESCRIPTION
## Summary

- Adds a `\PHP_VERSION_ID >= 80400` check before enabling `enable_native_lazy_objects` in test app Doctrine configurations
- Fixes test suite bootstrap crash when running on PHP 8.2/8.3 via DDEV

Fixes #7501