### PR TITLE
Add login_form_footer block to the login page template

### DIFF
--- a/doc/dashboards.rst
+++ b/doc/dashboards.rst
@@ -1090,6 +1090,29 @@ applications can rely on its default values::
         }
     }
 
+The template exposes a ``login_form_footer`` Twig block right after the form
+and before the inline login script, to render additional markup (for instance
+a disclaimer or a link to the terms of service). Create your own template
+that extends the login template and override the block:
+
+.. code-block:: twig
+
+    {# templates/security/login.html.twig #}
+    {% extends '@EasyAdmin/page/login.html.twig' %}
+
+    {% block login_form_footer %}
+        <p class="text-center mt-3">
+            <a href="{{ path('terms') }}">Terms of Service</a>
+        </p>
+    {% endblock %}
+
+Then update your security controller to render this custom template instead
+of ``@EasyAdmin/page/login.html.twig`` (or override EasyAdmin's template
+globally by placing the override at
+``templates/bundles/EasyAdminBundle/page/login.html.twig`` and extending
+``@!EasyAdmin/page/login.html.twig``, which keeps the original login
+controller untouched).
+
 .. _content_page_template:
 
 Content Page Template

--- a/templates/page/login.html.twig
+++ b/templates/page/login.html.twig
@@ -92,6 +92,8 @@
                 <twig:ea:Button type="submit" variant="primary" size="lg" isBlock htmlAttributes="{class: 'btn-block'}">{{ _sign_in_label }}</twig:ea:Button>
             </form>
 
+            {% block login_form_footer %}{% endblock login_form_footer %}
+
             {% guard function csp_nonce %}
                 <script src="{{ asset('login.js', constant('EasyCorp\\Bundle\\EasyAdminBundle\\Asset\\AssetPackage::PACKAGE_NAME')) }}" nonce="{{ csp_nonce('script') }}"></script>
             {% else %}


### PR DESCRIPTION
Adds an empty `login_form_footer` Twig block right after the `</form>` element in `templates/page/login.html.twig` so applications can render additional markup (disclaimer, terms of service, extra link) without copying the whole template.

Documented in `doc/dashboards.rst` next to the other login page options.

Closes #7544