### PR TITLE
Prevent ImageField from overwriting existing files

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -1127,8 +1127,8 @@ the full address is only visible on the detail and edit pages::
 
             [$local, $domain] = explode('@', $email, 2);
             $field->setFormattedValue(substr($local, 0, 1).'***@'.$domain);
-         }
-     }
+        }
+    }
 
 .. tip::
 

--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -141,8 +141,14 @@ class StringToFileTransformer implements DataTransformerInterface
             }
 
             $filename = ($this->uploadFilename)($value);
+            // Pass the full path (upload dir + filename) to the validator so
+            // it can detect existing files and avoid overwriting them. Strip
+            // the upload dir afterwards so only the relative name is stored.
+            $validatedPath = ($this->uploadValidate)($this->uploadDir.$filename);
 
-            return ($this->uploadValidate)($filename);
+            return str_starts_with($validatedPath, $this->uploadDir)
+                ? substr($validatedPath, \strlen($this->uploadDir))
+                : $validatedPath;
         }
 
         if ($value instanceof FlysystemFile) {

--- a/src/Form/Type/FileUploadType.php
+++ b/src/Form/Type/FileUploadType.php
@@ -175,6 +175,12 @@ class FileUploadType extends AbstractType implements DataMapperInterface
         // no file were stored. Overrides must preserve this contract.
         $uploadFilename = static fn (UploadedFile $file): string => basename(str_replace('\\', '/', $file->getClientOriginalName()));
 
+        // the upload_validate callable receives the full path (upload_dir + filename)
+        // so it can call file_exists() to detect collisions. Its return value may be
+        // either a full path inside upload_dir (the leading upload_dir will be stripped
+        // by StringToFileTransformer) or a plain relative filename. In both cases the
+        // value that is finally stored must satisfy the same safe-path contract as
+        // upload_filename (see comment above).
         $uploadValidate = static function (string $filename): string {
             if (!file_exists($filename)) {
                 return $filename;

--- a/tests/Unit/Form/DataTransformer/StringToFileTransformerTest.php
+++ b/tests/Unit/Form/DataTransformer/StringToFileTransformerTest.php
@@ -6,6 +6,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Form\DataTransformer\StringToFileTransformer
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class StringToFileTransformerTest extends TestCase
 {
@@ -72,6 +73,70 @@ class StringToFileTransformerTest extends TestCase
         yield 'backslash parent traversal' => ['sub\\..\\..\\etc'];
         yield 'null byte' => ["file\0.txt"];
         yield 'leading backslash' => ['\\etc\\passwd'];
+    }
+
+    public function testReverseTransformPassesFullPathToUploadValidate(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'ea_stf_');
+        file_put_contents($tmpFile, 'new content');
+        $uploaded = new UploadedFile($tmpFile, 'normal.txt', 'text/plain', null, true);
+
+        $receivedByValidate = null;
+        $transformer = new StringToFileTransformer(
+            $this->uploadDir,
+            static fn (UploadedFile $file): string => $file->getClientOriginalName(),
+            static function (string $filename) use (&$receivedByValidate): string {
+                $receivedByValidate = $filename;
+
+                return $filename;
+            },
+            false,
+        );
+
+        $transformer->reverseTransform($uploaded);
+
+        self::assertSame($this->uploadDir.'normal.txt', $receivedByValidate);
+
+        @unlink($tmpFile);
+    }
+
+    public function testReverseTransformStripsUploadDirFromValidateResult(): void
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'ea_stf_');
+        file_put_contents($tmpFile, 'new content');
+        $uploaded = new UploadedFile($tmpFile, 'normal.txt', 'text/plain', null, true);
+
+        // Default-style validator: if the file exists on disk, append a numeric
+        // suffix to avoid overwriting the existing file.
+        $uploadValidate = static function (string $filename): string {
+            if (!file_exists($filename)) {
+                return $filename;
+            }
+
+            $index = 1;
+            $pathInfo = pathinfo($filename);
+            while (file_exists($filename = sprintf('%s/%s_%d.%s', $pathInfo['dirname'], $pathInfo['filename'], $index, $pathInfo['extension']))) {
+                ++$index;
+            }
+
+            return $filename;
+        };
+
+        $transformer = new StringToFileTransformer(
+            $this->uploadDir,
+            static fn (UploadedFile $file): string => $file->getClientOriginalName(),
+            $uploadValidate,
+            false,
+        );
+
+        // "normal.txt" already exists in the upload dir (see setUp), so the
+        // validator must rename the incoming file to avoid an overwrite, and
+        // the returned value must be the relative filename (no upload dir).
+        $result = $transformer->reverseTransform($uploaded);
+
+        self::assertSame('normal_1.txt', $result);
+
+        @unlink($tmpFile);
     }
 
     private function createTransformer(): StringToFileTransformer


### PR DESCRIPTION
The default `upload_validate` callable in `FileUploadType` checks `file_exists()` to avoid collisions, but it only received the file basename, so the check was always false and existing files were silently overwritten.

`StringToFileTransformer` now passes the full `upload_dir + filename` path to `upload_validate` and strips the prefix from the returned value, restoring the intended collision detection for both local and Flysystem storage.

Fixes #7525