### PR TITLE
Fix the divisor used by MoneyField for Money objects of non-2-decimal currencies

### DIFF
--- a/src/Field/Configurator/MoneyConfigurator.php
+++ b/src/Field/Configurator/MoneyConfigurator.php
@@ -75,8 +75,12 @@ final class MoneyConfigurator implements FieldConfiguratorInterface
         $numDecimals = $field->getCustomOption(MoneyField::OPTION_NUM_DECIMALS);
         $field->setFormTypeOption('scale', $numDecimals);
 
-        // Money objects always store amounts in smallest units, so divisor is always 100
-        $field->setFormTypeOptionIfNotSet('divisor', self::DEFAULT_DIVISOR);
+        // Money objects store amounts in the smallest unit of their currency; the scale of that
+        // unit depends on the currency (e.g. 2 fraction digits for USD/EUR, 0 for JPY, 3 for BHD)
+        $divisor = null !== $currencyCode && CurrencyField::CURRENCY_NONE !== $currencyCode
+            ? 10 ** Currencies::getFractionDigits($currencyCode)
+            : self::DEFAULT_DIVISOR;
+        $field->setFormTypeOptionIfNotSet('divisor', $divisor);
 
         if (null === $value) {
             return;

--- a/tests/Unit/Field/Configurator/MoneyConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/MoneyConfiguratorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Configurator;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Intl\IntlFormatterInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\MoneyConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\MoneyField;
+use Money\Money;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class MoneyConfiguratorTest extends TestCase
+{
+    /**
+     * The divisor between a Money object's amount (expressed in the smallest currency
+     * unit) and the "main unit" value depends on the fraction digits of the currency;
+     * it's not always 100 (e.g. JPY has 0 fraction digits and BHD has 3).
+     *
+     * @dataProvider provideMoneyValues
+     */
+    public function testDivisorDependsOnCurrencyFractionDigits(Money $value, int $expectedDivisor, string $expectedAmount): void
+    {
+        $fieldDto = $this->configureField($value);
+
+        $this->assertSame($expectedDivisor, $fieldDto->getFormTypeOption('divisor'));
+        $this->assertSame($expectedAmount, $fieldDto->getFormattedValue());
+    }
+
+    public static function provideMoneyValues(): \Generator
+    {
+        yield 'EUR (2 fraction digits)' => [Money::EUR('1250'), 100, '12.5'];
+        yield 'JPY (0 fraction digits)' => [Money::JPY('1000'), 1, '1000'];
+        yield 'BHD (3 fraction digits)' => [Money::BHD('12345'), 1000, '12.345'];
+    }
+
+    public function testExplicitDivisorIsNotOverridden(): void
+    {
+        $fieldDto = $this->configureField(Money::JPY('1000'), customDivisor: 100);
+
+        $this->assertSame(100, $fieldDto->getFormTypeOption('divisor'));
+    }
+
+    private function configureField(Money $value, ?int $customDivisor = null): FieldDto
+    {
+        $field = MoneyField::new('price');
+        if (null !== $customDivisor) {
+            $field->setFormTypeOption('divisor', $customDivisor);
+        }
+
+        $fieldDto = $field->getAsDto();
+        $fieldDto->setValue($value);
+
+        // return the raw amount so tests can assert the exact value passed to the formatter
+        $intlFormatter = $this->createMock(IntlFormatterInterface::class);
+        $intlFormatter->method('formatCurrency')->willReturnCallback(static fn ($amount): string => (string) $amount);
+
+        $configurator = new MoneyConfigurator($intlFormatter, PropertyAccess::createPropertyAccessor());
+        $entityDto = new EntityDto(\stdClass::class, new ClassMetadata(\stdClass::class));
+        $configurator->configure($fieldDto, $entityDto, AdminContext::forTesting());
+
+        return $fieldDto;
+    }
+}


### PR DESCRIPTION
Money objects store amounts in the smallest unit of their currency, but
the scale of that unit is not always 1/100: JPY has 0 fraction digits and
BHD/KWD/OMR/TND have 3. Hardcoding the divisor to 100 displayed wrong
values for those currencies and corrupted stored amounts when the form
was submitted, because the same divisor is used by the form type.

The divisor is now derived from Currencies::getFractionDigits(), keeping
100 as the fallback when the currency is unknown.

