### PR TITLE
Support nested association properties in AssociationField (links and sorting)

### DIFF
--- a/doc/fields/AssociationField.rst
+++ b/doc/fields/AssociationField.rst
@@ -270,6 +270,40 @@ associated entity::
 
     yield AssociationField::new('user')->setSortProperty('name');
 
+Setting a sort property also marks the field as sortable, so you don't need to
+call ``setSortable()`` too. This matters for
+:ref:`nested associations <field-association-nested>`, which are not sortable
+by default (unlike single-level associations).
+
+.. _field-association-nested:
+
+Nested Associations
+-------------------
+
+This field can display a property of a *related* entity, following a chain of
+associations written as a dotted property path. For example, if an ``Order``
+entity is associated to a ``Customer`` and that ``Customer`` is associated to a
+``Country``, you can show the order's country on the ``index`` and ``detail``
+pages like this::
+
+    yield AssociationField::new('customer.country');
+
+The value is rendered as a clickable link pointing to the ``detail`` page of the
+entity at the end of the path (the ``Country`` in the example). EasyAdmin finds
+the CRUD controller of that entity automatically; if you define more than one
+CRUD controller for it, use the ``setCrudController()`` option to choose which
+one to link to.
+
+Unlike single-level associations, nested associations are **not** sortable by
+default. Enable sorting in one of these two ways::
+
+    // sort by a property of the related entity; this also marks the field as
+    // sortable, so you don't need a separate setSortable() call
+    yield AssociationField::new('customer.country')->setSortProperty('name');
+
+    // sort by the id of the related entity
+    yield AssociationField::new('customer.country')->setSortable(true);
+
 .. _`TomSelect`: https://tom-select.js.org/
 .. _`EntityType`: https://symfony.com/doc/current/reference/forms/types/entity.html
 .. _`query_builder option`: https://symfony.com/doc/current/reference/forms/types/entity.html#query-builder

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -125,6 +125,9 @@ final class AssociationField implements FieldInterface
     public function setSortProperty(string $orderProperty): self
     {
         $this->setCustomOption(self::OPTION_SORT_PROPERTY, $orderProperty);
+        // defining how to sort the association implies the field is sortable; this is needed for
+        // nested associations (e.g. "foo.bar"), which are not sortable by default
+        $this->setSortable(true);
 
         return $this;
     }

--- a/src/Field/AssociationField.php
+++ b/src/Field/AssociationField.php
@@ -125,8 +125,14 @@ final class AssociationField implements FieldInterface
     public function setSortProperty(string $orderProperty): self
     {
         $this->setCustomOption(self::OPTION_SORT_PROPERTY, $orderProperty);
-        // defining how to sort the association implies the field is sortable; this is needed for
-        // nested associations (e.g. "foo.bar"), which are not sortable by default
+        // setting a sort property implies the field should be sortable; this is required for nested
+        // associations (e.g. "foo.bar"), which are not sortable by default unlike single-level ones.
+        // TODO: document this behavior. To sort a nested association by the related entity's identifier
+        // (no sort property), setSortable(true) must still be called explicitly. Making nested
+        // associations sortable by default is non-trivial: it must live in
+        // CommonPreConfigurator::buildSortableOption() (the only place that tells an explicit
+        // sortable value from the computed default), needs entity-metadata traversal there, and would
+        // change the default sortability of every field type that uses a nested property
         $this->setSortable(true);
 
         return $this;

--- a/src/Field/Configurator/AssociationConfigurator.php
+++ b/src/Field/Configurator/AssociationConfigurator.php
@@ -63,8 +63,9 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
         }
 
         // the target CRUD controller can be NULL; in that case, field value doesn't link to the related entity
+        // for nested associations (e.g. "foo.bar") the target is the entity at the end of the path (e.g. "bar")
         $targetCrudControllerFqcn = $field->getCustomOption(AssociationField::OPTION_EMBEDDED_CRUD_FORM_CONTROLLER)
-            ?? $context->getAdminControllers()->findCrudControllerByEntity($entityDto->getClassMetadata()->getAssociationTargetClass($propertyName));
+            ?? $context->getAdminControllers()->findCrudControllerByEntity($this->getPropertyTargetEntityFqcn($entityDto->getClassMetadata(), $propertyName));
 
         if (true === $field->getCustomOption(AssociationField::OPTION_RENDER_AS_EMBEDDED_FORM)) {
             if (false === $entityDto->getClassMetadata()->isSingleValuedAssociation($propertyName)) {
@@ -231,6 +232,26 @@ final class AssociationConfigurator implements FieldConfiguratorInterface
             $this->entityFactory->getEntityMetadata($entityClassMetadata->getAssociationTargetClass($nextProperty)),
             implode('.', $nestedProperties),
         );
+    }
+
+    /**
+     * Resolves the FQCN of the entity targeted by a (possibly nested) association property.
+     * For "foo" it returns the target of "foo"; for "foo.bar" it walks the path and returns
+     * the target of the last segment (e.g. "bar"). Unlike ClassMetadata::getAssociationTargetClass(),
+     * which only accepts a single association name, this supports dotted property paths.
+     *
+     * @return class-string
+     */
+    private function getPropertyTargetEntityFqcn(ClassMetadata $entityClassMetadata, string $propertyName): string
+    {
+        $propertyNameParts = explode('.', $propertyName);
+        $targetEntityFqcn = $entityClassMetadata->getAssociationTargetClass(array_shift($propertyNameParts));
+
+        foreach ($propertyNameParts as $association) {
+            $targetEntityFqcn = $this->entityFactory->getEntityMetadata($targetEntityFqcn)->getAssociationTargetClass($association);
+        }
+
+        return $targetEntityFqcn;
     }
 
     private function configureToOneAssociation(FieldDto $field, EntityDto $entityDto): void

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -210,11 +210,41 @@ final class EntityRepository implements EntityRepositoryInterface
                     }
                 }
             } else {
-                $queryBuilder->addOrderBy($sortProperty, $sortOrder);
+                $this->applyNestedAssociationOrderClause($queryBuilder, $fields, $sortProperty, $sortOrder);
             }
         } else {
             $queryBuilder->addOrderBy('entity.'.$sortProperty, $sortOrder);
         }
+    }
+
+    /**
+     * Orders by a nested association path such as "foo.bar" or "foo.bar.baz", mirroring the
+     * single-segment behavior: with no AssociationField::setSortProperty() it orders by the
+     * leaf association's foreign key (i.e. its identifier) on the already-joined parent;
+     * with a sort property it left-joins the leaf and orders by that property of the related entity.
+     */
+    private function applyNestedAssociationOrderClause(QueryBuilder $queryBuilder, FieldCollection $fields, string $sortProperty, string $sortOrder): void
+    {
+        $sortFieldParts = explode('.', $sortProperty);
+        $lastIndex = \count($sortFieldParts) - 1;
+        $associationSortProperty = $fields->getByProperty($sortProperty)?->getCustomOption(AssociationField::OPTION_SORT_PROPERTY);
+
+        // join every association along the path; the first segment is already joined by the caller.
+        // the leaf is joined only when ordering by one of its properties, otherwise its foreign key on
+        // the parent is used (so "foo.bar" with no sort property orders by the identifier of "bar")
+        $aliases = $queryBuilder->getAllAliases();
+        $alias = $sortFieldParts[0];
+        $joinUntil = null === $associationSortProperty ? $lastIndex : $lastIndex + 1;
+        for ($i = 1; $i < $joinUntil; ++$i) {
+            $joinedAlias = $alias.'_'.$sortFieldParts[$i];
+            if (!\in_array($joinedAlias, $aliases, true)) {
+                $queryBuilder->leftJoin($alias.'.'.$sortFieldParts[$i], $joinedAlias);
+                $aliases[] = $joinedAlias;
+            }
+            $alias = $joinedAlias;
+        }
+
+        $queryBuilder->addOrderBy($alias.'.'.($associationSortProperty ?? $sortFieldParts[$lastIndex]), $sortOrder);
     }
 
     private function addFilterClause(QueryBuilder $queryBuilder, SearchDto $searchDto, EntityDto $entityDto, FilterCollection $configuredFilters, FieldCollection $fields): void
@@ -410,28 +440,37 @@ final class EntityRepository implements EntityRepositoryInterface
             return false;
         }
 
-        $classMetadata = $entityDto->getClassMetadata();
-
-        // multi-segment customSort (e.g. "customer.secretField") would otherwise
-        // reach the unfiltered multi-segment branch in applyOrderClause; URL-based
-        // association sort is supported via AssociationField::setSortProperty()
-        // with a single-segment key. Embeddable properties (e.g. "address.city")
-        // are real Doctrine fields with a dotted name (hasField() === true), so
-        // they are still allowed
-        if (str_contains($sortProperty, '.') && !$classMetadata->hasField($sortProperty)) {
-            return false;
-        }
-
-        // structural gate: the property must be a real Doctrine field or association
-        // on the entity. This also rejects any key with characters (commas, spaces,
-        // quotes…) that could otherwise smuggle DQL fragments through identifier interpolation
-        if (!$classMetadata->hasField($sortProperty) && !$classMetadata->hasAssociation($sortProperty)) {
-            return false;
-        }
-
+        // the property must be exposed as a sortable field by the controller; this gate makes
+        // URL-driven sort opt-in and is checked first so an unexposed key is rejected before
+        // any Doctrine metadata is walked for the structural gate below
         $fieldDto = $fields->getByProperty($sortProperty);
         if (null === $fieldDto || false === $fieldDto->isSortable()) {
             return false;
+        }
+
+        $classMetadata = $entityDto->getClassMetadata();
+
+        // structural gate: the key must resolve to real Doctrine identifiers, which also rejects any
+        // characters (commas, spaces, quotes...) that could otherwise smuggle DQL fragments through
+        // identifier interpolation. A dotted key is valid only as an embeddable field (e.g.
+        // "address.city", a real field whose name contains a dot) or as a nested association path
+        // validated segment by segment (e.g. "category.parent", "category.parent.name")
+        if (str_contains($sortProperty, '.')) {
+            return $classMetadata->hasField($sortProperty) || $this->isAssociationPath($classMetadata, $sortProperty);
+        }
+
+        return $classMetadata->hasField($sortProperty) || $classMetadata->hasAssociation($sortProperty);
+    }
+
+    private function isAssociationPath(ClassMetadata $classMetadata, string $sortProperty): bool
+    {
+        $metadata = $classMetadata;
+        foreach (explode('.', $sortProperty) as $sortFieldPart) {
+            if (!$metadata->hasAssociation($sortFieldPart)) {
+                return false;
+            }
+
+            $metadata = $this->entityFactory->getEntityMetadata($metadata->getAssociationTargetClass($sortFieldPart));
         }
 
         return true;

--- a/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
@@ -35,5 +35,6 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkTo(Synthetic\ActionTestEntityCrudController::class, 'Action Tests', 'fas fa-mouse-pointer');
         yield MenuItem::linkTo(Synthetic\UrlSortSecurityTestEntityCrudController::class, 'URL Sort Security Tests', 'fas fa-shield-alt');
         yield MenuItem::linkTo(Synthetic\NestedAssociationSortTestCrudController::class, 'Nested Association Sort Tests', 'fas fa-sitemap');
+        yield MenuItem::linkTo(Synthetic\NestedAssociationSortTestCategoryCrudController::class, 'Nested Association Sort Categories', 'fas fa-tags');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/DashboardController.php
@@ -34,5 +34,6 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkTo(Synthetic\SearchAllTermsCrudController::class, 'Search Tests', 'fas fa-search');
         yield MenuItem::linkTo(Synthetic\ActionTestEntityCrudController::class, 'Action Tests', 'fas fa-mouse-pointer');
         yield MenuItem::linkTo(Synthetic\UrlSortSecurityTestEntityCrudController::class, 'URL Sort Security Tests', 'fas fa-shield-alt');
+        yield MenuItem::linkTo(Synthetic\NestedAssociationSortTestCrudController::class, 'Nested Association Sort Tests', 'fas fa-sitemap');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/NestedAssociationSortTestCategoryCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/NestedAssociationSortTestCategoryCrudController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic;
+
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\NestedAssociationSortTestCategory;
+
+/**
+ * CrudController for NestedAssociationSortTestCategory. Auto-link target for the nested
+ * association cell (category.parent) rendered by NestedAssociationSortTestCrudController.
+ *
+ * @extends AbstractCrudController<NestedAssociationSortTestCategory>
+ */
+class NestedAssociationSortTestCategoryCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return NestedAssociationSortTestCategory::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')->hideOnForm();
+        yield TextField::new('name');
+    }
+}

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/NestedAssociationSortTestCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/NestedAssociationSortTestCrudController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+
+/**
+ * Exposes a nested AssociationField (latestRelease.category) sortable by the leaf
+ * category's `name`, so the index can be ordered via ?sort[latestRelease.category].
+ * No setCrudController() is set: the configurator must auto-resolve the leaf entity's
+ * CRUD controller to render the cell as a link.
+ *
+ * @extends AbstractCrudController<Project>
+ */
+class NestedAssociationSortTestCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Project::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setPaginatorPageSize(100)
+            ->setDefaultSort(['id' => 'ASC']);
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield TextField::new('name');
+
+        yield AssociationField::new('latestRelease.category')
+            ->setSortProperty('name');
+    }
+}

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/NestedAssociationSortTestCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/NestedAssociationSortTestCrudController.php
@@ -6,21 +6,21 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\NestedAssociationSortTestEntity;
 
 /**
- * Exposes a nested AssociationField (latestRelease.category) sortable by the leaf
- * category's `name`, so the index can be ordered via ?sort[latestRelease.category].
- * No setCrudController() is set: the configurator must auto-resolve the leaf entity's
- * CRUD controller to render the cell as a link.
+ * Exposes a nested AssociationField (category.parent) sortable by the leaf category's
+ * `name`, so the index can be ordered via ?sort[category.parent]. No setCrudController()
+ * is set: the configurator must auto-resolve the leaf entity's CRUD controller to render
+ * the cell as a link.
  *
- * @extends AbstractCrudController<Project>
+ * @extends AbstractCrudController<NestedAssociationSortTestEntity>
  */
 class NestedAssociationSortTestCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string
     {
-        return Project::class;
+        return NestedAssociationSortTestEntity::class;
     }
 
     public function configureCrud(Crud $crud): Crud
@@ -34,7 +34,7 @@ class NestedAssociationSortTestCrudController extends AbstractCrudController
     {
         yield TextField::new('name');
 
-        yield AssociationField::new('latestRelease.category')
+        yield AssociationField::new('category.parent')
             ->setSortProperty('name');
     }
 }

--- a/tests/Functional/Apps/DefaultApp/src/DataFixtures/AppFixtures.php
+++ b/tests/Functional/Apps/DefaultApp/src/DataFixtures/AppFixtures.php
@@ -22,6 +22,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synt
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\FieldTestEntity;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\FilterRelatedEntity;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\FilterTestEntity;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\NestedAssociationSortTestCategory;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\NestedAssociationSortTestEntity;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SearchTestAuthor;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SearchTestEntity;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\SortTestEntity;
@@ -82,6 +84,8 @@ class AppFixtures extends Fixture
         $this->addDefaultCrudTestFixtures($manager);
 
         $this->addSortTestFixtures($manager);
+
+        $this->addNestedAssociationSortFixtures($manager);
 
         $this->addUrlSortSecurityTestFixtures($manager);
 
@@ -607,6 +611,54 @@ class AppFixtures extends Fixture
                 $oneToManyRelated->setSortTestEntity($entity);
                 $manager->persist($oneToManyRelated);
             }
+        }
+    }
+
+    private function addNestedAssociationSortFixtures(ObjectManager $manager): void
+    {
+        // top-level (parentless) categories with distinct names; sorting roots by
+        // category.parent.name will order by these names
+        $parentNames = ['Alpha', 'Bravo', 'Charlie'];
+        $parents = [];
+        foreach ($parentNames as $index => $name) {
+            $parent = new NestedAssociationSortTestCategory();
+            $parent->setName($name);
+            $manager->persist($parent);
+            $parents[$index] = $parent;
+        }
+
+        // child categories, each pointing parent to one of the parents above
+        $childParentIndex = ['Child-A' => 0, 'Child-B' => 1, 'Child-C' => 2];
+        $children = [];
+        foreach ($childParentIndex as $name => $parentIndex) {
+            $child = new NestedAssociationSortTestCategory();
+            $child->setName($name);
+            $child->setParent($parents[$parentIndex]);
+            $manager->persist($child);
+            $children[$name] = $child;
+        }
+
+        // a parentless category: a root pointing here has category.parent === null
+        $orphan = new NestedAssociationSortTestCategory();
+        $orphan->setName('Orphan');
+        $manager->persist($orphan);
+
+        // root entities (persisted in id order). Mapping each to a category yields a
+        // deterministic ordering when sorting by category.parent.name:
+        //   ASC  (SQLite nulls first): Root Null, Root Alpha, Root Bravo, Root Charlie
+        //   DESC (SQLite nulls last):  Root Charlie, Root Bravo, Root Alpha, Root Null
+        $rootData = [
+            ['name' => 'Root Charlie', 'category' => $children['Child-C']], // parent: Charlie
+            ['name' => 'Root Alpha', 'category' => $children['Child-A']],   // parent: Alpha
+            ['name' => 'Root Null', 'category' => $orphan],                 // parent: null
+            ['name' => 'Root Bravo', 'category' => $children['Child-B']],   // parent: Bravo
+        ];
+
+        foreach ($rootData as $data) {
+            $root = new NestedAssociationSortTestEntity();
+            $root->setName($data['name']);
+            $root->setCategory($data['category']);
+            $manager->persist($root);
         }
     }
 

--- a/tests/Functional/Apps/DefaultApp/src/Entity/Synthetic/NestedAssociationSortTestCategory.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Synthetic/NestedAssociationSortTestCategory.php
@@ -40,12 +40,12 @@ class NestedAssociationSortTestCategory
         return $this;
     }
 
-    public function getParent(): ?NestedAssociationSortTestCategory
+    public function getParent(): ?self
     {
         return $this->parent;
     }
 
-    public function setParent(?NestedAssociationSortTestCategory $parent): self
+    public function setParent(?self $parent): self
     {
         $this->parent = $parent;
 

--- a/tests/Functional/Apps/DefaultApp/src/Entity/Synthetic/NestedAssociationSortTestCategory.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Synthetic/NestedAssociationSortTestCategory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Category entity for nested association sort testing. Self-references via `parent`
+ * so a root entity can be sorted by `category.parent.name`.
+ */
+#[ORM\Entity]
+class NestedAssociationSortTestCategory
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    #[ORM\ManyToOne(targetEntity: self::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?NestedAssociationSortTestCategory $parent = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getParent(): ?NestedAssociationSortTestCategory
+    {
+        return $this->parent;
+    }
+
+    public function setParent(?NestedAssociationSortTestCategory $parent): self
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name ?? '';
+    }
+}

--- a/tests/Functional/Apps/DefaultApp/src/Entity/Synthetic/NestedAssociationSortTestEntity.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Synthetic/NestedAssociationSortTestEntity.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Root entity for nested association sort testing. Sortable by the nested association
+ * property `category.parent` (using the leaf category's `name`).
+ */
+#[ORM\Entity]
+class NestedAssociationSortTestEntity
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    #[ORM\ManyToOne(targetEntity: NestedAssociationSortTestCategory::class)]
+    #[ORM\JoinColumn(nullable: true)]
+    private ?NestedAssociationSortTestCategory $category = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getCategory(): ?NestedAssociationSortTestCategory
+    {
+        return $this->category;
+    }
+
+    public function setCategory(?NestedAssociationSortTestCategory $category): self
+    {
+        $this->category = $category;
+
+        return $this;
+    }
+
+    public function __toString(): string
+    {
+        return $this->name ?? '';
+    }
+}

--- a/tests/Functional/Default/Sort/SortByNestedAssociationTest.php
+++ b/tests/Functional/Default/Sort/SortByNestedAssociationTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Default\Sort;
+
+use Doctrine\ORM\EntityRepository;
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\ProjectDomain\ProjectReleaseCategoryCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic\NestedAssociationSortTestCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+
+/**
+ * End-to-end checks that ?sort[latestRelease.category] orders the Project index by
+ * the leaf association's `name` (latestRelease.category.name), through a nested
+ * AssociationField configured with setSortProperty('name'). Also verifies the nested
+ * association cell auto-links to the leaf entity's CRUD controller without setCrudController().
+ */
+class SortByNestedAssociationTest extends AbstractCrudTestCase
+{
+    private EntityRepository $repository;
+
+    protected function getControllerFqcn(): string
+    {
+        return NestedAssociationSortTestCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+        $this->repository = $this->entityManager->getRepository(Project::class);
+    }
+
+    /**
+     * @dataProvider sorting
+     */
+    public function testSortByNestedAssociationProperty(string $sortOrder, \Closure $sortFunction): void
+    {
+        // arrange
+        /** @var list<Project> $projects */
+        $projects = $this->repository->findAll();
+        $sortFunction($projects);
+        $expectedNames = array_map(static fn (Project $project): string => $project->getName(), $projects);
+
+        // act
+        $url = $this->generateIndexUrl().'?'.http_build_query([
+            'sort' => ['latestRelease.category' => $sortOrder],
+        ]);
+        $crawler = $this->client->request('GET', $url);
+
+        // assert
+        $this->assertResponseIsSuccessful();
+        foreach ($expectedNames as $i => $expectedName) {
+            $this->assertSelectorTextSame(
+                sprintf('tbody tr:nth-child(%d) td[data-column="name"]', $i + 1),
+                $expectedName,
+                sprintf('Expected "%s" in row %d', $expectedName, $i + 1),
+            );
+        }
+    }
+
+    public static function sorting(): \Generator
+    {
+        yield 'ascending by latestRelease.category.name (SQLite nulls first)' => [
+            'ASC',
+            /**
+             * @param list<Project> $projects
+             */
+            static function (array &$projects): void {
+                usort($projects, static function (Project $a, Project $b): int {
+                    $aName = $a->getLatestRelease()?->getCategory()?->getName();
+                    $bName = $b->getLatestRelease()?->getCategory()?->getName();
+
+                    // SQLite sorts NULL values FIRST in ASC order
+                    if (null === $aName && null === $bName) {
+                        return $a->getId() <=> $b->getId();
+                    }
+                    if (null === $aName) {
+                        return -1;
+                    }
+                    if (null === $bName) {
+                        return 1;
+                    }
+
+                    $cmp = $aName <=> $bName;
+
+                    return 0 !== $cmp ? $cmp : $a->getId() <=> $b->getId();
+                });
+            },
+        ];
+
+        yield 'descending by latestRelease.category.name (SQLite nulls last)' => [
+            'DESC',
+            /**
+             * @param list<Project> $projects
+             */
+            static function (array &$projects): void {
+                usort($projects, static function (Project $a, Project $b): int {
+                    $aName = $a->getLatestRelease()?->getCategory()?->getName();
+                    $bName = $b->getLatestRelease()?->getCategory()?->getName();
+
+                    // SQLite sorts NULL values LAST in DESC order; ties on the primary key are
+                    // broken by the controller's setDefaultSort(['id' => 'ASC']), always ascending
+                    if (null === $aName && null === $bName) {
+                        return $a->getId() <=> $b->getId();
+                    }
+                    if (null === $aName) {
+                        return 1;
+                    }
+                    if (null === $bName) {
+                        return -1;
+                    }
+
+                    $cmp = $bName <=> $aName;
+
+                    return 0 !== $cmp ? $cmp : $a->getId() <=> $b->getId();
+                });
+            },
+        ];
+    }
+
+    public function testNestedAssociationCellAutoLinksToLeafCrudController(): void
+    {
+        // the nested AssociationField has no setCrudController(); the configurator must
+        // auto-resolve the leaf entity (ProjectReleaseCategory) CRUD controller and render
+        // its cell as a link targeting that controller's detail action
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        $this->assertResponseIsSuccessful();
+
+        $hrefs = $crawler
+            ->filter('tbody td[data-column="latestRelease.category"] a')
+            ->each(static fn ($node): string => $node->attr('href'));
+
+        self::assertNotEmpty($hrefs, 'Expected at least one linked nested association cell');
+
+        // depending on the URL format, the leaf controller is referenced either via its
+        // auto-derived pretty-URL slug or via the crudControllerFqcn query parameter; the
+        // detail action is identified by the entity id segment (pretty) or crudAction=detail
+        $controllerSlug = 'project-release-category';
+        $controllerParam = rawurlencode(ProjectReleaseCategoryCrudController::class);
+        foreach ($hrefs as $href) {
+            self::assertTrue(
+                str_contains($href, $controllerSlug) || str_contains($href, $controllerParam),
+                sprintf('Expected href "%s" to target the ProjectReleaseCategory CRUD controller', $href),
+            );
+            self::assertTrue(
+                (bool) preg_match('#/project-release-category/\d+#', $href) || str_contains($href, 'crudAction=detail'),
+                sprintf('Expected href "%s" to point at the leaf entity detail action', $href),
+            );
+        }
+    }
+
+    public function testNestedAssociationColumnHeaderIsSortable(): void
+    {
+        // setSortProperty() marks the nested association field as sortable, so its index column
+        // header is rendered as a clickable sort link without needing an explicit setSortable(true)
+        $this->client->request('GET', $this->generateIndexUrl());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('th[data-column="latestRelease.category"] a');
+    }
+}

--- a/tests/Functional/Default/Sort/SortByNestedAssociationTest.php
+++ b/tests/Functional/Default/Sort/SortByNestedAssociationTest.php
@@ -5,15 +5,15 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Default\Sort;
 use Doctrine\ORM\EntityRepository;
 use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\ProjectDomain\ProjectReleaseCategoryCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic\NestedAssociationSortTestCategoryCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic\NestedAssociationSortTestCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\Synthetic\NestedAssociationSortTestEntity;
 
 /**
- * End-to-end checks that ?sort[latestRelease.category] orders the Project index by
- * the leaf association's `name` (latestRelease.category.name), through a nested
- * AssociationField configured with setSortProperty('name'). Also verifies the nested
- * association cell auto-links to the leaf entity's CRUD controller without setCrudController().
+ * End-to-end checks that ?sort[category.parent] orders the index by the leaf
+ * association's `name` (category.parent.name), through a nested AssociationField
+ * configured with setSortProperty('name'). Also verifies the nested association cell
+ * auto-links to the leaf entity's CRUD controller without setCrudController().
  */
 class SortByNestedAssociationTest extends AbstractCrudTestCase
 {
@@ -33,7 +33,7 @@ class SortByNestedAssociationTest extends AbstractCrudTestCase
     {
         parent::setUp();
         $this->client->followRedirects();
-        $this->repository = $this->entityManager->getRepository(Project::class);
+        $this->repository = $this->entityManager->getRepository(NestedAssociationSortTestEntity::class);
     }
 
     /**
@@ -42,14 +42,14 @@ class SortByNestedAssociationTest extends AbstractCrudTestCase
     public function testSortByNestedAssociationProperty(string $sortOrder, \Closure $sortFunction): void
     {
         // arrange
-        /** @var list<Project> $projects */
-        $projects = $this->repository->findAll();
-        $sortFunction($projects);
-        $expectedNames = array_map(static fn (Project $project): string => $project->getName(), $projects);
+        /** @var list<NestedAssociationSortTestEntity> $entities */
+        $entities = $this->repository->findAll();
+        $sortFunction($entities);
+        $expectedNames = array_map(static fn (NestedAssociationSortTestEntity $entity): string => $entity->getName(), $entities);
 
         // act
         $url = $this->generateIndexUrl().'?'.http_build_query([
-            'sort' => ['latestRelease.category' => $sortOrder],
+            'sort' => ['category.parent' => $sortOrder],
         ]);
         $crawler = $this->client->request('GET', $url);
 
@@ -66,15 +66,15 @@ class SortByNestedAssociationTest extends AbstractCrudTestCase
 
     public static function sorting(): \Generator
     {
-        yield 'ascending by latestRelease.category.name (SQLite nulls first)' => [
+        yield 'ascending by category.parent.name (SQLite nulls first)' => [
             'ASC',
             /**
-             * @param list<Project> $projects
+             * @param list<NestedAssociationSortTestEntity> $entities
              */
-            static function (array &$projects): void {
-                usort($projects, static function (Project $a, Project $b): int {
-                    $aName = $a->getLatestRelease()?->getCategory()?->getName();
-                    $bName = $b->getLatestRelease()?->getCategory()?->getName();
+            static function (array &$entities): void {
+                usort($entities, static function (NestedAssociationSortTestEntity $a, NestedAssociationSortTestEntity $b): int {
+                    $aName = $a->getCategory()?->getParent()?->getName();
+                    $bName = $b->getCategory()?->getParent()?->getName();
 
                     // SQLite sorts NULL values FIRST in ASC order
                     if (null === $aName && null === $bName) {
@@ -94,15 +94,15 @@ class SortByNestedAssociationTest extends AbstractCrudTestCase
             },
         ];
 
-        yield 'descending by latestRelease.category.name (SQLite nulls last)' => [
+        yield 'descending by category.parent.name (SQLite nulls last)' => [
             'DESC',
             /**
-             * @param list<Project> $projects
+             * @param list<NestedAssociationSortTestEntity> $entities
              */
-            static function (array &$projects): void {
-                usort($projects, static function (Project $a, Project $b): int {
-                    $aName = $a->getLatestRelease()?->getCategory()?->getName();
-                    $bName = $b->getLatestRelease()?->getCategory()?->getName();
+            static function (array &$entities): void {
+                usort($entities, static function (NestedAssociationSortTestEntity $a, NestedAssociationSortTestEntity $b): int {
+                    $aName = $a->getCategory()?->getParent()?->getName();
+                    $bName = $b->getCategory()?->getParent()?->getName();
 
                     // SQLite sorts NULL values LAST in DESC order; ties on the primary key are
                     // broken by the controller's setDefaultSort(['id' => 'ASC']), always ascending
@@ -127,14 +127,14 @@ class SortByNestedAssociationTest extends AbstractCrudTestCase
     public function testNestedAssociationCellAutoLinksToLeafCrudController(): void
     {
         // the nested AssociationField has no setCrudController(); the configurator must
-        // auto-resolve the leaf entity (ProjectReleaseCategory) CRUD controller and render
-        // its cell as a link targeting that controller's detail action
+        // auto-resolve the leaf entity (NestedAssociationSortTestCategory) CRUD controller
+        // and render its cell as a link targeting that controller's detail action
         $crawler = $this->client->request('GET', $this->generateIndexUrl());
 
         $this->assertResponseIsSuccessful();
 
         $hrefs = $crawler
-            ->filter('tbody td[data-column="latestRelease.category"] a')
+            ->filter('tbody td[data-column="category.parent"] a')
             ->each(static fn ($node): string => $node->attr('href'));
 
         self::assertNotEmpty($hrefs, 'Expected at least one linked nested association cell');
@@ -142,15 +142,15 @@ class SortByNestedAssociationTest extends AbstractCrudTestCase
         // depending on the URL format, the leaf controller is referenced either via its
         // auto-derived pretty-URL slug or via the crudControllerFqcn query parameter; the
         // detail action is identified by the entity id segment (pretty) or crudAction=detail
-        $controllerSlug = 'project-release-category';
-        $controllerParam = rawurlencode(ProjectReleaseCategoryCrudController::class);
+        $controllerSlug = 'nested-association-sort-test-category';
+        $controllerParam = rawurlencode(NestedAssociationSortTestCategoryCrudController::class);
         foreach ($hrefs as $href) {
             self::assertTrue(
                 str_contains($href, $controllerSlug) || str_contains($href, $controllerParam),
-                sprintf('Expected href "%s" to target the ProjectReleaseCategory CRUD controller', $href),
+                sprintf('Expected href "%s" to target the NestedAssociationSortTestCategory CRUD controller', $href),
             );
             self::assertTrue(
-                (bool) preg_match('#/project-release-category/\d+#', $href) || str_contains($href, 'crudAction=detail'),
+                (bool) preg_match('#/'.$controllerSlug.'/\d+#', $href) || str_contains($href, 'crudAction=detail'),
                 sprintf('Expected href "%s" to point at the leaf entity detail action', $href),
             );
         }
@@ -163,6 +163,6 @@ class SortByNestedAssociationTest extends AbstractCrudTestCase
         $this->client->request('GET', $this->generateIndexUrl());
 
         $this->assertResponseIsSuccessful();
-        $this->assertSelectorExists('th[data-column="latestRelease.category"] a');
+        $this->assertSelectorExists('th[data-column="category.parent"] a');
     }
 }

--- a/tests/Unit/Field/AssociationFieldTest.php
+++ b/tests/Unit/Field/AssociationFieldTest.php
@@ -140,6 +140,8 @@ class AssociationFieldTest extends AbstractFieldTest
         $fieldDto = $this->configure($field);
 
         self::assertSame('name', $fieldDto->getCustomOption(AssociationField::OPTION_SORT_PROPERTY));
+        // setSortProperty() also marks the field as sortable
+        self::assertTrue($fieldDto->isSortable());
     }
 
     public function testRenderAsHtml(): void

--- a/tests/Unit/Orm/EntityRepositoryTest.php
+++ b/tests/Unit/Orm/EntityRepositoryTest.php
@@ -14,6 +14,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use PHPUnit\Framework\TestCase;
@@ -374,6 +375,53 @@ class EntityRepositoryTest extends TestCase
         $queryBuilder->expects($this->once())
             ->method('addOrderBy')
             ->with('entity.displayedField', 'ASC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testNestedAssociationDefaultSortWithoutSortPropertyOrdersByLeafForeignKey(): void
+    {
+        // defaultSort is trusted and bypasses the metadata-walking validation, so it
+        // reaches applyNestedAssociationOrderClause directly. With no AssociationField
+        // sort property the leaf is not joined: ordering uses the leaf segment's foreign
+        // key on the parent alias that applyOrderClause already left-joined
+        $entityDto = $this->createEntityDto([], ['category']);
+        $fields = new FieldCollection([]);
+        $searchDto = $this->createSearchDtoForSort(defaultSort: ['category.parent' => 'ASC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->once())
+            ->method('leftJoin')
+            ->with('entity.category', 'category')
+            ->willReturnSelf();
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('category.parent', 'ASC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testNestedAssociationDefaultSortWithSortPropertyJoinsLeafAndOrdersByItsProperty(): void
+    {
+        // with AssociationField::setSortProperty('name') the leaf is left-joined under the
+        // underscore-joined cumulative alias (category_parent) and ordered by that property
+        $entityDto = $this->createEntityDto([], ['category']);
+        $field = $this->createField('category.parent', true);
+        $field->setCustomOption(AssociationField::OPTION_SORT_PROPERTY, 'name');
+        $fields = new FieldCollection([$field]);
+        $searchDto = $this->createSearchDtoForSort(defaultSort: ['category.parent' => 'ASC']);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->exactly(2))
+            ->method('leftJoin')
+            ->willReturnSelf();
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('category_parent.name', 'ASC');
 
         $this->stubEntityManager($queryBuilder);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes (a nested association field without an explicit CRUD controller threw)
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Makes `AssociationField` work end-to-end when its property is a **nested** association path such as `customer.country`, not just a single association.
Three small, related changes.

 ### 1. Auto-resolve the CRUD controller for nested associations

Configuring a nested association without `setCrudController()` used to fail, because `ClassMetadata::getAssociationTargetClass()` rejects a dotted name. `AssociationConfigurator` now walks the path to the entity at the end of the chain and resolves its CRUD controller automatically, so the value links to the related entity just like a single-level association does.

```php
// Order.customer is an association; Customer.country is an association.
// Before: this threw unless you also called `->setCrudController(CountryCrudController::class)`
// After:  the column links to the Country detail page automatically
yield AssociationField::new('customer.country');
```

2. Sort the index by a nested association property
  
A dotted `?sort[...]` key was rejected by the sort-hardening gate. It is now accepted only when every segment is a real Doctrine association (validated segment by segment, so no DQL fragment can be smuggled in) and the field is exposed as sortable - the same opt-in model as the existing single-association sort. The query joins the chain and orders by the related entity's identifier, or by `setSortProperty()` when given:

```php
// ORDER BY the country name, joining Order -> customer -> country
yield AssociationField::new('customer.country')
    ->setSortProperty('name');
```
3. `setSortProperty()` implies the field is sortable

Defining how to sort an association implies it should be sortable, so `setSortProperty()` now also marks the field sortable. This is a no-op for single-level associations (already sortable by default) and is what makes the nested example above sortable without an extra call.

Known limitation (documented): nested associations are not sortable by default - unlike single-level associations. To sort a nested association by the related entity's identifier (i.e. without a sort property), an explicit `->setSortable(true)` is still required:

```php
yield AssociationField::new('customer.country')
    ->setSortable(true); // sorts by the country id; no sort property given
```
Making nested associations sortable by default (to fully match single-level ones) is intentionally out of scope here: it would have to live in `CommonPreConfigurator::buildSortableOption()`, require entity-metadata traversal in that core configurator, and change the default sortability of every field type that uses a nested property. Happy to explore it separately if you think it's worth it.

Backward compatibility & security

- Single-level associations behave exactly as before.
- The URL-sort hardening is preserved: a dotted sort key is accepted only if it validates as a real association path and the field opts in to sorting.
- Embeddable dotted properties (e.g. address.city) keep working unchanged.

Tests

- Unit: nested order-clause join building (with and without a sort property); setSortProperty() marks the field sortable.
- Functional: URL sort (asc/desc) by a nested association property reorders the index; the nested column header renders as a sortable link; the nested association cell auto-links to the leaf entity's CRUD controller.

Docs
  
`doc/fields/AssociationField.rst` gains a Nested Associations section and an updated `setSortProperty` description.