### PR TITLE
Skip CollectionField entry-type setup on INDEX/DETAIL pages

### DIFF
--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -134,6 +134,16 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
 
     private function configureEntryType(FieldDto $fieldDto, EntityDto $entityDto, AdminContext $context): void
     {
+        // entry_type and prototype options are only consumed when the field is
+        // rendered as a form (NEW/EDIT). On INDEX/DETAIL the field is rendered
+        // through formatCollection(), so the entry-type setup is wasted work
+        // and, more importantly, calling configureFields(PAGE_EDIT) on the
+        // target CRUD controller can run user code that expects a real entity
+        // instance (it has none here): see #7460.
+        if (!\in_array($context->getCrud()->getCurrentPage(), [Crud::PAGE_EDIT, Crud::PAGE_NEW], true)) {
+            return;
+        }
+
         if (true === $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_USES_CRUD_FORM)) {
             if (!$entityDto->getClassMetadata()->hasAssociation($fieldDto->getProperty())) {
                 throw new \RuntimeException(sprintf('The "%s" collection field of "%s" cannot use the "useEntryCrudForm()" method because it is not a Doctrine association.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn()));

--- a/tests/Unit/Field/Configurator/CollectionConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/CollectionConfiguratorTest.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Configurator;
 
 use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CollectionField;
@@ -63,7 +64,7 @@ class CollectionConfiguratorTest extends AbstractFieldTest
             ProjectCrudController::class,
         ));
 
-        $this->configure($field, controllerFqcn: ProjectCrudController::class);
+        $this->configure($field, pageName: Crud::PAGE_EDIT, controllerFqcn: ProjectCrudController::class);
     }
 
     public static function failsOnOptionEntryUsesCrudFormIfPropertyIsNotAssociation(): \Generator
@@ -89,7 +90,7 @@ class CollectionConfiguratorTest extends AbstractFieldTest
             ProjectCrudController::class,
         ));
 
-        $this->configure($field, controllerFqcn: ProjectCrudController::class);
+        $this->configure($field, pageName: Crud::PAGE_EDIT, controllerFqcn: ProjectCrudController::class);
     }
 
     public static function failsOnOptionEntryUsesCrudFormIfOptionEntryTypeIsUsed(): \Generator
@@ -114,7 +115,7 @@ class CollectionConfiguratorTest extends AbstractFieldTest
             $field->getAsDto()->getDoctrineMetadata()->get('targetEntity'),
         ));
 
-        $this->configure($field, controllerFqcn: ProjectCrudController::class);
+        $this->configure($field, pageName: Crud::PAGE_EDIT, controllerFqcn: ProjectCrudController::class);
     }
 
     public static function failsOnOptionRenderAsEmbeddedCrudFormIfNoCrudControllerCanBeFound(): \Generator


### PR DESCRIPTION
``CollectionConfigurator::configureEntryType()`` instantiates the target CRUD controller and calls ``configureFields(PAGE_EDIT)`` on it (or ``PAGE_NEW``) so it can build ``entry_type``/prototype options. These options are only consumed when the field is rendered as a form: on INDEX/DETAIL the field falls back to ``formatCollection()`` which only reads the value and a custom option.

Running ``configureFields(PAGE_EDIT)`` on the target controller while displaying the parent's DETAIL page wastes work and, more importantly, runs user code with no real entity instance available, which makes controllers that legitimately read ``$context->getEntity()->getInstance()`` inside ``configureFields()`` crash on a NULL entity.

Bail out early when the current page is neither EDIT nor NEW so the form setup only happens on the pages that actually need it.

Closes #7460