### PR TITLE
Fix RepeatedType fields not inheriting Bootstrap column classes

### DIFF
--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -118,6 +118,20 @@
     {% endif %}
 {% endblock form_row %}
 
+{% block repeated_row %}
+    {% set field = form.vars.ea_vars.field %}
+
+    <div class="{{ field.columns ?? field.defaultColumns ?? '' }}">
+        {{- block('form_rows') -}}
+    </div>
+
+    {# if a field doesn't define its columns explicitly, insert a fill element to make the field take the entire row space #}
+    {% if field.columns|default(null) is null %}
+        <div class="flex-fill"></div>
+    {% endif %}
+
+{% endblock repeated_row %}
+
 {% block choice_widget_collapsed %}
     {% if 'ea-autocomplete' == attr['data-ea-widget']|default(false) %}
         {% set attr = attr|merge({


### PR DESCRIPTION
Symfony defines a `repeated_row` block in `form_div_layout.html.twig` hat bypasses `form_row` entirely, rendering only child rows without any column wrapper. This caused fields using RepeatedType (e.g. password confirmation) to lose their Bootstrap grid classes.

Fix by overriding `repeated_row` in EasyAdmin's form theme to apply the same column wrapper logic used in `form_row`.

Fixes [#5676](https://github.com/EasyCorp/EasyAdminBundle/issues/5676)

<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
