### PR TITLE
Drop misleading @internal annotation on TextFilterType

### DIFF
--- a/src/Form/Filter/Type/TextFilterType.php
+++ b/src/Form/Filter/Type/TextFilterType.php
@@ -11,8 +11,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Yonel Ceruto <yonelceruto@gmail.com>
- *
- * @internal Don't use this to define a text filter. Use Filter\TextFilter instead.
  */
 class TextFilterType extends AbstractType
 {


### PR DESCRIPTION
``TextFilterType`` carried ``@internal Don't use this to define a text filter. Use Filter\\TextFilter instead.``, but ``Filter\\TextFilter::new()`` itself does ``->setFormType(TextFilterType::class)``: any custom filter that wants to reuse the text-filter form (e.g. an OR-flavored text filter) must reference ``TextFilterType``. The annotation made phpstan flag every legitimate external reference and steered users toward ``Filter\\TextFilter`` instead, which is not a ``FormTypeInterface`` and crashes the form registry.

Removing the annotation aligns ``TextFilterType`` with the 8 sibling ``*FilterType`` classes (``ArrayFilterType``, ``BooleanFilterType``, ``ChoiceFilterType``, ``ComparisonFilterType``, ``DateTimeFilterType``, ``EntityFilterType``, ``NullFilterType``, ``NumericFilterType``) which carry no such annotation. No behavior change.

Closes #7393