### PR TITLE
Remove the ENTITY_FQCN_TO_CRUD_FQCN cache entry, which was written but never read

### DIFF
--- a/src/Config/Option/CacheKey.php
+++ b/src/Config/Option/CacheKey.php
@@ -8,5 +8,4 @@ final class CacheKey
     public const ROUTE_ATTRIBUTES_TO_NAME = 'easyadmin.routes.fqcn_to_route';
     public const DASHBOARD_FQCN_TO_ROUTE = 'easyadmin.routes.controller_fqcn_to_dashboard_route';
     public const CRUD_FQCN_TO_ENTITY_FQCN = 'easyadmin.crud.controller_fqcn_to_entity_fqcn';
-    public const ENTITY_FQCN_TO_CRUD_FQCN = 'easyadmin.crud.entity_fqcn_to_controller_fqcn';
 }

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -111,7 +111,7 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
         // this dumps all admin routes in a performance-optimized format to later
         // find them quickly without having to use Symfony's router service
         $this->saveAdminRoutesInCache($adminRoutes);
-        $this->saveCrudControllersAndEntityFqcnMapInCache($this->crudControllers);
+        $this->saveCrudControllerToEntityFqcnMapInCache($this->crudControllers);
 
         return $collection;
     }
@@ -873,32 +873,21 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
     }
 
     // This replaces the ControllerRegistry that existed in previous EasyAdmin versions.
-    // It stores two maps between CRUD controllers and their associated entity FQCN:
-    //   controller_to_entity: $cache['crud_controller_fqcn'] => 'entity_fqcn'
-    //   entity_to_controller: $cache['entity_fqcn'] => ['crud_controller_fqcn1', 'crud_controller_fqcn2', ...]
+    // It stores the map between CRUD controllers and their associated entity FQCN:
+    //   $cache['crud_controller_fqcn'] => 'entity_fqcn'
+    // (AdminControllerRegistry derives the reverse entity-to-controller map from it)
     /**
      * @param iterable<CrudControllerInterface> $crudControllers
      */
-    private function saveCrudControllersAndEntityFqcnMapInCache(iterable $crudControllers): void
+    private function saveCrudControllerToEntityFqcnMapInCache(iterable $crudControllers): void
     {
         $crudToEntityMap = [];
-        $entityToCrudMap = [];
         foreach ($crudControllers as $crudController) {
-            $entityFqcn = $crudController::getEntityFqcn();
-            $crudToEntityMap[$crudController::class] = $entityFqcn;
-
-            if (!isset($entityToCrudMap[$entityFqcn])) {
-                $entityToCrudMap[$entityFqcn] = [];
-            }
-            $entityToCrudMap[$entityFqcn][] = $crudController::class;
+            $crudToEntityMap[$crudController::class] = $crudController::getEntityFqcn();
         }
 
         $crudToEntityCacheItem = $this->cache->getItem(CacheKey::CRUD_FQCN_TO_ENTITY_FQCN);
         $crudToEntityCacheItem->set($crudToEntityMap);
         $this->cache->save($crudToEntityCacheItem);
-
-        $entityToCrudCacheItem = $this->cache->getItem(CacheKey::ENTITY_FQCN_TO_CRUD_FQCN);
-        $entityToCrudCacheItem->set($entityToCrudMap);
-        $this->cache->save($entityToCrudCacheItem);
     }
 }


### PR DESCRIPTION
AdminRouteGenerator built and cached a one-to-many entity-to-controllers
map on every route generation, but no code reads that cache entry:
AdminControllerRegistry derives its own (documented, last-controller-wins)
reverse map with array_flip() from the CRUD_FQCN_TO_ENTITY_FQCN entry.

Note: this removes the public CacheKey::ENTITY_FQCN_TO_CRUD_FQCN constant.

