### PR TITLE
Add regression test for CollectionField::renderExpanded() on nested CRUD forms

### DIFF
--- a/doc/fields.rst
+++ b/doc/fields.rst
@@ -1127,8 +1127,8 @@ the full address is only visible on the detail and edit pages::
 
             [$local, $domain] = explode('@', $email, 2);
             $field->setFormattedValue(substr($local, 0, 1).'***@'.$domain);
-         }
-     }
+        }
+    }
 
 .. tip::
 

--- a/tests/Functional/Apps/DefaultApp/src/Controller/NestedCrudForm/ProjectWithNestedIssuesCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/NestedCrudForm/ProjectWithNestedIssuesCrudController.php
@@ -36,6 +36,7 @@ class ProjectWithNestedIssuesCrudController extends AbstractCrudController
         // ProjectIssueNestedCrudController. This controller accesses $context->getEntity()
         // in its configureFields(), which tests the bug fix
         yield CollectionField::new('projectIssues', 'Issues')
+            ->renderExpanded(true)
             ->useEntryCrudForm(ProjectIssueNestedCrudController::class);
     }
 }

--- a/tests/Functional/Fields/Collection/NestedCrudFormTest.php
+++ b/tests/Functional/Fields/Collection/NestedCrudFormTest.php
@@ -87,6 +87,39 @@ class NestedCrudFormTest extends AbstractCrudTestCase
     }
 
     /**
+     * Tests that renderExpanded(true) on CollectionField renders entries with the
+     * accordion already expanded (Bootstrap "show" class on the collapse wrapper and
+     * no "collapsed" class on the toggle button).
+     */
+    public function testRenderExpandedOnCollectionField(): void
+    {
+        $project = $this->createProjectWithIssues();
+
+        $crawler = $this->client->request('GET', $this->generateEditFormUrl($project->getId()));
+
+        static::assertResponseIsSuccessful();
+
+        $collapseWrappers = $crawler->filter('.field-collection .accordion-collapse');
+        static::assertGreaterThan(0, $collapseWrappers->count(), 'At least one accordion-collapse wrapper should be rendered');
+
+        foreach ($collapseWrappers as $wrapper) {
+            static::assertStringContainsString(
+                'show',
+                $wrapper->getAttribute('class'),
+                'renderExpanded(true) should add the "show" class on .accordion-collapse',
+            );
+        }
+
+        foreach ($crawler->filter('.field-collection .accordion-button') as $button) {
+            static::assertStringNotContainsString(
+                'collapsed',
+                $button->getAttribute('class'),
+                'renderExpanded(true) should not add the "collapsed" class on .accordion-button',
+            );
+        }
+    }
+
+    /**
      * Creates a Project with ProjectIssue entities for testing.
      */
     private function createProjectWithIssues(): Project


### PR DESCRIPTION
Following issue #7529, I wasn't able to reproduce the bug on current `5.x`: `renderExpanded(true)` does propagate to the accordion (the `show` class lands on `.accordion-collapse` and `collapsed` is stripped from `.accordion-button`). This PR adds a functional test pinning that behaviour so we catch any future regression.

Happy to extend the coverage or dig further if you can share a reproducer that still fails, I may have missed a specific setup.

Fixes #7529