### PR TITLE
Adjust select height

### DIFF
--- a/assets/css/easyadmin-theme/autocomplete.css
+++ b/assets/css/easyadmin-theme/autocomplete.css
@@ -595,7 +595,7 @@
 }
 .ts-wrapper .ts-control {
     block-size: unset;
-    min-block-size: 30px;
+    min-block-size: 28px;
     padding: 3px 28px 4px 7px;
 }
 .ts-wrapper.input-active {


### PR DESCRIPTION
On select fields, because the border is applied on parent element, select are rendered 2px bigger than other text fields.
This makes forms to be misaligned when rendering select and text fields on the same line side by side.

Before:

<img width="308" height="55" alt="image" src="https://github.com/user-attachments/assets/0c41d39b-6850-4f7c-87d6-14ba616ac1a2" />

After:

<img width="309" height="52" alt="image" src="https://github.com/user-attachments/assets/5f9dd7a8-4176-4071-b2a7-40b6d414d060" />
