### PR TITLE
Apply DefaultColumns to ChoiceField regardless of widget type

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -94,9 +94,10 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
 
         if (ChoiceField::WIDGET_AUTOCOMPLETE === $field->getCustomOption(ChoiceField::OPTION_WIDGET)) {
             $field->setFormTypeOption('attr.data-ea-widget', 'ea-autocomplete');
-            if ('' === $field->getDefaultColumns()) {
-                $field->setDefaultColumns($isMultipleChoice ? 'col-md-8 col-xxl-6' : 'col-md-6 col-xxl-5');
-            }
+        }
+
+        if ('' === $field->getDefaultColumns()) {
+            $field->setDefaultColumns($isMultipleChoice ? 'col-md-8 col-xxl-6' : 'col-md-6 col-xxl-5');
         }
 
         $field->setFormTypeOptionIfNotSet('placeholder', '');

--- a/tests/Unit/Field/Configurator/ChoiceConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/ChoiceConfiguratorTest.php
@@ -113,4 +113,39 @@ class ChoiceConfiguratorTest extends AbstractFieldTest
 
         $this->assertSame($choices, $this->configure($field)->getFormTypeOption('choices'));
     }
+
+    public function testDefaultColumnsAreAppliedOnAutocompleteWidget(): void
+    {
+        $field = ChoiceField::new(self::PROPERTY_NAME);
+
+        $this->assertSame('col-md-6 col-xxl-5', $this->configure($field)->getDefaultColumns());
+    }
+
+    public function testDefaultColumnsAreAppliedOnNativeWidget(): void
+    {
+        $field = ChoiceField::new(self::PROPERTY_NAME)->renderAsNativeWidget();
+
+        $this->assertSame('col-md-6 col-xxl-5', $this->configure($field)->getDefaultColumns());
+    }
+
+    public function testDefaultColumnsAreAppliedOnExpandedWidget(): void
+    {
+        $field = ChoiceField::new(self::PROPERTY_NAME)->renderExpanded();
+
+        $this->assertSame('col-md-6 col-xxl-5', $this->configure($field)->getDefaultColumns());
+    }
+
+    public function testDefaultColumnsAreWiderOnMultipleNativeWidget(): void
+    {
+        $field = ChoiceField::new(self::PROPERTY_NAME)->renderAsNativeWidget()->allowMultipleChoices();
+
+        $this->assertSame('col-md-8 col-xxl-6', $this->configure($field)->getDefaultColumns());
+    }
+
+    public function testUserDefinedColumnsAreNotOverridden(): void
+    {
+        $field = ChoiceField::new(self::PROPERTY_NAME)->renderAsNativeWidget()->setColumns('col-md-4');
+
+        $this->assertSame('col-md-4', $this->configure($field)->getColumns());
+    }
 }


### PR DESCRIPTION
When a ChoiceField uses the native `<select>` widget (via `renderAsNativeWidget(true)`), the default columns were never set because the call to `setDefaultColumns()` was nested inside the autocomplete branch, leaving the field with an overly wide layout.

Moving the default columns assignment outside that conditional restores the expected column sizing for all widget types, while preserving the existing values for the autocomplete widget.

Fixes #7550