### PR TITLE
Fix CrudTestSelectors::getActionSelector() not matching grouped actions

### DIFF
--- a/src/Test/Trait/CrudTestSelectors.php
+++ b/src/Test/Trait/CrudTestSelectors.php
@@ -16,7 +16,12 @@ trait CrudTestSelectors
 
     protected function getActionSelector(string $action): string
     {
-        return sprintf('.action-%s', $action);
+        // every action (top-level or nested in an ActionGroup) carries a
+        // `data-action-name` attribute set by ActionFactory::processAction(),
+        // so it's the only reliable selector for the test helpers. The legacy
+        // `.action-<name>` CSS class is only set on top-level actions and is
+        // therefore not usable when the action lives inside an ActionGroup.
+        return sprintf('[data-action-name="%s"]', $action);
     }
 
     protected function getGlobalActionSelector(string $action): string


### PR DESCRIPTION
``CrudTestSelectors::getActionSelector()`` looked for the ``.action-<name>`` CSS class. That class is set only on top-level actions by ``ActionFactory::transformActions()``; actions nested inside an ``ActionGroup`` go through ``processActionGroup()`` and never receive it, so test helpers like ``assertIndexEntityActionExists()`` silently failed on grouped actions.

Switch the selector to ``[data-action-name="<name>"]``, which ``ActionFactory::processAction()`` sets unconditionally on every action (top-level or nested). A single attribute selector also avoids the comma-OR composition pitfall in ``getGlobalActionSelector()`` / ``getIndexEntityActionSelector()``, which otherwise let the right-hand branch escape the scope.

Fixes #7518