### PR TITLE
Fix stale docblocks in AdminContext and AfterEntityUpdatedEvent

### DIFF
--- a/src/Context/AdminContext.php
+++ b/src/Context/AdminContext.php
@@ -25,8 +25,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * - DashboardContext: Dashboard configuration and menus
  * - I18nContext: Internationalization and templates
  *
- * IMPORTANT: any new methods added here MUST be duplicated in the AdminContextProvider class.
- *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  *
  * @template TEntity of object

--- a/src/Event/AfterEntityUpdatedEvent.php
+++ b/src/Event/AfterEntityUpdatedEvent.php
@@ -3,11 +3,13 @@
 namespace EasyCorp\Bundle\EasyAdminBundle\Event;
 
 /**
- * This event is triggered after the updateEntity() call in the
- * new() or edit() flows.
+ * This event is triggered after the updateEntity() call in the edit() flow
+ * (and in the ajaxEdit() flow of toggleable boolean fields). It is NOT
+ * triggered when creating entities in the new() flow: listen to the
+ * AfterEntityPersistedEvent for that.
  *
  * @see AbstractCrudController::edit
- * @see AbstractCrudController::new
+ * @see AbstractCrudController::ajaxEdit
  *
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
  *


### PR DESCRIPTION
- AfterEntityUpdatedEvent claimed to be triggered in the new() flow, but
  it is only dispatched from edit() and ajaxEdit(); the new() flow
  dispatches AfterEntityPersistedEvent instead. Listeners written against
  the old docblock silently missed entity creations.

- AdminContext claimed that any new method must be duplicated in
  AdminContextProvider, but that provider only exposes getContext() and
  duplicates nothing; the contract is a leftover from a previous
  architecture.

