### PR TITLE
Avoid formatting collection items when a custom formatting is used

### DIFF
--- a/src/Field/Configurator/CollectionConfigurator.php
+++ b/src/Field/Configurator/CollectionConfigurator.php
@@ -95,6 +95,13 @@ final class CollectionConfigurator implements FieldConfiguratorInterface
 
     private function formatCollection(FieldDto $field, AdminContext $context): int|string
     {
+        // when the field defines its own formatValue() callable, that callable runs later
+        // in CommonPostConfigurator and overwrites whatever we return here, so skip the
+        // text-joining work and avoid (string)-casting items that may not be valid UTF-8
+        if (null !== $field->getFormatValueCallable()) {
+            return $this->countNumElements($field->getValue());
+        }
+
         $doctrineMetadata = $field->getDoctrineMetadata();
         if ('array' !== $doctrineMetadata->get('type') && !$field->getValue() instanceof PersistentCollection) {
             return $this->countNumElements($field->getValue());

--- a/tests/Unit/Field/Configurator/CollectionConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/CollectionConfiguratorTest.php
@@ -124,4 +124,35 @@ class CollectionConfiguratorTest extends AbstractFieldTest
         yield [CollectionField::new('favouriteProjectOf')];
         yield [CollectionField::new('projectTags')];
     }
+
+    /**
+     * Regression test for #7613: when a user supplies a formatValue() callable, the
+     * (string)-casting loop inside formatCollection() must be skipped; otherwise an
+     * item whose __toString() returns invalid UTF-8 makes Symfony String's truncate()
+     * throw and the whole page returns a 500, even though the user's callable would
+     * have overwritten the formatted value anyway.
+     */
+    public function testFormatCollectionShortCircuitsWhenFormatValueCallableIsSet(): void
+    {
+        $field = CollectionField::new('projectIssues');
+
+        // force the (string)-casting code path by simulating an 'array' doctrine type
+        // (otherwise formatCollection() short-circuits earlier on association fields).
+        $field->getAsDto()->setDoctrineMetadata(['type' => 'array']);
+
+        $invalidUtf8Item = new class implements \Stringable {
+            public function __toString(): string
+            {
+                return "valid\xC3\x28more";
+            }
+        };
+        $field->setValue([$invalidUtf8Item]);
+        $field->formatValue(static fn ($coll): int => is_countable($coll) ? \count($coll) : 0);
+
+        // the user-provided callable is applied later by CommonPostConfigurator (not
+        // exercised here), so this assertion checks the configurator's own early return.
+        $fieldDto = $this->configure($field);
+
+        $this->assertSame(1, $fieldDto->getFormattedValue());
+    }
 }


### PR DESCRIPTION
An alternative solution for the issue reported in #7613.