### PR TITLE
feat: Adding typescript types for ea's events for users who wants to …

### DIFF
--- a/assets/types.d.ts
+++ b/assets/types.d.ts
@@ -1,0 +1,50 @@
+import TomSelect from 'tom-select';
+import { RecursivePartial } from 'tom-select/dist/esm/types/core.js';
+import { TomSettings } from 'tom-select/dist/esm/types/settings.js';
+
+//ea.autocomplete.connect
+export type EAAutocompleteConnectEvent = CustomEvent<{
+    tomSelect: TomSelect;
+    config: RecursivePartial<TomSettings>;
+    prefix: 'autocomplete';
+}>;
+//ea.autocomplete.pre-connect
+export type EAAutocompletePreConnectEvent = CustomEvent<{
+    config: RecursivePartial<TomSettings>;
+    prefix: 'autocomplete';
+}>;
+//ea.collection.item-added
+export type EACollectionItemAddedEvent = CustomEvent<{
+    newElement: HTMLDivElement;
+    collection: HTMLDivElement;
+}>;
+//ea.collection.item-removed
+export type EACollectionItemRemovedEvent = CustomEvent<{
+    deletedElement: HTMLDivElement;
+    collection: HTMLDivElement;
+}>;
+//ea.form.submit
+export type EAFormSubmitEvent = CustomEvent<{
+    page: 'new' | 'edit';
+    form: HTMLFormElement;
+}>;
+//ea.form.error
+export type EAFormErrorEvent = CustomEvent<{
+    page: 'new' | 'edit';
+    form: HTMLFormElement;
+}>;
+
+declare global {
+    interface HTMLElementEventMap {
+        'ea.autocomplete.connect': EAAutocompleteConnectEvent;
+        'ea.autocomplete.pre-connect': EAAutocompletePreConnectEvent;
+    }
+    interface DocumentEventMap {
+        'ea.autocomplete.connect': EAAutocompleteConnectEvent;
+        'ea.autocomplete.pre-connect': EAAutocompletePreConnectEvent;
+        'ea.collection.item-added': EACollectionItemAddedEvent;
+        'ea.collection.item-removed': EACollectionItemRemovedEvent;
+        'ea.form.submit': EAFormSubmitEvent;
+        'ea.form.error': EAFormErrorEvent;
+    }
+}


### PR DESCRIPTION
I am using easyadmin with typescript for the frontend and one of my issues is that the events aren't typed.
While the codebase is using JS and I'm not suggesting you to change that, I made for myself a little file to add the proper types to the events and while I was at it I thought I could simply make a PR so that anyone could use that instead and make it standard to ea.
Typescript users could then use it simply by adding ``"include": ["vendor/easycorp/easyadmin-bundle/assets/types.d.ts"]`` to their tsconfig.json.

(maybe there could be a better place for it but I'm not familiar enough with how symfony extensions are meant to share their own TS types with the assets in webpack, my apologies for that if it's in the wrong spot, feel free to change my PR accordingly)
