### PR TITLE
Restore BC by catching exceptions thrown by stringables

### DIFF
--- a/src/Twig/EasyAdminTwigExtension.php
+++ b/src/Twig/EasyAdminTwigExtension.php
@@ -225,8 +225,12 @@ class EasyAdminTwigExtension extends AbstractExtension implements GlobalsInterfa
                 return $value->trans($this->translator);
             }
 
-            if ($value instanceof \Stringable) {
-                return (string) $value;
+            try {
+                if ($value instanceof \Stringable) {
+                    return (string) $value;
+                }
+            } catch (\Throwable) {
+                return '';
             }
 
             if (method_exists($value, 'getId')) {


### PR DESCRIPTION
Fixes #7628 by wrapping the stringable call in a try/catch block.
If the too string fails it should still render