### PR TITLE
Update existing components to use the new size enum

### DIFF
--- a/src/Twig/Component/Badge.php
+++ b/src/Twig/Component/Badge.php
@@ -4,6 +4,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Twig\Component;
 
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\BadgeVariant;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Radius;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Size;
 
 /**
  * Renders a badge: a small, colored label used for statuses, counts and tags.
@@ -14,11 +15,11 @@ class Badge
     public ?BadgeVariant $variant = BadgeVariant::Secondary;
     public ?string $icon = null;
     public ?string $endIcon = null;
-    public string $size = 'md';
+    public Size $size = Size::Medium;
     public ?Radius $radius = null;
     private ?string $customVariant = null;
 
-    public function mount(string|BadgeVariant|null $variant = BadgeVariant::Secondary, string|Radius|null $radius = null): void
+    public function mount(string|BadgeVariant|null $variant = BadgeVariant::Secondary, string|Radius|null $radius = null, string|Size $size = Size::Medium): void
     {
         if ($variant instanceof BadgeVariant) {
             $this->variant = $variant;
@@ -41,6 +42,9 @@ class Badge
         } else {
             $this->radius = Radius::tryFrom($radius);
         }
+
+        // unknown sizes fall back to the base 'md' size, which emits no CSS class
+        $this->size = \is_string($size) ? (Size::tryFrom($size) ?? Size::Medium) : $size;
     }
 
     public function getDefaultCssClass(): string
@@ -53,7 +57,7 @@ class Badge
             $cssClasses[] = 'badge-'.$this->customVariant;
         }
 
-        if ('sm' === $this->size) {
+        if (Size::Small === $this->size) {
             $cssClasses[] = 'badge-sm';
         }
 

--- a/templates/components/Button.html.twig
+++ b/templates/components/Button.html.twig
@@ -2,7 +2,7 @@
     variant = 'default', # primary|default|danger|success|warning|info (default: 'default')
     isInvisible = false, # true|false (default: false) if true, button has transparent background and no border
     isBlock = false, # true|false (default: false) if true, button takes full width of container
-    size = 'md', # sm|md|lg (default: 'md')
+    size = 'md', # sm|md|lg (string or Option\Size enum) (default: 'md')
     icon = null, # icon name string (e.g., 'tabler:user' or 'fa fas fa-user')
     withTrailingIcon = false, # boolean to show icon after label (default: false)
     inactive = false, # boolean to disable the button (default: false)
@@ -19,9 +19,10 @@
 {# handle both string and enum values #}
 {% set html_element_value = htmlElement.value is defined ? htmlElement.value : htmlElement %}
 {% set variant_value = variant.value is defined ? variant.value : variant %}
+{% set size_value = size.value is defined ? size.value : size %}
 
 {% set variant_class = variant_value == 'default' ? 'btn-secondary' : 'btn-' ~ variant_value %}
-{% set size_class = size == 'md' ? '' : 'btn-' ~ size %}
+{% set size_class = size_value == 'md' ? '' : 'btn-' ~ size_value %}
 {% set css_class = html_classes('btn', variant_class, size_class, {
     'btn-invisible': isInvisible,
     'btn-block': isBlock,

--- a/tests/Functional/Component/BadgeTest.php
+++ b/tests/Functional/Component/BadgeTest.php
@@ -3,15 +3,16 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Component;
 
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\AbstractFieldFunctionalTest;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Size;
 
 /**
  * Rendering tests for the <twig:ea:Badge> component.
  */
 class BadgeTest extends AbstractFieldFunctionalTest
 {
-    private function renderBadge(string $template): string
+    private function renderBadge(string $template, array $context = []): string
     {
-        return static::getContainer()->get('twig')->createTemplate($template)->render();
+        return static::getContainer()->get('twig')->createTemplate($template)->render($context);
     }
 
     public function testDefaultVariantIsSecondary(): void
@@ -51,6 +52,14 @@ class BadgeTest extends AbstractFieldFunctionalTest
         self::assertSame(
             '<span class="badge badge-secondary badge-sm">x</span>',
             $this->renderBadge('<twig:ea:Badge size="sm">x</twig:ea:Badge>')
+        );
+    }
+
+    public function testSmallSizeAsEnum(): void
+    {
+        self::assertSame(
+            '<span class="badge badge-secondary badge-sm">x</span>',
+            $this->renderBadge('<twig:ea:Badge size="{{ size }}">x</twig:ea:Badge>', ['size' => Size::Small])
         );
     }
 

--- a/tests/Functional/Component/ButtonTest.php
+++ b/tests/Functional/Component/ButtonTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Component;
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\AbstractFieldFunctionalTest;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Size;
+
+/**
+ * Rendering tests for the <twig:ea:Button> component.
+ */
+class ButtonTest extends AbstractFieldFunctionalTest
+{
+    public function testDefaultSizeEmitsNoSizeClass(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button>Click</twig:ea:Button>');
+
+        self::assertStringContainsString('class="btn btn-secondary"', $html);
+        self::assertStringNotContainsString('btn-sm', $html);
+        self::assertStringNotContainsString('btn-md', $html);
+    }
+
+    public function testSmallSizeAsString(): void
+    {
+        self::assertStringContainsString(
+            'class="btn btn-secondary btn-sm"',
+            $this->renderButton('<twig:ea:Button size="sm">Click</twig:ea:Button>')
+        );
+    }
+
+    public function testLargeSizeAsString(): void
+    {
+        self::assertStringContainsString(
+            'class="btn btn-secondary btn-lg"',
+            $this->renderButton('<twig:ea:Button size="lg">Click</twig:ea:Button>')
+        );
+    }
+
+    public function testSmallSizeAsEnum(): void
+    {
+        self::assertStringContainsString(
+            'class="btn btn-secondary btn-sm"',
+            $this->renderButton('<twig:ea:Button size="{{ size }}">Click</twig:ea:Button>', ['size' => Size::Small])
+        );
+    }
+
+    public function testMediumSizeAsEnumEmitsNoSizeClass(): void
+    {
+        self::assertStringContainsString(
+            'class="btn btn-secondary"',
+            $this->renderButton('<twig:ea:Button size="{{ size }}">Click</twig:ea:Button>', ['size' => Size::Medium])
+        );
+    }
+
+    private function renderButton(string $template, array $context = []): string
+    {
+        return static::getContainer()->get('twig')->createTemplate($template)->render($context);
+    }
+}

--- a/tests/Unit/Twig/Component/BadgeTest.php
+++ b/tests/Unit/Twig/Component/BadgeTest.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Twig\Component;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Badge;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\BadgeVariant;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Radius;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Size;
 use PHPUnit\Framework\TestCase;
 
 class BadgeTest extends TestCase
@@ -99,13 +100,30 @@ class BadgeTest extends TestCase
     }
 
     /**
-     * @dataProvider provideGetDefaultCssClassData
+     * @dataProvider provideSizeValues
      */
-    public function testGetDefaultCssClass(string|BadgeVariant|null $variant, string $size, string|Radius|null $radius, string $expectedCssClass): void
+    public function testMountResolvesSize(string|Size $size, Size $expectedSize): void
     {
         $badge = new Badge();
-        $badge->mount($variant, $radius);
-        $badge->size = $size;
+        $badge->mount('secondary', null, $size);
+
+        $this->assertSame($expectedSize, $badge->size);
+    }
+
+    public static function provideSizeValues(): iterable
+    {
+        yield 'string' => ['sm', Size::Small];
+        yield 'enum' => [Size::Small, Size::Small];
+        yield 'unknown string falls back to md' => ['nope', Size::Medium];
+    }
+
+    /**
+     * @dataProvider provideGetDefaultCssClassData
+     */
+    public function testGetDefaultCssClass(string|BadgeVariant|null $variant, string|Size $size, string|Radius|null $radius, string $expectedCssClass): void
+    {
+        $badge = new Badge();
+        $badge->mount($variant, $radius, $size);
 
         $this->assertSame($expectedCssClass, $badge->getDefaultCssClass());
     }
@@ -116,6 +134,7 @@ class BadgeTest extends TestCase
         yield 'enum variant' => [BadgeVariant::Info, 'md', null, 'badge badge-info'];
         yield 'custom variant' => ['currency', 'md', null, 'badge badge-currency'];
         yield 'small size' => ['secondary', 'sm', null, 'badge badge-secondary badge-sm'];
+        yield 'small size as enum' => ['secondary', Size::Small, null, 'badge badge-secondary badge-sm'];
         yield 'radius full' => ['secondary', 'md', 'full', 'badge badge-secondary ea-rounded-full'];
         yield 'small size and radius' => ['warning', 'sm', Radius::Large, 'badge badge-warning badge-sm ea-rounded-lg'];
         yield 'no variant' => ['', 'md', null, 'badge'];


### PR DESCRIPTION
The `Size` enum was introduced as part of #7662.

Nothing changes in practice for end-users because you can still pass raw strings like `'md'` as the size option.