### PR TITLE
Fix an interface deprecation

### DIFF
--- a/src/Menu/MenuItemMatcherInterface.php
+++ b/src/Menu/MenuItemMatcherInterface.php
@@ -7,18 +7,18 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface as C
 trigger_deprecation(
     'easycorp/easyadmin-bundle',
     '4.8.1',
-    'The "%s" class is deprecated and it will be removed in EasyAdmin 5.0.0, use "%s" instead.',
+    'The "%s" interface is deprecated and it will be removed in EasyAdmin 5.0.0, use "%s" instead.',
     MenuItemMatcherInterface::class, ContractMenuItemMatcherInterface::class
 );
 
-class_exists(ContractMenuItemMatcherInterface::class);
+class_alias(ContractMenuItemMatcherInterface::class, MenuItemMatcherInterface::class);
 
 /** @phpstan-ignore-next-line */
 if (false) {
     /**
      * @deprecated since EasyAdmin 4.8.1, to be removed in 5.0, use {@link ContractMenuItemMatcherInterface} instead
      */
-    class MenuItemMatcherInterface
+    interface MenuItemMatcherInterface extends ContractMenuItemMatcherInterface
     {
     }
 }


### PR DESCRIPTION
PHPStan shows this error in 4.x branch:

> Call to function class_exists() with 'EasyCorp\Bundle\EasyAdminBundle\Contracts\Menu\MenuItemMatcherInterface' will always evaluate to false.

The target FQCN is an interface (`src/Contracts/Menu/MenuItemMatcherInterface.php`), and PHP's `class_exists()` returns `false` for interfaces, so PHPStan is correct.

While investigating, a second problem surfaced: this legacy file was meant to follow Symfony's deprecated-class-alias pattern, but the `class_alias()` half of the pattern was never added (no `class_alias` for this name exists anywhere in the repo). As a result, user code referencing the old `EasyCorp\Bundle\EasyAdminBundle\Menu\MenuItemMatcherInterface` triggers the deprecation and then fatals with "Interface not found" instead of working with a deprecation notice. The `if (false)` IDE stub also declares a class instead of an interface.
