### PR TITLE
Remove dead code and simplify redundant constructs

### DIFF
--- a/src/Dto/CrudDto.php
+++ b/src/Dto/CrudDto.php
@@ -231,13 +231,11 @@ final class CrudDto
      */
     public function getDefaultPageTitle(?string $pageName = null, ?object $entityInstance = null, array $translationParameters = []): ?TranslatableInterface
     {
-        if (null !== $entityInstance) {
-            if ($entityInstance instanceof \Stringable) {
-                $entityAsString = (string) $entityInstance;
+        if ($entityInstance instanceof \Stringable) {
+            $entityAsString = (string) $entityInstance;
 
-                if ('' !== $entityAsString) {
-                    return t($entityAsString, $translationParameters, 'EasyAdminBundle');
-                }
+            if ('' !== $entityAsString) {
+                return t($entityAsString, $translationParameters, 'EasyAdminBundle');
             }
         }
 

--- a/src/Dto/SearchDto.php
+++ b/src/Dto/SearchDto.php
@@ -112,9 +112,8 @@ final class SearchDto
     public function getQueryTerms(): array
     {
         preg_match_all('/"(?:\\\\.|[^\\\\"])*"|\S+/', $this->query, $matches);
-        $terms = array_map(static fn ($match) => trim($match, '" '), $matches[0]);
 
-        return $terms;
+        return array_map(static fn ($match) => trim($match, '" '), $matches[0]);
     }
 
     /**

--- a/src/Factory/AdminContextFactory.php
+++ b/src/Factory/AdminContextFactory.php
@@ -58,10 +58,9 @@ final readonly class AdminContextFactory
         $validPageNames = [Crud::PAGE_INDEX, Crud::PAGE_DETAIL, Crud::PAGE_EDIT, Crud::PAGE_NEW];
         $pageName = \in_array($crudAction, $validPageNames, true) ? $crudAction : null;
 
-        $dashboardDto = $this->getDashboardDto($request, $dashboardController);
+        $dashboardDto = $this->getDashboardDto($dashboardController);
         $assetDto = $this->getAssetDto($dashboardController, $crudController, $pageName);
         $filters = $this->getFilters($dashboardController, $crudController);
-        $user = $this->getUser($this->tokenStorage);
 
         // build a first version of CrudDto without actions so we can create AdminContext, which is
         // needed for action extensions; later, we'll update the CrudDto object with the full action config
@@ -105,7 +104,7 @@ final readonly class AdminContextFactory
         return $adminContext;
     }
 
-    private function getDashboardDto(Request $request, DashboardControllerInterface $dashboardControllerInstance): DashboardDto
+    private function getDashboardDto(DashboardControllerInterface $dashboardControllerInstance): DashboardDto
     {
         $dashboardRoutes = $this->adminRouteGenerator->getDashboardRoutes();
         $dashboardFqcn = $dashboardControllerInstance::class;
@@ -196,7 +195,7 @@ final readonly class AdminContextFactory
             $translationParameters['%entity_id%'] = $entityId = EntityIdReader::fromRequest($request);
             $translationParameters['%entity_short_id%'] = null === $entityId ? null : u($entityId)->truncate(7)->toString();
 
-            $entityInstance = null === $entityDto ? null : $entityDto->getInstance();
+            $entityInstance = $entityDto?->getInstance();
             $pageName = $crudDto->getCurrentPage();
 
             $singularLabel = $crudDto->getEntityLabelInSingular($entityInstance, $pageName)

--- a/src/Factory/FieldFactory.php
+++ b/src/Factory/FieldFactory.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\EntityCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;

--- a/src/Factory/FilterFactory.php
+++ b/src/Factory/FilterFactory.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Factory;
 
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FieldCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Collection\FilterCollection;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Mapping\JoinColumnMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -73,7 +72,7 @@ final readonly class CommonPreConfigurator implements FieldConfiguratorInterface
         $isVirtual = $this->buildVirtualOption($field, $entityDto);
         $field->setVirtual($isVirtual);
 
-        $templatePath = $this->buildTemplatePathOption($context, $field, $entityDto, $isReadable);
+        $templatePath = $this->buildTemplatePathOption($context, $field, $isReadable);
         $field->setTemplatePath($templatePath);
 
         $doctrineMetadata = [];
@@ -173,7 +172,7 @@ final readonly class CommonPreConfigurator implements FieldConfiguratorInterface
             && !$entityDto->getClassMetadata()->hasAssociation($field->getProperty());
     }
 
-    private function buildTemplatePathOption(AdminContext $adminContext, FieldDto $field, EntityDto $entityDto, bool $isReadable): string
+    private function buildTemplatePathOption(AdminContext $adminContext, FieldDto $field, bool $isReadable): string
     {
         if (null !== $templatePath = $field->getTemplatePath()) {
             return $templatePath;

--- a/src/Field/Configurator/DateTimeConfigurator.php
+++ b/src/Field/Configurator/DateTimeConfigurator.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Intl\IntlFormatterInterface;

--- a/src/Filter/Configurator/TextConfigurator.php
+++ b/src/Filter/Configurator/TextConfigurator.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Filter\Configurator;
 
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;

--- a/src/Form/Type/ComparisonType.php
+++ b/src/Form/Type/ComparisonType.php
@@ -31,7 +31,7 @@ class ComparisonType extends AbstractType
             'label' => false,
             'type' => 'numeric',
             'choices' => static function (Options $options) {
-                $choices = match ($options['type']) {
+                return match ($options['type']) {
                     'numeric' => [
                         'filter.label.is_equal_to' => self::EQ,
                         'filter.label.is_not_equal_to' => self::NEQ,
@@ -69,8 +69,6 @@ class ComparisonType extends AbstractType
                     ],
                     default => [],
                 };
-
-                return $choices;
             },
             'translation_domain' => 'EasyAdminBundle',
         ]);

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -5,7 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Orm;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\FieldMapping;
 use Doctrine\ORM\Query\Expr\Orx;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;

--- a/src/Provider/FieldProvider.php
+++ b/src/Provider/FieldProvider.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Provider;
 
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping\FieldMapping;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;

--- a/src/Test/Trait/CrudTestIndexAsserts.php
+++ b/src/Test/Trait/CrudTestIndexAsserts.php
@@ -38,7 +38,7 @@ trait CrudTestIndexAsserts
         }
 
         $message ??= sprintf('There should be %d results found in the current index page', $expectedIndexPageEntityCount);
-        static::assertSelectorNotExists('tr.no-results', );
+        static::assertSelectorNotExists('tr.no-results');
         static::assertSelectorExists('tbody tr');
 
         $indexPageEntityRows = $this->client->getCrawler()->filter('tbody tr');


### PR DESCRIPTION
- remove the unused Doctrine FieldMapping imports left over from the
  DBAL 3/4 compatibility work
- remove AdminContextFactory's duplicated getUser() call and the unused
  $request parameter of getDashboardDto()
- remove the unused $entityDto parameter of
  CommonPreConfigurator::buildTemplatePathOption()
- return expressions directly instead of assigning them to a variable
  used only once (SearchDto, MenuFactory, MenuItemMatcher,
  ComparisonType)
- flatten the nested null/Stringable checks in
  CrudDto::getDefaultPageTitle() and use the nullsafe operator in
  AdminContextFactory

