### PR TITLE
Render HTML attributes on form fieldset wrapper

### DIFF
--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -640,7 +640,7 @@
     {% set fieldset_has_errors = form.vars.ea_vars.field.getCustomOption(fieldset_error_count_option_name)|default(0) > 0 %}
     {% set is_collapsed = form.vars.ea_vars.field.getCustomOption(collapsed_option_name)|default(false) %}
 
-    <div class="form-fieldset {{ not fieldset_has_header ? 'form-fieldset-no-header' }} {{ fieldset_has_errors ? 'has-fieldset-error' }} {{ ea_css_class }}">
+    <div class="form-fieldset {{ not fieldset_has_header ? 'form-fieldset-no-header' }} {{ fieldset_has_errors ? 'has-fieldset-error' }} {{ ea_css_class }} {{ form.vars.attr.class|default('') }}" {% for key, value in form.vars.attr %}{% if key != 'class' %}{{ key }}="{{ value|e('html') }}" {% endif %}{% endfor %}>
         <fieldset>
             {% if fieldset_has_header %}
                 {{ form_label(form) }}


### PR DESCRIPTION
``FormField::addFieldset()->setHtmlAttribute('foo', 'bar')`` had no effect: the ``ea_form_fieldset_open_row`` block in the form theme rendered the wrapper ``<div>`` with a fixed class list and never projected ``form.vars.attr``, while the sibling tab pane block (``ea_form_tabpane_open_row``) already loops over it.

Mirror the same loop on the fieldset wrapper so ``setHtmlAttribute()`` and ``setFormTypeOptions(['attr' => [...]])`` reach the rendered DOM.

Closes #6285