### PR TITLE
Fix recursion issue with page_title and content_title in layout.html.…

### DIFF
--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -18,7 +18,7 @@
         {% endguard %}
     {% endblock head_metas %}
 
-    {% set page_title_block_output %}{% block page_title %}{{ block('content_title') }}{% endblock %}{% endset %}
+    {% set page_title_block_output %}{% block page_title %}{{ ea.dashboardTitle|raw }}{% endblock %}{% endset %}
     <title>{{ page_title_block_output|striptags|raw }}</title>
 
     {% block head_stylesheets %}


### PR DESCRIPTION
If both content_title and page_title blocks are not overridden when extending layout.html.twig, it causes a recursion problem. This commit relies on using the ea.dashboardTitle which is already used in other places instead.

A user can then still independently override content_title and/or page_title, and the recursion issue is gone if you do not override them.