### PR TITLE
AssociationField: Check if user has permission to see the related entity

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -374,6 +374,9 @@ return static function (ContainerConfigurator $container) {
             ->arg(2, service('request_stack'))
             ->arg(3, service(ControllerFactory::class))
             ->arg(4, new Reference(FieldFactory::class))
+            ->arg(5, new Reference(AuthorizationChecker::class))
+            ->arg(6, service(AdminContextProvider::class))
+            ->arg(7, service(AdminContextFactory::class))
 
         ->set(AvatarConfigurator::class)
 

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -12,8 +12,11 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\TextAlign;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\AdminContextFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
@@ -21,10 +24,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudAutocompleteType;
 use EasyCorp\Bundle\EasyAdminBundle\Form\Type\CrudFormType;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Security\Permission;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use function Symfony\Component\Translation\t;
 
 /**
@@ -38,6 +44,9 @@ final readonly class AssociationConfigurator implements FieldConfiguratorInterfa
         private RequestStack $requestStack,
         private ControllerFactory $controllerFactory,
         private FieldFactory $fieldFactory,
+        private AuthorizationCheckerInterface $authorizationChecker,
+        private AdminContextProviderInterface $adminContextProvider,
+        private AdminContextFactory $adminContextFactory,
     ) {
     }
 
@@ -298,7 +307,12 @@ final readonly class AssociationConfigurator implements FieldConfiguratorInterfa
         // associated entity is null (e.g. admin_post_index and Post <-> User)
         $crudAction = null === $primaryKeyValue ? Action::INDEX : Action::DETAIL;
 
-        // TODO: check if user has permission to see the related entity
+        $crudDto = $this->createCrudDto($crudController, $crudAction);
+
+        if (!$this->authorizationChecker->isGranted(Permission::EA_EXECUTE_ACTION, ['crud' => $crudDto, 'action' => $crudAction, 'entity' => $entityDto])) {
+            return null;
+        }
+
         return $this->adminUrlGenerator
             ->setController($crudController)
             ->setAction($crudAction)
@@ -379,6 +393,34 @@ final readonly class AssociationConfigurator implements FieldConfiguratorInterfa
         $this->fieldFactory->processFields($entityDto, new FieldCollection($fields), $crudPageName);
 
         return $entityDto;
+    }
+
+    /**
+     * @param class-string $crudControllerFqcn
+     */
+    private function createCrudDto(string $crudControllerFqcn, string $crudControllerAction): CrudDto
+    {
+        $request = new Request();
+
+        $dashboardController = $this->controllerFactory->getDashboardControllerInstance(
+            $this->adminContextProvider->getContext()->getDashboardControllerFqcn(),
+            $request,
+        );
+
+        $crudController = $this->controllerFactory->getCrudControllerInstance(
+            $crudControllerFqcn,
+            $crudControllerAction,
+            $request,
+        );
+
+        $adminContext = $this->adminContextFactory->create(
+            $request,
+            $dashboardController,
+            $crudController,
+            $crudControllerAction,
+        );
+
+        return $adminContext->getCrud();
     }
 
     private function configurePreferredChoices(FieldDto $field): void

--- a/src/Security/SecurityVoter.php
+++ b/src/Security/SecurityVoter.php
@@ -41,7 +41,7 @@ final class SecurityVoter extends Voter
         }
 
         if (Permission::EA_EXECUTE_ACTION === $permissionName) {
-            return $this->voteOnExecuteActionPermission($this->adminContextProvider->getContext()->getCrud(), $subject['action'] ?? null, $subject['entity'] ?? null, $subject['entityFqcn'] ?? null);
+            return $this->voteOnExecuteActionPermission($subject['crud'] ?? $this->adminContextProvider->getContext()->getCrud(), $subject['action'] ?? null, $subject['entity'] ?? null, $subject['entityFqcn'] ?? null);
         }
 
         if (Permission::EA_VIEW_FIELD === $permissionName) {

--- a/tests/Unit/Field/AbstractFieldTest.php
+++ b/tests/Unit/Field/AbstractFieldTest.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Context\CrudContext;
+use EasyCorp\Bundle\EasyAdminBundle\Context\DashboardContext;
 use EasyCorp\Bundle\EasyAdminBundle\Context\I18nContext;
 use EasyCorp\Bundle\EasyAdminBundle\Context\RequestContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
@@ -16,6 +17,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -62,6 +64,7 @@ abstract class AbstractFieldTest extends KernelTestCase
         return $this->adminContext = AdminContext::forTesting(
             requestContext: RequestContext::forTesting($request),
             crudContext: CrudContext::forTesting($crudDto),
+            dashboardContext: DashboardContext::forTesting(dashboardControllerFqcn: DashboardController::class),
             i18nContext: I18nContext::forTesting($requestLocale),
         );
     }

--- a/tests/Unit/Field/Configurator/AssociationConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/AssociationConfiguratorTest.php
@@ -5,14 +5,18 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Configurator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Factory\AdminContextFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\ControllerFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FieldFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\AssociationConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Provider\AdminContextProvider;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\ProjectDomain\DeveloperCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\ProjectDomain\ProjectCrudController;
@@ -24,10 +28,12 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Proj
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\AbstractFieldTest;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class AssociationConfiguratorTest extends AbstractFieldTest
 {
     private EntityDto $projectDto;
+    private RequestStack $requestStack;
 
     protected function setUp(): void
     {
@@ -37,18 +43,32 @@ class AssociationConfiguratorTest extends AbstractFieldTest
 
         $adminUrlGenerator = $this->getMockBuilder(AdminUrlGeneratorInterface::class)->disableOriginalConstructor()->getMock();
 
+        $this->requestStack = new RequestStack();
+
         $this->configurator = new AssociationConfigurator(
             static::getContainer()->get(EntityFactory::class),
             $adminUrlGenerator,
-            static::getContainer()->get(RequestStack::class),
+            $this->requestStack,
             static::getContainer()->get(ControllerFactory::class),
             static::getContainer()->get(FieldFactory::class),
+            static::getContainer()->get(AuthorizationCheckerInterface::class),
+            new AdminContextProvider($this->requestStack),
+            static::getContainer()->get(AdminContextFactory::class),
         );
     }
 
     protected function getEntityDto(): EntityDto
     {
         return $this->projectDto;
+    }
+
+    protected function getAdminContext(string $pageName, string $requestLocale, string $actionName, ?string $controllerFqcn = null): AdminContextInterface
+    {
+        $context = parent::getAdminContext($pageName, $requestLocale, $actionName, $controllerFqcn);
+        $context->getRequest()->attributes->set(EA::CONTEXT_REQUEST_ATTRIBUTE, $context);
+        $this->requestStack->push($context->getRequest());
+
+        return $context;
     }
 
     public function testToOneAssociation(): void


### PR DESCRIPTION
When using `AssociationField`, a link to the related entity detail page is displayed on the index page, but the check to verify if user has permission to open that page is missing:

https://github.com/EasyCorp/EasyAdminBundle/blob/0846e653f6943df87a5f22b688f01917f86dcfbc/src/Field/Configurator/AssociationConfigurator.php#L301

This PR fixes the issue. If not permitted, data is displayed as plain text without link.