### PR TITLE
Improve the Button component

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -97,6 +97,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Security\SecurityVoter;
 use EasyCorp\Bundle\EasyAdminBundle\Translation\EntityTranslationIdGenerator;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Alert;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Badge;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Button;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Flag;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Icon;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Pagination;
@@ -480,6 +481,10 @@ return static function (ContainerConfigurator $container) {
 
         ->set(Pagination::class)
             ->arg(0, service(AdminContextProvider::class))
+            ->tag('twig.component')
+
+        ->set(Button::class)
+            ->arg(0, service('translator'))
             ->tag('twig.component')
     ;
 };

--- a/src/Twig/Component/AGENTS.md
+++ b/src/Twig/Component/AGENTS.md
@@ -12,8 +12,8 @@ How to build UI components in EasyAdmin with [Symfony UX TwigComponent](https://
 
 ## Two kinds of components
 
-1. **Anonymous (template-only)** — for pure markup with no logic. Declare inputs with `{% props %}` at the top of `templates/components/<Name>.html.twig`. Examples: `Button.html.twig`, `ActionMenu`.
-2. **Class-backed** — when you need logic, computed values, defaults, or services. PHP class in `src/Twig/Component/<Name>.php` + template in `templates/components/<Name>.html.twig`. Examples: `Alert`, `Badge`, `Icon`, `Flag`.
+1. **Anonymous (template-only)** — for pure markup with no logic. Declare inputs with `{% props %}` at the top of `templates/components/<Name>.html.twig`. Examples: `Switch.html.twig`, `ActionMenu`.
+2. **Class-backed** — when you need logic, computed values, defaults, or services. PHP class in `src/Twig/Component/<Name>.php` + template in `templates/components/<Name>.html.twig`. Examples: `Alert`, `Badge`, `Button`, `Icon`, `Flag`.
 
 Prefer anonymous components; reach for a class only when there's real logic.
 

--- a/src/Twig/Component/Button.php
+++ b/src/Twig/Component/Button.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Twig\Component;
+
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonElement;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonType;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonVariant;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Size;
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\UX\TwigComponent\Attribute\PreMount;
+
+/**
+ * Renders a button as a <button>, <a> or <form> element, with optional
+ * leading/trailing icons and a label.
+ */
+class Button
+{
+    public ?ButtonVariant $variant = ButtonVariant::Default;
+    public bool $isInvisible = false;
+    public bool $isBlock = false;
+    public Size $size = Size::Medium;
+    public ?string $icon = null;
+    public bool $withTrailingIcon = false;
+    public bool $inactive = false;
+    public ButtonElement $htmlElement = ButtonElement::Button;
+    public ?string $href = null;
+    public ?string $action = null;
+    public string $method = 'POST';
+    public ButtonType $type = ButtonType::Submit;
+    public ?string $name = null;
+    public ?string $value = null;
+    private ?string $customVariant = null;
+
+    public function __construct(
+        private readonly TranslatorInterface $translator,
+    ) {
+    }
+
+    /**
+     * BC layer: transparently migrates the deprecated 'htmlAttributes' prop into
+     * the native attributes system (remove in EasyAdmin 6.0).
+     *
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    #[PreMount]
+    public function migrateHtmlAttributes(array $data): array
+    {
+        if (!\array_key_exists('htmlAttributes', $data)) {
+            return $data;
+        }
+
+        trigger_deprecation('easycorp/easyadmin-bundle', '5.2.0', 'The "htmlAttributes" prop of the <twig:ea:Button> component is deprecated, pass the attributes directly on the component (or use the "{{ ... }}" spread syntax for dynamic maps) instead.');
+
+        $htmlAttributes = $data['htmlAttributes'];
+        unset($data['htmlAttributes']);
+
+        // the old template silently ignored non-iterable values, keep that behavior
+        if (!is_iterable($htmlAttributes)) {
+            return $data;
+        }
+
+        foreach ($htmlAttributes as $attrName => $attrValue) {
+            // attributes passed directly on the component win over the map ones
+            if (\array_key_exists($attrName, $data)) {
+                continue;
+            }
+
+            if ($attrValue instanceof TranslatableInterface) {
+                $attrValue = $attrValue->trans($this->translator);
+            }
+
+            $data[$attrName] = $attrValue ?? '';
+        }
+
+        return $data;
+    }
+
+    public function mount(string|ButtonVariant|null $variant = null, string|ButtonElement|null $htmlElement = null, string|ButtonType|null $type = null, ?string $method = null, string|Size $size = Size::Medium): void
+    {
+        if ($variant instanceof ButtonVariant) {
+            $this->variant = $variant;
+        } elseif (null === $variant || '' === $variant) {
+            $this->variant = ButtonVariant::Default;
+        } else {
+            $resolved = ButtonVariant::tryFrom($variant);
+            $this->variant = $resolved;
+            if (null === $resolved) {
+                // unknown variants are passed through as a custom 'btn-{variant}' CSS class
+                $this->customVariant = $variant;
+            }
+        }
+
+        if ($htmlElement instanceof ButtonElement) {
+            $this->htmlElement = $htmlElement;
+        } else {
+            $this->htmlElement = ButtonElement::tryFrom($htmlElement ?? '') ?? ButtonElement::Button;
+        }
+
+        if ($type instanceof ButtonType) {
+            $this->type = $type;
+        } else {
+            $this->type = ButtonType::tryFrom($type ?? '') ?? ButtonType::Submit;
+        }
+
+        $this->method = null === $method || '' === $method ? 'POST' : strtoupper($method);
+
+        // unknown sizes fall back to the base 'md' size, which emits no CSS class
+        $this->size = \is_string($size) ? (Size::tryFrom($size) ?? Size::Medium) : $size;
+    }
+
+    public function getDefaultCssClass(): string
+    {
+        $cssClasses = ['btn'];
+
+        if (null !== $this->variant) {
+            $cssClasses[] = $this->variant->asCssClass();
+        } elseif (null !== $this->customVariant) {
+            $cssClasses[] = 'btn-'.$this->customVariant;
+        }
+
+        if (Size::Medium !== $this->size) {
+            $cssClasses[] = 'btn-'.$this->size->value;
+        }
+
+        if ($this->isInvisible) {
+            $cssClasses[] = 'btn-invisible';
+        }
+
+        if ($this->isBlock) {
+            $cssClasses[] = 'btn-block';
+        }
+
+        if ($this->inactive) {
+            $cssClasses[] = 'disabled';
+        }
+
+        return implode(' ', $cssClasses);
+    }
+
+    // HTML forms only support GET and POST methods; other methods (PUT, DELETE, etc.)
+    // require submitting a POST form with the real method in a '_method' hidden field
+    public function usesMethodOverride(): bool
+    {
+        return !\in_array($this->method, ['GET', 'POST'], true);
+    }
+
+    public function getFormMethod(): string
+    {
+        return $this->usesMethodOverride() ? 'POST' : $this->method;
+    }
+}

--- a/src/Twig/Component/Option/ButtonVariant.php
+++ b/src/Twig/Component/Option/ButtonVariant.php
@@ -13,4 +13,10 @@ enum ButtonVariant: string
     case Warning = 'warning';
     case Danger = 'danger';
     case Info = 'info';
+
+    public function asCssClass(): string
+    {
+        // the 'default' variant renders Bootstrap's secondary button style
+        return self::Default === $this ? 'btn-secondary' : 'btn-'.$this->value;
+    }
 }

--- a/templates/components/Button.html.twig
+++ b/templates/components/Button.html.twig
@@ -1,90 +1,42 @@
-{% props
-    variant = 'default', # primary|default|danger|success|warning|info (default: 'default')
-    isInvisible = false, # true|false (default: false) if true, button has transparent background and no border
-    isBlock = false, # true|false (default: false) if true, button takes full width of container
-    size = 'md', # sm|md|lg (string or Option\Size enum) (default: 'md')
-    icon = null, # icon name string (e.g., 'tabler:user' or 'fa fas fa-user')
-    withTrailingIcon = false, # boolean to show icon after label (default: false)
-    inactive = false, # boolean to disable the button (default: false)
-    htmlElement = 'button', # button|a|form (default: 'button')
-    htmlAttributes = {}, # additional HTML attributes as key-value pairs
-    href = '#', # URL for link buttons (default: '#')
-    action = null, # form action URL (for htmlElement='form')
-    method = 'POST', # HTTP method for forms (default: 'POST')
-    type = null, # button|submit (default: 'submit') button type attribute
-    name = null, # form button name attribute
-    value = null, # form button value attribute
-%}
+{# the inner content is the same for all button elements: leading icon + label + trailing icon #}
+{% set button_content %}
+    {%- if this.icon and not this.withTrailingIcon -%}
+        <twig:ea:Icon name="{{ this.icon }}" class="btn-icon" />
+    {%- endif -%}
+    {%- if block('content') is defined and block('content') is not empty -%}
+        <span {{- attributes.nested('label').defaults({class: 'btn-label'}) }}>{{ block('content') }}</span>
+    {%- endif -%}
+    {%- if this.icon and this.withTrailingIcon -%}
+        <twig:ea:Icon name="{{ this.icon }}" class="btn-icon btn-icon-trailing" />
+    {%- endif -%}
+{% endset %}
 
-{# handle both string and enum values #}
-{% set html_element_value = htmlElement.value is defined ? htmlElement.value : htmlElement %}
-{% set variant_value = variant.value is defined ? variant.value : variant %}
-{% set size_value = size.value is defined ? size.value : size %}
+{% if this.htmlElement.isLink %}
+    {% set link_defaults = {class: this.defaultCssClass(), role: 'button'} %}
+    {% if this.inactive %}
+        {% set link_defaults = link_defaults|merge({'aria-disabled': 'true', tabindex: '-1'}) %}
+    {% elseif this.href %}
+        {% set link_defaults = link_defaults|merge({href: this.href}) %}
+    {% endif %}
 
-{% set variant_class = variant_value == 'default' ? 'btn-secondary' : 'btn-' ~ variant_value %}
-{% set size_class = size_value == 'md' ? '' : 'btn-' ~ size_value %}
-{% set css_class = html_classes('btn', variant_class, size_class, {
-    'btn-invisible': isInvisible,
-    'btn-block': isBlock,
-    disabled: inactive,
-}) %}
-
-{% if html_element_value == 'a' %}
-    <a {{ attributes.only('class').defaults({class: css_class}) }}
-       href="{{ inactive ? '#' : href }}"
-       role="button"
-       {% if inactive %}aria-disabled="true" tabindex="-1"{% endif %}
-       {% for attrName, attrValue in htmlAttributes %}{{ attrName }}="{{ (attrValue.trans is defined ? attrValue|trans : attrValue)|e('html') }}" {% endfor %}
-       {{ attributes.without('class', 'href', 'role', 'aria-disabled', 'tabindex')|raw }}>
-        {% if icon and not withTrailingIcon %}
-            <twig:ea:Icon name="{{ icon }}" class="btn-icon" />
-        {% endif %}
-        {% if block('content') is defined and block('content') is not empty %}
-            <span {{ attributes.nested('label').defaults({class: 'btn-label'}) }}>{{ block('content') }}</span>
-        {% endif %}
-        {% if icon and withTrailingIcon %}
-            <twig:ea:Icon name="{{ icon }}" class="btn-icon btn-icon-trailing" />
-        {% endif %}
-    </a>
-{% elseif html_element_value == 'form' %}
-    <form action="{{ action }}" method="{{ method }}" {{ attributes.only('id', 'class', 'data-*') }}>
-        {% if method|upper not in ['GET', 'POST'] %}
-            <input type="hidden" name="_method" value="{{ method|upper }}">
-        {% endif %}
-
-        <button {{ attributes.only('class').defaults({class: css_class}) }}
-            type="{{ type ?? 'submit' }}"
-            {% if name %}name="{{ name }}"{% endif %}
-            {% if value %}value="{{ value }}"{% endif %}
-            {% if inactive %}disabled="disabled"{% endif %}
-            {% for attrName, attrValue in htmlAttributes %}{{ attrName }}="{{ (attrValue.trans is defined ? attrValue|trans : attrValue)|e('html') }}" {% endfor %}
-            {{ attributes.without('class', 'form', 'type', 'name', 'value', 'disabled')|raw }}
-        >
-            {% if icon and not withTrailingIcon %}
-                <twig:ea:Icon name="{{ icon }}" class="btn-icon" />
-            {% endif %}
-            {% if block('content') is defined and block('content') is not empty %}
-                <span {{ attributes.nested('label').defaults({class: 'btn-label'}) }}>{{ block('content') }}</span>
-            {% endif %}
-            {% if icon and withTrailingIcon %}
-                <twig:ea:Icon name="{{ icon }}" class="btn-icon btn-icon-trailing" />
-            {% endif %}
-        </button>
-    </form>
+    <a {{- attributes.defaults(link_defaults) }}>{{ button_content }}</a>
 {% else %}
-    <button {{ attributes.only('class').defaults({class: css_class}) }}
-        type="{{ type ?? 'submit' }}"
-        {% if inactive %}disabled="disabled"{% endif %}
-        {% for attrName, attrValue in htmlAttributes %}{{ attrName }}="{{ (attrValue.trans is defined ? attrValue|trans : attrValue)|e('html') }}" {% endfor %}
-        {{ attributes.without('class', 'type', 'disabled')|raw }}>
-        {% if icon and not withTrailingIcon %}
-            <twig:ea:Icon name="{{ icon }}" class="btn-icon" />
-        {% endif %}
-        {% if block('content') is defined and block('content') is not empty %}
-            <span {{ attributes.nested('label').defaults({class: 'btn-label'}) }}>{{ block('content') }}</span>
-        {% endif %}
-        {% if icon and withTrailingIcon %}
-            <twig:ea:Icon name="{{ icon }}" class="btn-icon btn-icon-trailing" />
-        {% endif %}
-    </button>
+    {% set button_defaults = {class: this.defaultCssClass(), type: this.type.value} %}
+    {% if this.name %}{% set button_defaults = button_defaults|merge({name: this.name}) %}{% endif %}
+    {% if this.value is not null %}{% set button_defaults = button_defaults|merge({value: this.value}) %}{% endif %}
+    {% if this.inactive %}{% set button_defaults = button_defaults|merge({disabled: true}) %}{% endif %}
+
+    {% if this.htmlElement.isForm %}
+        {# HTML forms only support GET and POST; other methods are submitted as POST
+           with the real method in the '_method' hidden field (needs 'http_method_override') #}
+        <form action="{{ this.action }}" method="{{ this.formMethod }}" {{- attributes.only('class') }}>
+            {% if this.usesMethodOverride %}
+                <input type="hidden" name="_method" value="{{ this.method }}">
+            {% endif %}
+
+            <button {{- attributes.defaults(button_defaults) }}>{{ button_content }}</button>
+        </form>
+    {% else %}
+        <button {{- attributes.defaults(button_defaults) }}>{{ button_content }}</button>
+    {% endif %}
 {% endif %}

--- a/templates/crud/action.html.twig
+++ b/templates/crud/action.html.twig
@@ -6,9 +6,9 @@
     variant="{{ action.variant }}"
     isInvisible="{{ action.usesTextStyle }}"
     class="{{ action.htmlElement.isLink and isIncludedInDropdown|default(false) ? 'dropdown-item' }} {{ action.cssClass }}"
-    htmlAttributes="{{ action.htmlAttributes|ea_html_attrs }}"
+    {{ ...action.htmlAttributes|ea_html_attrs|filter(v => v is not null) }}
     htmlElement="{{ action.htmlElement }}"
-    type="{{ action.buttonType.value }}"
+    type="{{ action.buttonType }}"
     icon="{{ action.icon }}"
     href="{{ action.htmlElement.isLink ? action.linkUrl : null }}"
     action="{{ action.htmlElement.isForm ? action.linkUrl : null }}"

--- a/templates/crud/action_group.html.twig
+++ b/templates/crud/action_group.html.twig
@@ -13,7 +13,7 @@
             action="{{ main_action.htmlElement.isForm ? main_action.linkUrl : null }}"
             method="{{ main_action.htmlElement.isForm ? 'POST' : null }}"
             icon="{{ main_action.icon ?: group.icon }}"
-            htmlAttributes="{{ main_action.htmlAttributes|ea_html_attrs|merge({'data-action-group-name-main-action': true, 'data-ea-action-url': main_action.htmlElement.isButton ? main_action.linkUrl : null})|filter((v) => v is not null) }}"
+            {{ ...main_action.htmlAttributes|ea_html_attrs|merge({'data-action-group-name-main-action': true, 'data-ea-action-url': main_action.htmlElement.isButton ? main_action.linkUrl : null})|filter((v) => v is not null) }}
         >
             {% set main_action_label = main_action.label|trans %}
             {%- if main_action_label is not same as(false) -%}{{ main_action_label|raw }}{%- endif -%}
@@ -24,7 +24,8 @@
                 htmlElement="button"
                 type="button"
                 class="{{ main_action.cssClass }} {{ main_action.addedCssClass }} dropdown-toggle dropdown-toggle-split"
-                htmlAttributes="{{ {'data-bs-toggle': 'dropdown', 'aria-expanded': 'false'} }}"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
                 label:class="visually-hidden"
         >
             {{ 'action.toggle_dropdown'|trans(domain: 'EasyAdminBundle') }}
@@ -36,7 +37,8 @@
             htmlElement="button"
             type="button"
             icon="{{ group.icon }}"
-            htmlAttributes="{{ {'data-bs-toggle': 'dropdown', 'aria-expanded': 'false'} }}"
+            data-bs-toggle="dropdown"
+            aria-expanded="false"
         >
             {% set group_label = group.label|trans %}
             {%- if group_label is not same as(false) -%}{{ group_label|raw }}{%- endif -%}

--- a/templates/page/login.html.twig
+++ b/templates/page/login.html.twig
@@ -89,7 +89,7 @@
                     </div>
                 {% endif %}
 
-                <twig:ea:Button type="submit" variant="primary" size="lg" isBlock htmlAttributes="{class: 'btn-block'}">{{ _sign_in_label }}</twig:ea:Button>
+                <twig:ea:Button type="submit" variant="primary" size="lg" isBlock>{{ _sign_in_label }}</twig:ea:Button>
             </form>
 
             {% block login_form_footer %}{% endblock login_form_footer %}

--- a/tests/Functional/Component/ButtonTest.php
+++ b/tests/Functional/Component/ButtonTest.php
@@ -3,56 +3,168 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Component;
 
 use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\AbstractFieldFunctionalTest;
-use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Size;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * Rendering tests for the <twig:ea:Button> component.
  */
 class ButtonTest extends AbstractFieldFunctionalTest
 {
-    public function testDefaultSizeEmitsNoSizeClass(): void
-    {
-        $html = $this->renderButton('<twig:ea:Button>Click</twig:ea:Button>');
+    use ExpectDeprecationTrait;
 
-        self::assertStringContainsString('class="btn btn-secondary"', $html);
-        self::assertStringNotContainsString('btn-sm', $html);
-        self::assertStringNotContainsString('btn-md', $html);
+    private function renderButton(string $template): string
+    {
+        return trim(static::getContainer()->get('twig')->createTemplate($template)->render());
     }
 
-    public function testSmallSizeAsString(): void
+    public function testDefaultButton(): void
     {
-        self::assertStringContainsString(
-            'class="btn btn-secondary btn-sm"',
-            $this->renderButton('<twig:ea:Button size="sm">Click</twig:ea:Button>')
-        );
+        $html = $this->renderButton('<twig:ea:Button>Save</twig:ea:Button>');
+
+        self::assertStringContainsString('<button class="btn btn-secondary" type="submit">', $html);
+        self::assertStringContainsString('<span class="btn-label">Save</span>', $html);
+        self::assertStringContainsString('</button>', $html);
     }
 
-    public function testLargeSizeAsString(): void
+    public function testVariantAndCustomClassAreMerged(): void
     {
-        self::assertStringContainsString(
-            'class="btn btn-secondary btn-lg"',
-            $this->renderButton('<twig:ea:Button size="lg">Click</twig:ea:Button>')
-        );
+        $html = $this->renderButton('<twig:ea:Button variant="danger" class="my-button">x</twig:ea:Button>');
+
+        self::assertStringContainsString('class="btn btn-danger my-button"', $html);
     }
 
-    public function testSmallSizeAsEnum(): void
+    public function testLinkWithHref(): void
     {
-        self::assertStringContainsString(
-            'class="btn btn-secondary btn-sm"',
-            $this->renderButton('<twig:ea:Button size="{{ size }}">Click</twig:ea:Button>', ['size' => Size::Small])
-        );
+        $html = $this->renderButton('<twig:ea:Button htmlElement="a" href="https://example.com">Go</twig:ea:Button>');
+
+        self::assertStringContainsString('<a class="btn btn-secondary" role="button" href="https://example.com">', $html);
+        self::assertStringContainsString('</a>', $html);
     }
 
-    public function testMediumSizeAsEnumEmitsNoSizeClass(): void
+    public function testLinkWithoutHrefOmitsTheAttribute(): void
     {
-        self::assertStringContainsString(
-            'class="btn btn-secondary"',
-            $this->renderButton('<twig:ea:Button size="{{ size }}">Click</twig:ea:Button>', ['size' => Size::Medium])
-        );
+        $html = $this->renderButton('<twig:ea:Button htmlElement="a">Go</twig:ea:Button>');
+
+        self::assertStringNotContainsString('href', $html);
+        self::assertStringContainsString('role="button"', $html);
     }
 
-    private function renderButton(string $template, array $context = []): string
+    public function testInactiveLinkHasNoHref(): void
     {
-        return static::getContainer()->get('twig')->createTemplate($template)->render($context);
+        $html = $this->renderButton('<twig:ea:Button htmlElement="a" href="https://example.com" inactive>Go</twig:ea:Button>');
+
+        self::assertStringNotContainsString('href', $html);
+        self::assertStringContainsString('aria-disabled="true"', $html);
+        self::assertStringContainsString('tabindex="-1"', $html);
+        self::assertStringContainsString('class="btn btn-secondary disabled"', $html);
+    }
+
+    public function testInactiveButtonIsDisabled(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button inactive>x</twig:ea:Button>');
+
+        self::assertStringContainsString('disabled', $html);
+        self::assertStringContainsString('class="btn btn-secondary disabled"', $html);
+    }
+
+    public function testFormButton(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button htmlElement="form" action="/delete" class="action-delete" id="delete-button" data-foo="bar">Delete</twig:ea:Button>');
+
+        // the wrapper <form> only keeps the CSS class; all the other attributes
+        // are rendered once, in the inner <button>
+        self::assertStringContainsString('<form action="/delete" method="POST" class="action-delete">', $html);
+        self::assertSame(1, substr_count($html, 'id="delete-button"'));
+        self::assertSame(1, substr_count($html, 'data-foo="bar"'));
+        self::assertStringContainsString('<button class="btn btn-secondary action-delete"', $html);
+        self::assertStringNotContainsString('_method', $html);
+    }
+
+    public function testFormButtonWithMethodOverride(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button htmlElement="form" action="/delete" method="delete">Delete</twig:ea:Button>');
+
+        self::assertStringContainsString('method="POST"', $html);
+        self::assertStringContainsString('<input type="hidden" name="_method" value="DELETE">', $html);
+    }
+
+    public function testFormButtonWithNameAndValue(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button htmlElement="form" action="/batch" name="batch" value="delete">x</twig:ea:Button>');
+
+        self::assertStringContainsString('name="batch"', $html);
+        self::assertStringContainsString('value="delete"', $html);
+    }
+
+    public function testSpreadAttributesLandOnTheRootElement(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button {{ ...{\'data-foo\': \'bar\'} }}>x</twig:ea:Button>');
+
+        self::assertStringContainsString('data-foo="bar"', $html);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedHtmlAttributesPropStillRenders(): void
+    {
+        $this->expectDeprecation('Since easycorp/easyadmin-bundle 5.2.0: The "htmlAttributes" prop of the <twig:ea:Button> component is deprecated, pass the attributes directly on the component (or use the "{{ ... }}" spread syntax for dynamic maps) instead.');
+
+        $html = $this->renderButton('<twig:ea:Button htmlAttributes="{{ {\'data-foo\': \'bar\'} }}">x</twig:ea:Button>');
+
+        self::assertStringContainsString('data-foo="bar"', $html);
+        self::assertStringNotContainsString('htmlattributes', $html);
+    }
+
+    public function testLabelNestedAttributesAreMergedIntoTheLabel(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button label:class="visually-hidden">x</twig:ea:Button>');
+
+        self::assertStringContainsString('<span class="btn-label visually-hidden">x</span>', $html);
+        self::assertStringNotContainsString('label:class', $html);
+    }
+
+    public function testLeadingIconIsRenderedBeforeLabel(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button icon="internal:check">Label</twig:ea:Button>');
+
+        self::assertStringContainsString('btn-icon', $html);
+        self::assertStringNotContainsString('btn-icon-trailing', $html);
+        self::assertLessThan(strpos($html, 'Label'), strpos($html, 'btn-icon'));
+    }
+
+    public function testTrailingIconIsRenderedAfterLabel(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button icon="internal:check" withTrailingIcon>Label</twig:ea:Button>');
+
+        self::assertStringContainsString('btn-icon-trailing', $html);
+        self::assertGreaterThan(strpos($html, 'Label'), strpos($html, 'btn-icon-trailing'));
+    }
+
+    public function testNoLabelSpanWithoutContent(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button icon="internal:check" aria-label="Close" />');
+
+        self::assertStringNotContainsString('btn-label', $html);
+        self::assertStringContainsString('aria-label="Close"', $html);
+    }
+
+    public function testAttributeValuesAreEscaped(): void
+    {
+        $html = $this->renderButton('<twig:ea:Button data-title="{{ \'a\' ~ \'"\' ~ \'b\' }}">x</twig:ea:Button>');
+
+        self::assertStringNotContainsString('a"b', $html);
+        self::assertStringContainsString('a&quot;b', $html);
+    }
+
+    public function testEnumValuesArePassedAsSingleExpressionAttributes(): void
+    {
+        $html = $this->renderButton(<<<'TWIG'
+            {% set element = enum('EasyCorp\\Bundle\\EasyAdminBundle\\Twig\\Component\\Option\\ButtonElement').A %}
+            {% set variant = enum('EasyCorp\\Bundle\\EasyAdminBundle\\Twig\\Component\\Option\\ButtonVariant').Danger %}
+            <twig:ea:Button htmlElement="{{ element }}" variant="{{ variant }}" href="/foo">x</twig:ea:Button>
+            TWIG);
+
+        self::assertStringContainsString('<a class="btn btn-danger" role="button" href="/foo">', $html);
     }
 }

--- a/tests/Unit/Twig/Component/ButtonTest.php
+++ b/tests/Unit/Twig/Component/ButtonTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Twig\Component;
+
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Button;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonElement;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonType;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonVariant;
+use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\Size;
+use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Component\Translation\TranslatableMessage;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class ButtonTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    private function createButton(): Button
+    {
+        $translator = $this->createMock(TranslatorInterface::class);
+        $translator->method('trans')->willReturnCallback(static fn (string $id): string => 'translated: '.$id);
+
+        return new Button($translator);
+    }
+
+    /**
+     * @dataProvider provideKnownStringVariants
+     */
+    public function testMountWithKnownStringVariant(string $variantString, ButtonVariant $expectedVariant): void
+    {
+        $button = $this->createButton();
+        $button->mount($variantString);
+
+        $this->assertSame($expectedVariant, $button->variant);
+    }
+
+    public static function provideKnownStringVariants(): iterable
+    {
+        yield ['default', ButtonVariant::Default];
+        yield ['primary', ButtonVariant::Primary];
+        yield ['success', ButtonVariant::Success];
+        yield ['warning', ButtonVariant::Warning];
+        yield ['danger', ButtonVariant::Danger];
+        yield ['info', ButtonVariant::Info];
+    }
+
+    public function testMountWithEnumVariant(): void
+    {
+        $button = $this->createButton();
+        $button->mount(ButtonVariant::Danger);
+
+        $this->assertSame(ButtonVariant::Danger, $button->variant);
+    }
+
+    /**
+     * @dataProvider provideEmptyVariants
+     */
+    public function testMountWithEmptyVariantUsesDefault(?string $variant): void
+    {
+        $button = $this->createButton();
+        $button->mount($variant);
+
+        $this->assertSame(ButtonVariant::Default, $button->variant);
+        $this->assertSame('btn btn-secondary', $button->getDefaultCssClass());
+    }
+
+    public static function provideEmptyVariants(): iterable
+    {
+        yield [null];
+        yield [''];
+    }
+
+    public function testMountWithUnknownVariantIsRenderedAsCustomVariant(): void
+    {
+        $button = $this->createButton();
+        $button->mount('custom');
+
+        $this->assertNull($button->variant);
+        $this->assertSame('btn btn-custom', $button->getDefaultCssClass());
+    }
+
+    /**
+     * @dataProvider provideHtmlElements
+     */
+    public function testMountHtmlElement(string|ButtonElement|null $htmlElement, ButtonElement $expected): void
+    {
+        $button = $this->createButton();
+        $button->mount(htmlElement: $htmlElement);
+
+        $this->assertSame($expected, $button->htmlElement);
+    }
+
+    public static function provideHtmlElements(): iterable
+    {
+        yield ['a', ButtonElement::A];
+        yield ['form', ButtonElement::Form];
+        yield ['button', ButtonElement::Button];
+        yield [ButtonElement::Form, ButtonElement::Form];
+        yield [null, ButtonElement::Button];
+        yield ['', ButtonElement::Button];
+        yield ['unknown', ButtonElement::Button];
+    }
+
+    /**
+     * @dataProvider provideTypes
+     */
+    public function testMountType(string|ButtonType|null $type, ButtonType $expected): void
+    {
+        $button = $this->createButton();
+        $button->mount(type: $type);
+
+        $this->assertSame($expected, $button->type);
+    }
+
+    public static function provideTypes(): iterable
+    {
+        yield ['button', ButtonType::Button];
+        yield ['submit', ButtonType::Submit];
+        yield [ButtonType::Button, ButtonType::Button];
+        yield [null, ButtonType::Submit];
+        yield ['', ButtonType::Submit];
+        yield ['unknown', ButtonType::Submit];
+    }
+
+    /**
+     * @dataProvider provideMethods
+     */
+    public function testMountMethod(?string $method, string $expectedMethod, bool $expectedOverride, string $expectedFormMethod): void
+    {
+        $button = $this->createButton();
+        $button->mount(method: $method);
+
+        $this->assertSame($expectedMethod, $button->method);
+        $this->assertSame($expectedOverride, $button->usesMethodOverride());
+        $this->assertSame($expectedFormMethod, $button->getFormMethod());
+    }
+
+    public static function provideMethods(): iterable
+    {
+        yield [null, 'POST', false, 'POST'];
+        yield ['', 'POST', false, 'POST'];
+        yield ['get', 'GET', false, 'GET'];
+        yield ['POST', 'POST', false, 'POST'];
+        yield ['delete', 'DELETE', true, 'POST'];
+        yield ['PATCH', 'PATCH', true, 'POST'];
+    }
+
+    /**
+     * @dataProvider provideSizeValues
+     */
+    public function testMountResolvesSize(string|Size $size, Size $expectedSize): void
+    {
+        $button = $this->createButton();
+        $button->mount(size: $size);
+
+        $this->assertSame($expectedSize, $button->size);
+    }
+
+    public static function provideSizeValues(): iterable
+    {
+        yield 'string' => ['sm', Size::Small];
+        yield 'enum' => [Size::Small, Size::Small];
+        yield 'unknown string falls back to md' => ['nope', Size::Medium];
+    }
+
+    /**
+     * @dataProvider provideCssClassCombinations
+     */
+    public function testGetDefaultCssClass(string|ButtonVariant|null $variant, string|Size $size, bool $isInvisible, bool $isBlock, bool $inactive, string $expected): void
+    {
+        $button = $this->createButton();
+        $button->mount($variant, size: $size);
+        $button->isInvisible = $isInvisible;
+        $button->isBlock = $isBlock;
+        $button->inactive = $inactive;
+
+        $this->assertSame($expected, $button->getDefaultCssClass());
+    }
+
+    public static function provideCssClassCombinations(): iterable
+    {
+        yield 'default' => [null, 'md', false, false, false, 'btn btn-secondary'];
+        yield 'primary' => [ButtonVariant::Primary, 'md', false, false, false, 'btn btn-primary'];
+        yield 'small size' => ['danger', 'sm', false, false, false, 'btn btn-danger btn-sm'];
+        yield 'large size' => ['info', 'lg', false, false, false, 'btn btn-info btn-lg'];
+        yield 'large size as enum' => ['info', Size::Large, false, false, false, 'btn btn-info btn-lg'];
+        yield 'invisible' => [null, 'md', true, false, false, 'btn btn-secondary btn-invisible'];
+        yield 'block' => [null, 'md', false, true, false, 'btn btn-secondary btn-block'];
+        yield 'inactive' => [null, 'md', false, false, true, 'btn btn-secondary disabled'];
+        yield 'all combined' => ['warning', 'sm', true, true, true, 'btn btn-warning btn-sm btn-invisible btn-block disabled'];
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedHtmlAttributesPropIsMigratedToRegularAttributes(): void
+    {
+        $button = $this->createButton();
+
+        $this->expectDeprecation('Since easycorp/easyadmin-bundle 5.2.0: The "htmlAttributes" prop of the <twig:ea:Button> component is deprecated, pass the attributes directly on the component (or use the "{{ ... }}" spread syntax for dynamic maps) instead.');
+
+        $data = $button->migrateHtmlAttributes([
+            'variant' => 'primary',
+            'data-foo' => 'direct',
+            'htmlAttributes' => [
+                'data-foo' => 'from-map',
+                'data-bar' => 'bar',
+                'data-null' => null,
+                'title' => new TranslatableMessage('some.title'),
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('htmlAttributes', $data);
+        // attributes passed directly on the component win over the map ones
+        $this->assertSame('direct', $data['data-foo']);
+        $this->assertSame('bar', $data['data-bar']);
+        // the old template rendered null values as attr=""
+        $this->assertSame('', $data['data-null']);
+        // the old template translated TranslatableInterface values
+        $this->assertSame('translated: some.title', $data['title']);
+        $this->assertSame('primary', $data['variant']);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedHtmlAttributesPropIgnoresNonIterableValues(): void
+    {
+        $button = $this->createButton();
+
+        $this->expectDeprecation('Since easycorp/easyadmin-bundle 5.2.0: The "htmlAttributes" prop of the <twig:ea:Button> component is deprecated, pass the attributes directly on the component (or use the "{{ ... }}" spread syntax for dynamic maps) instead.');
+
+        // the old template silently ignored non-iterable values (e.g. a string
+        // literal passed without the '{{ }}' delimiters)
+        $data = $button->migrateHtmlAttributes(['htmlAttributes' => "{class: 'btn-block'}"]);
+
+        $this->assertSame([], $data);
+    }
+
+    public function testMountWithoutHtmlAttributesDoesNotTriggerDeprecation(): void
+    {
+        $button = $this->createButton();
+
+        $this->assertSame(['variant' => 'primary'], $button->migrateHtmlAttributes(['variant' => 'primary']));
+    }
+}


### PR DESCRIPTION
For end users, nothing changes in practice: you can still use the buttons in the same way. But this PR turns the Twig component into a PHP-backed component, deprecates a weird `htmlAttributes` prop in favor of Twig Component built-in handling of attributes, uses the enums introduced to configure soem button props, etc.