### PR TITLE
Fix: Browser <title> tag is not rendered when overriding content_title in custom templates

### DIFF
--- a/templates/page/content.html.twig
+++ b/templates/page/content.html.twig
@@ -6,8 +6,7 @@
 {% block body_class 'page-content' %}
 
 {# deprecated 'The "page_title" block is deprecated, use "content_title" instead.' #}
-{% block page_title %}
-{% endblock %}
+{% block page_title %}{{ block('content_title') }}{% endblock %}
 
 {# deprecated 'The "page_content" block is deprecated, use "main" instead.' #}
 {% block page_content %}


### PR DESCRIPTION
When creating a custom template that extends @EasyAdmin/page/content.html.twig and overriding the content_title block (as recommended by the deprecation notices), the browser's <title> tag remains empty.
