### PR TITLE
Improve the ActionMenu component

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -6,12 +6,14 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
+use Symfony\Component\Uid\Ulid;
 use Symfony\Contracts\Translation\TranslatableInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
 use Twig\TwigFunction;
+use Twig\TwigTest;
 
 /**
  * Defines the filters and functions used to render the bundle's templates.
@@ -36,6 +38,17 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
             new TwigFunction('ea', [$this, 'ea']),
             new TwigFunction('ea_url', [$this, 'getAdminUrlGenerator']),
             new TwigFunction('ea_form_ealabel', null, ['node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => ['html']]),
+            new TwigFunction('ea_uid', static fn (string $prefix = 'ea-'): string => $prefix.Ulid::generate()),
+        ];
+    }
+
+    public function getTests(): array
+    {
+        return [
+            // 'foo is not empty' can't be used with TranslatableMessage values because it triggers
+            // a deprecation ("Method TranslatableMessage::__toString() is deprecated"); this test
+            // checks the same without casting the value to a string
+            new TwigTest('ea_is_not_empty', static fn (mixed $value): bool => false !== $value && null !== $value && '' !== $value),
         ];
     }
 

--- a/templates/components/ActionMenu/ActionList/Header.html.twig
+++ b/templates/components/ActionMenu/ActionList/Header.html.twig
@@ -5,8 +5,7 @@
     htmlAttributes = {},
 %}
 
-{# don't use 'label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-{% set has_label = label is not same as(false) and label is not null and label is not same as('') %}
+{% set has_label = label is ea_is_not_empty %}
 {% if has_label or icon is not empty %}
     <li {{ attributes.defaults({class: 'dropdown-header'}|merge(htmlAttributes)) }}>
         {%- if icon %}<twig:ea:Icon {{ ...attributes.nested('icon').defaults({name: icon}) }} /> {% endif -%}

--- a/templates/components/ActionMenu/ActionList/Item.html.twig
+++ b/templates/components/ActionMenu/ActionList/Item.html.twig
@@ -7,6 +7,7 @@
     renderAsForm = false, # if true, the item will be rendered as a <form> element (and POST method) instead of an <a> (and GET method)
     showBlankIcons = true, # (this is mostly an internal option) if false, the blank icon will not be rendered when action icon is null
     selected = null, # null = regular item; true/false turns the item into a selectable one (radio/checkbox) that shows a trailing checkmark
+    wrapInListItem = true, # (this is an internal option) if false, the <li> wrapper is not rendered, so the item can be embedded in custom markup (e.g. the split dropdown of ItemGroup)
 %}
 
 {% set is_selectable = selected is not null %}
@@ -14,8 +15,8 @@
    class is mirrored alongside it (kept for one release, in sync with page-color-scheme.js) #}
 {% set item_class = html_classes('dropdown-item', {'dropdown-item-selectable': is_selectable, active: selected}) %}
 
-<li>
-    {% set formId = renderAsForm ? 'ea-form-' ~ random() ~ random() %}
+{% if wrapInListItem %}<li>{% endif %}
+    {% set formId = renderAsForm ? ea_uid('ea-form-') : null %}
     {% if renderAsForm %}
         <form action="{{ url }}" method="POST" {% if formId %}id="{{ formId }}"{% endif %}></form>
     {% endif %}
@@ -34,9 +35,7 @@
         {% elseif showBlankIcons %}
             <twig:ea:Icon name="internal:blank" />
         {% endif %}
-        {# don't use 'label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-        {% set has_label = label is not same as(false) and label is not null and label is not same as('') %}
-        {% if has_label %}<span {{ attributes.nested('label') }}>{{ renderLabelRaw ? label|raw : label }}</span>{% endif %}
+        {% if label is ea_is_not_empty %}<span {{ attributes.nested('label') }}>{{ renderLabelRaw ? label|raw : label }}</span>{% endif %}
         {% if is_selectable %}<span class="dropdown-item-trailing"><twig:ea:Icon name="internal:check" class="dropdown-item-check" /></span>{% endif %}
     </a>
-</li>
+{% if wrapInListItem %}</li>{% endif %}

--- a/templates/components/ActionMenu/ActionList/ItemGroup.html.twig
+++ b/templates/components/ActionMenu/ActionList/ItemGroup.html.twig
@@ -8,44 +8,28 @@
     {% if group.hasMainAction and group.mainAction %}
         {# split dropdown: main action + submenu toggle #}
         <div class="d-flex flex-row-reverse position-relative">
-            {% set formId = group.mainAction.isRenderedAsForm ? 'ea-form-' ~ random() ~ random() : null %}
-            {% if group.mainAction.isRenderedAsForm %}
-                <form action="{{ group.mainAction.linkUrl }}" method="POST" {% if formId %}id="{{ formId }}"{% endif %}></form>
-            {% endif %}
-
-            <a class="dropdown-item flex-grow-1 border-end-0 {{ group.mainAction.cssClass }}"
-                {% if group.mainAction.isRenderedAsForm %}
-                    href="#"
-                    data-ea-action-form-id="{{ formId }}"
-                {% else %}
-                    href="{{ group.mainAction.linkUrl }}"
-                {% endif %}
-                {% for attr, value in group.mainAction.htmlAttributes|ea_html_attrs %}{{ attr }}="{{ value }}" {% endfor %}>
-                {% if group.icon %}
-                    <twig:ea:Icon name="{{ group.icon }}" />
-                {% elseif showBlankIcons or group.hasAnyActionWithIcon %}
-                    <twig:ea:Icon name="internal:blank" />
-                {% endif %}
-                    {# don't use 'label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-                    {% if group.mainAction.label is not same as(false) and group.mainAction.label is not null and group.mainAction.label is not same as('') %}
-                    <span>{{ group.mainAction.label|trans }}</span>
-                {% endif %}
-            </a>
+            <twig:ea:ActionMenu:ActionList:Item
+                :wrapInListItem="false"
+                class="flex-grow-1 border-end-0 {{ group.mainAction.cssClass }}"
+                label="{{ group.mainAction.label is ea_is_not_empty ? group.mainAction.label|trans }}"
+                icon="{{ group.icon }}"
+                htmlAttributes="{{ group.mainAction.htmlAttributes|ea_html_attrs }}"
+                url="{{ group.mainAction.linkUrl }}"
+                renderAsForm="{{ group.mainAction.isRenderedAsForm }}"
+                showBlankIcons="{{ showBlankIcons or group.hasAnyActionWithIcon }}" />
             <a class="dropdown-toggle dropdown-toggle-split dropdown-item border-start-0" href="#" role="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
                 <twig:ea:Icon name="internal:chevron-right" class="dropdown-submenu-chevron" />
             </a>
         </div>
     {% else %}
         {# regular submenu toggle #}
-        {# don't use 'group.label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-        {% set has_group_label = group.label is not same as(false) and group.label is not null and group.label is not same as('') %}
         <a class="dropdown-item dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
             {% if group.icon %}
                 <twig:ea:Icon name="{{ group.icon }}" />
             {% elseif showBlankIcons or group.hasAnyActionWithIcon %}
                 <twig:ea:Icon name="internal:blank" />
             {% endif %}
-            {% if has_group_label %}<span>{{ group.label|trans }}</span>{% endif %}
+            {% if group.label is ea_is_not_empty %}<span>{{ group.label|trans }}</span>{% endif %}
             <twig:ea:Icon name="internal:chevron-right" class="dropdown-submenu-chevron" />
         </a>
     {% endif %}

--- a/templates/crud/detail.html.twig
+++ b/templates/crud/detail.html.twig
@@ -68,8 +68,7 @@
 {% endblock %}
 
 {% macro render_field_contents(entity, field) %}
-    {# don't use 'field.help is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-    {% set has_help = field.help is not same as(false) and field.help is not null and field.help is not same as('') %}
+    {% set has_help = field.help is ea_is_not_empty %}
 
     <div class="field-group {{ field.cssClass }}" {% for name, value in field.htmlAttributes %}{{ name }}="{{ value|e('html') }}" {% endfor %}>
         {% if field.label is same as (false) %}
@@ -194,8 +193,7 @@
 
 {% macro render_column_open(field) %}
     {% set field_icon = field.getCustomOption('icon') %}
-    {# don't use 'field.label is not empty' or 'field.label != ...' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-    {% set has_label = field.label is not same as(false) and field.label is not null and field.label is not same as('') %}
+    {% set has_label = field.label is ea_is_not_empty %}
     {% set column_has_title = field_icon is not null or has_label or field.help is not null %}
 
     <div class="form-column {{ not column_has_title ? 'form-column-no-header' }} {{ field.cssClass }}">
@@ -218,10 +216,8 @@
 {% endmacro %}
 
 {% macro render_fieldset_open(field) %}
-    {# don't use 'field.help is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-    {% set has_help = field.help is not same as(false) and field.help is not null and field.help is not same as('') %}
-    {# don't use 'field.label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-    {% set has_label = field.label is not same as(false) and field.label is not null and field.label is not same as('') %}
+    {% set has_help = field.help is ea_is_not_empty %}
+    {% set has_label = field.label is ea_is_not_empty %}
     {% set fieldset_has_header = has_label or field.getCustomOption('icon') or has_help %}
     {% set is_collapsible_option_name = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Field\\FormField::OPTION_COLLAPSIBLE') %}
     {% set is_collapsed_option_name = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Field\\FormField::OPTION_COLLAPSED') %}

--- a/templates/crud/field/boolean.html.twig
+++ b/templates/crud/field/boolean.html.twig
@@ -18,8 +18,8 @@
         </twig:ea:Badge>
     {% endif %}
 {% else %}
-    {# a TranslatableMessage can't be stringified directly, so translate it first and guard against false/null/'' #}
-    {% set switch_aria_label = (field.label is not same as(false) and field.label is not null and field.label is not same as(''))
+    {# a TranslatableMessage can't be stringified directly, so translate it before passing it as an attribute #}
+    {% set switch_aria_label = (field.label is ea_is_not_empty)
         ? field.label|trans(domain: ea.i18n.translationDomain) : null %}
     <twig:ea:Switch
         id="{{ field.uniqueId }}"

--- a/templates/crud/form_theme.html.twig
+++ b/templates/crud/form_theme.html.twig
@@ -479,9 +479,8 @@
 {% block ea_form_column_open_row %}
     {% set field = form.vars.ea_vars.field %}
     {% set field_icon = field.getCustomOption('icon') %}
-    {# don't use "field.label|default()" here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-    {% set has_label = field.label is not same as(false) and field.label is not null and field.label is not same as('') %}
-    {% set has_help = field.help is not same as(false) and field.help is not null and field.help is not same as('') %}
+    {% set has_label = field.label is ea_is_not_empty %}
+    {% set has_help = field.help is ea_is_not_empty %}
     {% set column_has_title = field_icon != null or has_label or has_help %}
 
     <div class="form-column {{ not column_has_title ? 'form-column-no-header' }} {{ field.cssClass }}">
@@ -516,8 +515,7 @@
 {% endblock ea_form_fieldset_open_ealabel %}
 
 {% block ea_form_fieldset_open_label %}
-    {# don't use 'ea_help is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-    {% set has_help = ea_help is not same as(false) and ea_help is not null and ea_help is not same as('') %}
+    {% set has_help = ea_help is ea_is_not_empty %}
     {% set collapsed_option_name = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Field\\FormField::OPTION_COLLAPSED') %}
     {% set fieldset_error_count_option_name = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Field\\FormField::OPTION_FIELDSET_ERROR_COUNT') %}
     {% set fieldset_error_count = form.vars.ea_vars.field.getCustomOption(fieldset_error_count_option_name)|default(0) %}
@@ -551,10 +549,8 @@
 {% endblock ea_form_fieldset_open_label %}
 
 {% block ea_form_fieldset_open_row %}
-    {# don't use 'ea_help is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-    {% set has_help = ea_help is not same as(false) and ea_help is not null and ea_help is not same as('') %}
-    {# don't use 'form.vars.label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-    {% set has_label = form.vars.label is not same as(false) and form.vars.label is not null and form.vars.label is not same as('') %}
+    {% set has_help = ea_help is ea_is_not_empty %}
+    {% set has_label = form.vars.label is ea_is_not_empty %}
     {% set fieldset_has_header = has_label or ea_icon or has_help %}
     {% set collapsed_option_name = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Field\\FormField::OPTION_COLLAPSED') %}
     {% set fieldset_error_count_option_name = constant('EasyCorp\\Bundle\\EasyAdminBundle\\Field\\FormField::OPTION_FIELDSET_ERROR_COUNT') %}
@@ -645,8 +641,7 @@
                     <input type="checkbox" class="filter-checkbox" {% if field.vars.name in applied_filters %}checked{% endif %}>
                     <a data-bs-toggle="collapse" href="#filter-content-{{ loop.index }}" aria-expanded="{{ field.vars.name in applied_filters ? 'true' : 'false' }}" aria-controls="filter-content-{{ loop.index }}"
                         {% for name, value in field.vars.label_attr|default([]) %}{{ name }}="{{ value|e('html') }}" {% endfor %}>
-                        {# don't use 'field.vars.label is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-                        {% set has_filter_label = field.vars.label is not same as(false) and field.vars.label is not null and field.vars.label is not same as('') %}
+                        {% set has_filter_label = field.vars.label is ea_is_not_empty %}
                         {% set filter_label = has_filter_label ? field.vars.label : field.vars.name|humanize %}
                         {{ filter_label|trans(domain: ea().i18n.translationDomain) }}
                     </a>

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -352,8 +352,7 @@
                             <article class="content">
                                 {% block content_header_wrapper %}
                                     {% set crud_help_message = ea.crud.helpMessage ?? null %}
-                                    {# don't use 'crud_help_message is not empty' here; it'll trigger deprecation messages: Method TranslatableMessage::__toString() is deprecated #}
-                                    {% set has_help_message = crud_help_message is not same as(false) and crud_help_message is not null and crud_help_message is not same as('') %}
+                                    {% set has_help_message = crud_help_message is ea_is_not_empty %}
                                     <section class="content-header">
                                         {% block content_header %}
                                             <div class="content-header-title">

--- a/tests/Functional/Apps/AdminRouteApp/config/reference.php
+++ b/tests/Functional/Apps/AdminRouteApp/config/reference.php
@@ -1227,7 +1227,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  * }
  * @psalm-type TwigComponentConfig = array{
- *     defaults?: array<string, string|array{ // Default: ["__deprecated__use_old_naming_behavior"]
+ *     defaults?: array<string, string|array{ // Default: []
  *         template_directory?: scalar|Param|null, // Default: "components"
  *         name_prefix?: scalar|Param|null, // Default: ""
  *     }>,
@@ -1236,7 +1236,6 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         enabled?: bool|Param, // Default: "%kernel.debug%"
  *         collect_components?: bool|Param, // Collect components instances // Default: true
  *     },
- *     controllers_json?: scalar|Param|null, // Deprecated: The "twig_component.controllers_json" config option is deprecated, and will be removed in 3.0. // Default: null
  * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,

--- a/tests/Functional/Component/ActionMenuItemTest.php
+++ b/tests/Functional/Component/ActionMenuItemTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Component;
+
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\AbstractFieldFunctionalTest;
+
+/**
+ * Rendering tests for the <twig:ea:ActionMenu:ActionList:Item> component.
+ */
+class ActionMenuItemTest extends AbstractFieldFunctionalTest
+{
+    private function renderItem(string $template, array $context = []): string
+    {
+        return static::getContainer()->get('twig')->createTemplate($template)->render($context);
+    }
+
+    public function testRegularItemIsRenderedAsLinkInsideListItem(): void
+    {
+        $html = $this->renderItem('<twig:ea:ActionMenu:ActionList:Item label="Edit" url="/edit" />');
+
+        self::assertStringContainsString('<li>', $html);
+        self::assertStringContainsString('href="/edit"', $html);
+        self::assertMatchesRegularExpression('/<span\s*>Edit<\/span>/', $html);
+        self::assertStringNotContainsString('<form', $html);
+    }
+
+    public function testFormItemRendersFormWithGeneratedUniqueId(): void
+    {
+        $html = $this->renderItem('<twig:ea:ActionMenu:ActionList:Item label="Delete" url="/delete" renderAsForm="true" />');
+
+        self::assertMatchesRegularExpression('/<form action="\/delete" method="POST" id="ea-form-[0-9A-HJKMNP-TV-Z]{26}"><\/form>/', $html);
+        self::assertSame(1, preg_match('/id="(ea-form-[^"]+)"/', $html, $matches));
+        self::assertStringContainsString(sprintf('data-ea-action-form-id="%s"', $matches[1]), $html);
+        self::assertStringContainsString('href="#"', $html);
+    }
+
+    /**
+     * @dataProvider provideEmptyLabels
+     */
+    public function testEmptyLabelRendersNoSpan(string $labelAttribute): void
+    {
+        $html = $this->renderItem(sprintf('<twig:ea:ActionMenu:ActionList:Item %s url="/edit" :showBlankIcons="false" />', $labelAttribute));
+
+        self::assertStringNotContainsString('<span', $html);
+    }
+
+    public static function provideEmptyLabels(): iterable
+    {
+        yield 'no label' => [''];
+        yield 'empty string label' => ['label=""'];
+        yield 'null label' => ['label="{{ null }}"'];
+        yield 'false label' => ['label="{{ false }}"'];
+    }
+
+    public function testWithoutListItemWrapper(): void
+    {
+        $html = $this->renderItem('<twig:ea:ActionMenu:ActionList:Item label="Edit" url="/edit" :wrapInListItem="false" />');
+
+        self::assertStringNotContainsString('<li>', $html);
+        self::assertStringNotContainsString('</li>', $html);
+        self::assertStringContainsString('href="/edit"', $html);
+    }
+
+    public function testCustomClassIsMergedWithDefaults(): void
+    {
+        $html = $this->renderItem('<twig:ea:ActionMenu:ActionList:Item label="Edit" url="/edit" class="my-item" />');
+
+        self::assertStringContainsString('class="dropdown-item my-item"', $html);
+    }
+}

--- a/tests/Unit/Twig/EasyAdminTwigExtensionTest.php
+++ b/tests/Unit/Twig/EasyAdminTwigExtensionTest.php
@@ -77,6 +77,75 @@ class EasyAdminTwigExtensionTest extends KernelTestCase
         $this->assertSame($expected, $twigExtensionInstance->forceFileDownload($filename));
     }
 
+    /**
+     * @dataProvider provideValuesForIsNotEmpty
+     */
+    public function testIsNotEmpty(mixed $value, bool $expected): void
+    {
+        $isNotEmpty = $this->getTwigTestCallable('ea_is_not_empty');
+
+        $this->assertSame($expected, $isNotEmpty($value));
+    }
+
+    public function testUid(): void
+    {
+        $uid = $this->getTwigFunctionCallable('ea_uid');
+
+        // the generated IDs use the given prefix followed by a ULID (26 chars, Crockford base32)
+        $this->assertMatchesRegularExpression('/^ea-[0-9A-HJKMNP-TV-Z]{26}$/', $uid());
+        $this->assertMatchesRegularExpression('/^ea-form-[0-9A-HJKMNP-TV-Z]{26}$/', $uid('ea-form-'));
+        $this->assertNotSame($uid(), $uid());
+    }
+
+    public static function provideValuesForIsNotEmpty(): iterable
+    {
+        yield [false, false];
+        yield [null, false];
+        yield ['', false];
+
+        yield ['foo', true];
+        yield [' ', true];
+        yield [0, true];
+        yield ['0', true];
+        yield [[], true];
+        // TranslatableInterface values must not be stringified (that would trigger
+        // a deprecation for TranslatableMessage); any object counts as not empty
+        yield [new class implements TranslatableInterface {
+            public function trans(TranslatorInterface $translator, ?string $locale = null): string
+            {
+                return 'some value';
+            }
+        }, true];
+    }
+
+    private function getTwigFunctionCallable(string $name): callable
+    {
+        $reflectedClass = new \ReflectionClass(EasyAdminTwigExtension::class);
+        $twigExtensionInstance = $reflectedClass->newInstanceWithoutConstructor();
+
+        foreach ($twigExtensionInstance->getFunctions() as $function) {
+            if ($name === $function->getName()) {
+                return $function->getCallable();
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('The "%s" Twig function is not defined in %s.', $name, EasyAdminTwigExtension::class));
+    }
+
+    private function getTwigTestCallable(string $name): callable
+    {
+        $reflectedClass = new \ReflectionClass(EasyAdminTwigExtension::class);
+        $twigExtensionInstance = $reflectedClass->newInstanceWithoutConstructor();
+
+        foreach ($twigExtensionInstance->getTests() as $test) {
+            if ($name === $test->getName()) {
+                return $test->getCallable();
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('The "%s" Twig test is not defined in %s.', $name, EasyAdminTwigExtension::class));
+    }
+
     public static function provideValuesForForceFileDownload(): iterable
     {
         // files the browser renders inline and can execute scripts from


### PR DESCRIPTION
In #7673 we improved the design of this component. In this PR we're improving the internals.

We also added a new `ea_is_not_empty` Twig test to simplify both the code of this component and many other templates.