### PR TITLE
Add choice_label support to CrudAutocompleteType

### DIFF
--- a/src/Form/EventListener/CrudAutocompleteSubscriber.php
+++ b/src/Form/EventListener/CrudAutocompleteSubscriber.php
@@ -43,16 +43,20 @@ class CrudAutocompleteSubscriber implements EventSubscriberInterface
         // the renderAsHtml flag controls how TomSelect renders the item (via data-ea-autocomplete-render-items-as-html).
         $callback = $options['autocomplete_callback'] ?? null;
         $template = $options['autocomplete_template'] ?? null;
+        $choiceLabel = $options['choice_label'] ?? null;
 
-        if (null !== $template) {
-            $twig = $this->twig;
-            $options['choice_label'] = static function ($entity) use ($twig, $template): string {
-                return $twig->render($template, ['entity' => $entity]);
-            };
-        } elseif (null !== $callback) {
-            $options['choice_label'] = static function ($entity) use ($callback): string {
-                return (string) $callback($entity);
-            };
+        // only generate choice_label from template/callback if not already set by the user
+        if (null === $choiceLabel) {
+            if (null !== $template) {
+                $twig = $this->twig;
+                $options['choice_label'] = static function ($entity) use ($twig, $template): string {
+                    return $twig->render($template, ['entity' => $entity]);
+                };
+            } elseif (null !== $callback) {
+                $options['choice_label'] = static function ($entity) use ($callback): string {
+                    return (string) $callback($entity);
+                };
+            }
         }
 
         // remove custom options before passing to EntityType
@@ -60,6 +64,12 @@ class CrudAutocompleteSubscriber implements EventSubscriberInterface
             $options['autocomplete_callback'],
             $options['autocomplete_template']
         );
+
+        // Don't pass null choice_label to EntityType - let it use __toString() default
+        // (passing null explicitly behaves differently than omitting the option in Symfony < 8.1)
+        if (null === ($options['choice_label'] ?? null)) {
+            unset($options['choice_label']);
+        }
 
         $form->add('autocomplete', EntityType::class, $options);
     }

--- a/src/Form/Type/CrudAutocompleteType.php
+++ b/src/Form/Type/CrudAutocompleteType.php
@@ -48,11 +48,14 @@ class CrudAutocompleteType extends AbstractType implements DataMapperInterface
             // options for custom rendering of selected items (to match the rendering of the other entries in the dropdown)
             'autocomplete_callback' => null,
             'autocomplete_template' => null,
+            // allow choice_label to customize how selected items are displayed
+            'choice_label' => null,
         ]);
 
         $resolver->setRequired(['class']);
         $resolver->setAllowedTypes('autocomplete_callback', ['null', 'callable']);
         $resolver->setAllowedTypes('autocomplete_template', ['null', 'string']);
+        $resolver->setAllowedTypes('choice_label', ['null', 'string', 'callable', 'bool']);
     }
 
     public function getBlockPrefix(): string


### PR DESCRIPTION
## Summary

When using `EntityFilter` with `->autocomplete()` and a custom `choice_label`, the form crashed with:

```
The option "choice_label" does not exist.
```

**Root cause:** `CrudAutocompleteType` did not define `choice_label` as a valid option.

**Changes:**
- Add `choice_label` option to `CrudAutocompleteType` (supports `null`, `string`, `callable`, `bool`)
- Update `CrudAutocompleteSubscriber` to preserve user-defined `choice_label` instead of overwriting it

**Usage example:**
```php
public function configureFilters(Filters $filters): Filters
{
    return $filters
        ->add(EntityFilter::new('plan')
            ->autocomplete()
            ->setFormTypeOption('value_type_options', [
                'choice_label' => static function (Plan $plan) {
                    return $plan->name . ' [' . $plan->project->getName() . ']';
                },
            ])
        );
}
```

## Test plan

- [ ] Manual testing with EntityFilter + autocomplete + custom choice_label

Fix #7462