### PR TITLE
fix(buttons): adjust padding for small and large buttons

### DIFF
--- a/assets/css/easyadmin-theme/buttons.css
+++ b/assets/css/easyadmin-theme/buttons.css
@@ -299,11 +299,13 @@ fieldset:disabled a.btn {
 }
 
 .btn-sm:not(:has(.btn-label)) {
-    padding: var(--button-padding-y-sm);
+    padding-block-start: var(--button-padding-y-sm);
+    padding-block-end: var(--button-padding-y-sm);
 }
 
 .btn-lg:not(:has(.btn-label)) {
-    padding: var(--button-padding-y-lg);
+    padding-block-start: var(--button-padding-y-lg);
+    padding-block-end: var(--button-padding-y-lg);
 }
 
 /* Button groups */


### PR DESCRIPTION
EA button overrides breaks every native BS buttons with a size (`btn btn-primary btn-sm`). 

Buttons ends up without padding X.