### PR TITLE
Add support for "no currency"

### DIFF
--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -63,7 +63,7 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
             $currencyCode = $value->getCurrency()->getCode();
         }
 
-        if (null !== $currencyCode && !Currencies::exists($currencyCode)) {
+        if (null !== $currencyCode && 'XXX' !== $currencyCode && !Currencies::exists($currencyCode)) {
             throw new \InvalidArgumentException(sprintf('The "%s" value used as the currency of the "%s" money field is not a valid ICU currency code.', $currencyCode, $field->getProperty()));
         }
 
@@ -90,7 +90,7 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
     private function configureForScalarValue(FieldDto $field, EntityDto $entityDto): void
     {
         $currencyCode = $this->getCurrency($field, $entityDto);
-        if (null !== $currencyCode && !Currencies::exists($currencyCode)) {
+        if (null !== $currencyCode && 'XXX' !== $currencyCode && !Currencies::exists($currencyCode)) {
             throw new \InvalidArgumentException(sprintf('The "%s" value used as the currency of the "%s" money field is not a valid ICU currency code.', $currencyCode, $field->getProperty()));
         }
         $field->setFormTypeOption('currency', $currencyCode);

--- a/src/Field/MoneyField.php
+++ b/src/Field/MoneyField.php
@@ -40,7 +40,7 @@ final class MoneyField implements FieldInterface
 
     public function setCurrency(string $currencyCode): self
     {
-        if (!Currencies::exists($currencyCode)) {
+        if ('XXX' !== $currencyCode && !Currencies::exists($currencyCode)) {
             throw new \InvalidArgumentException(sprintf('The argument of the "%s()" method must be a valid currency code according to ICU data ("%s" given).', __METHOD__, $currencyCode));
         }
 


### PR DESCRIPTION
`XXX` is a special currency code used when no currency is specified or unknown.

See: https://en.wikipedia.org/wiki/ISO_4217#Active_codes_(list_one)

In our application, we have to save amount, but sometimes, we do not know the currency yet.
And we use `XXX` temporarily for this where the symbol is `¤`.

When using `XXX`:

<img width="666" height="169" alt="image" src="https://github.com/user-attachments/assets/42e0e9c8-951f-4bf3-8c9e-43c5587a3bce" />
