### PR TITLE
Check delete action CSRF unconditionally

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -385,7 +385,7 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         $csrfToken = $context->getRequest()->request->has('token')
             ? (string) $context->getRequest()->request->get('token')
             : null;
-        if ($this->container->has('security.csrf.token_manager') && !$this->isCsrfTokenValid('ea-delete', $csrfToken)) {
+        if (!$this->isCsrfTokenValid('ea-delete', $csrfToken)) {
             return $this->redirectToRoute($context->getDashboardRouteName());
         }
 


### PR DESCRIPTION
`delete()` only checks CSRF if the CSRF manager service exists. However, `batchDelete()`, in the same controller, does not have that loophole and checks CSRF unconditionally. Let's do the same in the `delete()` method.