### PR TITLE
Add native property types to the test app entities

### DIFF
--- a/tests/Functional/Apps/DefaultApp/src/Entity/Bill.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Bill.php
@@ -13,13 +13,13 @@ class Bill
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private $id;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $name;
+    private ?string $name = null;
 
     #[ORM\ManyToMany(targetEntity: Customer::class, inversedBy: 'bills')]
-    private $customers;
+    private Collection $customers;
 
     public function __construct()
     {

--- a/tests/Functional/Apps/DefaultApp/src/Entity/BlogPost.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/BlogPost.php
@@ -12,29 +12,29 @@ class BlogPost
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private $id;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $title;
+    private ?string $title = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $slug;
+    private ?string $slug = null;
 
     #[ORM\Column(type: 'text')]
-    private $content;
+    private ?string $content = null;
 
     #[ORM\ManyToMany(targetEntity: Category::class, inversedBy: 'blogPosts')]
-    private $categories;
+    private Collection $categories;
 
     #[ORM\Column(type: 'datetime_immutable')]
-    private $createdAt;
+    private ?\DateTimeInterface $createdAt = null;
 
     #[ORM\Column(type: 'datetime_immutable', nullable: true)]
-    private $publishedAt;
+    private ?\DateTimeImmutable $publishedAt = null;
 
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'blogPosts')]
     #[ORM\JoinColumn(nullable: false)]
-    private $author;
+    private ?User $author = null;
 
     #[ORM\ManyToOne(targetEntity: User::class)]
     private $publisher;

--- a/tests/Functional/Apps/DefaultApp/src/Entity/Category.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Category.php
@@ -13,17 +13,17 @@ class Category
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private $id;
+    private ?int $id = null;
 
     #[Assert\NotBlank]
     #[ORM\Column(type: 'string', length: 255)]
-    private $name;
+    private ?string $name = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $slug;
+    private ?string $slug = null;
 
     #[ORM\ManyToMany(targetEntity: BlogPost::class, mappedBy: 'categories')]
-    private $blogPosts;
+    private Collection $blogPosts;
 
     #[ORM\Column(type: 'boolean')]
     private bool $active = false;

--- a/tests/Functional/Apps/DefaultApp/src/Entity/Customer.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Customer.php
@@ -13,13 +13,13 @@ class Customer
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private $id;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $name;
+    private ?string $name = null;
 
     #[ORM\ManyToMany(targetEntity: Bill::class, mappedBy: 'customers')]
-    private $bills;
+    private Collection $bills;
 
     public function __construct()
     {

--- a/tests/Functional/Apps/DefaultApp/src/Entity/Page.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Page.php
@@ -11,10 +11,10 @@ class Page
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private $id;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $name;
+    private ?string $name = null;
 
     #[ORM\ManyToOne(targetEntity: Website::class, inversedBy: 'pages')]
     #[ORM\JoinColumn(nullable: false)]
@@ -42,7 +42,7 @@ class Page
         return $this->website;
     }
 
-    public function setWebsite(?Website $website)
+    public function setWebsite(?Website $website): static
     {
         $this->website = $website;
 

--- a/tests/Functional/Apps/DefaultApp/src/Entity/User.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/User.php
@@ -13,16 +13,16 @@ class User implements \Stringable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private $id;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $name;
+    private ?string $name = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $email;
+    private ?string $email = null;
 
     #[ORM\OneToMany(targetEntity: BlogPost::class, mappedBy: 'author', orphanRemoval: true)]
-    private $blogPosts;
+    private Collection $blogPosts;
 
     public function __construct()
     {

--- a/tests/Functional/Apps/DefaultApp/src/Entity/Website.php
+++ b/tests/Functional/Apps/DefaultApp/src/Entity/Website.php
@@ -13,13 +13,13 @@ class Website implements \Stringable
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
-    private $id;
+    private ?int $id = null;
 
     #[ORM\Column(type: 'string', length: 255)]
-    private $name;
+    private ?string $name = null;
 
     #[ORM\OneToMany(targetEntity: Page::class, mappedBy: 'website', orphanRemoval: true)]
-    private $pages;
+    private Collection $pages;
 
     public function __construct()
     {


### PR DESCRIPTION
Collection-valued associations are typed with the Collection interface
(Doctrine hydrates them as PersistentCollection, so ArrayCollection
would fail), and nullable properties get an explicit null default to
keep behaving like the untyped properties they replace (e.g. reading
the id of a not-yet-persisted entity).

