### PR TITLE
menu.html.twig: avoid rendering empty style attribute in menu badges …

### DIFF
--- a/templates/menu.html.twig
+++ b/templates/menu.html.twig
@@ -49,7 +49,7 @@
                 {{ item.label|trans|raw }}
             </span>
             {% if item.badge %}
-                <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" {{ _self.render_html_attributes(item.badge) }} style="{{ item.badge.htmlStyle }}">{{ item.badge.content }}</span>
+                <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" {{ _self.render_html_attributes(item.badge) }} {{ item.badge.htmlStyle ? 'style="' ~ item.badge.htmlStyle ~ '"' : '' }}">{{ item.badge.content }}</span>
             {% endif %}
         </span>
     {% else %}
@@ -60,7 +60,7 @@
             </span>
             {% if item.hasSubItems %}<twig:ea:Icon name="internal:chevron-right" class="submenu-toggle-icon" />{% endif %}
             {% if item.hasVisibleBadge %}
-                <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" {{ _self.render_html_attributes(item.badge) }} style="{{ item.badge.htmlStyle }}">{{ item.badge.content }}</span>
+                <span class="menu-item-badge rounded-pill badge {{ item.badge.cssClass }}" {{ _self.render_html_attributes(item.badge) }} {{ item.badge.htmlStyle ? 'style="' ~ item.badge.htmlStyle ~ '"' : '' }}">{{ item.badge.content }}</span>
             {% endif %}
         </a>
     {% endif %}


### PR DESCRIPTION
…(CSP compatibility)

EasyAdmin always rendered a `style` attribute for menu item badges, even when `item.badge.htmlStyle` was empty. This produced `style=""`, which still counts as inline CSS and violates strict Content Security Policies (CSP) that do not allow `unsafe-inline`.  
The style attribute is now only rendered when a non-empty value is provided.
