### PR TITLE
Fix vertical jump of icons in compact sidebar on hover

### DIFF
--- a/assets/css/easyadmin-theme/menu.css
+++ b/assets/css/easyadmin-theme/menu.css
@@ -176,9 +176,11 @@ body.ea-sidebar-width-compact .sidebar #main-menu .menu .menu-item {
     }
     body.ea-sidebar-width-compact #main-menu .menu .menu-item .menu-item-label {
         flex: 1;
+        line-height: 21px;
     }
     body.ea-sidebar-width-compact #main-menu .menu .menu-item .menu-item-contents {
         align-items: center;
+        block-size: 35px;
         border-radius: 0 var(--border-radius) var(--border-radius) 0;
         display: flex;
         min-inline-size: max-content;


### PR DESCRIPTION
In compact sidebar mode (desktop), `.menu-item-contents` has no fixed height and uses `align-items: center`. On hover, `.menu-item-label` (display: none → block) adds its line-height to the flex line, growing the container by 1-3px and visibly shifting the icon vertically.

Pin `.menu-item-contents` block-size to 35px (padding 7+7 + icon 21) and the label's line-height to 21px, scoped to the existing compact-on-desktop rules. Other widths (mobile, expanded desktop) are untouched.

Fixes #7614