### PR TITLE
Fix sorting on embeddable

### DIFF
--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -410,18 +410,21 @@ final class EntityRepository implements EntityRepositoryInterface
             return false;
         }
 
+        $classMetadata = $entityDto->getClassMetadata();
+
         // multi-segment customSort (e.g. "customer.secretField") would otherwise
         // reach the unfiltered multi-segment branch in applyOrderClause; URL-based
         // association sort is supported via AssociationField::setSortProperty()
-        // with a single-segment key
-        if (str_contains($sortProperty, '.')) {
+        // with a single-segment key. Embeddable properties (e.g. "address.city")
+        // are real Doctrine fields with a dotted name (hasField() === true), so
+        // they are still allowed
+        if (str_contains($sortProperty, '.') && !$classMetadata->hasField($sortProperty)) {
             return false;
         }
 
         // structural gate: the property must be a real Doctrine field or association
         // on the entity. This also rejects any key with characters (commas, spaces,
         // quotes…) that could otherwise smuggle DQL fragments through identifier interpolation
-        $classMetadata = $entityDto->getClassMetadata();
         if (!$classMetadata->hasField($sortProperty) && !$classMetadata->hasAssociation($sortProperty)) {
             return false;
         }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/SearchTestAuthorCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/SearchTestAuthorCrudController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SearchTestAuthor;
+
+/**
+ * CRUD controller used to test sorting by an embedded (embeddable) property.
+ * The `address.city` field belongs to the embedded Address value object.
+ *
+ * @extends AbstractCrudController<SearchTestAuthor>
+ */
+class SearchTestAuthorCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return SearchTestAuthor::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setDefaultSort(['id' => 'ASC']);
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id');
+        yield TextField::new('name');
+        // embeddable property; sortable by default
+        yield TextField::new('address.city');
+    }
+}

--- a/tests/Functional/Default/Sort/SortByEmbeddablePropertyTest.php
+++ b/tests/Functional/Default/Sort/SortByEmbeddablePropertyTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Default\Sort;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic\SearchTestAuthorCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SearchTestAuthor;
+
+/**
+ * Sorting by an embedded (embeddable) property such as `address.city`.
+ *
+ * #7621 hardened the URL `?sort[...]` parameter by rejecting any key containing a
+ * dot before the structural checks; embeddable properties are written with a dot,
+ * so this regressed embeddable sorting (#7635). This test guards the fix that lets
+ * real Doctrine fields with a dotted name (embeddables) through while still
+ * rejecting multi-segment association keys.
+ */
+class SortByEmbeddablePropertyTest extends AbstractCrudTestCase
+{
+    private EntityRepository $repository;
+
+    protected function getControllerFqcn(): string
+    {
+        return SearchTestAuthorCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->repository = $this->entityManager->getRepository(SearchTestAuthor::class);
+    }
+
+    public function testSortByEmbeddablePropertyAscending(): void
+    {
+        $expected = $this->citiesInOrder(\SORT_ASC);
+
+        $url = $this->generateIndexUrl().'?'.http_build_query(['sort' => ['address.city' => 'ASC']]);
+        $this->client->request('GET', $url);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertCitiesInOrder($expected);
+    }
+
+    public function testSortByEmbeddablePropertyDescending(): void
+    {
+        $expected = $this->citiesInOrder(\SORT_DESC);
+
+        $url = $this->generateIndexUrl().'?'.http_build_query(['sort' => ['address.city' => 'DESC']]);
+        $this->client->request('GET', $url);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertCitiesInOrder($expected);
+    }
+
+    /**
+     * Returns the embedded `address.city` values of every fixture row, ordered by
+     * the given direction. Duplicate cities are fine: the assertion compares the
+     * city values in order, which are deterministic under `ORDER BY address.city`.
+     *
+     * @return list<string>
+     */
+    private function citiesInOrder(int $direction): array
+    {
+        $cities = array_map(
+            static fn (SearchTestAuthor $author): string => $author->getAddress()->getCity(),
+            $this->repository->findAll(),
+        );
+
+        \SORT_ASC === $direction ? sort($cities) : rsort($cities);
+
+        return $cities;
+    }
+
+    /**
+     * @param list<string> $expectedCities
+     */
+    private function assertCitiesInOrder(array $expectedCities): void
+    {
+        foreach ($expectedCities as $i => $city) {
+            $this->assertSelectorTextSame(
+                sprintf('tbody tr:nth-child(%d) td[data-column="address.city"]', $i + 1),
+                $city,
+                sprintf('Expected "%s" in row %d', $city, $i + 1),
+            );
+        }
+    }
+}


### PR DESCRIPTION
#7621 hardened the `?sort[...]` parameter by rejecting any sort key containing a dot before the structural checks. Embeddable properties are written with a dot (e.g. `address.city`), so this also rejected legitimate embeddable sorting.

This PR relaxes only the dotted-key check: a dotted key is still rejected unless it is a real Doctrine field (`ClassMetadata::hasField()` is `true` for embeddable sub-fields, `false` for multi-segment association keys such as `customer.secretField`). All other checks from #7621 stay in place, so the hardening is preserved.

This PR also adds a regression test sorting an index by an embeddable property, which was previously untested.

Fixes #7635 and it's an alternative to #7636.