### PR TITLE
Fix duplicated <tr> class attribute when entity_row_attributes overrides class

### DIFF
--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -642,6 +642,25 @@ Clicks on checkboxes, buttons, links, or any action elements within the row won'
 trigger the navigation to preserve the expected behavior of those elements.
 Also, rows selected in batch mode won't navigate when clicked.
 
+When the default row action is enabled, each row receives the ``ea-clickable-row``
+CSS class. To add custom classes alongside it (for example, to colorize rows by
+status), override the ``entity_row_class`` block of the
+``@EasyAdmin/crud/index.html.twig`` template:
+
+.. code-block:: twig
+
+    {# templates/admin/crud/index.html.twig #}
+    {% extends '@EasyAdmin/crud/index.html.twig' %}
+
+    {% block entity_row_class %}status-row status-row-{{ entity.instance.status.name|lower }}{% endblock %}
+
+This block contributes to the same ``class="..."`` attribute as
+``ea-clickable-row``, so they coexist without producing duplicate ``class``
+attributes. The neighbour ``entity_row_attributes`` block is meant for any
+other ``<tr>`` attribute (``data-*``, ``aria-*``, etc.); putting a ``class=``
+in it would render two ``class`` attributes, and per HTML only the first is
+kept, so the user-supplied class would be silently dropped.
+
 Other Options
 ~~~~~~~~~~~~~
 

--- a/templates/crud/index.html.twig
+++ b/templates/crud/index.html.twig
@@ -143,7 +143,7 @@
             {% for entity in entities %}
                 {% block table_body_row %}
                 {% if entity.isAccessible %}
-                    <tr data-id="{{ entity.primaryKeyValueAsString }}" {% if entity.defaultActionUrl %}data-default-action-url="{{ entity.defaultActionUrl }}" class="ea-clickable-row" role="link" tabindex="0"{% endif %} {% block entity_row_attributes %}{% endblock %}>
+                    <tr data-id="{{ entity.primaryKeyValueAsString }}" {% if entity.defaultActionUrl %}data-default-action-url="{{ entity.defaultActionUrl }}" role="link" tabindex="0"{% endif %} class="{% if entity.defaultActionUrl %}ea-clickable-row {% endif %}{% block entity_row_class %}{% endblock %}" {% block entity_row_attributes %}{% endblock %}>
                         {% if has_batch_actions %}
                             <td class="batch-actions-selector">
                                 <div class="form-check">


### PR DESCRIPTION
The default row action commit (ec2e667bc) introduced an inline ``class="ea-clickable-row"`` inside the ``if entity.defaultActionUrl`` branch of the index ``<tr>`` tag. When users override the pre-existing ``entity_row_attributes`` block to add a class, the rendered ``<tr>`` ends up with two ``class="..."`` attributes; per HTML the first one wins, so the user-supplied class is silently dropped.

This patch merges everything into a single ``class="..."`` and exposes a new ``entity_row_class`` block dedicated to row classes, so user-supplied classes coexist with ``ea-clickable-row``. The companion ``entity_row_attributes`` block stays available for non-class attributes (``data-*``, ``aria-*``, etc.).

Migration: existing users who put a ``class=`` inside ``entity_row_attributes`` should move it to ``entity_row_class`` (which contributes to the same single ``class`` attribute as ``ea-clickable-row``). Documented next to the "Default Row Action" section in ``doc/crud.rst``.

Fixes #7562