### PR TITLE
Add ButtonVariant::Info

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -1127,8 +1127,8 @@ the full address is only visible on the detail and edit pages::
 
             [$local, $domain] = explode('@', $email, 2);
             $field->setFormattedValue(substr($local, 0, 1).'***@'.$domain);
-         }
-     }
+        }
+    }
 
 .. tip::
 

--- a/src/Config/Action.php
+++ b/src/Config/Action.php
@@ -294,6 +294,19 @@ final class Action implements \Stringable
     }
 
     /**
+     * By default, actions are rendered as `btn-secondary` buttons. This method makes
+     * the action to be rendered as a `btn-info` button with light blue text.
+     */
+    public function asInfoAction(bool $asInfoAction = true): self
+    {
+        if ($asInfoAction) {
+            $this->dto->setVariant(ButtonVariant::Info);
+        }
+
+        return $this;
+    }
+
+    /**
      * By default, actions are rendered as solid buttons. This method makes
      * the action to be rendered as a simple text link without button background
      * (the background is shown when hovering the action link).

--- a/src/Config/ActionGroup.php
+++ b/src/Config/ActionGroup.php
@@ -212,6 +212,15 @@ final class ActionGroup implements \Stringable
         return $this;
     }
 
+    public function asInfoActionGroup(bool $asInfoActionGroup = true): self
+    {
+        if ($asInfoActionGroup) {
+            $this->dto->setVariant(ButtonVariant::Info);
+        }
+
+        return $this;
+    }
+
     public function getAsDto(): ActionGroupDto
     {
         if (null === $this->dto->getIcon() && (null === $this->dto->getLabel() || false === $this->dto->getLabel())) {

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -389,6 +389,7 @@ final class ActionDto
         $action->asSuccessAction(ButtonVariant::Success === $this->variant);
         $action->asDangerAction(ButtonVariant::Danger === $this->variant);
         $action->asWarningAction(ButtonVariant::Warning === $this->variant);
+        $action->asInfoAction(ButtonVariant::Info === $this->variant);
 
         if (null !== $this->crudActionName) {
             $action->linkToCrudAction($this->crudActionName);

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -492,6 +492,7 @@ final readonly class ActionFactory
             ButtonVariant::Primary => 100,
             ButtonVariant::Default => 90,
             ButtonVariant::Success => 80,
+            ButtonVariant::Info => 75,
             ButtonVariant::Warning => 70,
             ButtonVariant::Danger => 60,
         };

--- a/src/Twig/Component/Option/ButtonVariant.php
+++ b/src/Twig/Component/Option/ButtonVariant.php
@@ -12,4 +12,5 @@ enum ButtonVariant: string
     case Success = 'success';
     case Warning = 'warning';
     case Danger = 'danger';
+    case Info = 'info';
 }

--- a/templates/components/Button.html.twig
+++ b/templates/components/Button.html.twig
@@ -1,5 +1,5 @@
 {% props
-    variant = 'default', # primary|default|danger|success|warning (default: 'default')
+    variant = 'default', # primary|default|danger|success|warning|info (default: 'default')
     isInvisible = false, # true|false (default: false) if true, button has transparent background and no border
     isBlock = false, # true|false (default: false) if true, button takes full width of container
     size = 'md', # sm|md|lg (default: 'md')

--- a/tests/Unit/Factory/ActionFactoryTest.php
+++ b/tests/Unit/Factory/ActionFactoryTest.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Factory;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ActionFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonVariant;
 use PHPUnit\Framework\TestCase;
 
 class ActionFactoryTest extends TestCase
@@ -18,6 +19,7 @@ class ActionFactoryTest extends TestCase
         $actions->add('index', Action::new('action_primary')->linkToCrudAction('index')->asPrimaryAction());
         $actions->add('index', Action::new('action_danger_text')->linkToCrudAction('index')->asDangerAction()->asTextLink());
         $actions->add('index', Action::new('action_success')->linkToCrudAction('index')->asSuccessAction());
+        $actions->add('index', Action::new('action_info')->linkToCrudAction('index')->asInfoAction());
         $actions->add('index', Action::new('action_text')->linkToCrudAction('index')->asTextLink());
         $actions->add('index', Action::new('action_danger')->linkToCrudAction('index')->asDangerAction());
         $actions->add('index', Action::new('action_default')->linkToCrudAction('index'));
@@ -31,6 +33,7 @@ class ActionFactoryTest extends TestCase
             'action_primary',
             'action_danger_text',
             'action_success',
+            'action_info',
             'action_text',
             'action_danger',
             'action_default',
@@ -38,6 +41,15 @@ class ActionFactoryTest extends TestCase
 
         // since automatic ordering is enabled by default, this should be the order before ActionFactory processes them
         $this->assertSame($expectedOrderBeforeSorting, $actionNames);
+    }
+
+    public function testInfoVariantSurvivesConfigObjectRoundTrip(): void
+    {
+        $action = Action::new('info_action')->linkToCrudAction('index')->asInfoAction();
+
+        $roundTripped = $action->getAsDto()->getAsConfigObject();
+
+        $this->assertSame(ButtonVariant::Info, $roundTripped->getAsDto()->getVariant());
     }
 
     public function testDisableAutomaticOrdering(): void


### PR DESCRIPTION
Adds the `Info` variant to `ButtonVariant` to support Bootstrap's `btn-info` buttons, with the `asInfoAction()` and `asInfoActionGroup()` helpers consistent with other variants.

Closes #7261