### PR TITLE
Add style for ButtonVariant::Info

### DIFF
--- a/assets/css/easyadmin-theme/buttons.css
+++ b/assets/css/easyadmin-theme/buttons.css
@@ -143,6 +143,23 @@
     --button-active-border-color: var(--button-danger-active-border-color);
 }
 
+.btn-info,
+.btn-info.btn.disabled,
+.btn-info.btn:disabled {
+    --button-box-shadow: var(--button-info-box-shadow);
+    --button-bg: var(--button-info-bg);
+    --button-color: var(--button-info-color);
+    --button-icon-color: var(--button-info-icon-color);
+    --button-border-color: var(--button-info-border-color);
+    --button-hover-bg: var(--button-info-hover-bg);
+    --button-hover-color: var(--button-info-hover-color);
+    --button-hover-border-color: var(--button-info-hover-border-color);
+    --button-active-box-shadow: var(--button-info-active-box-shadow);
+    --button-active-color: var(--button-info-active-color);
+    --button-active-bg: var(--button-info-active-bg);
+    --button-active-border-color: var(--button-info-active-border-color);
+}
+
 .btn-invisible,
 .btn-invisible.btn.disabled,
 .btn-invisible.btn:disabled {

--- a/assets/css/easyadmin-theme/datagrids.css
+++ b/assets/css/easyadmin-theme/datagrids.css
@@ -222,6 +222,13 @@ table.datagrid:not(.datagrid-empty) tr:not(.empty-row) td.actions.actions-as-dro
     background: var(--dropdown-item-danger-bg);
     color: var(--dropdown-item-danger-color);
 }
+.datagrid td.actions .dropdown-item-variant-info:hover,
+.page-actions .dropdown-item-variant-info:hover {
+    --dropdown-icon-color: var(--dropdown-item-info-color);
+
+    background: var(--dropdown-item-info-bg);
+    color: var(--dropdown-item-info-color);
+}
 
 @media (min-width: 992px) {
     .datagrid td.actions-as-dropdown {

--- a/assets/css/easyadmin-theme/variables-theme.css
+++ b/assets/css/easyadmin-theme/variables-theme.css
@@ -112,9 +112,11 @@
     --dropdown-item-success-bg: #dafbe1;
     --dropdown-item-warning-bg: #fff8c5;
     --dropdown-item-danger-bg: #ffebe9;
+    --dropdown-item-info-bg: #e0f8ff;
     --dropdown-item-success-color: #1a7f37;
     --dropdown-item-warning-color: #9a6700;
     --dropdown-item-danger-color: #d1242f;
+    --dropdown-item-info-color: #0da1f0;
     --datagrid-noresults-placeholder-bg: var(--gray-100);
     --datagrid-hidden-results-gradient-bg: var(--gray-50);
     --table-thead-color: var(--gray-800);

--- a/assets/css/easyadmin-theme/variables-theme.css
+++ b/assets/css/easyadmin-theme/variables-theme.css
@@ -342,6 +342,19 @@
     --button-danger-active-color: var(--white);
     --button-danger-active-border-color: #1f23280a;
 
+    --button-info-box-shadow: 0 1px 0 0 #1f23280a;
+    --button-info-bg: linear-gradient(to bottom, white, #f6f8fa);
+    --button-info-color: #0da1f0;
+    --button-info-icon-color: inherit;
+    --button-info-border-color: #1f232826;
+    --button-info-hover-bg: #0db3f0;
+    --button-info-hover-color: var(--white);
+    --button-info-hover-border-color: #1f23280a;
+    --button-info-active-box-shadow: inset 0 1px 0 0 #4c001433;
+    --button-info-active-bg: #0db3f0;
+    --button-info-active-color: var(--white);
+    --button-info-active-border-color: #1f23280a;
+
     --button-invisible-box-shadow: none;
     --button-invisible-bg: transparent;
     --button-invisible-color: inherit;


### PR DESCRIPTION
Since #7573 we can now use `asInfoAction()` but the corresponding button style was not present.

Here’s how it looks with this change:
normal state:
<img width="159" height="48" alt="Capture d’écran 2026-05-16 à 21 29 22" src="https://github.com/user-attachments/assets/9b228091-a181-4f11-bbc9-0a08a80924c2" />

hover state:
<img width="154" height="48" alt="Capture d’écran 2026-05-16 à 21 29 39" src="https://github.com/user-attachments/assets/df85eb87-a85b-42bc-b811-e96cb6edee8a" />

in dropdown, normal state:
<img width="183" height="133" alt="Capture d’écran 2026-05-16 à 22 20 36" src="https://github.com/user-attachments/assets/4183eca1-0864-4347-a32f-1389af7b5bf0" />

in dropdown, hover state:
<img width="174" height="136" alt="Capture d’écran 2026-05-16 à 22 20 50" src="https://github.com/user-attachments/assets/4f691492-d6df-47ca-b32c-7ba1759b0ff8" />
