### PR TITLE
Initialise FileUploadField only on the newly added collection item

### DIFF
--- a/assets/js/field-file-upload.js
+++ b/assets/js/field-file-upload.js
@@ -1,13 +1,23 @@
 import { toggleVisibilityClasses } from './helpers';
 
-const eaFileUploadHandler = (event) => {
-    document.querySelectorAll('.ea-fileupload input[type="file"]').forEach((fileUploadElement) => {
+const initFileUploadFields = (root) => {
+    root.querySelectorAll('.ea-fileupload input[type="file"]').forEach((fileUploadElement) => {
+        if (fileUploadElement.dataset.eaFileuploadInitialized === '1') {
+            return;
+        }
+        fileUploadElement.dataset.eaFileuploadInitialized = '1';
         new FileUploadField(fileUploadElement);
     });
 };
 
-window.addEventListener('DOMContentLoaded', eaFileUploadHandler);
-document.addEventListener('ea.collection.item-added', eaFileUploadHandler);
+window.addEventListener('DOMContentLoaded', () => initFileUploadFields(document));
+document.addEventListener('ea.collection.item-added', (event) => {
+    // only initialise the file upload fields contained in the newly added collection item:
+    // re-running the query on the whole document would re-attach listeners to already
+    // processed fields and double-fire their handlers (see #6637). The dataset flag
+    // already protects against double-init if `event.detail.newElement` is missing.
+    initFileUploadFields(event?.detail?.newElement ?? document);
+});
 
 class FileUploadField {
     #fieldContainerElement;


### PR DESCRIPTION
The \`ea.collection.item-added\` listener was re-running the document-wide query for file upload inputs, so every already-initialised \`<input type="file">\` was passed back to a fresh \`FileUploadField\` and got its change/click handlers bound a second time. The newly added field also didn't always behave correctly, the symptom reported being that selecting a file in a freshly added collection entry didn't display the filename or size.

The handler now scopes the query to \`event.detail.newElement\` (so existing fields are left alone) and tags each input with a \`data-ea-fileupload-initialized\` flag to make re-entry idempotent.

Fixes #6637