### PR TITLE
Call embedded controller's createEntity() for CollectionField entries

### DIFF
--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -170,20 +170,46 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
             return;
         }
 
+        $targetEntityFqcn = $entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty());
+
         $editEntityDto = $this->createEntityDto(
-            $entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()),
+            $targetEntityFqcn,
             $targetCrudControllerFqcn,
             Action::EDIT,
             $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_EDIT_PAGE_NAME) ?? Crud::PAGE_EDIT,
             Crud::PAGE_EDIT,
         );
         $newEntityDto = $this->createEntityDto(
-            $entityDto->getClassMetadata()->getAssociationTargetClass($fieldDto->getProperty()),
+            $targetEntityFqcn,
             $targetCrudControllerFqcn,
             Action::NEW,
             $fieldDto->getCustomOption(CollectionField::OPTION_ENTRY_CRUD_NEW_PAGE_NAME) ?? Crud::PAGE_NEW,
             Crud::PAGE_NEW,
         );
+
+        // Build new collection entries through the embedded controller's createEntity()
+        // so its overrides (default values, factory pattern, etc.) are honored, instead of
+        // falling back to instantiating `$targetEntityFqcn` directly via Symfony Form.
+        // - `prototype_data` shapes the rendered prototype HTML (read at build time).
+        // - `entry_options.empty_data` is called by Symfony when binding a new (empty)
+        //   entry on form submit, once per added entry.
+        // The context is intentionally NOT swapped to the embedded entity around the
+        // createEntity() call: callers commonly read `$this->getContext()->getEntity()`
+        // to populate the parent foreign key on the new entry, which only works when the
+        // parent context is left in place.
+        // See #6991.
+        $controllerFactory = $this->controllerFactory;
+        $requestStack = $this->requestStack;
+        $createEntryEntity = static function () use ($controllerFactory, $requestStack, $targetCrudControllerFqcn, $targetEntityFqcn): object {
+            $request = $requestStack->getMainRequest();
+            $controller = null !== $request
+                ? $controllerFactory->getCrudControllerInstance($targetCrudControllerFqcn, Action::NEW, $request)
+                : null;
+
+            return null !== $controller
+                ? $controller->createEntity($targetEntityFqcn)
+                : new $targetEntityFqcn();
+        };
 
         $fieldDto->setFormTypeOption('entry_type', CrudFormType::class);
         $fieldDto->setFormTypeOption('entry_options.entityDto', $editEntityDto);
@@ -192,6 +218,8 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
         } catch (UndefinedOptionsException $exception) {
             throw new \RuntimeException(sprintf('The "%s" collection field of "%s" uses the "useEntryCrudForm()" method, which requires Symfony 6.1 or newer to work. Upgrade your Symfony version or use instead the "setEntryType()" method to render the collection entries using a Symfony form.', $fieldDto->getProperty(), $context->getCrud()?->getControllerFqcn()), 0, $exception);
         }
+        $fieldDto->setFormTypeOptionIfNotSet('prototype_data', $createEntryEntity());
+        $fieldDto->setFormTypeOptionIfNotSet('entry_options.empty_data', $createEntryEntity);
     }
 
     /**

--- a/tests/Functional/Apps/DefaultApp/src/Controller/NestedCrudForm/ProjectIssueNestedCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/NestedCrudForm/ProjectIssueNestedCrudController.php
@@ -15,6 +15,10 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Proj
  */
 class ProjectIssueNestedCrudController extends AbstractCrudController
 {
+    public const DEFAULT_ENTRY_NAME = 'New issue (from createEntity)';
+
+    public static int $createEntityCallCount = 0;
+
     public static function getEntityFqcn(): string
     {
         return ProjectIssue::class;
@@ -46,5 +50,19 @@ class ProjectIssueNestedCrudController extends AbstractCrudController
         }
 
         yield TextField::new('name', 'Issue Name');
+    }
+
+    public function createEntity(string $entityFqcn): object
+    {
+        // overriding createEntity() must be honored when this controller is embedded
+        // via CollectionField::useEntryCrudForm() (see #6991). The static counter lets
+        // tests verify that both `prototype_data` (build) and `entry_options.empty_data`
+        // (submit) reach this method.
+        ++self::$createEntityCallCount;
+
+        $issue = new $entityFqcn();
+        $issue->setName(self::DEFAULT_ENTRY_NAME);
+
+        return $issue;
     }
 }

--- a/tests/Functional/Fields/Collection/NestedCrudFormTest.php
+++ b/tests/Functional/Fields/Collection/NestedCrudFormTest.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Fields\Collection;
 use Doctrine\ORM\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\NestedCrudForm\ProjectIssueNestedCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\NestedCrudForm\ProjectWithNestedIssuesCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\ProjectIssue;
@@ -84,6 +85,95 @@ class NestedCrudFormTest extends AbstractCrudTestCase
         $html = $crawler->html();
         static::assertStringContainsString('Test Issue 1', $html, 'First issue should be visible');
         static::assertStringContainsString('Test Issue 2', $html, 'Second issue should be visible');
+    }
+
+    /**
+     * Tests that the embedded CRUD controller's createEntity() override shapes the
+     * prototype HTML, so users see their defaults in the rendered form (see #6991).
+     */
+    public function testNestedCreateEntityShapesPrototypeHtml(): void
+    {
+        $crawler = $this->client->request('GET', $this->generateNewFormUrl());
+        static::assertResponseIsSuccessful();
+
+        $prototype = $crawler->filter('[data-prototype]');
+        static::assertGreaterThanOrEqual(1, $prototype->count(), 'A collection prototype should exist');
+        static::assertStringContainsString(
+            ProjectIssueNestedCrudController::DEFAULT_ENTRY_NAME,
+            $prototype->attr('data-prototype'),
+            'createEntity() defaults from the embedded controller should be reflected in the prototype HTML',
+        );
+    }
+
+    /**
+     * Tests that the embedded CRUD controller's createEntity() is reached when Symfony
+     * Form binds a new (empty) collection entry on submit, i.e. that
+     * `entry_options.empty_data` is wired in addition to `prototype_data` (see #6991).
+     */
+    public function testNestedCreateEntityIsCalledForEmptyDataOnSubmit(): void
+    {
+        $project = $this->createProjectWithIssues();
+
+        $crawler = $this->client->request('GET', $this->generateEditFormUrl($project->getId()));
+        static::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form[name="Project"]')->form();
+        $values = $form->getPhpValues();
+        // simulate the JS "add entry" behaviour: append an entry with no submitted fields
+        // so Symfony Form has to invoke entry_options.empty_data to materialise the new
+        // ProjectIssue (which then routes to the embedded controller's createEntity()).
+        $values['Project']['projectIssues'][] = [];
+
+        $callsBeforeSubmit = ProjectIssueNestedCrudController::$createEntityCallCount;
+        try {
+            // form binding may fail on this fixture (the new ProjectIssue's `name` is
+            // required and not submitted, so PropertyAccessor will refuse to set null).
+            // We are not testing the persistence side here, only that empty_data was
+            // reached before the binding step ran.
+            $this->client->catchExceptions(false);
+            $this->client->request($form->getMethod(), $form->getUri(), $values, [], ['CONTENT_TYPE' => 'application/x-www-form-urlencoded']);
+        } catch (\Throwable) {
+            // expected on this fixture, see comment above.
+        }
+
+        static::assertGreaterThan(
+            $callsBeforeSubmit,
+            ProjectIssueNestedCrudController::$createEntityCallCount,
+            'createEntity() should be invoked through entry_options.empty_data when a new entry is bound',
+        );
+    }
+
+    /**
+     * Tests that renderExpanded(true) on CollectionField renders entries with the
+     * accordion already expanded (Bootstrap "show" class on the collapse wrapper and
+     * no "collapsed" class on the toggle button).
+     */
+    public function testRenderExpandedOnCollectionField(): void
+    {
+        $project = $this->createProjectWithIssues();
+
+        $crawler = $this->client->request('GET', $this->generateEditFormUrl($project->getId()));
+
+        static::assertResponseIsSuccessful();
+
+        $collapseWrappers = $crawler->filter('.field-collection .accordion-collapse');
+        static::assertGreaterThan(0, $collapseWrappers->count(), 'At least one accordion-collapse wrapper should be rendered');
+
+        foreach ($collapseWrappers as $wrapper) {
+            static::assertStringContainsString(
+                'show',
+                $wrapper->getAttribute('class'),
+                'renderExpanded(true) should add the "show" class on .accordion-collapse',
+            );
+        }
+
+        foreach ($crawler->filter('.field-collection .accordion-button') as $button) {
+            static::assertStringNotContainsString(
+                'collapsed',
+                $button->getAttribute('class'),
+                'renderExpanded(true) should not add the "collapsed" class on .accordion-button',
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
When a `CollectionField` uses `useEntryCrudForm()` (or the field's CRUD controller is auto-discovered through the entity's association), Symfony Form was instantiating new entries through reflection on `data_class`, bypassing the embedded controller's `createEntity()` override. Default values, factory patterns, and any other logic placed in `createEntity()` were silently dropped on the entries added through the parent form.

This wires up the embedded controller's `createEntity()` in two places in `CollectionConfigurator::configureEntryType()`:

- `prototype_data`: read at build time, so the rendered prototype HTML reflects the defaults (e.g. checked checkboxes, pre-filled text inputs).
- `entry_options.empty_data`: called by Symfony Form for every new (empty) entry bound on submit, so the persisted entities also carry the defaults.

Both default-`createEntity()` (returns `new $entityFqcn()`) and overridden ones now flow through the same path, so there is no behavior change for users who don't override it.

A regression test was added on top of `NestedCrudFormTest`: `ProjectIssueNestedCrudController` now overrides `createEntity()` with a marker name, and the test asserts that the marker shows up in the rendered prototype.

Fixes #6991