### PR TITLE
fix: Multiple click event listeners get added to delete buttons on co…

### DIFF
--- a/assets/js/field-collection.js
+++ b/assets/js/field-collection.js
@@ -11,6 +11,10 @@ const eaCollectionHandler = (event) => {
     });
 
     document.querySelectorAll('button.field-collection-delete-button').forEach((deleteButton) => {
+        if(deleteButton.classList.contains('processed')) {
+            return;
+        }
+        deleteButton.classList.add('processed')
         deleteButton.addEventListener('click', () => {
             const collection = deleteButton.closest('[data-ea-collection-field]');
             const item = deleteButton.closest('.field-collection-item');


### PR DESCRIPTION
Proposed fix to this issue:
https://github.com/EasyCorp/EasyAdminBundle/issues/7625

This should prevent the js from adding multiple 'click' event listeners on the delete buttons which cascades into other bugs.