### PR TITLE
Fix filter labels not translated with correct domain

### DIFF
--- a/src/Filter/Configurator/CommonConfigurator.php
+++ b/src/Filter/Configurator/CommonConfigurator.php
@@ -9,7 +9,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDto;
 use EasyCorp\Bundle\EasyAdminBundle\Generator\LabelGenerator;
-use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use function Symfony\Component\Translation\t;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -30,16 +31,16 @@ final class CommonConfigurator implements FilterConfiguratorInterface
     {
         if (null === $filterDto->getLabel()) {
             $fieldLabel = $fieldDto?->getLabel();
-            if ($fieldLabel instanceof TranslatableMessage) {
-                $fieldLabel = $fieldLabel->getMessage();
-            }
+            $translationDomain = $context->getI18n()->getTranslationDomain();
 
-            if (null !== $fieldLabel) {
+            if ($fieldLabel instanceof TranslatableInterface) {
                 $label = $fieldLabel;
+            } elseif (null !== $fieldLabel) {
+                $label = t($fieldLabel, [], $translationDomain);
             } elseif ($context->isUseEntityTranslations()) {
                 $label = $this->entityTranslationIdGenerator->generateForProperty($entityDto->getFqcn(), $filterDto->getProperty());
             } else {
-                $label = LabelGenerator::humanize($filterDto->getProperty());
+                $label = t(LabelGenerator::humanize($filterDto->getProperty()), [], $translationDomain);
             }
 
             $filterDto->setLabel($label);

--- a/tests/Unit/Filter/Configurator/CommonConfiguratorTest.php
+++ b/tests/Unit/Filter/Configurator/CommonConfiguratorTest.php
@@ -38,7 +38,7 @@ class CommonConfiguratorTest extends TestCase
         $this->assertTrue($configurator->supports($filterDto, null, $this->entityDto, $adminContext));
     }
 
-    public function testConfigureUsesFieldLabelWhenAvailable(): void
+    public function testConfigureUsesFieldLabelAndWrapsInTranslatable(): void
     {
         $configurator = $this->createConfigurator();
         $filter = TextFilter::new('name');
@@ -51,37 +51,61 @@ class CommonConfiguratorTest extends TestCase
 
         $configurator->configure($filterDto, $fieldDto, $this->entityDto, $adminContext);
 
-        $this->assertSame('Product Name', $filterDto->getLabel());
+        $label = $filterDto->getLabel();
+        $this->assertInstanceOf(TranslatableMessage::class, $label);
+        $this->assertSame('Product Name', $label->getMessage());
     }
 
-    public function testConfigureUsesFieldTranslatableMessageLabel(): void
+    public function testConfigurePreservesTranslatableInterfaceFromField(): void
     {
         $configurator = $this->createConfigurator();
         $filter = TextFilter::new('name');
         $filterDto = $filter->getAsDto();
 
+        $translatableLabel = new TranslatableMessage('product.name', [], 'messages');
         $field = TextField::new('name');
         $fieldDto = $field->getAsDto();
-        $fieldDto->setLabel(new TranslatableMessage('product.name'));
+        $fieldDto->setLabel($translatableLabel);
 
         $adminContext = $this->createAdminContext();
 
         $configurator->configure($filterDto, $fieldDto, $this->entityDto, $adminContext);
 
-        $this->assertSame('product.name', $filterDto->getLabel());
+        $this->assertSame($translatableLabel, $filterDto->getLabel());
     }
 
-    public function testConfigureHumanizesLabelWhenFieldIsNullAndEntityTranslationsDisabled(): void
+    public function testConfigureHumanizesLabelAndWrapsInTranslatable(): void
     {
         $configurator = $this->createConfigurator();
         $filter = TextFilter::new('productName');
         $filterDto = $filter->getAsDto();
 
-        $adminContext = $this->createAdminContext(useEntityTranslations: false);
+        $adminContext = $this->createAdminContext();
 
         $configurator->configure($filterDto, null, $this->entityDto, $adminContext);
 
-        $this->assertSame('Product Name', $filterDto->getLabel());
+        $label = $filterDto->getLabel();
+        $this->assertInstanceOf(TranslatableMessage::class, $label);
+        $this->assertSame('Product Name', $label->getMessage());
+    }
+
+    public function testConfigureUsesCorrectTranslationDomain(): void
+    {
+        $configurator = $this->createConfigurator();
+        $filter = TextFilter::new('name');
+        $filterDto = $filter->getAsDto();
+
+        $field = TextField::new('name', 'custom.translation.key');
+        $fieldDto = $field->getAsDto();
+
+        $adminContext = $this->createAdminContext(translationDomain: 'my_domain');
+
+        $configurator->configure($filterDto, $fieldDto, $this->entityDto, $adminContext);
+
+        $label = $filterDto->getLabel();
+        $this->assertInstanceOf(TranslatableMessage::class, $label);
+        $this->assertSame('custom.translation.key', $label->getMessage());
+        $this->assertSame('my_domain', $label->getDomain());
     }
 
     public function testConfigureUsesEntityTranslationWhenFieldIsNullAndEntityTranslationsEnabled(): void
@@ -125,7 +149,7 @@ class CommonConfiguratorTest extends TestCase
         return new CommonConfigurator($generator);
     }
 
-    private function createAdminContext(bool $useEntityTranslations = false): AdminContext
+    private function createAdminContext(bool $useEntityTranslations = false, string $translationDomain = 'messages'): AdminContext
     {
         $dashboardDto = Dashboard::new()->getAsDto();
         if ($useEntityTranslations) {
@@ -136,7 +160,7 @@ class CommonConfiguratorTest extends TestCase
             RequestContext::forTesting(new Request()),
             null,
             DashboardContext::forTesting($dashboardDto),
-            I18nContext::forTesting('en', 'ltr')
+            I18nContext::forTesting('en', 'ltr', $translationDomain)
         );
     }
 }


### PR DESCRIPTION
## Summary

- Filter labels were not being translated the same way as on other CRUD pages (index, edit, etc.)
- The issue was that `CommonConfigurator` passed plain strings as labels, but filters use `translation_domain: EasyAdminBundle`
- This caused labels like `command.label.lastRunAt` to be looked up in `EasyAdminBundle` domain instead of the application's domain

**Changes:**
- Preserve `TranslatableInterface` labels from fields instead of extracting the message
- Wrap string labels in `t()` with the application's translation domain from `$context->getI18n()->getTranslationDomain()`

## Test plan

- [x] Added unit tests for `CommonConfigurator`
- [x] Tests verify that labels are wrapped in `TranslatableInterface`
- [x] Tests verify that the correct translation domain is used
- [ ] Manual testing with custom translation keys in filters

Fix #7373