### PR TITLE
Fixed mixed up Hungarian translations for date filter labels

### DIFF
--- a/translations/EasyAdminBundle.hu.php
+++ b/translations/EasyAdminBundle.hu.php
@@ -98,10 +98,10 @@ return [
         'label.not_exactly' => 'nem pontosan',
         'label.is_same' => 'megegyezik',
         'label.is_not_same' => 'nem egyezik meg',
-        'label.is_after' => 'korábbi',
-        'label.is_after_or_same' => 'korábbi vagy egyezik',
-        'label.is_before' => 'későbbi',
-        'label.is_before_or_same' => 'későbbi vagy egyezik',
+        'label.is_after' => 'későbbi',
+        'label.is_after_or_same' => 'későbbi vagy egyezik',
+        'label.is_before' => 'korábbi',
+        'label.is_before_or_same' => 'korábbi vagy egyezik',
     ],
 
     'form' => [


### PR DESCRIPTION
Fixes #7670 

This has gone unnoticed for some time. 
For reference: 
after(=>later)=>későbbi
before(=>earlier)=>korábbi

