### PR TITLE
Add more security protection to autocomplete action

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -494,6 +494,11 @@ abstract class AbstractCrudController extends AbstractController implements Crud
 
     public function autocomplete(AdminContext $context): JsonResponse
     {
+        // not a typo; we intentionally reuse the INDEX action for permission checks in autocomplete
+        if (!$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => Action::INDEX, 'entity' => null, 'entityFqcn' => $context->getEntity()->getFqcn()])) {
+            throw new ForbiddenActionException($context);
+        }
+
         $queryBuilder = $this->createIndexQueryBuilder($context->getSearch(), $context->getEntity(), new FieldCollection([]), new FilterCollection());
 
         $autocompleteContext = $context->getRequest()->query->all(AssociationField::PARAM_AUTOCOMPLETE_CONTEXT);

--- a/tests/Functional/Apps/SecuredApp/src/Controller/ProtectedCategoryCrudController.php
+++ b/tests/Functional/Apps/SecuredApp/src/Controller/ProtectedCategoryCrudController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\SecuredApp\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Category;
+
+/**
+ * Used by RolePermissionTest to exercise the INDEX-based permission check
+ * inside AbstractCrudController::autocomplete().
+ *
+ * @extends AbstractCrudController<Category>
+ */
+class ProtectedCategoryCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Category::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            IdField::new('id')->hideOnForm(),
+            TextField::new('name'),
+        ];
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions->setPermission(Action::INDEX, 'ROLE_ADMIN');
+    }
+}

--- a/tests/Functional/Security/RolePermissionTest.php
+++ b/tests/Functional/Security/RolePermissionTest.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Security;
 use EasyCorp\Bundle\EasyAdminBundle\Exception\ForbiddenActionException;
 use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\SecuredApp\Controller\CategoryCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\SecuredApp\Controller\ProtectedCategoryCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\SecuredApp\Controller\SecuredDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\SecuredApp\Kernel;
 use Symfony\Component\HttpFoundation\Response;
@@ -128,5 +129,45 @@ class RolePermissionTest extends AbstractCrudTestCase
         yield 'user cannot see protected field' => ['user', false];
         yield 'admin cannot see protected field' => ['admin', false];
         yield 'super_admin can see protected field' => ['super_admin', true];
+    }
+
+    /**
+     * @dataProvider provideRolesForAutocompleteAction
+     */
+    public function testAutocompleteActionPermission(string $username, int $expectedStatusCode): void
+    {
+        if (Response::HTTP_FORBIDDEN === $expectedStatusCode) {
+            $this->expectException(ForbiddenActionException::class);
+            $this->client->catchExceptions(false);
+        }
+
+        $autocompleteUrl = $this->getCrudUrl(
+            'autocomplete',
+            null,
+            [
+                'autocompleteContext[crudControllerFqcn]' => ProtectedCategoryCrudController::class,
+                'autocompleteContext[propertyName]' => 'name',
+                'autocompleteContext[originatingPage]' => 'new',
+            ],
+            SecuredDashboardController::class,
+            ProtectedCategoryCrudController::class,
+        );
+
+        $this->client->request(
+            'GET',
+            $autocompleteUrl,
+            [],
+            [],
+            ['PHP_AUTH_USER' => $username, 'PHP_AUTH_PW' => '1234']
+        );
+
+        static::assertResponseStatusCodeSame($expectedStatusCode);
+    }
+
+    public static function provideRolesForAutocompleteAction(): \Generator
+    {
+        yield 'user role cannot access autocomplete without INDEX permission' => ['user', Response::HTTP_FORBIDDEN];
+        yield 'admin role can access autocomplete with INDEX permission' => ['admin', Response::HTTP_OK];
+        yield 'super_admin role can access autocomplete with INDEX permission' => ['super_admin', Response::HTTP_OK];
     }
 }


### PR DESCRIPTION
The `index`, `detail`, `edit`, `new`, `delete`, and `batchDelete` actions all call

```php
$this->isGranted(Permission::EA_EXECUTE_ACTION, ['action' => Action::…, …]);
```

The `autocomplete` action does **not**. A low-privileged admin user can call the autocomplete endpoint for any CRUD controller FQCN and enumerate related entities (IDs + `__toString()`) they should not be able to see.