### PR TITLE
Clean up the test suite

### DIFF
--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/BatchActionTestEntityCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/BatchActionTestEntityCrudController.php
@@ -5,7 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Contr
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
-use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\BatchActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
@@ -57,7 +56,7 @@ class BatchActionTestEntityCrudController extends AbstractCrudController
     }
 
     #[AdminRoute('/batch-activate', 'batch_activate', options: ['methods' => ['POST']])]
-    public function batchActivate(AdminContext $context, BatchActionDto $batchActionDto): Response
+    public function batchActivate(BatchActionDto $batchActionDto): Response
     {
         $entityManager = $this->container->get('doctrine')->getManagerForClass($batchActionDto->getEntityFqcn());
         $repository = $entityManager->getRepository($batchActionDto->getEntityFqcn());
@@ -78,7 +77,7 @@ class BatchActionTestEntityCrudController extends AbstractCrudController
     }
 
     #[AdminRoute('/batch-deactivate', 'batch_deactivate', options: ['methods' => ['POST']])]
-    public function batchDeactivate(AdminContext $context, BatchActionDto $batchActionDto): Response
+    public function batchDeactivate(BatchActionDto $batchActionDto): Response
     {
         $entityManager = $this->container->get('doctrine')->getManagerForClass($batchActionDto->getEntityFqcn());
         $repository = $entityManager->getRepository($batchActionDto->getEntityFqcn());

--- a/tests/Functional/Default/Sort/SortByManyToOneTest.php
+++ b/tests/Functional/Default/Sort/SortByManyToOneTest.php
@@ -47,9 +47,6 @@ class SortByManyToOneTest extends AbstractCrudTestCase
             $sortFunction($entities);
         }
 
-        /**
-         * @var SortTestEntity $entity
-         */
         foreach ($entities as $entity) {
             // easyAdmin shows "Null" label for null associations
             $relatedName = $entity->getManyToOneRelation()?->getName() ?? 'Null';

--- a/tests/Unit/Config/ActionGroupTest.php
+++ b/tests/Unit/Config/ActionGroupTest.php
@@ -5,7 +5,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Config;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\ActionGroup;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\ActionDto;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use PHPUnit\Framework\TestCase;
 use function Symfony\Component\Translation\t;
 

--- a/tests/Unit/Dto/CrudDtoTest.php
+++ b/tests/Unit/Dto/CrudDtoTest.php
@@ -52,10 +52,8 @@ class CrudDtoTest extends TestCase
 
     /**
      * @dataProvider provideLabels
-     *
-     * @param string|closure|null $setLabel
      */
-    public function testGetEntityLabelInSingular($setLabel, ?string $expectedGetLabel): void
+    public function testGetEntityLabelInSingular(string|\Closure|null $setLabel, ?string $expectedGetLabel): void
     {
         $crudDto = new CrudDto();
 

--- a/tests/Unit/Factory/ActionFactoryTest.php
+++ b/tests/Unit/Factory/ActionFactoryTest.php
@@ -4,7 +4,6 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Factory;
 
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
-use EasyCorp\Bundle\EasyAdminBundle\Factory\ActionFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Twig\Component\Option\ButtonVariant;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Unit/Factory/PaginatorFactoryTest.php
+++ b/tests/Unit/Factory/PaginatorFactoryTest.php
@@ -50,7 +50,7 @@ class PaginatorFactoryTest extends TestCase
         $this->entityPaginator
             ->expects($this->once())
             ->method('paginate')
-            ->willReturnCallback(function (PaginatorDto $dto, $qb) use (&$capturedDto) {
+            ->willReturnCallback(function (PaginatorDto $dto) use (&$capturedDto) {
                 $capturedDto = $dto;
 
                 return $this->entityPaginator;
@@ -87,7 +87,7 @@ class PaginatorFactoryTest extends TestCase
         $this->entityPaginator
             ->expects($this->once())
             ->method('paginate')
-            ->willReturnCallback(function (PaginatorDto $dto, $qb) use (&$capturedDto) {
+            ->willReturnCallback(function (PaginatorDto $dto) use (&$capturedDto) {
                 $capturedDto = $dto;
 
                 return $this->entityPaginator;
@@ -122,7 +122,7 @@ class PaginatorFactoryTest extends TestCase
         $this->entityPaginator
             ->expects($this->once())
             ->method('paginate')
-            ->willReturnCallback(function (PaginatorDto $dto, $qb) use (&$capturedDto) {
+            ->willReturnCallback(function (PaginatorDto $dto) use (&$capturedDto) {
                 $capturedDto = $dto;
 
                 return $this->entityPaginator;
@@ -157,7 +157,7 @@ class PaginatorFactoryTest extends TestCase
         $this->entityPaginator
             ->expects($this->once())
             ->method('paginate')
-            ->willReturnCallback(function (PaginatorDto $dto, $qb) use (&$capturedDto) {
+            ->willReturnCallback(function (PaginatorDto $dto) use (&$capturedDto) {
                 $capturedDto = $dto;
 
                 return $this->entityPaginator;
@@ -192,7 +192,7 @@ class PaginatorFactoryTest extends TestCase
         $this->entityPaginator
             ->expects($this->once())
             ->method('paginate')
-            ->willReturnCallback(function (PaginatorDto $dto, $qb) use (&$capturedDto) {
+            ->willReturnCallback(function (PaginatorDto $dto) use (&$capturedDto) {
                 $capturedDto = $dto;
 
                 return $this->entityPaginator;

--- a/tests/Unit/Field/AbstractFieldTest.php
+++ b/tests/Unit/Field/AbstractFieldTest.php
@@ -12,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Context\DashboardContext;
 use EasyCorp\Bundle\EasyAdminBundle\Context\I18nContext;
 use EasyCorp\Bundle\EasyAdminBundle\Context\RequestContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Context\AdminContextInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\CrudDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
@@ -26,8 +27,8 @@ use Twig\Environment;
 abstract class AbstractFieldTest extends KernelTestCase
 {
     protected EntityDto $entityDto;
-    protected $adminContext;
-    protected $configurator;
+    protected AdminContextInterface $adminContext;
+    protected FieldConfiguratorInterface $configurator;
 
     protected function getEntityDto(): EntityDto
     {

--- a/tests/Unit/Field/NumberFieldTest.php
+++ b/tests/Unit/Field/NumberFieldTest.php
@@ -92,8 +92,8 @@ class NumberFieldTest extends AbstractFieldTest
         $field->setRoundingMode($mode);
         $fieldDto = $this->configure($field);
 
-        self::assertSame($mode, $fieldDto->getCustomOption(NumberField::OPTION_ROUNDING_MODE));
-        self::assertSame($mode, $fieldDto->getFormTypeOption('rounding_mode'));
+        self::assertSame($mode, $fieldDto->getCustomOption(NumberField::OPTION_ROUNDING_MODE), $modeName);
+        self::assertSame($mode, $fieldDto->getFormTypeOption('rounding_mode'), $modeName);
     }
 
     public function testSetRoundingModeThrowsExceptionForInvalidMode(): void

--- a/tests/Unit/Field/Trait/DateTimeWidgetTestTrait.php
+++ b/tests/Unit/Field/Trait/DateTimeWidgetTestTrait.php
@@ -3,7 +3,6 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Trait;
 
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 
 /**

--- a/tests/Unit/Twig/EasyAdminTwigExtensionTest.php
+++ b/tests/Unit/Twig/EasyAdminTwigExtensionTest.php
@@ -227,7 +227,7 @@ class EasyAdminTwigExtensionTest extends KernelTestCase
             }
         }, 'foo bar'];
         yield [new class {
-            public function getId()
+            public function getId(): int
             {
                 return 1234;
             }
@@ -235,7 +235,7 @@ class EasyAdminTwigExtensionTest extends KernelTestCase
 
         yield ['foo', 'foo bar', false, static fn ($value) => $value.' bar'];
         yield [new class {
-            public function someMethod()
+            public function someMethod(): string
             {
                 return 'foo';
             }


### PR DESCRIPTION
- add native types to test class properties, data provider parameters
  and anonymous class methods
- remove unused imports, closure parameters and a stale @var annotation
- remove the unused AdminContext parameter of the batch action fixtures
- pass the rounding mode name to NumberFieldTest assertions so failures
  identify the failing case

