### PR TITLE
Support absolute filesystem paths in setUploadDir()

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -1127,8 +1127,8 @@ the full address is only visible on the detail and edit pages::
 
             [$local, $domain] = explode('@', $email, 2);
             $field->setFormattedValue(substr($local, 0, 1).'***@'.$domain);
-         }
-     }
+        }
+    }
 
 .. tip::
 

--- a/src/Field/Configurator/FileConfigurator.php
+++ b/src/Field/Configurator/FileConfigurator.php
@@ -130,11 +130,12 @@ final readonly class FileConfigurator implements FieldConfiguratorInterface
             // Disable download_path for Flysystem (URLs are built via flysystem_url_prefix)
             $field->setFormTypeOption('download_path', null);
         } else {
-            $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
-            $isStreamWrapper = filter_var($relativeUploadDir, \FILTER_VALIDATE_URL);
-            if (false !== $isStreamWrapper) {
-                $absoluteUploadDir = $relativeUploadDir;
+            $isStreamWrapper = false !== filter_var($relativeUploadDir, \FILTER_VALIDATE_URL);
+            $isAbsolutePath = str_starts_with($relativeUploadDir, \DIRECTORY_SEPARATOR);
+            if ($isStreamWrapper || $isAbsolutePath) {
+                $absoluteUploadDir = u($relativeUploadDir)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
             } else {
+                $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
                 $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
             }
             $field->setFormTypeOption('upload_dir', $absoluteUploadDir);

--- a/src/Field/Configurator/ImageConfigurator.php
+++ b/src/Field/Configurator/ImageConfigurator.php
@@ -120,11 +120,12 @@ final readonly class ImageConfigurator implements FieldConfiguratorInterface
             // Disable download_path for Flysystem (URLs are built via flysystem_url_prefix)
             $field->setFormTypeOption('download_path', null);
         } else {
-            $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
-            $isStreamWrapper = filter_var($relativeUploadDir, \FILTER_VALIDATE_URL);
-            if (false !== $isStreamWrapper) {
-                $absoluteUploadDir = $relativeUploadDir;
+            $isStreamWrapper = false !== filter_var($relativeUploadDir, \FILTER_VALIDATE_URL);
+            $isAbsolutePath = str_starts_with($relativeUploadDir, \DIRECTORY_SEPARATOR);
+            if ($isStreamWrapper || $isAbsolutePath) {
+                $absoluteUploadDir = u($relativeUploadDir)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
             } else {
+                $relativeUploadDir = u($relativeUploadDir)->trimStart(\DIRECTORY_SEPARATOR)->ensureEnd(\DIRECTORY_SEPARATOR)->toString();
                 $absoluteUploadDir = u($relativeUploadDir)->ensureStart($this->projectDir.\DIRECTORY_SEPARATOR)->toString();
             }
             $field->setFormTypeOption('upload_dir', $absoluteUploadDir);

--- a/src/Field/FileField.php
+++ b/src/Field/FileField.php
@@ -70,7 +70,8 @@ final class FileField implements FieldInterface
     }
 
     /**
-     * Relative to project's root directory (e.g. use 'public/uploads/' for `<your-project-dir>/public/uploads/`)
+     * Relative paths are resolved from the project's root directory (e.g. 'public/uploads/' for `<your-project-dir>/public/uploads/`).
+     * Absolute filesystem paths are also supported (e.g. '/mnt/data/uploads/'), and so are stream wrappers (e.g. 's3://bucket/path/').
      * Default upload dir: `<your-project-dir>/public/uploads/files/`.
      */
     public function setUploadDir(string $uploadDirPath): self

--- a/src/Field/ImageField.php
+++ b/src/Field/ImageField.php
@@ -73,7 +73,8 @@ final class ImageField implements FieldInterface
     }
 
     /**
-     * Relative to project's root directory (e.g. use 'public/uploads/' for `<your-project-dir>/public/uploads/`)
+     * Relative paths are resolved from the project's root directory (e.g. 'public/uploads/' for `<your-project-dir>/public/uploads/`).
+     * Absolute filesystem paths are also supported (e.g. '/mnt/data/uploads/'), and so are stream wrappers (e.g. 's3://bucket/path/').
      * Default upload dir: `<your-project-dir>/public/uploads/images/`.
      */
     public function setUploadDir(string $uploadDirPath): self


### PR DESCRIPTION
`ImageField::setUploadDir()` and `FileField::setUploadDir()` currently strip any leading directory separator, so true absolute paths like `/mnt/data/uploads/` are silently rewritten to `<project-dir>/mnt/data/uploads/`.

This change detects absolute filesystem paths before the existing relative-path normalization, and uses them as-is, while preserving the current behavior for relative paths and stream wrappers.

Fixes #7459