### PR TITLE
Use formattedValue consistently in UrlField on index and detail pages

### DIFF
--- a/templates/crud/field/url.html.twig
+++ b/templates/crud/field/url.html.twig
@@ -5,8 +5,6 @@
   (see https://web.dev/external-anchors-use-rel-noopener/) #}
 {% if field.customOptions.get('isUnsafe') %}
     <span class="text-muted">{{ field.value }}</span>
-{% elseif ea().crud.currentAction == 'detail' %}
-    <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.value }}</a>
 {% else %}
     <a target="_blank" rel="noopener" href="{{ field.value }}">{{ field.formattedValue }}</a>
 {% endif %}

--- a/tests/Functional/Fields/Text/UrlFieldTest.php
+++ b/tests/Functional/Fields/Text/UrlFieldTest.php
@@ -41,8 +41,9 @@ class UrlFieldTest extends AbstractFieldFunctionalTest
 
     public function testUrlFieldDisplaysOnDetail(): void
     {
+        $url = 'https://www.detailed.example.org/path';
         $entity = $this->createFieldTestEntity([
-            'urlField' => 'https://detailed.example.org/path',
+            'urlField' => $url,
         ]);
 
         $crawler = $this->client->request('GET', $this->generateDetailUrl($entity->getId()));
@@ -56,8 +57,11 @@ class UrlFieldTest extends AbstractFieldFunctionalTest
 
             if (false !== stripos($label, 'UrlField') || false !== stripos($label, 'Url Field') || false !== stripos($label, 'URL')) {
                 $urlFieldFound = true;
-                $fieldValue = $groupCrawler->filter('.field-value');
-                static::assertStringContainsString('detailed.example.org', $fieldValue->text());
+                $urlLink = $groupCrawler->filter('.field-value a');
+                static::assertGreaterThan(0, $urlLink->count(), 'UrlField should render as a link on the detail page');
+                static::assertSame($url, $urlLink->attr('href'));
+                // the displayed text should be "pretty" (without https://, www., trailing /)
+                static::assertSame('detailed.example.org/path', trim($urlLink->text()));
                 break;
             }
         }


### PR DESCRIPTION
The `UrlField` template uses `field.formattedValue` as the anchor text on the index page but `field.value` on the detail page. This asymmetry prevents `->formatValue()` callbacks from affecting the detail rendering, even though `CommonPostConfigurator` already computes the formatted value for both pages.

## Behavior change

`UrlConfigurator::configure()` sets `formattedValue` to a "pretty" URL for every `UrlField` (strips `http://`, `https://`, `www.`, and the trailing `/`; additionally truncates to 32 chars on index only). This PR aligns the detail page rendering with the index rendering, minus the truncation. For `https://www.example.com/path/` the anchor text on detail changes from `https://www.example.com/path/` to `example.com/path`.

The `href` attribute keeps using `field.value` (the raw URL), so the link target is unchanged.

The `isUnsafe` branch is kept as-is: it intentionally renders the raw value as muted text to signal that a dangerous URL was blocked.

Closes #6864