### PR TITLE
Harden the security of the sort feature

### DIFF
--- a/src/Dto/SearchDto.php
+++ b/src/Dto/SearchDto.php
@@ -44,6 +44,22 @@ final class SearchDto
     /**
      * @return array<string, 'ASC'|'DESC'>
      */
+    public function getCustomSort(): array
+    {
+        return $this->customSort;
+    }
+
+    /**
+     * @return array<string, 'ASC'|'DESC'>
+     */
+    public function getDefaultSort(): array
+    {
+        return $this->defaultSort;
+    }
+
+    /**
+     * @return array<string, 'ASC'|'DESC'>
+     */
     public function getSort(): array
     {
         if (null !== $this->cachedSortConfig) {

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -12,6 +12,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SearchMode;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SortOrder;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\EntityRepositoryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -146,57 +147,73 @@ final class EntityRepository implements EntityRepositoryInterface
 
     private function addOrderClause(QueryBuilder $queryBuilder, SearchDto $searchDto, EntityDto $entityDto, FieldCollection $fields): void
     {
-        foreach ($searchDto->getSort() as $sortProperty => $sortOrder) {
-            $aliases = $queryBuilder->getAllAliases();
-            $sortFieldIsDoctrineAssociation = $this->isAssociation($entityDto, $sortProperty);
+        // customSort comes from the URL and is validated; defaultSort comes from
+        // Crud::setDefaultSort() and is trusted. A rejected customSort entry must
+        // still leave the developer-supplied default for the same property in place
+        $validatedCustomSort = array_filter(
+            $searchDto->getCustomSort(),
+            fn (string $sortOrder, string $sortProperty): bool => $this->isValidCustomSort($sortProperty, $sortOrder, $entityDto, $fields),
+            \ARRAY_FILTER_USE_BOTH,
+        );
 
-            if ($sortFieldIsDoctrineAssociation) {
-                $sortFieldParts = explode('.', $sortProperty, 2);
-                // check if join has been added once before.
-                if (!\in_array($sortFieldParts[0], $aliases, true)) {
-                    $queryBuilder->leftJoin('entity.'.$sortFieldParts[0], $sortFieldParts[0]);
-                }
+        // array union preserves keys from the left operand, so customSort wins
+        // over defaultSort for the same property — same precedence as SearchDto::getSort()
+        foreach ($validatedCustomSort + $searchDto->getDefaultSort() as $sortProperty => $sortOrder) {
+            $this->applyOrderClause($queryBuilder, $entityDto, $fields, $sortProperty, $sortOrder);
+        }
+    }
 
-                if (1 === \count($sortFieldParts)) {
-                    if ($entityDto->getClassMetadata()->isCollectionValuedAssociation($sortProperty)) {
-                        /** @var EntityManagerInterface $entityManager */
-                        $entityManager = $this->doctrine->getManagerForClass($entityDto->getFqcn());
-                        $countQueryBuilder = $entityManager->createQueryBuilder();
+    private function applyOrderClause(QueryBuilder $queryBuilder, EntityDto $entityDto, FieldCollection $fields, string $sortProperty, string $sortOrder): void
+    {
+        $aliases = $queryBuilder->getAllAliases();
+        $sortFieldIsDoctrineAssociation = $this->isAssociation($entityDto, $sortProperty);
 
-                        if (ClassMetadata::MANY_TO_MANY === $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['type']) {
-                            // many-to-many relation
-                            $countQueryBuilder
-                                ->select($queryBuilder->expr()->count('subQueryEntity'))
-                                ->from($entityDto->getFqcn(), 'subQueryEntity')
-                                ->join(sprintf('subQueryEntity.%s', $sortProperty), 'relatedEntity')
-                                ->where('subQueryEntity = entity');
-                        } else {
-                            // one-to-many relation
-                            $countQueryBuilder
-                                ->select($queryBuilder->expr()->count('subQueryEntity'))
-                                ->from($entityDto->getClassMetadata()->getAssociationTargetClass($sortProperty), 'subQueryEntity')
-                                ->where(sprintf('subQueryEntity.%s = entity', $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['mappedBy']));
-                        }
+        if ($sortFieldIsDoctrineAssociation) {
+            $sortFieldParts = explode('.', $sortProperty, 2);
+            // check if join has been added once before.
+            if (!\in_array($sortFieldParts[0], $aliases, true)) {
+                $queryBuilder->leftJoin('entity.'.$sortFieldParts[0], $sortFieldParts[0]);
+            }
 
-                        $queryBuilder->addSelect(sprintf('(%s) as HIDDEN sub_query_sort', $countQueryBuilder->getDQL()));
-                        $queryBuilder->addOrderBy('sub_query_sort', $sortOrder);
-                        $queryBuilder->addOrderBy('entity.'.$entityDto->getClassMetadata()->getSingleIdentifierFieldName(), $sortOrder);
+            if (1 === \count($sortFieldParts)) {
+                if ($entityDto->getClassMetadata()->isCollectionValuedAssociation($sortProperty)) {
+                    /** @var EntityManagerInterface $entityManager */
+                    $entityManager = $this->doctrine->getManagerForClass($entityDto->getFqcn());
+                    $countQueryBuilder = $entityManager->createQueryBuilder();
+
+                    if (ClassMetadata::MANY_TO_MANY === $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['type']) {
+                        // many-to-many relation
+                        $countQueryBuilder
+                            ->select($queryBuilder->expr()->count('subQueryEntity'))
+                            ->from($entityDto->getFqcn(), 'subQueryEntity')
+                            ->join(sprintf('subQueryEntity.%s', $sortProperty), 'relatedEntity')
+                            ->where('subQueryEntity = entity');
                     } else {
-                        $field = $fields->getByProperty($sortProperty);
-                        $associationSortProperty = $field?->getCustomOption(AssociationField::OPTION_SORT_PROPERTY);
-
-                        if (null === $associationSortProperty) {
-                            $queryBuilder->addOrderBy('entity.'.$sortProperty, $sortOrder);
-                        } else {
-                            $queryBuilder->addOrderBy($sortProperty.'.'.$associationSortProperty, $sortOrder);
-                        }
+                        // one-to-many relation
+                        $countQueryBuilder
+                            ->select($queryBuilder->expr()->count('subQueryEntity'))
+                            ->from($entityDto->getClassMetadata()->getAssociationTargetClass($sortProperty), 'subQueryEntity')
+                            ->where(sprintf('subQueryEntity.%s = entity', $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['mappedBy']));
                     }
+
+                    $queryBuilder->addSelect(sprintf('(%s) as HIDDEN sub_query_sort', $countQueryBuilder->getDQL()));
+                    $queryBuilder->addOrderBy('sub_query_sort', $sortOrder);
+                    $queryBuilder->addOrderBy('entity.'.$entityDto->getClassMetadata()->getSingleIdentifierFieldName(), $sortOrder);
                 } else {
-                    $queryBuilder->addOrderBy($sortProperty, $sortOrder);
+                    $field = $fields->getByProperty($sortProperty);
+                    $associationSortProperty = $field?->getCustomOption(AssociationField::OPTION_SORT_PROPERTY);
+
+                    if (null === $associationSortProperty) {
+                        $queryBuilder->addOrderBy('entity.'.$sortProperty, $sortOrder);
+                    } else {
+                        $queryBuilder->addOrderBy($sortProperty.'.'.$associationSortProperty, $sortOrder);
+                    }
                 }
             } else {
-                $queryBuilder->addOrderBy('entity.'.$sortProperty, $sortOrder);
+                $queryBuilder->addOrderBy($sortProperty, $sortOrder);
             }
+        } else {
+            $queryBuilder->addOrderBy('entity.'.$sortProperty, $sortOrder);
         }
     }
 
@@ -382,5 +399,38 @@ final class EntityRepository implements EntityRepositoryInterface
         $propertyNameParts = explode('.', $propertyName, 2);
 
         return $entityDto->getClassMetadata()->hasAssociation($propertyNameParts[0]);
+    }
+
+    private function isValidCustomSort(string $sortProperty, string $sortOrder, EntityDto $entityDto, FieldCollection $fields): bool
+    {
+        // the order direction reaches DQL via Expr\OrderBy as "$property $direction",
+        // so an unvalidated value can smuggle a second ORDER BY column (e.g. "ASC, x DESC")
+        $direction = strtoupper($sortOrder);
+        if (SortOrder::ASC !== $direction && SortOrder::DESC !== $direction) {
+            return false;
+        }
+
+        // multi-segment customSort (e.g. "customer.secretField") would otherwise
+        // reach the unfiltered multi-segment branch in applyOrderClause; URL-based
+        // association sort is supported via AssociationField::setSortProperty()
+        // with a single-segment key
+        if (str_contains($sortProperty, '.')) {
+            return false;
+        }
+
+        // structural gate: the property must be a real Doctrine field or association
+        // on the entity. This also rejects any key with characters (commas, spaces,
+        // quotes…) that could otherwise smuggle DQL fragments through identifier interpolation
+        $classMetadata = $entityDto->getClassMetadata();
+        if (!$classMetadata->hasField($sortProperty) && !$classMetadata->hasAssociation($sortProperty)) {
+            return false;
+        }
+
+        $fieldDto = $fields->getByProperty($sortProperty);
+        if (null === $fieldDto || false === $fieldDto->isSortable()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
@@ -33,5 +33,6 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkTo(Synthetic\DefaultCrudTestEntityCrudController::class, 'Default CRUD Tests', 'fas fa-cog');
         yield MenuItem::linkTo(Synthetic\SearchAllTermsCrudController::class, 'Search Tests', 'fas fa-search');
         yield MenuItem::linkTo(Synthetic\ActionTestEntityCrudController::class, 'Action Tests', 'fas fa-mouse-pointer');
+        yield MenuItem::linkTo(Synthetic\UrlSortSecurityTestEntityCrudController::class, 'URL Sort Security Tests', 'fas fa-shield-alt');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/UrlSortSecurityTestEntityCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/UrlSortSecurityTestEntityCrudController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\UrlSortSecurityTestEntity;
+
+/**
+ * @extends AbstractCrudController<UrlSortSecurityTestEntity>
+ */
+class UrlSortSecurityTestEntityCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return UrlSortSecurityTestEntity::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setPaginatorPageSize(100)
+            ->setDefaultSort(['id' => 'ASC']);
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        // `hiddenField` and `otherField` are Doctrine-mapped on the entity but
+        // intentionally not exposed here, so ?sort[hiddenField] / ?sort[otherField]
+        // requests must be rejected by EntityRepository::addOrderClause
+        yield IdField::new('id')->hideOnForm();
+        yield TextField::new('displayedField');
+    }
+}

--- a/tests/Functional/Apps/DefaultApp/src/DataFixtures/AppFixtures.php
+++ b/tests/Functional/Apps/DefaultApp/src/DataFixtures/AppFixtures.php
@@ -26,6 +26,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synt
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SearchTestEntity;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SortTestEntity;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SortTestRelatedEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\UrlSortSecurityTestEntity;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\User;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Website;
 
@@ -81,6 +82,8 @@ class AppFixtures extends Fixture
         $this->addDefaultCrudTestFixtures($manager);
 
         $this->addSortTestFixtures($manager);
+
+        $this->addUrlSortSecurityTestFixtures($manager);
 
         $this->addSearchTestFixtures($manager);
 
@@ -604,6 +607,28 @@ class AppFixtures extends Fixture
                 $oneToManyRelated->setSortTestEntity($entity);
                 $manager->persist($oneToManyRelated);
             }
+        }
+    }
+
+    private function addUrlSortSecurityTestFixtures(ObjectManager $manager): void
+    {
+        // values chosen so that sorting by id, displayedField, hiddenField, or
+        // otherField each produces a distinct row order — that lets the test
+        // assert a specific expected order and detect when an attacker-controlled
+        // sort actually took effect (vs. being rejected and falling back to id ASC)
+        $rows = [
+            ['displayedField' => 'Zulu',  'hiddenField' => 'Alpha',   'otherField' => 'Bravo'],
+            ['displayedField' => 'Alpha', 'hiddenField' => 'Zulu',    'otherField' => 'Charlie'],
+            ['displayedField' => 'Mike',  'hiddenField' => 'Mike',    'otherField' => 'Alpha'],
+        ];
+
+        foreach ($rows as $row) {
+            $entity = (new UrlSortSecurityTestEntity())
+                ->setDisplayedField($row['displayedField'])
+                ->setHiddenField($row['hiddenField'])
+                ->setOtherField($row['otherField']);
+
+            $manager->persist($entity);
         }
     }
 

--- a/tests/Functional/Apps/DefaultApp/src/Entity/Synthetic/UrlSortSecurityTestEntity.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Synthetic/UrlSortSecurityTestEntity.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Entity used by UrlSortSecurityTest to verify that ?sort[...] cannot order
+ * the index by a Doctrine-mapped property that isn't exposed via
+ * configureFields(), and cannot smuggle extra ORDER BY columns through the
+ * value or the key.
+ */
+#[ORM\Entity]
+class UrlSortSecurityTestEntity
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $displayedField = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $hiddenField = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $otherField = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getDisplayedField(): ?string
+    {
+        return $this->displayedField;
+    }
+
+    public function setDisplayedField(?string $displayedField): self
+    {
+        $this->displayedField = $displayedField;
+
+        return $this;
+    }
+
+    public function getHiddenField(): ?string
+    {
+        return $this->hiddenField;
+    }
+
+    public function setHiddenField(?string $hiddenField): self
+    {
+        $this->hiddenField = $hiddenField;
+
+        return $this;
+    }
+
+    public function getOtherField(): ?string
+    {
+        return $this->otherField;
+    }
+
+    public function setOtherField(?string $otherField): self
+    {
+        $this->otherField = $otherField;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->displayedField ?? '';
+    }
+}

--- a/tests/Functional/Default/Sort/UrlSortSecurityTest.php
+++ b/tests/Functional/Default/Sort/UrlSortSecurityTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Default\Sort;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic\UrlSortSecurityTestEntityCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\UrlSortSecurityTestEntity;
+
+/**
+ * End-to-end checks that the URL-derived ?sort[...] parameter cannot order the
+ * index by a Doctrine-mapped property that the controller hasn't exposed, and
+ * cannot smuggle extra ORDER BY columns through either the key or the value.
+ *
+ * The fixture is set up so that sorting by `id`, `displayedField`, `hiddenField`
+ * or `otherField` each produces a distinct row order — that lets every test
+ * compare against the controller's default `id ASC` order and detect when an
+ * attacker-controlled sort actually took effect.
+ */
+class UrlSortSecurityTest extends AbstractCrudTestCase
+{
+    private EntityRepository $repository;
+
+    protected function getControllerFqcn(): string
+    {
+        return UrlSortSecurityTestEntityCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->repository = $this->entityManager->getRepository(UrlSortSecurityTestEntity::class);
+    }
+
+    public function testValidCustomSortByExposedFieldIsApplied(): void
+    {
+        // sanity: ?sort[displayedField]=ASC is legitimate and reorders the index
+        $expected = $this->displayedFieldsInOrder('displayedField', \SORT_ASC);
+
+        $this->client->request('GET', $this->generateIndexUrl().'?sort%5BdisplayedField%5D=ASC');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertRowsInOrder($expected);
+    }
+
+    public function testCustomSortByHiddenMappedFieldFallsBackToDefault(): void
+    {
+        // ?sort[hiddenField]=ASC: `hiddenField` is mapped on the entity but not
+        // exposed via configureFields(), so the gate must reject it and the
+        // controller's `setDefaultSort(['id' => 'ASC'])` must remain in effect
+        $expected = $this->displayedFieldsInOrder('id', \SORT_ASC);
+
+        $this->client->request('GET', $this->generateIndexUrl().'?sort%5BhiddenField%5D=ASC');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertRowsInOrder($expected);
+    }
+
+    public function testCustomSortValueSmugglingIsRejected(): void
+    {
+        // ?sort[displayedField]=ASC, entity.hiddenField DESC
+        // Expr\OrderBy::add() concatenates "$property $direction", so without a
+        // direction-value check this smuggles a second OrderByItem into the DQL
+        $expected = $this->displayedFieldsInOrder('id', \SORT_ASC);
+
+        $url = $this->generateIndexUrl().'?'.http_build_query([
+            'sort' => ['displayedField' => 'ASC, entity.hiddenField DESC'],
+        ]);
+        $this->client->request('GET', $url);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertRowsInOrder($expected);
+    }
+
+    public function testCustomSortKeyWithCommaIsRejected(): void
+    {
+        // ?sort[displayedField,entity.hiddenField]=ASC — comma in the key would
+        // otherwise expand into two ORDER BY columns
+        $expected = $this->displayedFieldsInOrder('id', \SORT_ASC);
+
+        $url = $this->generateIndexUrl().'?'.http_build_query([
+            'sort' => ['displayedField,entity.hiddenField' => 'ASC'],
+        ]);
+        $this->client->request('GET', $url);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertRowsInOrder($expected);
+    }
+
+    /**
+     * Returns the `displayedField` values of the fixture rows, ordered by the
+     * given property name and direction. Used to build the expected row sequence
+     * for each test independently of the DB engine's tie-breaking behavior.
+     *
+     * @return list<string>
+     */
+    private function displayedFieldsInOrder(string $property, int $direction): array
+    {
+        $entities = $this->repository->findAll();
+        usort(
+            $entities,
+            static function (UrlSortSecurityTestEntity $a, UrlSortSecurityTestEntity $b) use ($property, $direction): int {
+                $cmp = match ($property) {
+                    'id' => $a->getId() <=> $b->getId(),
+                    'displayedField' => $a->getDisplayedField() <=> $b->getDisplayedField(),
+                    'hiddenField' => $a->getHiddenField() <=> $b->getHiddenField(),
+                    'otherField' => $a->getOtherField() <=> $b->getOtherField(),
+                };
+
+                return \SORT_ASC === $direction ? $cmp : -$cmp;
+            }
+        );
+
+        return array_map(static fn (UrlSortSecurityTestEntity $e): string => $e->getDisplayedField(), $entities);
+    }
+
+    /**
+     * @param list<string> $expectedDisplayedFieldValues
+     */
+    private function assertRowsInOrder(array $expectedDisplayedFieldValues): void
+    {
+        foreach ($expectedDisplayedFieldValues as $i => $value) {
+            $this->assertSelectorTextSame(
+                sprintf('tbody tr:nth-child(%d) td[data-column="displayedField"]', $i + 1),
+                $value,
+                sprintf('Expected "%s" in row %d', $value, $i + 1),
+            );
+        }
+    }
+}

--- a/tests/Unit/Orm/EntityRepositoryTest.php
+++ b/tests/Unit/Orm/EntityRepositoryTest.php
@@ -8,11 +8,13 @@ use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -225,6 +227,159 @@ class EntityRepositoryTest extends TestCase
         $this->assertSame($queryBuilder, $result);
     }
 
+    public function testCustomSortByExposedSortableFieldIsApplied(): void
+    {
+        $entityDto = $this->createEntityDto(['displayedField']);
+        $fields = new FieldCollection([$this->createField('displayedField', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['displayedField' => 'ASC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('entity.displayedField', 'ASC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testCustomSortByFieldAbsentFromFieldCollectionIsIgnored(): void
+    {
+        // simulates ?sort[hiddenField]=ASC against a controller whose
+        // configureFields(INDEX) doesn't expose `hiddenField`
+        $entityDto = $this->createEntityDto(['hiddenField']);
+        $fields = new FieldCollection([]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['hiddenField' => 'ASC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->never())->method('addOrderBy');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testCustomSortByExplicitlyNonSortableFieldIsIgnored(): void
+    {
+        $entityDto = $this->createEntityDto(['displayedField']);
+        $fields = new FieldCollection([$this->createField('displayedField', false)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['displayedField' => 'ASC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->never())->method('addOrderBy');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testCustomSortKeyContainingCommaIsIgnored(): void
+    {
+        // ?sort[name,entity.email]=ASC — comma would smuggle an extra ORDER BY column
+        $entityDto = $this->createEntityDto(['displayedField']);
+        $fields = new FieldCollection([$this->createField('displayedField', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['displayedField,entity.hiddenField' => 'ASC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->never())->method('addOrderBy');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testCustomSortKeyContainingDotIsIgnored(): void
+    {
+        // ?sort[customer.secretField]=ASC — multi-segment keys reach the unfiltered
+        // multi-segment branch of applyOrderClause; URL-based association sort is
+        // supported via single-segment keys + AssociationField::setSortProperty()
+        $entityDto = $this->createEntityDto([], ['customer']);
+        $fields = new FieldCollection([$this->createField('customer', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['customer.secretField' => 'ASC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->never())->method('addOrderBy');
+        $queryBuilder->expects($this->never())->method('leftJoin');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testCustomSortWithNonAscDescValueIsIgnored(): void
+    {
+        // ?sort[displayedField]=ASC,%20entity.hiddenField%20DESC — Expr\OrderBy
+        // concatenates "$property $direction", so an unvalidated direction smuggles
+        // a second OrderByItem that the DQL parser happily accepts
+        $entityDto = $this->createEntityDto(['displayedField']);
+        $fields = new FieldCollection([$this->createField('displayedField', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['displayedField' => 'ASC, entity.hiddenField DESC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->never())->method('addOrderBy');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testInvalidCustomSortFallsBackToDefaultSortForSameKey(): void
+    {
+        // ?sort[hiddenField]=ASC must not suppress setDefaultSort(['hiddenField' => 'DESC']):
+        // the customSort entry is rejected, the defaultSort entry still applies
+        $entityDto = $this->createEntityDto(['hiddenField']);
+        $fields = new FieldCollection([]);
+        $searchDto = $this->createSearchDtoForSort(
+            customSort: ['hiddenField' => 'ASC'],
+            defaultSort: ['hiddenField' => 'DESC'],
+        );
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('entity.hiddenField', 'DESC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testDefaultSortByFieldAbsentFromFieldCollectionIsStillApplied(): void
+    {
+        // developer-supplied default sort is trusted unconditionally
+        $entityDto = $this->createEntityDto(['createdAt']);
+        $fields = new FieldCollection([]);
+        $searchDto = $this->createSearchDtoForSort(defaultSort: ['createdAt' => 'DESC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('entity.createdAt', 'DESC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testValidCustomSortOverridesDefaultSortForSameKey(): void
+    {
+        $entityDto = $this->createEntityDto(['displayedField']);
+        $fields = new FieldCollection([$this->createField('displayedField', true)]);
+        $searchDto = $this->createSearchDtoForSort(
+            customSort: ['displayedField' => 'ASC'],
+            defaultSort: ['displayedField' => 'DESC'],
+        );
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('entity.displayedField', 'ASC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
     private function createSearchDto(string $query = '', array $sort = [], ?array $appliedFilters = []): SearchDto
     {
         return new SearchDto(
@@ -237,15 +392,58 @@ class EntityRepositoryTest extends TestCase
         );
     }
 
-    private function createEntityDto(): EntityDto
+    /**
+     * @param array<string, string> $customSort
+     * @param array<string, string> $defaultSort
+     */
+    private function createSearchDtoForSort(array $customSort = [], array $defaultSort = []): SearchDto
+    {
+        return new SearchDto(new Request(), null, '', $defaultSort, $customSort, []);
+    }
+
+    /**
+     * @param list<string> $mappedFields
+     * @param list<string> $mappedAssociations
+     */
+    private function createEntityDto(array $mappedFields = [], array $mappedAssociations = []): EntityDto
     {
         $metadata = $this->createMock(ClassMetadata::class);
         $metadata->method('getSingleIdentifierFieldName')->willReturn('id');
-        $metadata->method('hasAssociation')->willReturn(false);
-        $metadata->method('getFieldNames')->willReturn([]);
-        $metadata->fieldMappings = [];
+        $metadata->method('hasField')->willReturnCallback(static fn (string $name): bool => \in_array($name, $mappedFields, true));
+        $metadata->method('hasAssociation')->willReturnCallback(static fn (string $name): bool => \in_array($name, $mappedAssociations, true));
+        $metadata->method('getFieldNames')->willReturn($mappedFields);
+        $metadata->fieldMappings = array_fill_keys($mappedFields, []);
 
         return new EntityDto('App\Entity\Product', $metadata);
+    }
+
+    private function createField(string $property, bool $sortable): FieldInterface
+    {
+        $field = Field::new($property);
+        $field->setSortable($sortable);
+
+        return $field;
+    }
+
+    /**
+     * Builds a QueryBuilder mock pre-wired for the select/from/getAllAliases
+     * calls EntityRepository::createQueryBuilder makes before addOrderClause runs.
+     */
+    private function createSortingQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('getAllAliases')->willReturn(['entity']);
+
+        return $queryBuilder;
+    }
+
+    private function stubEntityManager(QueryBuilder $queryBuilder): void
+    {
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('createQueryBuilder')->willReturn($queryBuilder);
+        $this->doctrine->method('getManagerForClass')->willReturn($entityManager);
     }
 
     /**


### PR DESCRIPTION
**Thanks to Anthropic and The PHP Foundation, the EasyAdmin codebase was recently analyzed by Claude Mythos.** It reported some issues and after analyzing them, we'll publish a CVE later but this other issue is being fixed as "hardening" and "defense in depth".

-----

### Problem

The `?sort` query parameter on index pages was passed through to Doctrine without validating the   property name or the direction against the controller's configured fields. This let an authenticated admin reorder the result set by any Doctrine-mapped property (even ones not exposed via `configureFields()`) and smuggle extra `ORDER BY` columns through either the key or the value.

### Examples of abusing this

Assume a `UserCrudController` whose `configureFields(INDEX)` exposes only `email`, while `password` is mapped on the entity but not shown.

**1) Sort by a hidden column**
`?sort[password]=ASC` produced ORDER BY entity.password ASC — rows can be probed across many requests to learn relative ordering of the password hash column.

After this fix: rejected, the controller's default sort applies.
  
**2) Comma in the key smuggles a second column**
`?sort[email,entity.password]=ASC` produced `ORDER BY entity.email, entity.password ASC` — two `ORDER BY` columns from one request.

After this fix: rejected.

**3) Direction value smuggles a second column**
`?sort[email]=ASC, entity.password DESC` Doctrine's `Expr\OrderBy` concatenates `"$property $direction"`, so the DQL parser sees `ORDER BY entity.email ASC, entity.password DESC` — two columns again.

After this fix: rejected.
  
**4) Multi-segment key bypasses AssociationField::setSortProperty()**
`?sort[customer.passwordHash]=ASC` (with customer exposed as an AssociationField) forced a leftJoin on customer and sorted by an arbitrary column on the joined table, ignoring `setSortProperty()`.

After this fix: rejected. URL-based association sort still works via the documented `?sort[customer]=ASC` + `AssociationField::setSortProperty('name')` pattern.

### Why not a a security advisory?

* Authenticated admin required
* No SQL injection. Doctrine's DQL parser blocks classic SQLi, stacked queries, and arbitrary expressions. No code execution and no writes; just information disclosure via ordering as a side channel.
* Slow, low-bandwidth oracle. Inferring a sensitive column value would require many requests' worth of relative-ordering comparisons; not arbitrary read.
* EasyAdmin's default field provider already excludes the obvious sensitive names (`password`, `salt`, `slug`, `updatedAt`, `uuid`) from INDEX fields, so apps relying on default `configureFields()` are not exposed.
