### PR TITLE
Fix the swapped debug messages of InsufficientEntityPermissionException

### DIFF
--- a/src/Exception/InsufficientEntityPermissionException.php
+++ b/src/Exception/InsufficientEntityPermissionException.php
@@ -18,9 +18,9 @@ final class InsufficientEntityPermissionException extends BaseException
         ];
 
         if (null !== $entityId) {
-            $debugMessage = sprintf('You don\'t have enough permissions to access this instance of the "%s" entity.', $parameters['entity_fqcn']);
+            $debugMessage = sprintf('You don\'t have enough permissions to access the instance of the "%s" entity with id = %s.', $parameters['entity_fqcn'], $entityId);
         } else {
-            $debugMessage = sprintf('You don\'t have enough permissions to access the instance of the "%s" entity with id  = %s.', $parameters['entity_fqcn'], $entityId);
+            $debugMessage = sprintf('You don\'t have enough permissions to access this instance of the "%s" entity.', $parameters['entity_fqcn']);
         }
 
         $exceptionContext = new ExceptionContext(


### PR DESCRIPTION
The if/else branches were inverted: when the entity ID was present, the
message omitted it, and when it was absent, the message interpolated a
null ID. Also remove the double space in 'id  ='.

