### PR TITLE
Add native types to DTO properties, getters and event interfaces

### DIFF
--- a/src/Contracts/Event/EntityLifecycleEventInterface.php
+++ b/src/Contracts/Event/EntityLifecycleEventInterface.php
@@ -10,9 +10,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Contracts\Event;
 interface EntityLifecycleEventInterface
 {
     /**
-     * @return object
-     *
      * @phpstan-return TEntity
      */
-    public function getEntityInstance();
+    public function getEntityInstance(): object;
 }

--- a/src/Dto/ActionDto.php
+++ b/src/Dto/ActionDto.php
@@ -241,7 +241,7 @@ final class ActionDto
     /**
      * @return array<string, mixed>|callable
      */
-    public function getRouteParameters()/* : array|callable */
+    public function getRouteParameters(): array|callable
     {
         return $this->routeParameters;
     }
@@ -254,10 +254,7 @@ final class ActionDto
         $this->routeParameters = $routeParameters;
     }
 
-    /**
-     * @return string|callable|null
-     */
-    public function getUrl()
+    public function getUrl(): callable|string|null
     {
         return $this->url;
     }

--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -149,11 +149,7 @@ final class CrudDto
         $this->entityFqcn = $entityFqcn;
     }
 
-    /**
-     * @param object|null $entityInstance
-     * @param string|null $pageName
-     */
-    public function getEntityLabelInSingular(/* ?object */ $entityInstance = null, /* ?string */ $pageName = null): TranslatableInterface|string|null
+    public function getEntityLabelInSingular(?object $entityInstance = null, ?string $pageName = null): TranslatableInterface|string|null
     {
         if (null === $this->entityLabelInSingular) {
             return null;
@@ -174,11 +170,7 @@ final class CrudDto
         $this->entityLabelInSingular = $label;
     }
 
-    /**
-     * @param object|null $entityInstance
-     * @param string|null $pageName
-     */
-    public function getEntityLabelInPlural(/* ?object */ $entityInstance = null, /* ?string */ $pageName = null): TranslatableInterface|string|null
+    public function getEntityLabelInPlural(?object $entityInstance = null, ?string $pageName = null): TranslatableInterface|string|null
     {
         if (null === $this->entityLabelInPlural) {
             return null;
@@ -200,10 +192,9 @@ final class CrudDto
     }
 
     /**
-     * @param object|null          $entityInstance
      * @param array<string, mixed> $translationParameters
      */
-    public function getCustomPageTitle(?string $pageName = null, /* ?object */ $entityInstance = null, array $translationParameters = [], ?string $domain = null): ?TranslatableInterface
+    public function getCustomPageTitle(?string $pageName = null, ?object $entityInstance = null, array $translationParameters = [], ?string $domain = null): ?TranslatableInterface
     {
         $title = $this->customPageTitles[$pageName ?? $this->pageName];
         if (\is_callable($title)) {

--- a/src/Dto/DashboardDto.php
+++ b/src/Dto/DashboardDto.php
@@ -10,13 +10,11 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ColorScheme;
  */
 final class DashboardDto
 {
-    /** @var string */
-    private $routeName;
+    private string $routeName;
     private string $faviconPath = 'data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 128 128%22><text y=%221.2em%22 font-size=%2296%22>⬛</text></svg>';
     private string $title = 'EasyAdmin';
     private string $translationDomain = 'messages';
-    /** @var string|null */
-    private $textDirection;
+    private ?string $textDirection = null;
     private string $contentWidth = Crud::LAYOUT_CONTENT_DEFAULT;
     private string $sidebarWidth = Crud::LAYOUT_SIDEBAR_DEFAULT;
     private bool $absoluteUrls = true;

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -31,16 +31,14 @@ final class FieldDto
     private mixed $formattedValue = null;
     /** @var callable|null */
     private $formatValueCallable;
-    /** @var TranslatableInterface|string|false|null */
-    private $label;
+    private TranslatableInterface|string|false|null $label = null;
     private ?string $formType = null;
     private KeyValueStore $formTypeOptions;
     private ?bool $sortable = null;
     private ?bool $virtual = null;
     private string|Expression|null $permission = null;
     private ?string $textAlign = null;
-    /** @var TranslatableInterface|string|null */
-    private $help;
+    private TranslatableInterface|string|null $help = null;
     private string $cssClass = '';
     // how many columns the field takes when rendering
     // (defined as Bootstrap 5 grid classes; e.g. 'col-md-6 col-xxl-3')
@@ -58,10 +56,8 @@ final class FieldDto
     private KeyValueStore $doctrineMetadata;
     /**
      * @internal
-     *
-     * @var string|Ulid
      */
-    private $uniqueId;
+    private Ulid|string $uniqueId;
     private KeyValueStore $displayedOn;
     /** @var array<string, bool|int|float|string> */
     private array $htmlAttributes = [];

--- a/src/Dto/FilterDataDto.php
+++ b/src/Dto/FilterDataDto.php
@@ -10,8 +10,7 @@ final class FilterDataDto
     private int $index;
     private string $entityAlias;
     private FilterDto $filterDto;
-    /** @var string */
-    private $comparison;
+    private string $comparison;
     private mixed $value;
     private mixed $value2;
 

--- a/src/Dto/FilterDto.php
+++ b/src/Dto/FilterDto.php
@@ -16,8 +16,7 @@ final class FilterDto
     private KeyValueStore $formTypeOptions;
     private KeyValueStore $customOptions;
     private ?string $propertyName = null;
-    /** @var TranslatableInterface|string|false|null */
-    private $label;
+    private TranslatableInterface|string|false|null $label = null;
     /** @var callable */
     private $applyCallable;
 

--- a/src/Form/DataTransformer/StringToFileTransformer.php
+++ b/src/Form/DataTransformer/StringToFileTransformer.php
@@ -30,7 +30,10 @@ class StringToFileTransformer implements DataTransformerInterface
         $this->uploadValidate = $uploadValidate;
     }
 
-    public function transform(mixed $value): mixed
+    /**
+     * @return array<File|FlysystemFile|null>|File|FlysystemFile|null
+     */
+    public function transform(mixed $value): array|File|FlysystemFile|null
     {
         if (null === $value || [] === $value) {
             return null;
@@ -47,7 +50,10 @@ class StringToFileTransformer implements DataTransformerInterface
         return array_map([$this, 'doTransform'], $value);
     }
 
-    public function reverseTransform(mixed $value): mixed
+    /**
+     * @return array<string|null>|string|null
+     */
+    public function reverseTransform(mixed $value): array|string|null
     {
         if (null === $value || [] === $value) {
             return $this->multiple ? [] : '';

--- a/src/Intl/IntlFormatter.php
+++ b/src/Intl/IntlFormatter.php
@@ -262,10 +262,7 @@ final class IntlFormatter implements IntlFormatterInterface
         return $this->numberFormatters[$hash];
     }
 
-    /**
-     * @param \DateTimeZone|string|bool|null $timezone
-     */
-    private function convertDate(?\DateTimeInterface $date, $timezone = null): ?\DateTimeInterface
+    private function convertDate(?\DateTimeInterface $date, bool|\DateTimeZone|string|null $timezone = null): ?\DateTimeInterface
     {
         if (null === $date) {
             return null;


### PR DESCRIPTION
Adds native property types (with null defaults preserving the previous
implicit null of untyped properties), union return types on getters that
only had phpdoc types, and explicit nullable parameter types (PHP 8.4
deprecates implicitly-nullable parameters). Doctrine-hydrated collection
properties stay out of this commit; DTO collaborators keep their exact
runtime behavior.

