### PR TITLE
remove redundant getEntityFqcn backed by interface

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -74,12 +74,10 @@ use function Symfony\Component\String\u;
  *
  * @template TEntity of object
  *
- * @implements  CrudControllerInterface<TEntity>
+ * @implements CrudControllerInterface<TEntity>
  */
 abstract class AbstractCrudController extends AbstractController implements CrudControllerInterface
 {
-    abstract public static function getEntityFqcn(): string;
-
     public function configureCrud(Crud $crud): Crud
     {
         return $crud;


### PR DESCRIPTION
<!--
Thanks for your contribution! If you are proposing a new feature that is complex,
please open an issue first so we can discuss about it.

Note: all your contributions adhere implicitly to the MIT license
-->
