### PR TITLE
Fix TypeError when calling Crud::setFilters(null)

### DIFF
--- a/src/Config/Crud.php
+++ b/src/Config/Crud.php
@@ -288,7 +288,9 @@ final class Crud
 
     public function setFilters(?FilterConfigDto $filters): self
     {
-        $this->dto->setFiltersConfig($filters);
+        // 'null' means "no filters", which is represented by an empty filter config
+        // (CrudDto::setFiltersConfig() doesn't accept null values)
+        $this->dto->setFiltersConfig($filters ?? new FilterConfigDto());
 
         return $this;
     }

--- a/tests/Unit/Config/CrudTest.php
+++ b/tests/Unit/Config/CrudTest.php
@@ -5,6 +5,7 @@ namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Config;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Option\ClickTrigger;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterConfigDto;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Translation\TranslatableMessage;
 
@@ -307,5 +308,13 @@ class CrudTest extends TestCase
 
         $crudConfig = Crud::new();
         $crudConfig->setDefaultRowActionTrigger($clickTrigger);
+    }
+
+    public function testSetFiltersAcceptsNull(): void
+    {
+        $crudConfig = Crud::new();
+        $crudConfig->setFilters(null);
+
+        $this->assertInstanceOf(FilterConfigDto::class, $crudConfig->getAsDto()->getFiltersConfig());
     }
 }


### PR DESCRIPTION
The method signature accepts null but forwarded the value unchanged to
CrudDto::setFiltersConfig(), whose parameter is not nullable. Null now
means 'no filters' and is normalized to an empty FilterConfigDto.

