### PR TITLE
Adapt the actions test fixture to the stricter URL generation

### DIFF
--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/ActionsCustomizationCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/ActionsCustomizationCrudController.php
@@ -31,21 +31,21 @@ class ActionsCustomizationCrudController extends AbstractCrudController
 
     public function configureActions(Actions $actions): Actions
     {
-        $action1 = Action::new('action1')->linkToCrudAction('');
-        $action2 = Action::new('action2')->linkToCrudAction('')->setCssClass('foo');
-        $action3 = Action::new('action3')->linkToCrudAction('')->addCssClass('bar');
-        $action4 = Action::new('action4')->linkToCrudAction('')->setCssClass('foo')->addCssClass('bar');
-        $action5 = Action::new('action5')->linkToCrudAction('')->setLabel(static fn (ActionTestEntity $entity) => 'Action 5: '.$entity->getName());
+        $action1 = Action::new('action1')->linkToCrudAction(Action::DETAIL);
+        $action2 = Action::new('action2')->linkToCrudAction(Action::DETAIL)->setCssClass('foo');
+        $action3 = Action::new('action3')->linkToCrudAction(Action::DETAIL)->addCssClass('bar');
+        $action4 = Action::new('action4')->linkToCrudAction(Action::DETAIL)->setCssClass('foo')->addCssClass('bar');
+        $action5 = Action::new('action5')->linkToCrudAction(Action::DETAIL)->setLabel(static fn (ActionTestEntity $entity) => 'Action 5: '.$entity->getName());
 
         $labelGenerator = new ActionLabelGenerator();
-        $action6 = Action::new('action6')->linkToCrudAction('')->setLabel(static fn (ActionTestEntity $entity) => $labelGenerator->generateLabel($entity));
+        $action6 = Action::new('action6')->linkToCrudAction(Action::DETAIL)->setLabel(static fn (ActionTestEntity $entity) => $labelGenerator->generateLabel($entity));
 
-        $action7 = Action::new('action7')->linkToCrudAction('')->setLabel(static fn (ActionTestEntity $entity) => t('Action %number%: %name%', ['%number%' => 7, '%name%' => $entity->getName()]));
+        $action7 = Action::new('action7')->linkToCrudAction(Action::DETAIL)->setLabel(static fn (ActionTestEntity $entity) => t('Action %number%: %name%', ['%number%' => 7, '%name%' => $entity->getName()]));
 
         // this tests that the 'Reset' label is interpreted as a string and not as a callable to the PHP reset() function
-        $action8 = Action::new('action8')->linkToCrudAction('')->setLabel('Reset');
+        $action8 = Action::new('action8')->linkToCrudAction(Action::DETAIL)->setLabel('Reset');
 
-        $action9 = Action::new('action9')->linkToCrudAction('')->createAsGlobalAction()->renderAsForm();
+        $action9 = Action::new('action9')->linkToCrudAction(Action::INDEX)->createAsGlobalAction()->renderAsForm();
 
         return $actions
             ->add(Crud::PAGE_INDEX, $action1)


### PR DESCRIPTION
The synthetic actions linked to an empty CRUD action name (''), which
relied on AdminUrlGenerator silently falling back to the dashboard URL;
that fallback now throws an exception. Link the actions to real built-in
actions instead (the tests only assert CSS classes, labels and form
rendering, not the URLs).

