### PR TITLE
Preserve custom query parameters in index search forms

### DIFF
--- a/src/Dto/SearchDto.php
+++ b/src/Dto/SearchDto.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Dto;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SearchMode;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -136,5 +137,38 @@ final class SearchDto
     public function getSearchMode(): string
     {
         return $this->searchMode;
+    }
+
+    /**
+     * Returns the query string parameters that must be preserved when submitting
+     * the index search form. Browsers discard the query string of GET forms, so
+     * these parameters are rendered as hidden fields in the search form template.
+     *
+     * @return array<string, mixed>
+     */
+    public function getPreservedQueryParameters(): array
+    {
+        $parameters = $this->request->query->all();
+
+        foreach ([
+            EA::QUERY,
+            EA::PAGE,
+            EA::FILTERS,
+            EA::CRUD_ACTION,
+            EA::CRUD_CONTROLLER_FQCN,
+            EA::DASHBOARD_CONTROLLER_FQCN,
+            EA::ENTITY_FQCN,
+            EA::ENTITY_ID,
+            EA::ROUTE_NAME,
+            EA::ROUTE_PARAMS,
+            EA::BATCH_ACTION_NAME,
+            EA::BATCH_ACTION_URL,
+            EA::BATCH_ACTION_CSRF_TOKEN,
+            EA::BATCH_ACTION_ENTITY_IDS,
+        ] as $reservedParameter) {
+            unset($parameters[$reservedParameter]);
+        }
+
+        return $parameters;
     }
 }

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -300,6 +300,12 @@
                                                             <input type="hidden" name="filters[{{ field }}]" value="{{ fieldValue }}">
                                                         {% endif %}
                                                     {% endfor %}
+
+                                                    {# Browsers remove the query string when submitting forms using GET;
+                                                       that's why the remaining query string parameters are added as hidden form fields #}
+                                                    {% for paramName, paramValue in ea.search.preservedQueryParameters|ea_flatten_array %}
+                                                        <input type="hidden" name="{{ paramName }}" value="{{ paramValue }}">
+                                                    {% endfor %}
                                                 {% endblock %}
 
                                                 <div class="form-group">

--- a/tests/Functional/Default/Search/SearchAllTermsTest.php
+++ b/tests/Functional/Default/Search/SearchAllTermsTest.php
@@ -69,6 +69,21 @@ class SearchAllTermsTest extends AbstractCrudTestCase
         $this->assertStringStartsWith($this->generateIndexUrl(), $resetUrl);
     }
 
+    public function testSearchPreservesCustomQueryParameters(): void
+    {
+        $crawler = $this->client->request('GET', $this->getCrudUrl('index', null, ['customContext' => 'test']));
+
+        $form = $crawler->filter('form.form-action-search');
+        $hiddenInput = $form->filter('input[type="hidden"][name="customContext"]');
+        $this->assertCount(1, $hiddenInput);
+        $this->assertSame('test', $hiddenInput->attr('value'));
+
+        $this->client->submit($form->form(['query' => 'PHP']));
+
+        $this->assertStringContainsString('customContext=test', $this->client->getRequest()->getUri());
+        $this->assertStringContainsString('query=PHP', $this->client->getRequest()->getUri());
+    }
+
     public function testSearchIsPersistedAfterPaginationAndSorting(): void
     {
         // make some query

--- a/tests/Unit/Dto/SearchDtoTest.php
+++ b/tests/Unit/Dto/SearchDtoTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Dto;
 
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\SearchMode;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use PHPUnit\Framework\TestCase;
@@ -76,6 +77,41 @@ class SearchDtoTest extends TestCase
     {
         yield 'any terms search mode' => [SearchMode::ANY_TERMS];
         yield 'all terms search mode' => [SearchMode::ALL_TERMS];
+    }
+
+    /**
+     * @dataProvider providePreservedQueryParametersTests
+     */
+    public function testGetPreservedQueryParameters(array $queryParameters, array $expectedPreservedParameters): void
+    {
+        $request = new Request($queryParameters);
+        $dto = new SearchDto($request, null, $queryParameters[EA::QUERY] ?? null, [], [], null);
+
+        $this->assertSame($expectedPreservedParameters, $dto->getPreservedQueryParameters());
+    }
+
+    public static function providePreservedQueryParametersTests(): iterable
+    {
+        yield 'custom query parameters are preserved' => [
+            ['query' => 'foo', 'page' => '2', 'customContext' => 'test'],
+            ['customContext' => 'test'],
+        ];
+
+        yield 'sort parameters are preserved' => [
+            ['query' => 'foo', 'sort' => ['title' => 'ASC']],
+            ['sort' => ['title' => 'ASC']],
+        ];
+
+        yield 'filters and reserved parameters are excluded' => [
+            [
+                'query' => 'foo',
+                'page' => '2',
+                'filters' => ['title' => ['comparison' => '=', 'value' => 'bar']],
+                EA::CRUD_ACTION => 'index',
+                'customContext' => 'test',
+            ],
+            ['customContext' => 'test'],
+        ];
     }
 
     public static function provideSortDirectionTests(): iterable


### PR DESCRIPTION
Fixes #7640

## Summary

Browsers discard the query string of GET forms when they are submitted. EasyAdmin already works around this for:

- official `filters[...]` parameters (hidden fields in `search_form_filters`, see #4707)
- the filters modal form (`form_action_query_string_as_array|ea_flatten_array` in `filters.html.twig`)

However, **other query parameters** (custom menu context like `_status`, sort state, etc.) are preserved in links generated by `AdminUrlGenerator`, but **lost when submitting the index search form** in real browsers. This has been known since #1573.

This PR generalizes the existing approach by preserving all remaining query parameters as hidden fields in the search form.

## Changes

- Add `SearchDto::getPreservedQueryParameters()` to return current query params minus reserved EasyAdmin keys (`query`, `page`, `filters`, batch params, etc.)
- Render those parameters as hidden fields in `layout.html.twig` (same comment/pattern as `filters.html.twig`)
- Add unit and functional tests

## Test plan

- [x] `SearchDtoTest::testGetPreservedQueryParameters`
- [x] `SearchAllTermsTest::testSearchPreservesCustomQueryParameters`

## Related issues

- #1573 (search button does not pass custom parameters)
- #4707 (search did not respect active filters — fixed for native filters only)