### PR TITLE
Compile the CountryField choice label template only once

### DIFF
--- a/src/Field/Configurator/CountryConfigurator.php
+++ b/src/Field/Configurator/CountryConfigurator.php
@@ -12,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\CountryField;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Intl\Exception\MissingResourceException;
 use Twig\Environment;
+use Twig\TemplateWrapper;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
@@ -96,6 +97,11 @@ final readonly class CountryConfigurator implements FieldConfiguratorInterface
         $usesAlpha3Codes = CountryField::FORMAT_ISO_3166_ALPHA3 === $countryCodeFormat;
         $choices = [];
 
+        // create the choice label template only once and render it with different variables
+        // for each country; compiling a different template per country would be very
+        // expensive because there are ~250 countries
+        $labelTemplate = $this->createChoiceLabelTemplate($showFlag, $showName);
+
         $countries = $usesAlpha3Codes ? Countries::getAlpha3Names() : Countries::getNames();
         foreach ($countries as $countryCode => $countryName) {
             if (null !== $countryCodesToKeep && !\in_array($countryCode, $countryCodesToKeep, true)) {
@@ -107,7 +113,9 @@ final readonly class CountryConfigurator implements FieldConfiguratorInterface
             }
 
             $countryCodeAlpha2 = $usesAlpha3Codes ? Countries::getAlpha2Code($countryCode) : $countryCode;
-            $choiceKey = $this->generateChoiceLabel($countryCodeAlpha2, $countryName, $showFlag, $showName);
+            $choiceKey = null === $labelTemplate
+                ? $countryName
+                : $labelTemplate->render(['countryCode' => $countryCodeAlpha2, 'countryName' => $countryName]);
 
             $choices[$choiceKey] = $countryCode;
         }
@@ -115,12 +123,12 @@ final readonly class CountryConfigurator implements FieldConfiguratorInterface
         return $choices;
     }
 
-    private function generateChoiceLabel(string $countryCodeAlpha2, string $countryName, bool $showFlag, bool $showName): string
+    private function createChoiceLabelTemplate(bool $showFlag, bool $showName): ?TemplateWrapper
     {
         return match ([$showFlag, $showName]) {
-            [true, true] => $this->twig->createTemplate(sprintf('<div class="country-name-flag"><twig:ea:Flag countryCode="%s" /> <span>%s</span></div>', $countryCodeAlpha2, $countryName))->render(),
-            [true, false] => $this->twig->createTemplate(sprintf('<div class="country-name-flag"><twig:ea:Flag countryCode="%s" /></div>', $countryCodeAlpha2))->render(),
-            default => $countryName,
+            [true, true] => $this->twig->createTemplate('<div class="country-name-flag"><twig:ea:Flag countryCode="{{ countryCode }}" /> <span>{{ countryName }}</span></div>'),
+            [true, false] => $this->twig->createTemplate('<div class="country-name-flag"><twig:ea:Flag countryCode="{{ countryCode }}" /></div>'),
+            default => null,
         };
     }
 }

--- a/tests/Unit/Field/Configurator/CountryConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/CountryConfiguratorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Configurator;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CountryConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CountryField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\AbstractFieldTest;
+
+class CountryConfiguratorTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        /** @var CountryConfigurator $countryConfigurator */
+        $countryConfigurator = static::getContainer()->get(CountryConfigurator::class);
+        $this->configurator = $countryConfigurator;
+    }
+
+    public function testFormChoicesWithFlagAndName(): void
+    {
+        $fieldDto = $this->configure(CountryField::new('country'), pageName: Crud::PAGE_NEW);
+        $choices = $fieldDto->getFormTypeOption('choices');
+
+        $franceLabel = array_search('FR', $choices, true);
+        $this->assertIsString($franceLabel);
+        $this->assertStringContainsString('France', $franceLabel);
+        $this->assertStringContainsString('country-flag-wrapper', $franceLabel);
+
+        // each country must get its own label (the same template is rendered with different variables)
+        $germanyLabel = array_search('DE', $choices, true);
+        $this->assertIsString($germanyLabel);
+        $this->assertStringContainsString('Germany', $germanyLabel);
+        $this->assertNotSame($franceLabel, $germanyLabel);
+    }
+
+    public function testFormChoicesWithFlagOnly(): void
+    {
+        $fieldDto = $this->configure(CountryField::new('country')->showName(false), pageName: Crud::PAGE_NEW);
+        $choices = $fieldDto->getFormTypeOption('choices');
+
+        $franceLabel = array_search('FR', $choices, true);
+        $this->assertIsString($franceLabel);
+        // the country name only appears inside the SVG flag (for accessibility), not as a visible label
+        $this->assertStringNotContainsString('<span>France</span>', $franceLabel);
+        $this->assertStringContainsString('country-flag-wrapper', $franceLabel);
+    }
+
+    public function testFormChoicesWithNameOnly(): void
+    {
+        $fieldDto = $this->configure(CountryField::new('country')->showFlag(false), pageName: Crud::PAGE_NEW);
+        $choices = $fieldDto->getFormTypeOption('choices');
+
+        $this->assertSame('FR', $choices['France'] ?? null);
+    }
+}


### PR DESCRIPTION
generateChoiceLabel() built a different Twig template source per country
via sprintf() and compiled it on the fly, so rendering a New/Edit page
with flags enabled compiled up to ~250 throwaway templates on every
request. The template is now created once and rendered with variables,
which also avoids building Twig source through string interpolation.

