### PR TITLE
Propagate embedded controllers' field assets to parent form page

### DIFF
--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -430,10 +430,20 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             $crudPageName = Crud::PAGE_EDIT;
         }
 
-        $field->setFormTypeOption(
-            'entityDto',
-            $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, $targetCrudControllerAction, $targetCrudControllerPageName, $crudPageName),
-        );
+        $embeddedEntityDto = $this->createEntityDto($targetEntityFqcn, $targetCrudControllerFqcn, $targetCrudControllerAction, $targetCrudControllerPageName, $crudPageName);
+        $field->setFormTypeOption('entityDto', $embeddedEntityDto);
+
+        // The assets declared by the embedded controller's fields (e.g. TextEditorField,
+        // FileField, a nested CollectionField...) live on the embedded EntityDto, not on
+        // the parent AssociationField. Propagate them up so that
+        // AbstractCrudController::getFieldAssets(), which only walks top-level fields,
+        // picks them up and outputs the required CSS/JS on the form page that hosts the
+        // embedded CRUD form. See #6127.
+        $assets = $field->getAssets();
+        foreach ($embeddedEntityDto->getFields() ?? [] as $embeddedField) {
+            $assets = $assets->mergeWith($embeddedField->getAssets());
+        }
+        $field->setAssets($assets);
     }
 
     /**

--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -214,6 +214,19 @@ final readonly class CollectionConfigurator implements FieldConfiguratorInterfac
         $fieldDto->setFormTypeOption('prototype_options.entityDto', $newEntityDto);
         $fieldDto->setFormTypeOptionIfNotSet('prototype_data', $createEntryEntity());
         $fieldDto->setFormTypeOptionIfNotSet('entry_options.empty_data', $createEntryEntity);
+
+        // The assets declared by entry fields (e.g. TextEditorField, FileField, a nested
+        // CollectionField...) live on the entry EntityDto, not on the parent CollectionField.
+        // Propagate them up so that AbstractCrudController::getFieldAssets(), which only
+        // walks top-level fields, picks them up and outputs the required CSS/JS on the
+        // form page that hosts the embedded CRUD form. See #6127.
+        $assets = $fieldDto->getAssets();
+        foreach ([$editEntityDto, $newEntityDto] as $entryEntityDto) {
+            foreach ($entryEntityDto->getFields() ?? [] as $entryField) {
+                $assets = $assets->mergeWith($entryField->getAssets());
+            }
+        }
+        $fieldDto->setAssets($assets);
     }
 
     /**


### PR DESCRIPTION
When a form embeds another CRUD controller via ``AssociationField::renderAsEmbeddedForm()`` or ``CollectionField::useEntryCrudForm()``, the embedded controller's fields (``TextEditorField``, ``FileField``, a nested ``CollectionField``, etc.) carry their own CSS/JS assets. They live on the embedded ``EntityDto``, never on the parent field, so ``AbstractCrudController::getFieldAssets()`` (which only walks top-level fields) never sees them: the parent form page renders without the editor JS, the collection JS, etc., and the nested widgets break visually and functionally.

Merge each embedded field's assets back into the parent ``FieldDto``'s own assets right after the embedded ``EntityDto`` is processed in both ``CollectionConfigurator::configureEntryType()`` and ``AssociationConfigurator::configureCrudForm()``. Multi-level nesting cascades naturally because each level merges before its own parent does.

Closes #6127