### PR TITLE
Allow to use "id" in addition to "entityId" as the route placeholder

### DIFF
--- a/doc/actions.rst
+++ b/doc/actions.rst
@@ -718,7 +718,7 @@ The following example shows all kinds of actions in practice::
             ;
         }
 
-        #[AdminRoute('/{entityId:order.id}/invoice')]
+        #[AdminRoute('/{id}/invoice')]
         public function renderInvoice(Order $order): Response
         {
             // add your custom order logic here...
@@ -728,8 +728,23 @@ The following example shows all kinds of actions in practice::
 Apply the ``#[AdminRoute]`` attribute to turn CRUD controller methods into custom
 CRUD actions with their own admin routes. In the above example, if the dashboard
 uses ``admin`` as the main route name, EasyAdmin generates a route named
-``admin_order_render_invoice`` with the path ``/admin/order/{entityId}/invoice``.
+``admin_order_render_invoice`` with the path ``/admin/order/{id}/invoice``.
 You can :ref:`customize the name, path, and methods <crud_routes>` of this route.
+
+The placeholder that identifies the current entity in EasyAdmin routes is called
+``{entityId}``, but you can also use ``{id}`` as an alias of it. Both work the
+same but ``{id}`` provides a nicer integration with Symfony: since the placeholder
+name matches the identifier property of most entities, Symfony's ``EntityValueResolver``
+can inject the entity as a typed controller argument (the ``Order $order`` argument
+in the above example) without any extra configuration.
+
+.. note::
+
+    If your application doesn't enable the ``controller_resolver.auto_mapping``
+    option of DoctrineBundle, add the ``#[MapEntity]`` attribute to the controller
+    argument (``#[MapEntity] Order $order``) to inject the entity. When using the
+    ``{entityId}`` placeholder instead of ``{id}``, you must always use the explicit
+    `mapped route parameters`_ syntax: ``#[AdminRoute('/{entityId:order.id}/invoice')]``.
 
 .. tip::
 
@@ -1145,6 +1160,7 @@ backends. Instead of defining it repeatedly, you can create a reusable package
     }
 
 .. _`FontAwesome`: https://fontawesome.com/
+.. _`mapped route parameters`: https://symfony.com/doc/current/doctrine.html#fetch-automatically
 .. _`Symfony base controller class`: https://symfony.com/doc/current/controller.html#the-base-controller-class-services
 .. _`Symfony controllers`: https://symfony.com/doc/current/controller.html
 .. _`Symfony bundle`: https://symfony.com/doc/current/bundles.html

--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -119,6 +119,15 @@ Admin route name                Admin route path
 ``admin_product_view``          ``/admin/product/324``
 ==============================  =====================================
 
+.. tip::
+
+    The route paths of the ``edit``, ``delete`` and ``detail`` actions must contain
+    the ``{entityId}`` placeholder, which identifies the current entity. You can also
+    use ``{id}`` as an alias of ``{entityId}`` (e.g. ``'detail' => ['routePath' => '/{id}']``).
+    Both placeholders work the same in EasyAdmin, but ``{id}`` also allows Symfony
+    to inject the entity as a typed controller argument automatically
+    (see :ref:`custom actions <actions-custom>`).
+
 You can also customize the path and/or route name of CRUD controllers using the
 ``#[AdminRoute]`` attribute with the following options:
 
@@ -982,6 +991,25 @@ method (it will be called automatically for you):
     {% set url = ea_url()
         .setController('App\\Controller\\Admin\\SomeCrudController')
         .setAction('theActionName') %}
+
+When the URL points to an action that operates on a specific entity (e.g. ``edit``,
+``detail`` or a custom action), set the entity identifier with the ``setEntityId()``
+method. You can also use ``setId()``, a more concise alias of ``setEntityId()``
+(both work no matter if the route path uses the ``{entityId}`` placeholder or
+its ``{id}`` alias):
+
+.. code-block:: twig
+
+    {% set url = ea_url()
+        .setController('App\\Controller\\Admin\\SomeCrudController')
+        .setAction('detail')
+        .setId(product.id) %}
+
+.. note::
+
+    The ``setId()`` method is not part of ``AdminUrlGeneratorInterface`` yet (it will
+    be added in the next major version of EasyAdmin). If you generate URLs in PHP code
+    and type-hint the ``AdminUrlGeneratorInterface``, use ``setEntityId()`` instead.
 
 Generating CRUD URLs from outside EasyAdmin
 ...........................................

--- a/src/DataCollector/EasyAdminDataCollector.php
+++ b/src/DataCollector/EasyAdminDataCollector.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\DataCollector;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Router\EntityIdReader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector as BaseDataCollector;
@@ -60,7 +61,7 @@ class EasyAdminDataCollector extends BaseDataCollector
         return [
             'CRUD Controller FQCN' => null === $context->getCrud() ? null : $context->getCrud()->getControllerFqcn(),
             'CRUD Action' => $attributes[EA::CRUD_ACTION] ?? $query[EA::CRUD_ACTION] ?? null,
-            'Entity ID' => $attributes[EA::ENTITY_ID] ?? $query[EA::ENTITY_ID] ?? null,
+            'Entity ID' => EntityIdReader::fromRequest($context->getRequest()),
             'Sort' => $attributes[EA::SORT] ?? $query[EA::SORT] ?? null,
         ];
     }

--- a/src/EventListener/AdminRouterSubscriber.php
+++ b/src/EventListener/AdminRouterSubscriber.php
@@ -90,16 +90,41 @@ readonly class AdminRouterSubscriber implements EventSubscriberInterface
             } catch (BaseException $e) {
                 // if context creation fails (e.g. entity not found), create a context
                 // without the entity so the ExceptionListener can still render the
-                // EasyAdmin error page with the proper layout
-                $entityId = $request->attributes->get(EA::ENTITY_ID) ?? $request->query->get(EA::ENTITY_ID);
+                // EasyAdmin error page with the proper layout. To prevent the entity from
+                // being loaded again, the entity ID must be removed from everywhere it can be
+                // read from: the canonical 'entityId' attribute, its 'id' alias, and the matched
+                // '_route_params' (used for mapped route placeholders). Only the values that
+                // originally existed are restored afterwards, so the exception message stays accurate
+                // and no attribute that wasn't present before is introduced.
+                $hadEntityIdAttribute = $request->attributes->has(EA::ENTITY_ID);
+                $hadIdAttribute = $request->attributes->has('id');
+                $hadRouteParams = $request->attributes->has('_route_params');
+                $entityIdAttribute = $request->attributes->get(EA::ENTITY_ID);
+                $idAttribute = $request->attributes->get('id');
+                $routeParams = $request->attributes->get('_route_params', []);
+
                 $request->attributes->remove(EA::ENTITY_ID);
+                $request->attributes->remove('id');
                 $request->query->remove(EA::ENTITY_ID);
+                if ($hadRouteParams) {
+                    $cleanedRouteParams = $routeParams;
+                    unset($cleanedRouteParams[EA::ENTITY_ID], $cleanedRouteParams['id']);
+                    $request->attributes->set('_route_params', $cleanedRouteParams);
+                }
 
                 $adminContext = $this->adminContextFactory->create($request, $dashboardControllerInstance, $crudControllerInstance, $actionName);
                 $request->attributes->set(EA::CONTEXT_REQUEST_ATTRIBUTE, $adminContext);
 
-                // restore the entity ID so the exception message is accurate
-                $request->attributes->set(EA::ENTITY_ID, $entityId);
+                // restore the original request data so the exception message is accurate
+                if ($hadEntityIdAttribute) {
+                    $request->attributes->set(EA::ENTITY_ID, $entityIdAttribute);
+                }
+                if ($hadIdAttribute) {
+                    $request->attributes->set('id', $idAttribute);
+                }
+                if ($hadRouteParams) {
+                    $request->attributes->set('_route_params', $routeParams);
+                }
 
                 throw $e;
             }

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -26,6 +26,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterConfigDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\I18nDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Registry\TemplateRegistry;
+use EasyCorp\Bundle\EasyAdminBundle\Router\EntityIdReader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -192,7 +193,7 @@ final readonly class AdminContextFactory
         if (null !== $crudDto) {
             $translationParameters['%entity_name%'] = basename(str_replace('\\', '/', $crudDto->getEntityFqcn()));
             $translationParameters['%entity_as_string%'] = null === $entityDto ? '' : (string) $entityDto;
-            $translationParameters['%entity_id%'] = $entityId = $request->attributes->get(EA::ENTITY_ID) ?? $request->query->get(EA::ENTITY_ID);
+            $translationParameters['%entity_id%'] = $entityId = EntityIdReader::fromRequest($request);
             $translationParameters['%entity_short_id%'] = null === $entityId ? null : u($entityId)->truncate(7)->toString();
 
             $entityInstance = null === $entityDto ? null : $entityDto->getInstance();
@@ -261,7 +262,7 @@ final readonly class AdminContextFactory
             return null;
         }
 
-        $entityId = $request->attributes->get(EA::ENTITY_ID) ?? $request->query->get(EA::ENTITY_ID);
+        $entityId = EntityIdReader::fromRequest($request);
 
         return $this->entityFactory->create($crudDto->getEntityFqcn(), $entityId, $crudDto->getEntityPermission());
     }

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -215,10 +215,12 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
                     }
                 }
 
-                // by default, the 'detail' route uses a catch-all route pattern (/{entityId});
+                // by default, the 'detail' route uses a catch-all route pattern (/{entityId} or its /{id} alias);
                 // so, if the user hasn't customized the 'detail' route path, we need to sort the actions
-                // to make sure that the 'detail' action is always the last one
-                if (isset($actionsRouteConfig['detail']) && '/{entityId}' === $actionsRouteConfig['detail']['routePath']) {
+                // to make sure that the 'detail' action is always the last one. The path is canonicalized via a
+                // temporary Route so mapped placeholders (e.g. /{id:product.id}) are also detected as catch-all.
+                $detailRoutePath = $actionsRouteConfig['detail']['routePath'] ?? null;
+                if (null !== $detailRoutePath && \in_array((new Route($detailRoutePath))->getPath(), ['/{entityId}', '/{id}'], true)) {
                     uasort($actionsRouteConfig, static function ($a, $b) {
                         $aRouteName = $a['routeName'] ?? '';
                         $bRouteName = $b['routeName'] ?? '';
@@ -554,8 +556,8 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
                 throw new \RuntimeException(sprintf('In the #[AdminDashboard] attribute of the "%s" dashboard controller, the route name "%s" for the "%s" action is not valid. It can only contain letter, numbers, dashes, and underscores.', $dashboardFqcn, $customRouteConfig['routeName'], $action));
             }
 
-            if (isset($customRouteConfig['routePath']) && \in_array($action, [Action::EDIT, Action::DETAIL, Action::DELETE], true) && !str_contains($customRouteConfig['routePath'], '{entityId}')) {
-                throw new \RuntimeException(sprintf('In the #[AdminDashboard] attribute of the "%s" dashboard controller, the path for the "%s" action must contain the "{entityId}" placeholder.', $action, $dashboardFqcn));
+            if (isset($customRouteConfig['routePath']) && \in_array($action, [Action::EDIT, Action::DETAIL, Action::DELETE], true) && null === $this->getEntityIdPlaceholderName($customRouteConfig['routePath'])) {
+                throw new \RuntimeException(sprintf('In the #[AdminDashboard] attribute of the "%s" dashboard controller, the path for the "%s" action must contain the "{id}" or "{entityId}" placeholder.', $action, $dashboardFqcn));
             }
         }
 
@@ -665,8 +667,8 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
                 $routeId = $action.'_route_'.++$index;
 
                 if (null !== $adminRouteInstance->path) {
-                    if (\in_array($action, [Action::EDIT, Action::DETAIL, Action::DELETE], true) && !str_contains($adminRouteInstance->path, '{entityId}')) {
-                        throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminRoute] attribute applied to the "%s()" action is missing the "{entityId}" placeholder in its route path.', $crudControllerFqcn, $action));
+                    if (\in_array($action, [Action::EDIT, Action::DETAIL, Action::DELETE], true) && null === $this->getEntityIdPlaceholderName($adminRouteInstance->path)) {
+                        throw new \RuntimeException(sprintf('In the "%s" CRUD controller, the #[AdminRoute] attribute applied to the "%s()" action is missing the "{id}" or "{entityId}" placeholder in its route path.', $crudControllerFqcn, $action));
                     }
 
                     $customActionsConfig[$routeId]['routePath'] = $adminRouteInstance->path;
@@ -718,6 +720,23 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         }
 
         return $customActionsConfig;
+    }
+
+    /**
+     * Returns the name of the placeholder used in the given route path to identify the
+     * current entity: 'entityId' (canonical) or its 'id' alias; null if neither is present.
+     *
+     * It matches both the bare placeholders ({id}, {entityId}) and their mapped/constrained
+     * forms ({id:product.id}, {entityId<\d+>}, etc.) while ignoring unrelated variables such
+     * as {userId} or {idCard}.
+     */
+    private function getEntityIdPlaceholderName(string $routePath): ?string
+    {
+        if (1 === preg_match('#\{!?(id|entityId)(:[\w\x80-\xFF]++(\.[\w\x80-\xFF]++)?)?(<.*?>)?(\?[^}]*+)?\}#', $routePath, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
     }
 
     /**
@@ -847,10 +866,19 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         $routeNameToRouteAttributes = [];
         $routeFqcnToRouteName = [];
         foreach ($adminRoutes as $routeName => $route) {
+            // store which placeholder (if any) this route uses to identify the current entity,
+            // so AdminUrlGenerator knows whether to generate the URL with 'entityId' or its 'id' alias.
+            // the canonical compiled path variables are used (instead of parsing the raw path) to ignore
+            // any literal '{id}' that might appear inside route defaults or requirements
+            $pathVariables = $route->compile()->getPathVariables();
+            $entityIdParamName = \in_array(EA::ENTITY_ID, $pathVariables, true) ? EA::ENTITY_ID
+                : (\in_array('id', $pathVariables, true) ? 'id' : null);
+
             $routeNameToRouteAttributes[$routeName] = [
                 EA::DASHBOARD_CONTROLLER_FQCN => $route->getDefault(EA::DASHBOARD_CONTROLLER_FQCN),
                 EA::CRUD_CONTROLLER_FQCN => $route->getDefault(EA::CRUD_CONTROLLER_FQCN),
                 EA::CRUD_ACTION => $route->getDefault(EA::CRUD_ACTION),
+                'entityIdParamName' => $entityIdParamName,
             ];
 
             $routeFqcnToRouteName[$route->getDefault(EA::DASHBOARD_CONTROLLER_FQCN)][$route->getDefault(EA::CRUD_CONTROLLER_FQCN) ?? ''][$route->getDefault(EA::CRUD_ACTION) ?? ''] = $routeName;

--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -73,6 +73,23 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
         return $this;
     }
 
+    /**
+     * Convenient alias of setEntityId() that reads better in templates, where "id" is
+     * more intuitive than "entityId". It works for routes using either the "{id}" or the
+     * "{entityId}" placeholder because it sets the canonical "entityId" parameter, which
+     * generateUrl() then translates to "id" when the target route uses the "{id}" alias.
+     *
+     * Note: this method is not part of AdminUrlGeneratorInterface yet (to avoid a BC break);
+     * it will be added to the interface in the next major version of EasyAdmin. Its return
+     * type is "self" (not the interface) so it can be chained in statically-analyzed code.
+     */
+    public function setId(mixed $id): self
+    {
+        $this->setEntityId($id);
+
+        return $this;
+    }
+
     public function get(string $paramName): mixed
     {
         if (false === $this->isInitialized) {
@@ -211,6 +228,16 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
 
         unset($canonicalRouteParameters[EA::DASHBOARD_CONTROLLER_FQCN], $canonicalRouteParameters[EA::CRUD_CONTROLLER_FQCN], $canonicalRouteParameters[EA::CRUD_ACTION]);
 
+        // if the target route identifies the current entity with the "{id}" alias (instead of the
+        // canonical "{entityId}" placeholder), generate the URL using "id" so the value fills the
+        // route placeholder instead of leaking into the query string. An explicit "id" parameter (if
+        // any) is preserved, but the canonical "entityId" is always dropped on these routes.
+        $adminRoutes = $this->cache->getItem(CacheKey::ROUTE_NAME_TO_ATTRIBUTES)->get() ?? [];
+        if ('id' === ($adminRoutes[$routeName]['entityIdParamName'] ?? null) && \array_key_exists(EA::ENTITY_ID, $canonicalRouteParameters)) {
+            $canonicalRouteParameters['id'] ??= $canonicalRouteParameters[EA::ENTITY_ID];
+            unset($canonicalRouteParameters[EA::ENTITY_ID]);
+        }
+
         $url = $this->urlGenerator->generate($routeName, $canonicalRouteParameters, $urlType);
         $url = '' === $url ? '?' : $url;
 
@@ -262,7 +289,9 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
                 EA::DASHBOARD_CONTROLLER_FQCN => $adminContext?->getRequest()->attributes->get(EA::DASHBOARD_CONTROLLER_FQCN),
                 EA::CRUD_CONTROLLER_FQCN => $adminContext?->getRequest()->attributes->get(EA::CRUD_CONTROLLER_FQCN),
                 EA::CRUD_ACTION => $adminContext?->getRequest()->attributes->get(EA::CRUD_ACTION),
-                EA::ENTITY_ID => $adminContext?->getRequest()->attributes->get(EA::ENTITY_ID),
+                // read the entity ID through EntityIdReader so it's also seeded from the "{id}" alias
+                // (and from mapped placeholders), and not only from the canonical "entityId" attribute
+                EA::ENTITY_ID => null === $adminContext ? null : EntityIdReader::fromRequest($adminContext->getRequest()),
             ],
             static fn (mixed $value): bool => null !== $value
         );

--- a/src/Router/AdminUrlGeneratorInterface.php
+++ b/src/Router/AdminUrlGeneratorInterface.php
@@ -23,6 +23,10 @@ interface AdminUrlGeneratorInterface
 
     public function setEntityId(mixed $entityId): self;
 
+    // This method will be added to this interface in the next major version of EasyAdmin.
+    // It's a convenient alias of setEntityId() that reads better in templates ("id" vs "entityId").
+    // public function setId(mixed $id): self;
+
     public function get(string $paramName): mixed;
 
     public function set(string $paramName, mixed $paramValue): self;

--- a/src/Router/EntityIdReader.php
+++ b/src/Router/EntityIdReader.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Router;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Reads the current entity ID from the request, supporting both the canonical
+ * "entityId" route parameter and its "id" alias.
+ *
+ * It also looks into "_route_params" because, for mapped route placeholders
+ * (e.g. {entityId:user.id} or {id:user.id}), Symfony's value resolver may consume
+ * the top-level request attribute while the original matched value remains stored
+ * in "_route_params". The "id" alias is never read from the query string on purpose
+ * ("id" is too common a query parameter); the route-matched value always lands in
+ * the request attributes (or "_route_params").
+ *
+ * @internal
+ *
+ * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ */
+final class EntityIdReader
+{
+    public static function fromRequest(Request $request): mixed
+    {
+        /** @var array<string, mixed> $routeParams */
+        $routeParams = $request->attributes->get('_route_params', []);
+
+        return $request->attributes->get(EA::ENTITY_ID)
+            ?? $request->attributes->get('id')
+            ?? ($routeParams[EA::ENTITY_ID] ?? null)
+            ?? ($routeParams['id'] ?? null)
+            ?? $request->query->get(EA::ENTITY_ID);
+    }
+}

--- a/tests/Functional/AdminRoute/AdminRouteTest.php
+++ b/tests/Functional/AdminRoute/AdminRouteTest.php
@@ -2,7 +2,13 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\AdminRoute;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Controller\MultipleRouteCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Entity\Product;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Kernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -601,5 +607,145 @@ class AdminRouteTest extends WebTestCase
             'EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Controller\AdvancedOptionsDashboardController',
             $defaults['dashboardControllerFqcn']
         );
+    }
+
+    public function testEntityIdAliasRoutesAreGenerated(): void
+    {
+        $client = static::createClient();
+        $router = $client->getContainer()->get('router');
+
+        // custom actions can use the "{id}" placeholder (alias of "{entityId}")
+        $safeDeleteRoute = $router->getRouteCollection()->get('admin_multiple_route_safe_delete_id');
+        $this->assertNotNull($safeDeleteRoute, 'Route for the "{id}" custom action should exist');
+        $this->assertSame('/admin/multiple-route/safe-delete-id/{id}', $safeDeleteRoute->getPath());
+        $this->assertSame(['POST'], $safeDeleteRoute->getMethods());
+
+        $detailByIdRoute = $router->getRouteCollection()->get('admin_multiple_route_detail_by_id');
+        $this->assertNotNull($detailByIdRoute, 'Route for the "{id}" detail custom action should exist');
+        $this->assertSame('/admin/multiple-route/detail-by-id/{id}', $detailByIdRoute->getPath());
+
+        // a built-in 'detail' action can also be overridden with the "{id}" placeholder; this used to
+        // throw a RuntimeException because only the literal "{entityId}" placeholder was accepted
+        $idDetailRoute = $router->getRouteCollection()->get('admin_id_detail_detail');
+        $this->assertNotNull($idDetailRoute, 'Built-in detail action overridden with "{id}" should generate a route');
+        $this->assertSame('/admin/id-detail/{id}', $idDetailRoute->getPath());
+
+        // the "{id}" alias is also accepted in the 'routes' option of the #[AdminDashboard] attribute
+        // (see IdAliasDashboardController); this used to throw a RuntimeException too
+        $dashboardDetailRoute = $router->getRouteCollection()->get('id_alias_admin_multiple_route_detail');
+        $this->assertNotNull($dashboardDetailRoute, 'Dashboard-level detail route customized with "{id}" should exist');
+        $this->assertSame('/id-alias-admin/multiple-route/{id}', $dashboardDetailRoute->getPath());
+
+        $dashboardEditRoute = $router->getRouteCollection()->get('id_alias_admin_multiple_route_edit');
+        $this->assertNotNull($dashboardEditRoute, 'Dashboard-level edit route customized with "{id}" should exist');
+        $this->assertSame('/id-alias-admin/multiple-route/{id}/edit', $dashboardEditRoute->getPath());
+
+        // the existing "{entityId}" routes keep working unchanged (BC)
+        $action3Route = $router->getRouteCollection()->get('admin_multiple_route_action3');
+        $this->assertNotNull($action3Route);
+        $this->assertSame('/admin/multiple-route/action3/{entityId}', $action3Route->getPath());
+    }
+
+    public function testEntityIdAliasUrlGeneration(): void
+    {
+        $client = static::createClient();
+        // make sure the admin routes (and their cached metadata) are loaded before generating URLs
+        $client->getContainer()->get('router')->getRouteCollection();
+
+        /** @var AdminUrlGenerator $urlGenerator */
+        $urlGenerator = static::getContainer()->get(AdminUrlGenerator::class);
+
+        // for an "{id}" route, the entity ID set via setEntityId() fills the "{id}" placeholder
+        // instead of leaking into the query string as "?entityId=..."
+        $url = $urlGenerator
+            ->setDashboard(DashboardController::class)
+            ->setController(MultipleRouteCrudController::class)
+            ->setAction('safeDeleteById')
+            ->setEntityId(123)
+            ->generateUrl();
+        $this->assertStringEndsWith('/admin/multiple-route/safe-delete-id/123', $url);
+        $this->assertStringNotContainsString('entityId', $url);
+
+        // the new setId() alias produces the same URL on an "{id}" route... (setId() is called first
+        // in the chain because, unlike the other setters, it's defined only on the concrete class)
+        $url = $urlGenerator
+            ->setId(456)
+            ->setDashboard(DashboardController::class)
+            ->setController(MultipleRouteCrudController::class)
+            ->setAction('safeDeleteById')
+            ->generateUrl();
+        $this->assertStringEndsWith('/admin/multiple-route/safe-delete-id/456', $url);
+        $this->assertStringNotContainsString('entityId', $url);
+
+        // ...and also works on an "{entityId}" route (the built-in 'edit' action), because it sets
+        // the canonical "entityId" parameter that fills the "{entityId}" placeholder
+        $url = $urlGenerator
+            ->setId(789)
+            ->setDashboard(DashboardController::class)
+            ->setController(MultipleRouteCrudController::class)
+            ->setAction('edit')
+            ->generateUrl();
+        $this->assertStringEndsWith('/admin/multiple-route/789/edit', $url);
+        $this->assertStringNotContainsString('entityId', $url);
+    }
+
+    public function testEntityIdAliasResolvesTheEntity(): void
+    {
+        $client = static::createClient();
+        $container = static::getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get(EntityManagerInterface::class);
+
+        // the test app uses an in-memory SQLite database with no schema, so create it on the fly
+        $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
+        $schemaTool = new SchemaTool($entityManager);
+        $schemaTool->dropSchema($metadata);
+        $schemaTool->createSchema($metadata);
+
+        $product = new Product();
+        $product->setName('Test Product');
+        $product->setPrice(9.99);
+        $entityManager->persist($product);
+        $entityManager->flush();
+
+        // request a custom action whose route uses the "{id}" placeholder: EasyAdmin must load the
+        // entity from the "id" route parameter and expose it through AdminContext::getEntity()
+        $client->request('GET', sprintf('/admin/multiple-route/detail-by-id/%d', $product->getId()));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSame(
+            sprintf('Detail by id: %d:Test Product', $product->getId()),
+            $client->getResponse()->getContent()
+        );
+    }
+
+    public function testEntityIdAliasCatchAllDetailRouteIsSortedLast(): void
+    {
+        $client = static::createClient();
+        $router = $client->getContainer()->get('router');
+
+        // when a dashboard customizes the 'detail' route path with the "{id}" alias (see
+        // IdAliasDashboardController), the resulting route is still a catch-all pattern, so it must
+        // be registered after the routes of the rest of the actions to not shadow them
+        $multipleRouteRouteNames = [];
+        foreach (array_keys($router->getRouteCollection()->all()) as $name) {
+            if (str_starts_with($name, 'id_alias_admin_multiple_route_')) {
+                $multipleRouteRouteNames[] = $name;
+            }
+        }
+
+        $this->assertNotEmpty($multipleRouteRouteNames);
+        $this->assertSame(
+            'id_alias_admin_multiple_route_detail',
+            end($multipleRouteRouteNames),
+            'The catch-all detail route ("/{id}") must be the last route of its CRUD controller'
+        );
+
+        // since the catch-all detail route is registered last, the URL of a custom action
+        // matches the custom action route instead of the detail route with id = 'action1'
+        $client->request('GET', '/id-alias-admin/multiple-route/action1');
+        $this->assertResponseIsSuccessful();
+        $this->assertSame('Custom Action 1', $client->getResponse()->getContent());
     }
 }

--- a/tests/Functional/Apps/AdminRouteApp/config/reference.php
+++ b/tests/Functional/Apps/AdminRouteApp/config/reference.php
@@ -78,6 +78,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     tags?: TagsType,
  *     resource_tags?: TagsType,
  *     decorates?: string,
+ *     decorates_tag?: string,
  *     decoration_inner_name?: string,
  *     decoration_priority?: int,
  *     decoration_on_invalid?: 'exception'|'ignore'|null,
@@ -118,6 +119,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     stack: list<DefinitionType|AliasType|PrototypeType|array<class-string, ArgumentsType|null>>,
  *     public?: bool,
  *     deprecated?: DeprecationType,
+ *     decorates?: string,
+ *     decorates_tag?: string,
+ *     decoration_inner_name?: string,
+ *     decoration_priority?: int,
+ *     decoration_on_invalid?: 'exception'|'ignore'|null,
  * }
  * @psalm-type ServicesConfig = array{
  *     _defaults?: DefaultsType,
@@ -168,7 +174,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         allow_revalidate?: bool|Param,
  *         stale_while_revalidate?: int|Param,
  *         stale_if_error?: int|Param,
- *         terminate_on_cache_hit?: bool|Param,
+ *         terminate_on_cache_hit?: bool|Param, // Deprecated: Setting the "framework.http_cache.terminate_on_cache_hit.terminate_on_cache_hit" configuration option is deprecated. It will be removed in version 9.0.
  *     },
  *     esi?: bool|array{ // ESI configuration
  *         enabled?: bool|Param, // Default: false
@@ -188,7 +194,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         only_exceptions?: bool|Param, // Default: false
  *         only_main_requests?: bool|Param, // Default: false
  *         dsn?: scalar|Param|null, // Default: "file:%kernel.cache_dir%/profiler"
- *         collect_serializer_data?: true|Param, // Default: true
+ *         collect_serializer_data?: true|Param, // Deprecated: Setting the "framework.profiler.collect_serializer_data.collect_serializer_data" configuration option is deprecated. It will be removed in version 9.0. // Default: true
  *     },
  *     workflows?: bool|array{
  *         enabled?: bool|Param, // Default: false
@@ -340,6 +346,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             endpoint?: scalar|Param|null, // API endpoint for the NotCompromisedPassword Validator. // Default: null
  *         },
  *         disable_translation?: bool|Param, // Default: false
+ *         property_metadata_existence_check?: bool|Param, // When enabled, validateProperty() and validatePropertyValue() throw an exception if no metadata is found for the given property. // Default: false
  *         auto_mapping?: array<string, array{ // Default: []
  *             services?: list<scalar|Param|null>,
  *         }>,
@@ -396,6 +403,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             provider?: scalar|Param|null, // Overwrite the setting from the default provider for this adapter.
  *             early_expiration_message_bus?: scalar|Param|null,
  *             clearer?: scalar|Param|null,
+ *             marshaller?: scalar|Param|null, // The marshaller service to use for this pool.
  *         }>,
  *     },
  *     php_errors?: array{ // PHP errors handling configuration
@@ -420,9 +428,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     messenger?: bool|array{ // Messenger configuration
  *         enabled?: bool|Param, // Default: false
- *         routing?: array<string, string|array{ // Default: []
- *             senders?: list<scalar|Param|null>,
- *         }>,
+ *         routing?: array<string, string|list<scalar|Param|null>>,
  *         serializer?: array{
  *             default_serializer?: scalar|Param|null, // Service id to use as the default serializer for the transports. // Default: "messenger.transport.native_php_serializer"
  *             symfony_serializer?: array{
@@ -498,7 +504,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
  *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. // Default: 86400
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
@@ -514,7 +520,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 jitter?: float|Param, // Randomness in percent (between 0 and 1) to apply to the delay. // Default: 0.1
  *             },
  *         },
- *         mock_response_factory?: scalar|Param|null, // The id of the service that should generate mock responses. It should be either an invokable or an iterable.
+ *         mock_response_factory?: scalar|Param|null, // `true` to always return empty 200 responses, or the id of the service to use to generate mock responses - which should be either an invokable or an iterable.
  *         scoped_clients?: array<string, string|array{ // Default: []
  *             scope?: scalar|Param|null, // The regular expression that the request URL must match before adding the other options. When none is provided, the base URI is used instead.
  *             base_uri?: scalar|Param|null, // The URI to resolve relative URLs, following rules in RFC 3985, section 2.
@@ -545,13 +551,14 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 md5?: mixed,
  *             },
  *             crypto_method?: scalar|Param|null, // The minimum version of TLS to accept; must be one of STREAM_CRYPTO_METHOD_TLSv*_CLIENT constants.
+ *             mock_response_factory?: scalar|Param|null, // `true` to always return empty 200 responses, `false` to disable mocking, or the id of the service to use to generate mock responses (invokable or iterable).
  *             extra?: array<string, mixed>,
  *             rate_limiter?: scalar|Param|null, // Rate limiter name to use for throttling requests. // Default: null
  *             caching?: bool|array{ // Caching configuration.
  *                 enabled?: bool|Param, // Default: false
  *                 cache_pool?: string|Param, // The taggable cache pool to use for storing the responses. // Default: "cache.http_client"
  *                 shared?: bool|Param, // Indicates whether the cache is shared (public) or private. // Default: true
- *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. Null means no cap. // Default: null
+ *                 max_ttl?: int|Param, // The maximum TTL (in seconds) allowed for cached responses. // Default: 86400
  *             },
  *             retry_failed?: bool|array{
  *                 enabled?: bool|Param, // Default: false
@@ -635,6 +642,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 interval?: scalar|Param|null, // Configures the rate interval. The value must be a number followed by "second", "minute", "hour", "day", "week" or "month" (or their plural equivalent).
  *                 amount?: int|Param, // Amount of tokens to add each interval. // Default: 1
  *             },
+ *             anchor_at?: scalar|Param|null, // Aligns the "fixed_window" policy to a calendar (e.g. "2024-01-05 00:00:00 UTC" combined with `interval: 1 month` resets the counter on the 5th of each month). UTC if not specified. // Default: null
  *         }>,
  *     },
  *     uid?: bool|array{ // Uid configuration
@@ -644,10 +652,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         name_based_uuid_namespace?: scalar|Param|null,
  *         time_based_uuid_version?: 7|6|1|Param, // Default: 7
  *         time_based_uuid_node?: scalar|Param|null,
+ *         uuid47_secret?: scalar|Param|null, // A high-entropy secret used by the "uuid47_transformer" service. Defaults to "kernel.secret". // Default: null
  *     },
  *     html_sanitizer?: bool|array{ // HtmlSanitizer configuration
  *         enabled?: bool|Param, // Default: false
  *         sanitizers?: array<string, array{ // Default: []
+ *             default_action?: "drop"|"block"|"allow"|Param, // Defines how the sanitizer must behave by default.
  *             allow_safe_elements?: bool|Param, // Allows "safe" elements and attributes. // Default: false
  *             allow_static_elements?: bool|Param, // Allows all static elements and attributes from the W3C Sanitizer API standard. // Default: false
  *             allow_elements?: array<string, mixed>,
@@ -671,6 +681,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     webhook?: bool|array{ // Webhook configuration
  *         enabled?: bool|Param, // Default: false
  *         message_bus?: scalar|Param|null, // The message bus to use. // Default: "messenger.default_bus"
+ *         event_header_name?: scalar|Param|null, // Default: "Webhook-Event"
+ *         id_header_name?: scalar|Param|null, // Default: "Webhook-Id"
+ *         signature_header_name?: scalar|Param|null, // Default: "Webhook-Signature"
+ *         signing_algorithm?: scalar|Param|null, // Default: "sha256"
  *         routing?: array<string, array{ // Default: []
  *             service?: scalar|Param|null,
  *             secret?: scalar|Param|null, // Default: ""
@@ -681,6 +695,10 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     json_streamer?: bool|array{ // JSON streamer configuration
  *         enabled?: bool|Param, // Default: false
+ *         default_options?: array{
+ *             include_null_properties?: bool|Param, // Encode the properties with null value // Default: false
+ *             ...<string, mixed>
+ *         },
  *     },
  * }
  * @psalm-type DoctrineConfig = array{
@@ -709,7 +727,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -755,7 +773,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -834,7 +852,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                     lock_path?: scalar|Param|null, // Default: "%kernel.cache_dir%/doctrine/orm/slc/filelock"
  *                     lock_lifetime?: scalar|Param|null, // Default: 60
  *                     type?: scalar|Param|null, // Default: "default"
- *                     lifetime?: scalar|Param|null, // Default: 0
+ *                     lifetime?: scalar|Param|null, // Default: null
  *                     service?: scalar|Param|null,
  *                     name?: scalar|Param|null,
  *                 }>,
@@ -871,7 +889,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     access_denied_url?: scalar|Param|null, // Default: null
  *     session_fixation_strategy?: "none"|"migrate"|"invalidate"|Param, // Default: "migrate"
  *     expose_security_errors?: \Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::None|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::AccountStatus|\Symfony\Component\Security\Http\Authentication\ExposeSecurityLevel::All|Param, // Default: "none"
- *     erase_credentials?: bool|Param, // Default: true
+ *     erase_credentials?: bool|Param, // Deprecated: Setting the "security.erase_credentials.erase_credentials" configuration option is deprecated. It will be removed in Symfony 9.0, as the "eraseCredentials()" method was removed in Symfony 8.0. // Default: true
  *     access_decision_manager?: array{
  *         strategy?: "affirmative"|"consensus"|"unanimous"|"priority"|Param,
  *         service?: scalar|Param|null,
@@ -943,7 +961,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             path?: scalar|Param|null, // Default: "/logout"
  *             target?: scalar|Param|null, // Default: "/"
  *             invalidate_session?: bool|Param, // Default: true
- *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"executionContexts"|Param>,
+ *             clear_site_data?: string|list<"*"|"cache"|"cookies"|"storage"|"clientHints"|"executionContexts"|"prefetchCache"|"prerenderCache"|Param>,
  *             delete_cookies?: string|array<string, array{ // Default: []
  *                 path?: scalar|Param|null, // Default: null
  *                 domain?: scalar|Param|null, // Default: null
@@ -1101,6 +1119,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                         cache?: array{
  *                             id?: scalar|Param|null, // Cache service id to use to cache the OIDC discovery configuration.
  *                         },
+ *                         enforce_key_usage_verification?: bool|Param, // When enabled (default), only keys explicitly designated for signature (via "use":"sig" or a "key_ops" entry containing "sign"/"verify") are accepted. When disabled, keys without any usage designation are also accepted; keys explicitly restricted to encryption are still rejected. // Default: true
  *                     },
  *                     claim?: scalar|Param|null, // Claim which contains the user identifier (e.g.: sub, email..). // Default: "sub"
  *                     audience?: scalar|Param|null, // Audience set in the token, for validation purpose.
@@ -1208,7 +1227,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  * }
  * @psalm-type TwigComponentConfig = array{
- *     defaults?: array<string, string|array{ // Default: []
+ *     defaults?: array<string, string|array{ // Default: ["__deprecated__use_old_naming_behavior"]
  *         template_directory?: scalar|Param|null, // Default: "components"
  *         name_prefix?: scalar|Param|null, // Default: ""
  *     }>,
@@ -1217,6 +1236,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: "%kernel.debug%"
  *         collect_components?: bool|Param, // Collect components instances // Default: true
  *     },
+ *     controllers_json?: scalar|Param|null, // Deprecated: The "twig_component.controllers_json" config option is deprecated, and will be removed in 3.0. // Default: null
  * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,

--- a/tests/Functional/Apps/AdminRouteApp/src/Controller/IdAliasDashboardController.php
+++ b/tests/Functional/Apps/AdminRouteApp/src/Controller/IdAliasDashboardController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+
+/**
+ * Dashboard controller that customizes the paths of built-in entity actions using
+ * the "{id}" placeholder (alias of the canonical "{entityId}") in the 'routes' option
+ * of the #[AdminDashboard] attribute. This tests that:
+ *   1) the route generator accepts the "{id}" alias in dashboard-level route configs
+ *      (it used to require the literal "{entityId}" placeholder);
+ *   2) a custom 'detail' path of "/{id}" is detected as a catch-all route and sorted
+ *      last, so it doesn't shadow the routes of the other actions.
+ */
+#[AdminDashboard(
+    routePath: '/id-alias-admin',
+    routeName: 'id_alias_admin',
+    routes: [
+        'detail' => ['routePath' => '/{id}'],
+        'edit' => ['routePath' => '/{id}/edit'],
+    ],
+    allowedControllers: [MultipleRouteCrudController::class],
+)]
+class IdAliasDashboardController extends AbstractDashboardController
+{
+}

--- a/tests/Functional/Apps/AdminRouteApp/src/Controller/IdDetailCrudController.php
+++ b/tests/Functional/Apps/AdminRouteApp/src/Controller/IdDetailCrudController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Controller;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Entity\Product;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Test CRUD controller that overrides the built-in 'detail' action using the "{id}" placeholder
+ * instead of the canonical "{entityId}" one. This verifies that the route generator accepts the
+ * "{id}" alias for built-in entity actions (it used to require the literal "{entityId}" placeholder).
+ */
+class IdDetailCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Product::class;
+    }
+
+    #[AdminRoute('/{id}', name: 'detail')]
+    public function detail(AdminContext $context): KeyValueStore|Response
+    {
+        return parent::detail($context);
+    }
+}

--- a/tests/Functional/Apps/AdminRouteApp/src/Controller/MultipleRouteCrudController.php
+++ b/tests/Functional/Apps/AdminRouteApp/src/Controller/MultipleRouteCrudController.php
@@ -3,6 +3,7 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Controller;
 
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Entity\Product;
 use Symfony\Component\HttpFoundation\Response;
@@ -58,5 +59,26 @@ class MultipleRouteCrudController extends AbstractCrudController
     public function customAction6(): Response
     {
         return new Response('Custom Action 6');
+    }
+
+    // custom action using the "{id}" placeholder (alias of "{entityId}"). This is the cleaner,
+    // forward-looking form that also lets Symfony's MapEntity resolve a typed argument natively.
+    #[AdminRoute('/safe-delete-id/{id}', 'safe_delete_id', options: ['methods' => ['POST']])]
+    public function safeDeleteById($id): Response
+    {
+        return new Response('Safe delete by id: '.$id);
+    }
+
+    // custom action that reads the entity loaded by EasyAdmin from the "{id}" placeholder, to prove
+    // that AdminContext::getEntity() works the same with "{id}" as it does with "{entityId}".
+    #[AdminRoute('/detail-by-id/{id}', 'detail_by_id', options: ['methods' => ['GET']])]
+    public function detailById(AdminContext $context): Response
+    {
+        $instance = $context->getEntity()?->getInstance();
+
+        return new Response(sprintf(
+            'Detail by id: %s',
+            $instance instanceof Product ? $instance->getId().':'.$instance->getName() : 'NO ENTITY'
+        ));
     }
 }

--- a/tests/Unit/Router/AdminRouteGeneratorTest.php
+++ b/tests/Unit/Router/AdminRouteGeneratorTest.php
@@ -11,6 +11,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Controll
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\Fixtures\FooBatchCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\Fixtures\FooBatchResolvedCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\Fixtures\FooCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\Fixtures\InvalidDetailPathCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\Fixtures\InvalidDetailPathDashboardController;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -70,6 +72,64 @@ class AdminRouteGeneratorTest extends KernelTestCase
 
         $routeName = $adminRouteGenerator->findRouteName($dashboardControllerFqcn, $crudControllerFqcn, $action);
         $this->assertSame($expectedRouteName, $routeName);
+    }
+
+    /**
+     * @dataProvider provideEntityIdPlaceholderData
+     */
+    public function testGetEntityIdPlaceholderName(string $routePath, ?string $expectedPlaceholderName): void
+    {
+        $adminRouteGenerator = new AdminRouteGenerator(
+            [],
+            [],
+            $this->getMockBuilder(CacheItemPoolInterface::class)->getMock(),
+        );
+
+        $method = new \ReflectionMethod($adminRouteGenerator, 'getEntityIdPlaceholderName');
+
+        $this->assertSame($expectedPlaceholderName, $method->invoke($adminRouteGenerator, $routePath));
+    }
+
+    public function testDashboardRoutesConfigWithoutEntityIdPlaceholderThrows(): void
+    {
+        $adminRouteGenerator = new AdminRouteGenerator(
+            [new InvalidDetailPathDashboardController()],
+            [],
+            $this->getMockBuilder(CacheItemPoolInterface::class)->getMock(),
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/must contain the "\{id\}" or "\{entityId\}" placeholder/');
+
+        $adminRouteGenerator->generateAll();
+    }
+
+    public function testAdminRouteAttributeWithoutEntityIdPlaceholderThrows(): void
+    {
+        $adminRouteGenerator = new AdminRouteGenerator(
+            [new DashboardController()],
+            [new InvalidDetailPathCrudController()],
+            $this->getMockBuilder(CacheItemPoolInterface::class)->getMock(),
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/missing the "\{id\}" or "\{entityId\}" placeholder/');
+
+        $adminRouteGenerator->generateAll();
+    }
+
+    public static function provideEntityIdPlaceholderData(): iterable
+    {
+        yield 'plain id' => ['/{id}', 'id'];
+        yield 'plain entityId' => ['/{entityId}', 'entityId'];
+        yield 'mapped id' => ['/{id:product.id}', 'id'];
+        yield 'mapped entityId' => ['/{entityId:product.id}', 'entityId'];
+        yield 'constrained id' => ['/{id<\d+>}', 'id'];
+        yield 'id in a longer path' => ['/safe-delete/{id}/confirm', 'id'];
+        yield 'entityId in a longer path' => ['/{entityId}/safe-delete', 'entityId'];
+        yield 'no placeholder' => ['/safe-delete', null];
+        yield 'unrelated userId is not matched' => ['/{userId}', null];
+        yield 'unrelated idCard is not matched' => ['/{idCard}', null];
     }
 
     public static function provideFindRouteData(): iterable

--- a/tests/Unit/Router/Fixtures/InvalidDetailPathCrudController.php
+++ b/tests/Unit/Router/Fixtures/InvalidDetailPathCrudController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\Fixtures;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\AdminRouteApp\Entity\Product;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Fixture CRUD controller that overrides the built-in 'detail' action with an invalid route
+ * path: it contains neither the canonical "{entityId}" placeholder nor its "{id}" alias
+ * ("{userId}" must not be matched as such).
+ */
+class InvalidDetailPathCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Product::class;
+    }
+
+    #[AdminRoute('/{userId}', name: 'detail')]
+    public function detail(AdminContext $context): KeyValueStore|Response
+    {
+        return parent::detail($context);
+    }
+}

--- a/tests/Unit/Router/Fixtures/InvalidDetailPathDashboardController.php
+++ b/tests/Unit/Router/Fixtures/InvalidDetailPathDashboardController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\Fixtures;
+
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+
+/**
+ * Fixture dashboard with an invalid 'detail' route path: it contains neither the canonical
+ * "{entityId}" placeholder nor its "{id}" alias ("{userId}" must not be matched as such).
+ */
+#[AdminDashboard(routePath: '/invalid-admin', routeName: 'invalid_admin', routes: [
+    'detail' => ['routePath' => '/{userId}'],
+])]
+class InvalidDetailPathDashboardController extends AbstractDashboardController
+{
+}


### PR DESCRIPTION
This is not only for using a more concise `{id}` placeholder in your custom routes. This change also enables Symfony entity resolver to work out-of-the-box for most apps, without having to configure the route mapping explicitly:

```php
// before
#[AdminRoute('/{entityId:order.id}/mark-as-paid')]
public function markAsPaid(Order $order): Response

// after
#[AdminRoute('/{id}/mark-as-paid')]
public function markAsPaid(Order $order): Response
```

And this also works for built-in routes and in your templates you can now also use `.setId()` instead of `.setEntityId()`. 