### PR TITLE
Fix filter label translation when field is hidden via hideOnIndex

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -337,6 +337,7 @@ return static function (ContainerConfigurator $container) {
         ->set(ChoiceFilterConfigurator::class)
 
         ->set(CommonFilterConfigurator::class)
+            ->arg(0, service(EntityTranslationIdGeneratorInterface::class))
             ->tag(EasyAdminExtension::TAG_FILTER_CONFIGURATOR, ['priority' => 9999])
 
         ->set(ComparisonFilterConfigurator::class)

--- a/src/Filter/Configurator/CommonConfigurator.php
+++ b/src/Filter/Configurator/CommonConfigurator.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
 
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
@@ -13,8 +14,13 @@ use Symfony\Component\Translation\TranslatableMessage;
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  */
-final class CommonConfigurator implements FilterConfiguratorInterface
+final readonly class CommonConfigurator implements FilterConfiguratorInterface
 {
+    public function __construct(
+        private EntityTranslationIdGeneratorInterface $entityTranslationIdGenerator,
+    ) {
+    }
+
     public function supports(FilterDto $filterDto, ?FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): bool
     {
         return true;
@@ -27,7 +33,15 @@ final class CommonConfigurator implements FilterConfiguratorInterface
             if ($fieldLabel instanceof TranslatableMessage) {
                 $fieldLabel = $fieldLabel->getMessage();
             }
-            $label = $fieldLabel ?? LabelGenerator::humanize($filterDto->getProperty());
+
+            if (null !== $fieldLabel) {
+                $label = $fieldLabel;
+            } elseif ($context->isUseEntityTranslations()) {
+                $label = $this->entityTranslationIdGenerator->generateForProperty($entityDto->getFqcn(), $filterDto->getProperty());
+            } else {
+                $label = LabelGenerator::humanize($filterDto->getProperty());
+            }
+
             $filterDto->setLabel($label);
         }
     }

--- a/tests/Unit/Filter/Configurator/CommonConfiguratorTest.php
+++ b/tests/Unit/Filter/Configurator/CommonConfiguratorTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Filter\Configurator;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\DashboardContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\I18nContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\RequestContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator\CommonConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Translation\TranslatableMessage;
+
+class CommonConfiguratorTest extends TestCase
+{
+    private EntityDto $entityDto;
+
+    protected function setUp(): void
+    {
+        $metadata = new ClassMetadata('App\Entity\Product');
+        $metadata->setIdentifier(['id']);
+        $this->entityDto = new EntityDto('App\Entity\Product', $metadata);
+    }
+
+    public function testSupportsAllFilters(): void
+    {
+        $configurator = $this->createConfigurator();
+        $filter = TextFilter::new('name');
+        $filterDto = $filter->getAsDto();
+        $adminContext = $this->createAdminContext();
+
+        $this->assertTrue($configurator->supports($filterDto, null, $this->entityDto, $adminContext));
+    }
+
+    public function testConfigureUsesFieldLabelWhenAvailable(): void
+    {
+        $configurator = $this->createConfigurator();
+        $filter = TextFilter::new('name');
+        $filterDto = $filter->getAsDto();
+
+        $field = TextField::new('name', 'Product Name');
+        $fieldDto = $field->getAsDto();
+
+        $adminContext = $this->createAdminContext();
+
+        $configurator->configure($filterDto, $fieldDto, $this->entityDto, $adminContext);
+
+        $this->assertSame('Product Name', $filterDto->getLabel());
+    }
+
+    public function testConfigureUsesFieldTranslatableMessageLabel(): void
+    {
+        $configurator = $this->createConfigurator();
+        $filter = TextFilter::new('name');
+        $filterDto = $filter->getAsDto();
+
+        $field = TextField::new('name');
+        $fieldDto = $field->getAsDto();
+        $fieldDto->setLabel(new TranslatableMessage('product.name'));
+
+        $adminContext = $this->createAdminContext();
+
+        $configurator->configure($filterDto, $fieldDto, $this->entityDto, $adminContext);
+
+        $this->assertSame('product.name', $filterDto->getLabel());
+    }
+
+    public function testConfigureHumanizesLabelWhenFieldIsNullAndEntityTranslationsDisabled(): void
+    {
+        $configurator = $this->createConfigurator();
+        $filter = TextFilter::new('productName');
+        $filterDto = $filter->getAsDto();
+
+        $adminContext = $this->createAdminContext(useEntityTranslations: false);
+
+        $configurator->configure($filterDto, null, $this->entityDto, $adminContext);
+
+        $this->assertSame('Product Name', $filterDto->getLabel());
+    }
+
+    public function testConfigureUsesEntityTranslationWhenFieldIsNullAndEntityTranslationsEnabled(): void
+    {
+        $expectedTranslationId = 'entities.App\\Entity\\Product.properties.productName';
+
+        $generator = $this->createMock(EntityTranslationIdGeneratorInterface::class);
+        $generator->expects($this->once())
+            ->method('generateForProperty')
+            ->with('App\Entity\Product', 'productName')
+            ->willReturn($expectedTranslationId);
+
+        $configurator = new CommonConfigurator($generator);
+        $filter = TextFilter::new('productName');
+        $filterDto = $filter->getAsDto();
+
+        $adminContext = $this->createAdminContext(useEntityTranslations: true);
+
+        $configurator->configure($filterDto, null, $this->entityDto, $adminContext);
+
+        $this->assertSame($expectedTranslationId, $filterDto->getLabel());
+    }
+
+    public function testConfigureDoesNotOverrideExplicitFilterLabel(): void
+    {
+        $configurator = $this->createConfigurator();
+        $filter = TextFilter::new('name')->setLabel('Custom Label');
+        $filterDto = $filter->getAsDto();
+
+        $adminContext = $this->createAdminContext();
+
+        $configurator->configure($filterDto, null, $this->entityDto, $adminContext);
+
+        $this->assertSame('Custom Label', $filterDto->getLabel());
+    }
+
+    private function createConfigurator(): CommonConfigurator
+    {
+        $generator = $this->createMock(EntityTranslationIdGeneratorInterface::class);
+
+        return new CommonConfigurator($generator);
+    }
+
+    private function createAdminContext(bool $useEntityTranslations = false): AdminContext
+    {
+        $dashboardDto = Dashboard::new()->getAsDto();
+        if ($useEntityTranslations) {
+            $dashboardDto->setUseEntityTranslations(true);
+        }
+
+        return AdminContext::forTesting(
+            RequestContext::forTesting(new Request()),
+            null,
+            DashboardContext::forTesting($dashboardDto),
+            I18nContext::forTesting('en', 'ltr')
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- When `useEntityTranslation` is enabled and a field is hidden via `hideOnIndex()`, the corresponding filter label was not translated
- The issue was in `CommonConfigurator`: when `$fieldDto` is null (field not in collection), it fell back to `LabelGenerator::humanize()` instead of using the entity translation system
- Now `CommonConfigurator` uses `EntityTranslationIdGenerator` to generate the proper translation key when the field is not available

## Test plan

- [x] Added unit tests for `CommonConfigurator`
- [x] Tests cover: field label available, TranslatableMessage label, humanized label (no entity translations), entity translation key (with entity translations enabled)
- [ ] Manual testing with `useEntityTranslation` enabled and a field hidden via `hideOnIndex()`

Fix #7512