### PR TITLE
Improve the security of the Url field

### DIFF
--- a/doc/fields/UrlField.rst
+++ b/doc/fields/UrlField.rst
@@ -23,6 +23,37 @@ Basic Information
 Options
 -------
 
-This field does not define any custom option.
+allowedProtocols
+~~~~~~~~~~~~~~~~
+
+Restricts the protocols accepted as valid input by attaching a Symfony
+``Url`` constraint to the form field. Pass the protocols without the
+trailing colon::
+
+    UrlField::new('homepage')
+        ->allowedProtocols(['http', 'https']);
+
+By default no protocol restriction is applied, so any scheme-looking
+value (like ``ftp://``, ``ssh://`` or ``mailto:``) is accepted. Use this
+option when you know the field should only store web URLs.
+
+Regardless of this option, EasyAdmin always renders known-dangerous
+schemes (``javascript:``, ``data:``, ``vbscript:`` and ``file:``) as
+plain text instead of clickable links, to prevent stored XSS attacks in
+the backend.
+
+setDefaultProtocol
+~~~~~~~~~~~~~~~~~~
+
+Defines the protocol prepended to the submitted value when it doesn't
+include one. If you don't set it, no protocol is prepended and the field
+is rendered using an ``<input type="url">`` element so the browser
+validates the value::
+
+    UrlField::new('homepage')
+        ->setDefaultProtocol('https');
+
+See the `UrlType default_protocol option`_ for details.
 
 .. _`UrlType`: https://symfony.com/doc/current/reference/forms/types/url.html
+.. _`UrlType default_protocol option`: https://symfony.com/doc/current/reference/forms/types/url.html#default-protocol

--- a/src/Field/Configurator/UrlConfigurator.php
+++ b/src/Field/Configurator/UrlConfigurator.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\UrlField;
+use Symfony\Component\Validator\Constraints\Url;
 use function Symfony\Component\String\u;
 
 /**
@@ -15,6 +16,15 @@ use function Symfony\Component\String\u;
  */
 final class UrlConfigurator implements FieldConfiguratorInterface
 {
+    /**
+     * These schemes are considered dangerous and make the URL to not be rendered as a clickable link:
+     *
+     * `javascript:` - executes script in the document's origin on click.
+     * `data:` - `data:text/html,...` renders attacker HTML (and inline script) in the clicked tab.
+     * `vbscript:` - legacy IE / some embedded browsers execute VBScript.
+     */
+    private const DANGEROUS_SCHEMES = ['javascript', 'data', 'vbscript', 'file'];
+
     public function supports(FieldDto $field, EntityDto $entityDto): bool
     {
         return UrlField::class === $field->getFieldFqcn();
@@ -25,7 +35,24 @@ final class UrlConfigurator implements FieldConfiguratorInterface
         $field->setFormTypeOptionIfNotSet('attr.inputmode', 'url');
         $field->setFormTypeOptionIfNotSet('default_protocol', $field->getCustomOption(UrlField::OPTION_DEFAULT_PROTOCOL));
 
-        $prettyUrl = str_replace(['http://www.', 'https://www.', 'http://', 'https://'], '', (string) $field->getValue());
+        $allowedProtocols = $field->getCustomOption(UrlField::OPTION_ALLOWED_PROTOCOLS);
+        if (\is_array($allowedProtocols)) {
+            $constraints = $field->getFormTypeOption('constraints') ?? [];
+            $constraints[] = new Url(protocols: $allowedProtocols);
+            $field->setFormTypeOption('constraints', $constraints);
+        }
+
+        $url = (string) $field->getValue();
+        // browsers strip leading whitespace and control bytes before parsing the scheme,
+        // so the same normalization must happen here before matching against the denylist
+        $normalizedUrl = ltrim($url, "\0..\x20");
+
+        // scheme characters per RFC 3986: scheme = `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`
+        $isUnsafe = 1 === preg_match('#^([a-z][a-z0-9+.\-]*):#i', $normalizedUrl, $matches)
+            && \in_array(strtolower($matches[1]), self::DANGEROUS_SCHEMES, true);
+        $field->setCustomOption(UrlField::OPTION_IS_UNSAFE, $isUnsafe);
+
+        $prettyUrl = str_replace(['http://www.', 'https://www.', 'http://', 'https://'], '', $url);
         $prettyUrl = rtrim($prettyUrl, '/');
 
         if (Action::INDEX === $context->getCrud()->getCurrentAction()) {

--- a/src/Field/UrlField.php
+++ b/src/Field/UrlField.php
@@ -14,6 +14,8 @@ final class UrlField implements FieldInterface
     use FieldTrait;
 
     public const OPTION_DEFAULT_PROTOCOL = 'defaultProtocol';
+    public const OPTION_IS_UNSAFE = 'isUnsafe';
+    public const OPTION_ALLOWED_PROTOCOLS = 'allowedProtocols';
 
     /**
      * @param TranslatableInterface|string|false|null $label
@@ -27,7 +29,8 @@ final class UrlField implements FieldInterface
             ->setFormType(UrlType::class)
             ->addCssClass('field-url')
             ->setDefaultColumns('col-md-10 col-xxl-8')
-            ->setCustomOption(self::OPTION_DEFAULT_PROTOCOL, null);
+            ->setCustomOption(self::OPTION_DEFAULT_PROTOCOL, null)
+            ->setCustomOption(self::OPTION_ALLOWED_PROTOCOLS, null);
     }
 
     /**
@@ -39,6 +42,20 @@ final class UrlField implements FieldInterface
     public function setDefaultProtocol(string $protocol): self
     {
         $this->setCustomOption(self::OPTION_DEFAULT_PROTOCOL, $protocol);
+
+        return $this;
+    }
+
+    /**
+     * Restricts the protocols accepted as valid form input via a
+     * Symfony Url constraint. Pass protocols without the trailing colon
+     * (e.g. ['http', 'https']).
+     *
+     * @param string[] $protocols
+     */
+    public function allowedProtocols(array $protocols): self
+    {
+        $this->setCustomOption(self::OPTION_ALLOWED_PROTOCOLS, $protocols);
 
         return $this;
     }

--- a/templates/crud/field/url.html.twig
+++ b/templates/crud/field/url.html.twig
@@ -3,7 +3,9 @@
 {# @var entity \EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto #}
 {# NOTE: the rel="noopener" attr is needed to avoid performance and security issues
   (see https://web.dev/external-anchors-use-rel-noopener/) #}
-{% if ea().crud.currentAction == 'detail' %}
+{% if field.customOptions.get('isUnsafe') %}
+    <span class="text-muted">{{ field.value }}</span>
+{% elseif ea().crud.currentAction == 'detail' %}
     <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.value }}</a>
 {% else %}
     <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.formattedValue }}</a>

--- a/tests/Unit/Field/UrlFieldTest.php
+++ b/tests/Unit/Field/UrlFieldTest.php
@@ -3,8 +3,10 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\UrlConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\UrlField;
+use Symfony\Component\Validator\Constraints\Url;
 
 class UrlFieldTest extends AbstractFieldTest
 {
@@ -57,6 +59,244 @@ class UrlFieldTest extends AbstractFieldTest
         $fieldDto = $this->configure($field);
 
         self::assertSame($expectedRenderedUrl, $fieldDto->getFormattedValue());
+    }
+
+    /**
+     * @testWith ["javascript:alert(1)"]
+     *           ["JavaScript:alert(1)"]
+     *           ["JaVaScRiPt:alert(1)"]
+     *           ["data:text/html,<script>alert(1)</script>"]
+     *           ["vbscript:msgbox(1)"]
+     *           ["file:///etc/passwd"]
+     *           ["  javascript:alert(1)"]
+     *           ["\tjavascript:alert(1)"]
+     *           ["\njavascript:alert(1)"]
+     *           ["\u0000javascript:alert(1)"]
+     */
+    public function testDangerousSchemesAreMarkedUnsafe(string $url): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->setValue($url);
+        $fieldDto = $this->configure($field);
+
+        self::assertTrue($fieldDto->getCustomOption(UrlField::OPTION_IS_UNSAFE));
+    }
+
+    /**
+     * @testWith ["http://example.com"]
+     *           ["https://example.com"]
+     *           ["ftp://example.com"]
+     *           ["ftps://example.com"]
+     *           ["ssh://user@example.com"]
+     *           ["sftp://user@example.com"]
+     *           ["git://example.com/repo.git"]
+     *           ["mailto:user@example.com"]
+     *           ["webcal://example.com/cal.ics"]
+     *           ["/relative/path"]
+     *           ["relative/path"]
+     *           ["//example.com/protocol-relative"]
+     *           [""]
+     */
+    public function testSafeSchemesAreNotMarkedUnsafe(string $url): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->setValue($url);
+        $fieldDto = $this->configure($field);
+
+        self::assertFalse($fieldDto->getCustomOption(UrlField::OPTION_IS_UNSAFE));
+    }
+
+    public function testTemplateRendersDangerousUrlAsSpanInsteadOfLink(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->setValue('javascript:alert(1)');
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        // the dangerous scheme must not be rendered inside an anchor's href attribute
+        self::assertStringNotContainsString('<a ', $html);
+        self::assertStringNotContainsString('href=', $html);
+        self::assertStringContainsString('<span', $html);
+        self::assertStringContainsString('javascript:alert(1)', $html);
+    }
+
+    public function testTemplateEscapesDangerousUrlContainingHtml(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->setValue('data:text/html,<script>alert(1)</script>');
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testTemplateRendersSafeUrlAsLink(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->setValue('https://example.com');
+        $fieldDto = $this->configure($field);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringContainsString('<a ', $html);
+        self::assertStringContainsString('href="https://example.com"', $html);
+        self::assertStringContainsString('target="_blank"', $html);
+        self::assertStringContainsString('rel="noopener"', $html);
+    }
+
+    public function testTemplateRendersDangerousUrlAsSpanOnDetailAction(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->setValue('javascript:alert(1)');
+        $fieldDto = $this->configure($field, pageName: Crud::PAGE_DETAIL, actionName: Action::DETAIL);
+
+        $html = $this->renderFieldTemplate($fieldDto, $this->entityDto, $this->adminContext);
+
+        self::assertStringNotContainsString('<a ', $html);
+        self::assertStringContainsString('<span', $html);
+    }
+
+    public function testAllowedProtocolsOptionDefaultsToNull(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo');
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        self::assertNull($fieldDto->getCustomOption(UrlField::OPTION_ALLOWED_PROTOCOLS));
+        self::assertNull($fieldDto->getFormTypeOption('constraints'));
+    }
+
+    public function testAllowedProtocolsAddsUrlConstraint(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->allowedProtocols(['http', 'https']);
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        self::assertSame(['http', 'https'], $fieldDto->getCustomOption(UrlField::OPTION_ALLOWED_PROTOCOLS));
+
+        $constraints = $fieldDto->getFormTypeOption('constraints');
+        self::assertIsArray($constraints);
+        self::assertCount(1, $constraints);
+        self::assertInstanceOf(Url::class, $constraints[0]);
+        self::assertSame(['http', 'https'], $constraints[0]->protocols);
+    }
+
+    public function testAllowedProtocolsAppendsToExistingConstraints(): void
+    {
+        $this->initializeConfigurator();
+
+        $existingConstraint = new Url();
+        $field = UrlField::new('foo')
+            ->setFormTypeOption('constraints', [$existingConstraint])
+            ->allowedProtocols(['ftp', 'sftp']);
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        $constraints = $fieldDto->getFormTypeOption('constraints');
+        self::assertIsArray($constraints);
+        self::assertCount(2, $constraints);
+        self::assertSame($existingConstraint, $constraints[0]);
+        self::assertInstanceOf(Url::class, $constraints[1]);
+        self::assertSame(['ftp', 'sftp'], $constraints[1]->protocols);
+    }
+
+    public function testAllowedProtocolsReturnsSelfForFluentInterface(): void
+    {
+        $field = UrlField::new('foo');
+
+        self::assertSame($field, $field->allowedProtocols(['http', 'https']));
+    }
+
+    /**
+     * @testWith [["http"]]
+     *           [["https"]]
+     *           [["ftp", "ftps"]]
+     *           [["ssh", "sftp", "git"]]
+     *           [["http", "https", "ftp", "mailto", "webcal"]]
+     */
+    public function testAllowedProtocolsAcceptsDifferentProtocolSets(array $protocols): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->allowedProtocols($protocols);
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        self::assertSame($protocols, $fieldDto->getCustomOption(UrlField::OPTION_ALLOWED_PROTOCOLS));
+
+        $constraints = $fieldDto->getFormTypeOption('constraints');
+        self::assertCount(1, $constraints);
+        self::assertInstanceOf(Url::class, $constraints[0]);
+        self::assertSame($protocols, $constraints[0]->protocols);
+    }
+
+    public function testAllowedProtocolsWithEmptyArrayStillAddsConstraint(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')->allowedProtocols([]);
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        self::assertSame([], $fieldDto->getCustomOption(UrlField::OPTION_ALLOWED_PROTOCOLS));
+
+        $constraints = $fieldDto->getFormTypeOption('constraints');
+        self::assertCount(1, $constraints);
+        self::assertInstanceOf(Url::class, $constraints[0]);
+        self::assertSame([], $constraints[0]->protocols);
+    }
+
+    public function testAllowedProtocolsLastCallWins(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')
+            ->allowedProtocols(['http', 'https'])
+            ->allowedProtocols(['ftp']);
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        self::assertSame(['ftp'], $fieldDto->getCustomOption(UrlField::OPTION_ALLOWED_PROTOCOLS));
+
+        $constraints = $fieldDto->getFormTypeOption('constraints');
+        self::assertCount(1, $constraints);
+        self::assertSame(['ftp'], $constraints[0]->protocols);
+    }
+
+    public function testAllowedProtocolsIsIndependentFromDefaultProtocol(): void
+    {
+        $this->initializeConfigurator();
+
+        $field = UrlField::new('foo')
+            ->setDefaultProtocol('https')
+            ->allowedProtocols(['http', 'https']);
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        self::assertSame('https', $fieldDto->getCustomOption(UrlField::OPTION_DEFAULT_PROTOCOL));
+        self::assertSame('https', $fieldDto->getFormTypeOption('default_protocol'));
+        self::assertSame(['http', 'https'], $fieldDto->getCustomOption(UrlField::OPTION_ALLOWED_PROTOCOLS));
+        self::assertCount(1, $fieldDto->getFormTypeOption('constraints'));
+    }
+
+    public function testNoConstraintIsAddedWhenAllowedProtocolsIsNotCalled(): void
+    {
+        $this->initializeConfigurator();
+
+        $existingConstraint = new Url();
+        $field = UrlField::new('foo')
+            ->setFormTypeOption('constraints', [$existingConstraint]);
+        $fieldDto = $this->configure($field, actionName: Action::EDIT);
+
+        $constraints = $fieldDto->getFormTypeOption('constraints');
+        self::assertCount(1, $constraints);
+        self::assertSame($existingConstraint, $constraints[0]);
     }
 
     private function initializeConfigurator(): void


### PR DESCRIPTION
This was spotted by a security analysis made by Claude. It is related to security issues CWE-79 (XSS), CWE-601 (related: open redirect), CWE-184 (Incomplete Disallow-List of URL schemes).

Summary _(I removed most of the details and exploitable steps)_:

EasyAdmin's built-in `UrlField` renders its value directly into an HTML `href` attribute on both the list and detail pages. Twig auto-escaping turns quotes into `&quot;` but does not filter URI schemes — values such as `javascript:alert(document.cookie)` are stored verbatim and rendered as a live, clickable `<a href="javascript:…">`.