### PR TITLE
Do not convert translatable enum choices into an associative array

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -78,6 +78,8 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         if ($areChoicesTranslatable && !$choicesSupportTranslatableInterface) {
             $field->setFormTypeOptionIfNotSet('choices', array_keys($choices));
             $field->setFormTypeOptionIfNotSet('choice_label', static fn ($value) => $choices[$value]);
+        } elseif ($choicesSupportTranslatableInterface && $allChoicesAreEnums) {
+            $field->setFormTypeOptionIfNotSet('choices', array_values($choices));
         } else {
             $field->setFormTypeOptionIfNotSet('choices', $choices);
         }


### PR DESCRIPTION
Fixes https://github.com/EasyCorp/EasyAdminBundle/issues/7242

EasyAdmin was transforming all enum choices into an associative array.
But we should not transform translatable enums and let the `EnumType` to handle enums with its own logic.

Note: we cannot completely remove the associative array because it is used later in the code to handle translations.
So we just remove keys when passing it to the `choices` form option.

Different approach from https://github.com/EasyCorp/EasyAdminBundle/pull/7243 as suggested by https://github.com/EasyCorp/EasyAdminBundle/pull/7243#issuecomment-4066477464