### PR TITLE
Improve performance of some Twig Components

### DIFF
--- a/src/Twig/Component/Flag.php
+++ b/src/Twig/Component/Flag.php
@@ -12,6 +12,12 @@ class Flag
     public bool $showName = false;
     public ?string $countryName = null;
 
+    private ?bool $flagExists = null;
+    private ?string $flagFilePath = null;
+
+    /** @var array<string, string> */
+    private static array $svgCache = [];
+
     public function getCountryName(): string
     {
         if (null !== $this->countryName) {
@@ -28,7 +34,7 @@ class Flag
     public function flagExists(): bool
     {
         // checking the country code first is essential to prevent path traversal attacks
-        return Countries::exists($this->countryCode) && is_file($this->getFlagFilePath());
+        return $this->flagExists ??= Countries::exists($this->countryCode) && is_file($this->getFlagFilePath());
     }
 
     public function getFlagAsSvg(): string
@@ -37,7 +43,11 @@ class Flag
             return $this->getFallbackSvg();
         }
 
-        $content = file_get_contents($this->getFlagFilePath());
+        // the same flag can be rendered many times per page (e.g. once per row on
+        // CRUD index pages), so cache the SVG file contents to avoid reading the
+        // same files from disk repeatedly; the raw contents keep the placeholders,
+        // which are replaced per render because they vary per component instance
+        $content = self::$svgCache[$this->countryCode] ??= file_get_contents($this->getFlagFilePath());
         $escapedCountryName = htmlspecialchars($this->getCountryName(), \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
 
         return str_replace(['__HEIGHT__', '__COUNTRY_NAME__'], [(string) $this->height, $escapedCountryName], $content);
@@ -52,6 +62,6 @@ class Flag
 
     private function getFlagFilePath(): string
     {
-        return sprintf('%s/../../../assets/icons/flags/%s.svg', __DIR__, $this->countryCode);
+        return $this->flagFilePath ??= sprintf('%s/../../../assets/icons/flags/%s.svg', __DIR__, $this->countryCode);
     }
 }

--- a/src/Twig/Component/Icon.php
+++ b/src/Twig/Component/Icon.php
@@ -9,10 +9,13 @@ use EasyCorp\Bundle\EasyAdminBundle\Dto\IconDto;
 class Icon
 {
     private const FILETYPES_ICON_PREFIX = 'filetypes';
+    private const ICONS_DIR = __DIR__.'/../../../assets/icons';
 
     public ?string $name = null;
-    private string $iconsDir = __DIR__.'/../../../assets/icons';
     private ?string $iconSet = null;
+
+    /** @var array<string, array{path: string, contents: string}> */
+    private static array $internalIconCache = [];
 
     public function __construct(
         private readonly AdminContextProviderInterface $adminContextProvider,
@@ -59,17 +62,24 @@ class Icon
 
     private function getInternalIcon(string $internalIconName): IconDto
     {
-        [$iconPrefix, $iconName] = explode(':', $internalIconName, 2);
-        if (1 !== preg_match('/^[a-zA-Z0-9_-]+$/D', $iconName)) {
-            throw new \RuntimeException(sprintf('The icon "%s" does not exist. Check the icon name spelling and make sure that the "%s.svg" file exists in the "assets/icons/%s/" directory of EasyAdmin.', $internalIconName, $iconName, $iconPrefix));
+        // the same internal icons are rendered many times per page (e.g. once per
+        // row on CRUD index pages), so cache the SVG file contents to avoid
+        // reading the same files from disk repeatedly
+        if (null === $cachedIcon = self::$internalIconCache[$internalIconName] ?? null) {
+            [$iconPrefix, $iconName] = explode(':', $internalIconName, 2);
+            if (1 !== preg_match('/^[a-zA-Z0-9_-]+$/D', $iconName)) {
+                throw new \RuntimeException(sprintf('The icon "%s" does not exist. Check the icon name spelling and make sure that the "%s.svg" file exists in the "assets/icons/%s/" directory of EasyAdmin.', $internalIconName, $iconName, $iconPrefix));
+            }
+
+            $iconFilePath = sprintf('%s/%s/%s.svg', self::ICONS_DIR, $iconPrefix, $iconName);
+            $content = @file_get_contents($iconFilePath);
+            if (!\is_string($content)) {
+                throw new \RuntimeException(sprintf('The icon "%s" does not exist. Check the icon name spelling and make sure that the "%s.svg" file exists in the "assets/icons/%s/" directory of EasyAdmin.', $internalIconName, $iconName, $iconPrefix));
+            }
+
+            $cachedIcon = self::$internalIconCache[$internalIconName] = ['path' => $iconFilePath, 'contents' => $content];
         }
 
-        $iconFilePath = sprintf('%s/%s/%s.svg', $this->iconsDir, $iconPrefix, $iconName);
-        $content = @file_get_contents($iconFilePath);
-        if (!\is_string($content)) {
-            throw new \RuntimeException(sprintf('The icon "%s" does not exist. Check the icon name spelling and make sure that the "%s.svg" file exists in the "assets/icons/%s/" directory of EasyAdmin.', $internalIconName, $iconName, $iconPrefix));
-        }
-
-        return IconDto::new(name: $internalIconName, path: $iconFilePath, svgContents: $content, iconSet: IconSet::Internal);
+        return IconDto::new(name: $internalIconName, path: $cachedIcon['path'], svgContents: $cachedIcon['contents'], iconSet: IconSet::Internal);
     }
 }

--- a/templates/components/Pagination.html.twig
+++ b/templates/components/Pagination.html.twig
@@ -6,20 +6,25 @@
             {% endblock %}
         {%- endif -%}
     </div>
-    {% if this.hasPreviousPage or this.hasNextPage %}
+    {% set has_previous_page = this.hasPreviousPage %}
+    {% set has_next_page = this.hasNextPage %}
+    {% if has_previous_page or has_next_page %}
+        {% set current_page = this.getCurrentPage %}
+        {% set page_link_css_class = this.pageLinkCssClass %}
+        {% set is_rtl = this.isRtl %}
         <nav class="{{ this.navCssClass }}" aria-label="{{ 'paginator.label'|trans({}, this.translationDomain) }}">
             <ul class="{{ this.listCssClass }}">
                 {% if this.showFirstLast %}
-                    <li class="page-item page-item-first {{ not this.hasPreviousPage ? 'disabled' }}">
-                        <a class="{{ this.pageLinkCssClass }}" href="{{ not this.hasPreviousPage ? '#' : this.urlForPage(1) }}"{% if not this.hasPreviousPage %} aria-disabled="true" tabindex="-1"{% endif %}>
+                    <li class="page-item page-item-first {{ not has_previous_page ? 'disabled' }}">
+                        <a class="{{ page_link_css_class }}" href="{{ not has_previous_page ? '#' : this.urlForPage(1) }}"{% if not has_previous_page %} aria-disabled="true" tabindex="-1"{% endif %}>
                             <span class="btn-label">{{ 'paginator.first'|trans({}, this.translationDomain) }}</span>
                         </a>
                     </li>
                 {% endif %}
 
-                <li class="page-item page-item-previous {{ not this.hasPreviousPage ? 'disabled' }}">
-                    <a class="{{ this.pageLinkCssClass }}" href="{{ not this.hasPreviousPage ? '#' : this.urlForPage(this.previousPage) }}"{% if this.hasPreviousPage %} rel="prev"{% else %} aria-disabled="true" tabindex="-1"{% endif %}>
-                        {% if this.isRtl %}
+                <li class="page-item page-item-previous {{ not has_previous_page ? 'disabled' }}">
+                    <a class="{{ page_link_css_class }}" href="{{ not has_previous_page ? '#' : this.urlForPage(this.previousPage) }}"{% if has_previous_page %} rel="prev"{% else %} aria-disabled="true" tabindex="-1"{% endif %}>
+                        {% if is_rtl %}
                             <twig:ea:Icon name="internal:chevron-right" class="mx-1" aria-hidden="true" />
                         {% else %}
                             <twig:ea:Icon name="internal:chevron-left" class="mx-1" aria-hidden="true" />
@@ -31,25 +36,25 @@
 
                 {% if this.showPageNumbers %}
                     {% for page in this.pageRange %}
-                        <li class="page-item {{ page == this.getCurrentPage ? 'active' }} {{ page is null ? 'disabled' }}">
+                        <li class="page-item {{ page == current_page ? 'active' }} {{ page is null ? 'disabled' }}">
                             {% if page is null %}
-                                <span class="{{ this.pageLinkCssClass }}"><span aria-hidden="true">&hellip;</span><span class="visually-hidden">{{ 'paginator.more_pages'|trans({}, this.translationDomain) }}</span></span>
+                                <span class="{{ page_link_css_class }}"><span aria-hidden="true">&hellip;</span><span class="visually-hidden">{{ 'paginator.more_pages'|trans({}, this.translationDomain) }}</span></span>
                             {% else %}
-                                <a class="{{ this.pageLinkCssClass }}" href="{{ this.urlForPage(page) }}"{% if page == this.getCurrentPage %} aria-current="page"{% endif %}>{{ page }}</a>
+                                <a class="{{ page_link_css_class }}" href="{{ this.urlForPage(page) }}"{% if page == current_page %} aria-current="page"{% endif %}>{{ page }}</a>
                             {% endif %}
                         </li>
                     {% endfor %}
                 {% else %}
                     <li class="page-item active">
-                        <a class="{{ this.pageLinkCssClass }}" href="{{ this.urlForPage(this.getCurrentPage) }}" aria-current="page">{{ this.getCurrentPage }}</a>
+                        <a class="{{ page_link_css_class }}" href="{{ this.urlForPage(current_page) }}" aria-current="page">{{ current_page }}</a>
                     </li>
                 {% endif %}
 
-                <li class="page-item page-item-next {{ not this.hasNextPage ? 'disabled' }}">
-                    <a class="{{ this.pageLinkCssClass }}" href="{{ not this.hasNextPage ? '#' : this.urlForPage(this.nextPage) }}"{% if this.hasNextPage %} rel="next"{% else %} aria-disabled="true" tabindex="-1"{% endif %}>
+                <li class="page-item page-item-next {{ not has_next_page ? 'disabled' }}">
+                    <a class="{{ page_link_css_class }}" href="{{ not has_next_page ? '#' : this.urlForPage(this.nextPage) }}"{% if has_next_page %} rel="next"{% else %} aria-disabled="true" tabindex="-1"{% endif %}>
                         <span class="{{ this.showPreviousNextLabels ? 'btn-label' : 'visually-hidden' }}">{% block next_label %}{{ 'paginator.next'|trans({}, this.translationDomain) }}{% endblock %}</span>
 
-                        {% if this.isRtl %}
+                        {% if is_rtl %}
                             <twig:ea:Icon name="internal:chevron-left" class="mx-1" aria-hidden="true" />
                         {% else %}
                             <twig:ea:Icon name="internal:chevron-right" class="mx-1" aria-hidden="true" />
@@ -58,8 +63,8 @@
                 </li>
 
                 {% if this.showFirstLast %}
-                    <li class="page-item page-item-last {{ not this.hasNextPage ? 'disabled' }}">
-                        <a class="{{ this.pageLinkCssClass }}" href="{{ not this.hasNextPage ? '#' : this.urlForPage(this.getLastPage) }}"{% if not this.hasNextPage %} aria-disabled="true" tabindex="-1"{% endif %}>
+                    <li class="page-item page-item-last {{ not has_next_page ? 'disabled' }}">
+                        <a class="{{ page_link_css_class }}" href="{{ not has_next_page ? '#' : this.urlForPage(this.getLastPage) }}"{% if not has_next_page %} aria-disabled="true" tabindex="-1"{% endif %}>
                             <span class="btn-label">{{ 'paginator.last'|trans({}, this.translationDomain) }}</span>
                         </a>
                     </li>


### PR DESCRIPTION
This PR applies some small performance tweaks to the Twig components.

Profiling a real backend showed that components are instantiated hundreds of times per page
(e.g. one `<twig:ea:Icon>` per action per row on CRUD index pages), so any per-render work that can be cached or avoided pays off quickly.

Changes made:

* **`Icon`**: internal SVG icons (`internal:*`, `filetypes:*`) were validated
with a regex and read from disk with `file_get_contents()` on every render. They are now cached in a static property, so each distinct icon is read from disk only once per process (this also benefits worker-mode runtimes like FrankenPHP).
* **`Flag`**: the country/file existence checks and the flag file path were computed 2-3 times per render; they are now memoized per instance. The raw SVG contents are cached statically per country code, so country columns that repeat the same flag across rows don't re-read the file.
* **`Pagination` template**: constant-per-render values (`hasPreviousPage`, `hasNextPage`, `getCurrentPage`, `pageLinkCssClass`, `isRtl`) were called up to once per page number inside the page loop. They are now hoisted into template variables set once per render.

All changes are behavior-preserving; no template output changes.
