### PR TITLE
Fix a minor Composer autoloading issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,10 @@
     "autoload": {
         "psr-4": {
             "EasyCorp\\Bundle\\EasyAdminBundle\\": "src/"
-        }
+        },
+        "exclude-from-classmap": [
+            "/tests/Functional/Apps/*/config/reference.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/Unit/Orm/EscaperTest.php
+++ b/tests/Unit/Orm/EscaperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router;
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Orm;
 
 use EasyCorp\Bundle\EasyAdminBundle\Orm\Escaper;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Fixes this issue:

```
[composer-install] Class                                          
EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\EscaperTest located in
./tests/Unit/Orm/EscaperTest.php does not comply with psr-4 autoloading standard
(rule: EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\ => ./tests/Unit).     
Skipping.                                                    
```