### PR TITLE
Adjust DDEV for EasyAdmin 5.x

### DIFF
--- a/.ddev/commands/web/build-assets
+++ b/.ddev/commands/web/build-assets
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+echo 'Deprecation notice: The "ddev build-assets" command is deprecated'
+echo 'Please use "ddev make build" and "ddev make build-assets" instead'
+echo ""
+
 cd ../easyadminbundle
-yarn install
-yarn encore production
-php ./src/Resources/bin/fix-assets-manifest-file.php
-../html/bin/console assets:install --symlink
+make build
+make build-assets

--- a/.ddev/commands/web/make
+++ b/.ddev/commands/web/make
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd ../easyadminbundle
+make $@

--- a/.ddev/commands/web/run-tests
+++ b/.ddev/commands/web/run-tests
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo 'Deprecation notice: The "ddev run-tests" command is deprecated'
+echo 'Please use "ddev make tests" instead'
+echo ''
+
 cd ../easyadminbundle
-composer update
-vendor/bin/simple-phpunit -v
+make tests

--- a/.ddev/commands/web/setup
+++ b/.ddev/commands/web/setup
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Installing Symfony Framework
-composer create-project symfony/skeleton:"7.2.*" -n
+composer create-project symfony/skeleton:"8.0.*" -n
 mv -f ./skeleton/* ./
 mv -f ./skeleton/.env ./
 mv -f ./skeleton/.env.dev ./
@@ -29,6 +29,8 @@ ln -s ../../../easyadminbundle/.ddev/example/config/routes/easyadmin.yaml config
 # Initialize DB
 echo 'DATABASE_URL="mysql://db:db@db:3306/db?serverVersion=10.11.0-MariaDB&charset=utf8mb4"' >> .env.local
 ./bin/console doc:sch:up --force
+
+bin/console assets:install --symlink
 
 # Clear Cache
 sleep 2

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,19 +1,20 @@
-name: easy-admin-bundle
-type: php
-docroot: public
+name: "easy-admin-bundle"
+type: "php"
+docroot: "public"
 no_project_mount: true
-php_version: "8.3"
-webserver_type: apache-fpm
+php_version: "8.5"
+webserver_type: "apache-fpm"
 router_http_port: "80"
 router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 database:
-  type: mariadb
+  type: "mariadb"
   version: "10.11"
 use_dns_when_possible: true
 composer_version: "2"
 web_environment: []
+webimage_extra_packages: ["build-essential"]
 nodejs_version: "22"
 timezone: "Europe/Berlin"

--- a/.ddev/example/Controller/Admin/DashboardController.php
+++ b/.ddev/example/Controller/Admin/DashboardController.php
@@ -7,15 +7,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
 
-#[AdminDashboard]
+#[AdminDashboard(routePath: '/', routeName: 'admin')]
 class DashboardController extends AbstractDashboardController
 {
-    #[Route('/', name: 'admin')]
     public function index(): Response
     {
-        return $this->render('@EasyAdmin/page/content.html.twig');
+        return $this->render('@EasyAdmin/layout.html.twig');
     }
 
     public function configureDashboard(): Dashboard

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ Symfony Framework project providing example entities and CRUD Controllers.
 * Checkout the EasyAdmin git repository and switch in the project directory
 * Perform `ddev setup` which starts and provisions the web container
 * EasyAdmin is available under the URL: https://easy-admin-bundle.ddev.site
-* To (re-)build frontend assets perform `ddev build-assets`
-* To run unit tests perform `ddev run-tests`
+* With `ddev make <target>` you can execute predefined tasks from [`Makefile`](./Makefile). Examples:
+  * To update dependencies (Composer and Yarn): `ddev make build`
+  * To (re-)build frontend assets perform `ddev make build-assets`
+  * To run unit tests perform `ddev make tests`
 
 ## Resources
 


### PR DESCRIPTION
Also, added "ddev make" command to run the original defined tasks from Makefile directly and marked existing commands "build-assets" and "run-tests" as deprecated.

Raised PHP version to 8.5
Using Symfony 8.0
