### PR TITLE
Mark immutable promoted properties as readonly

### DIFF
--- a/src/Config/KeyValueStore.php
+++ b/src/Config/KeyValueStore.php
@@ -15,7 +15,7 @@ final class KeyValueStore
      */
     private function __construct(
         private array $map,
-        private ?string $delimiter,
+        private readonly ?string $delimiter,
     ) {
     }
 

--- a/src/Factory/ActionFactory.php
+++ b/src/Factory/ActionFactory.php
@@ -43,7 +43,7 @@ final readonly class ActionFactory
         private AuthorizationCheckerInterface $authChecker,
         private AdminUrlGeneratorInterface $adminUrlGenerator,
         private ?CsrfTokenManagerInterface $csrfTokenManager = null,
-        private readonly iterable $actionsExtensions = [],
+        private iterable $actionsExtensions = [],
     ) {
     }
 

--- a/src/Filter/Configurator/CommonConfigurator.php
+++ b/src/Filter/Configurator/CommonConfigurator.php
@@ -18,7 +18,7 @@ use function Symfony\Component\Translation\t;
 final class CommonConfigurator implements FilterConfiguratorInterface
 {
     public function __construct(
-        private EntityTranslationIdGeneratorInterface $entityTranslationIdGenerator,
+        private readonly EntityTranslationIdGeneratorInterface $entityTranslationIdGenerator,
     ) {
     }
 

--- a/src/Filter/Configurator/EntityConfigurator.php
+++ b/src/Filter/Configurator/EntityConfigurator.php
@@ -19,7 +19,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGeneratorInterface;
 final class EntityConfigurator implements FilterConfiguratorInterface
 {
     public function __construct(
-        private AdminUrlGeneratorInterface $adminUrlGenerator,
+        private readonly AdminUrlGeneratorInterface $adminUrlGenerator,
     ) {
     }
 

--- a/src/Router/AdminRouteLoader.php
+++ b/src/Router/AdminRouteLoader.php
@@ -14,7 +14,7 @@ final class AdminRouteLoader extends Loader
     public const ROUTE_LOADER_TYPE = 'easyadmin.routes';
 
     public function __construct(
-        private AdminRouteGeneratorInterface $adminRouteGenerator,
+        private readonly AdminRouteGeneratorInterface $adminRouteGenerator,
     ) {
         parent::__construct(null);
     }


### PR DESCRIPTION
Also removes the one redundant 'readonly' modifier in ActionFactory,
which is already a readonly class.

