### PR TITLE
Fix extending @EasyAdmin/page/content.html.twig throwing on AdminContextProvider

### DIFF
--- a/templates/page/content.html.twig
+++ b/templates/page/content.html.twig
@@ -1,7 +1,8 @@
-{# @var ea \EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext #}
-{% set ea = ea() %}
-{% extends null != ea ? ea.templatePath('layout') : '@EasyAdmin/layout.html.twig' %}
-{% trans_default_domain null != ea ? ea.i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
+{# ea() is called inline below: {% extends %} is evaluated by doGetParent(),
+   which runs before any {% set %} in doDisplay(), so a local `ea` variable
+   would not be set yet when a user template extends this file. #}
+{% extends ea() is not null ? ea().templatePath('layout') : '@EasyAdmin/layout.html.twig' %}
+{% trans_default_domain ea() is not null ? ea().i18n.translationDomain : (translation_domain is defined ? translation_domain ?? 'messages') %}
 
 {% block body_class 'page-content' %}
 


### PR DESCRIPTION
``@EasyAdmin/page/content.html.twig`` did ``{% set ea = ea() %}`` then ``{% extends null != ea ? ea.templatePath('layout') : ... %}``. Twig evaluates ``{% extends %}`` via ``doGetParent()`` before ``doDisplay()`` runs, so when a user template extends this file the local ``ea`` is not set yet, the expression sees the global ``AdminContextProvider``, and ``ea.templatePath('layout')`` blows up.

Call ``ea()`` inline in ``{% extends %}`` and ``{% trans_default_domain %}`` so the lookup no longer relies on the local variable.

Fixes #7586