### PR TITLE
Prevent EntityDto::getActions() TypeError

### DIFF
--- a/src/Dto/EntityDto.php
+++ b/src/Dto/EntityDto.php
@@ -19,7 +19,7 @@ final class EntityDto implements \Stringable
     private bool $isAccessible = true;
     private mixed $primaryKeyValue = null;
     private ?FieldCollection $fields = null;
-    private ?ActionCollection $actions = null;
+    private ActionCollection $actions;
     private ?string $defaultActionUrl = null;
 
     /**
@@ -33,6 +33,7 @@ final class EntityDto implements \Stringable
         private readonly string|Expression|null $permission = null,
         private ?object $entityInstance = null,
     ) {
+        $this->actions = new ActionCollection();
     }
 
     public function __toString(): string


### PR DESCRIPTION
## Summary

`EntityDto::getActions()` is declared to return `ActionCollection`, but `$actions` was nullable and initialized to `null`.

When `EntityDto` is used before `setActions()` is called, `getActions()` triggers a PHP `TypeError`:

`Return value must be of type ActionCollection, null returned`

I hit this while working with forms in Live Components, where this path can happen more easily.

## Root Cause

The DTO contract says `getActions()` is non-nullable, but internal state allowed `null`.

## Fix

- Make `$actions` non-nullable in `EntityDto`.
- Initialize it in the constructor with an empty `ActionCollection`.

This guarantees `getActions()` always returns a valid collection and aligns runtime behavior with the method signature.

## Impact

- Prevents unrecoverable PHP errors when actions were not explicitly set.
- Keeps behavior backward-compatible (`empty collection` = `no actions`).