### PR TITLE
Avoid interdependent `content_title` and `page_title` Twig blocks

### DIFF
--- a/templates/page/content.html.twig
+++ b/templates/page/content.html.twig
@@ -5,13 +5,11 @@
 
 {% block body_class 'page-content' %}
 
-{# deprecated 'The "page_title" block is deprecated, use "content_title" instead.' #}
-{% block page_title %}{{ block('content_title') }}{% endblock %}
-
 {# deprecated 'The "page_content" block is deprecated, use "main" instead.' #}
 {% block page_content %}
 {% endblock %}
 
-{% block content_title %}{{ block('page_title') }}{% endblock %}
+{# deprecated 'The "page_title" block is deprecated, use "content_title" instead.' #}
+{% block page_title %}{% block content_title %}{% endblock %}{% endblock %}
 
 {% block main %}{{ block('page_content') }}{% endblock %}


### PR DESCRIPTION
Two Twig blocks rendering each other would create an infinite loop if none is overridden.

This PR moves `page_title` inside  `content_title` so no need to manually render any of those.

Fixes #7676
