### PR TITLE
Add support for Symfony Reprise assets

### DIFF
--- a/src/Config/Asset.php
+++ b/src/Config/Asset.php
@@ -97,6 +97,13 @@ final readonly class Asset implements \Stringable
         return $this;
     }
 
+    public function reprisePackageName(?string $packageName = null): self
+    {
+        $this->dto->setReprisePackageName($packageName);
+
+        return $this;
+    }
+
     public function htmlAttr(string $attrName, string $attrValue): self
     {
         $this->dto->setHtmlAttribute($attrName, $attrValue);

--- a/src/Config/Assets.php
+++ b/src/Config/Assets.php
@@ -37,6 +37,21 @@ final readonly class Assets
         return $this;
     }
 
+    public function addRepriseEntry(Asset|string $entryNameOrAsset): self
+    {
+        if (!class_exists('Symfony\\Reprise\\RepriseBundle')) {
+            throw new \RuntimeException(sprintf('You are trying to add a Reprise entry called "%s" but Symfony Reprise is not installed in your project. Try running "composer require symfony/reprise"', $entryNameOrAsset));
+        }
+
+        if (\is_string($entryNameOrAsset)) {
+            $this->dto->addRepriseAsset(new AssetDto($entryNameOrAsset));
+        } else {
+            $this->dto->addRepriseAsset($entryNameOrAsset->getAsDto());
+        }
+
+        return $this;
+    }
+
     public function addAssetMapperEntry(Asset|string ...$entryNameOrAsset): self
     {
         if (!class_exists('Symfony\\Component\\AssetMapper\\AssetMapper')) {

--- a/src/Contracts/Field/FieldTraitAwareInterface.php
+++ b/src/Contracts/Field/FieldTraitAwareInterface.php
@@ -72,6 +72,8 @@ interface FieldTraitAwareInterface extends FieldInterface
 
     public function addWebpackEncoreEntries(Asset|string ...$entryNamesOrAssets): self;
 
+    public function addRepriseEntries(Asset|string ...$entryNamesOrAssets): self;
+
     public function addCssFiles(Asset|string ...$pathsOrAssets): self;
 
     public function addJsFiles(Asset|string ...$pathsOrAssets): self;

--- a/src/Dto/AssetDto.php
+++ b/src/Dto/AssetDto.php
@@ -18,6 +18,7 @@ final class AssetDto implements \Stringable
     private bool $nopush = false;
     private ?string $webpackPackageName = null;
     private string $webpackEntrypointName = '_default';
+    private ?string $reprisePackageName = null;
     /** @var array<string, string> */
     private array $htmlAttributes = [];
     private KeyValueStore $loadedOn;
@@ -110,6 +111,16 @@ final class AssetDto implements \Stringable
     public function getWebpackEntrypointName(): string
     {
         return $this->webpackEntrypointName;
+    }
+
+    public function setReprisePackageName(?string $packageName): void
+    {
+        $this->reprisePackageName = $packageName;
+    }
+
+    public function getReprisePackageName(): ?string
+    {
+        return $this->reprisePackageName;
     }
 
     public function setHtmlAttribute(string $attrName, string $attrValue): void

--- a/src/Dto/AssetsDto.php
+++ b/src/Dto/AssetsDto.php
@@ -13,6 +13,8 @@ final class AssetsDto
     /** @var AssetDto[] */
     private array $webpackEncoreAssets = [];
     /** @var AssetDto[] */
+    private array $repriseAssets = [];
+    /** @var AssetDto[] */
     private array $assetMapperAssets = [];
     /** @var AssetDto[] */
     private array $cssAssets = [];
@@ -36,6 +38,15 @@ final class AssetsDto
         }
 
         $this->webpackEncoreAssets[$entryName] = $assetDto;
+    }
+
+    public function addRepriseAsset(AssetDto $assetDto): void
+    {
+        if (\array_key_exists($entryName = $assetDto->getValue(), $this->repriseAssets)) {
+            throw new \InvalidArgumentException(sprintf('The "%s" Reprise entry has been added more than once via the addRepriseEntry() method, but each entry can only be added once (to not overwrite its configuration).', $entryName));
+        }
+
+        $this->repriseAssets[$entryName] = $assetDto;
     }
 
     public function addAssetMapperAsset(AssetDto $assetDto): void
@@ -104,6 +115,14 @@ final class AssetsDto
     public function getWebpackEncoreAssets(): array
     {
         return $this->webpackEncoreAssets;
+    }
+
+    /**
+     * @return AssetDto[]
+     */
+    public function getRepriseAssets(): array
+    {
+        return $this->repriseAssets;
     }
 
     /**
@@ -186,6 +205,11 @@ final class AssetsDto
                 $filteredAssets->addWebpackEncoreAsset($webpackEncoreAsset);
             }
         }
+        foreach ($this->repriseAssets as $repriseAsset) {
+            if ($repriseAsset->getLoadedOn()->has($pageName)) {
+                $filteredAssets->addRepriseAsset($repriseAsset);
+            }
+        }
         foreach ($this->headContents as $headContent) {
             $filteredAssets->addHtmlContentToHead($headContent);
         }
@@ -200,6 +224,7 @@ final class AssetsDto
     {
         $this->assetMapperAssets = array_merge($this->assetMapperAssets, $assetsDto->getAssetMapperAssets());
         $this->webpackEncoreAssets = array_merge($this->webpackEncoreAssets, $assetsDto->getWebpackEncoreAssets());
+        $this->repriseAssets = array_merge($this->repriseAssets, $assetsDto->getRepriseAssets());
         $this->cssAssets = array_merge($this->cssAssets, $assetsDto->getCssAssets());
         $this->jsAssets = array_merge($this->jsAssets, $assetsDto->getJsAssets());
         $this->headContents = array_merge($this->headContents, $assetsDto->getHeadContents());

--- a/src/Dto/FieldDto.php
+++ b/src/Dto/FieldDto.php
@@ -436,6 +436,11 @@ final class FieldDto
         $this->assets->addWebpackEncoreAsset($assetDto);
     }
 
+    public function addRepriseAsset(AssetDto $assetDto): void
+    {
+        $this->assets->addRepriseAsset($assetDto);
+    }
+
     public function addCssAsset(AssetDto $assetDto): void
     {
         $this->assets->addCssAsset($assetDto);

--- a/src/Field/FieldTrait.php
+++ b/src/Field/FieldTrait.php
@@ -295,6 +295,23 @@ trait FieldTrait
         return $this;
     }
 
+    public function addRepriseEntries(Asset|string ...$entryNamesOrAssets): self
+    {
+        if (!class_exists('Symfony\\Reprise\\Twig\\AssetExtension')) {
+            throw new \RuntimeException('You are trying to add Reprise entries in a field but Symfony Reprise is not installed in your project. Try running "composer require symfony/reprise"');
+        }
+
+        foreach ($entryNamesOrAssets as $entryNameOrAsset) {
+            if (\is_string($entryNameOrAsset)) {
+                $this->dto->addRepriseAsset(new AssetDto($entryNameOrAsset));
+            } else {
+                $this->dto->addRepriseAsset($entryNameOrAsset->getAsDto());
+            }
+        }
+
+        return $this;
+    }
+
     public function addAssetMapperEntries(Asset|string ...$entryNamesOrAssets): self
     {
         if (!class_exists('Symfony\\Component\\AssetMapper\\AssetMapper')) {

--- a/templates/crud/detail.html.twig
+++ b/templates/crud/detail.html.twig
@@ -26,12 +26,14 @@
     {{ parent() }}
     {{ include('@EasyAdmin/includes/_css_assets.html.twig', {assets: ea_field_assets.cssAssets}, with_context: false) }}
     {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', {assets: ea_field_assets.webpackEncoreAssets}, with_context: false) }}
+    {{ include('@EasyAdmin/includes/_reprise_link_tags.html.twig', {assets: ea_field_assets.repriseAssets}, with_context: false) }}
 {% endblock %}
 
 {% block configured_javascripts %}
     {{ parent() }}
     {{ include('@EasyAdmin/includes/_js_assets.html.twig', {assets: ea_field_assets.jsAssets}, with_context: false) }}
     {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', {assets: ea_field_assets.webpackEncoreAssets}, with_context: false) }}
+    {{ include('@EasyAdmin/includes/_reprise_script_tags.html.twig', {assets: ea_field_assets.repriseAssets}, with_context: false) }}
 {% endblock %}
 
 {% block content_title %}

--- a/templates/crud/edit.html.twig
+++ b/templates/crud/edit.html.twig
@@ -38,12 +38,14 @@
     {{ parent() }}
     {{ include('@EasyAdmin/includes/_css_assets.html.twig', {assets: ea_field_assets.cssAssets}, with_context: false) }}
     {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', {assets: ea_field_assets.webpackEncoreAssets}, with_context: false) }}
+    {{ include('@EasyAdmin/includes/_reprise_link_tags.html.twig', {assets: ea_field_assets.repriseAssets}, with_context: false) }}
 {% endblock %}
 
 {% block configured_javascripts %}
     {{ parent() }}
     {{ include('@EasyAdmin/includes/_js_assets.html.twig', {assets: ea_field_assets.jsAssets}, with_context: false) }}
     {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', {assets: ea_field_assets.webpackEncoreAssets}, with_context: false) }}
+    {{ include('@EasyAdmin/includes/_reprise_script_tags.html.twig', {assets: ea_field_assets.repriseAssets}, with_context: false) }}
 {% endblock %}
 
 {% block content_title %}

--- a/templates/crud/index.html.twig
+++ b/templates/crud/index.html.twig
@@ -28,12 +28,14 @@
     {{ parent() }}
     {{ include('@EasyAdmin/includes/_css_assets.html.twig', {assets: ea_field_assets.cssAssets}, with_context: false) }}
     {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', {assets: ea_field_assets.webpackEncoreAssets}, with_context: false) }}
+    {{ include('@EasyAdmin/includes/_reprise_link_tags.html.twig', {assets: ea_field_assets.repriseAssets}, with_context: false) }}
 {% endblock %}
 
 {% block configured_javascripts %}
     {{ parent() }}
     {{ include('@EasyAdmin/includes/_js_assets.html.twig', {assets: ea_field_assets.jsAssets}, with_context: false) }}
     {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', {assets: ea_field_assets.webpackEncoreAssets}, with_context: false) }}
+    {{ include('@EasyAdmin/includes/_reprise_script_tags.html.twig', {assets: ea_field_assets.repriseAssets}, with_context: false) }}
 {% endblock %}
 
 {% block content_title %}

--- a/templates/crud/new.html.twig
+++ b/templates/crud/new.html.twig
@@ -38,12 +38,14 @@
     {{ parent() }}
     {{ include('@EasyAdmin/includes/_css_assets.html.twig', {assets: ea_field_assets.cssAssets}, with_context: false) }}
     {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', {assets: ea_field_assets.webpackEncoreAssets}, with_context: false) }}
+    {{ include('@EasyAdmin/includes/_reprise_link_tags.html.twig', {assets: ea_field_assets.repriseAssets}, with_context: false) }}
 {% endblock %}
 
 {% block configured_javascripts %}
     {{ parent() }}
     {{ include('@EasyAdmin/includes/_js_assets.html.twig', {assets: ea_field_assets.jsAssets}, with_context: false) }}
     {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', {assets: ea_field_assets.webpackEncoreAssets}, with_context: false) }}
+    {{ include('@EasyAdmin/includes/_reprise_script_tags.html.twig', {assets: ea_field_assets.repriseAssets}, with_context: false) }}
 {% endblock %}
 
 {% block content_title %}

--- a/templates/includes/_reprise_link_tags.html.twig
+++ b/templates/includes/_reprise_link_tags.html.twig
@@ -1,0 +1,6 @@
+{# @var assets \EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto[] #}
+{% for reprise_asset in assets %}
+    {% guard function reprise_entry_link_tags %}
+        {{ reprise_entry_link_tags(reprise_asset.value, reprise_asset.reprisePackageName) }}
+    {% endguard %}
+{% endfor %}

--- a/templates/includes/_reprise_script_tags.html.twig
+++ b/templates/includes/_reprise_script_tags.html.twig
@@ -1,0 +1,6 @@
+{# @var assets \EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto[] #}
+{% for reprise_asset in assets %}
+    {% guard function reprise_entry_script_tags %}
+        {{ reprise_entry_script_tags(reprise_asset.value, reprise_asset.reprisePackageName) }}
+    {% endguard %}
+{% endfor %}

--- a/templates/layout.html.twig
+++ b/templates/layout.html.twig
@@ -32,6 +32,7 @@
     {% block configured_stylesheets %}
         {{ include('@EasyAdmin/includes/_css_assets.html.twig', {assets: ea.assets.cssAssets ?? []}, with_context: false) }}
         {{ include('@EasyAdmin/includes/_encore_link_tags.html.twig', {assets: ea.assets.webpackEncoreAssets ?? []}, with_context: false) }}
+        {{ include('@EasyAdmin/includes/_reprise_link_tags.html.twig', {assets: ea.assets.repriseAssets ?? []}, with_context: false) }}
     {% endblock %}
 
     {% block head_favicon %}
@@ -53,6 +54,7 @@
     {% block configured_javascripts %}
         {{ include('@EasyAdmin/includes/_js_assets.html.twig', {assets: ea.assets.jsAssets ?? []}, with_context: false) }}
         {{ include('@EasyAdmin/includes/_encore_script_tags.html.twig', {assets: ea.assets.webpackEncoreAssets ?? []}, with_context: false) }}
+        {{ include('@EasyAdmin/includes/_reprise_script_tags.html.twig', {assets: ea.assets.repriseAssets ?? []}, with_context: false) }}
     {% endblock %}
 
     {% block configured_head_contents %}

--- a/tests/Unit/Config/AssetTest.php
+++ b/tests/Unit/Config/AssetTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Config;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Asset;
+use PHPUnit\Framework\TestCase;
+
+class AssetTest extends TestCase
+{
+    public function testReprisePackageNameDefaultsToNull(): void
+    {
+        $asset = Asset::new('admin');
+
+        $this->assertNull($asset->getAsDto()->getReprisePackageName());
+    }
+
+    public function testReprisePackageName(): void
+    {
+        $asset = Asset::new('admin')->reprisePackageName('my_package');
+
+        $this->assertSame('my_package', $asset->getAsDto()->getReprisePackageName());
+    }
+}

--- a/tests/Unit/Config/AssetsTest.php
+++ b/tests/Unit/Config/AssetsTest.php
@@ -33,4 +33,13 @@ class AssetsTest extends TestCase
         $this->assertSame(IconSet::Custom, $assetsConfig->getAsDto()->getIconSet());
         $this->assertSame('some-prefix', $assetsConfig->getAsDto()->getDefaultIconPrefix());
     }
+
+    public function testAddRepriseEntryThrowsWhenRepriseNotInstalled(): void
+    {
+        // Symfony Reprise is not a dependency of this package, so the guard must throw.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('composer require symfony/reprise');
+
+        Assets::new()->addRepriseEntry('admin');
+    }
 }

--- a/tests/Unit/Dto/AssetDtoTest.php
+++ b/tests/Unit/Dto/AssetDtoTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Dto;
+
+use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto;
+use PHPUnit\Framework\TestCase;
+
+class AssetDtoTest extends TestCase
+{
+    public function testReprisePackageNameDefaultsToNull(): void
+    {
+        $assetDto = new AssetDto('admin');
+
+        $this->assertNull($assetDto->getReprisePackageName());
+    }
+
+    public function testSetReprisePackageName(): void
+    {
+        $assetDto = new AssetDto('admin');
+        $assetDto->setReprisePackageName('my_package');
+
+        $this->assertSame('my_package', $assetDto->getReprisePackageName());
+    }
+}

--- a/tests/Unit/Dto/AssetsDtoTest.php
+++ b/tests/Unit/Dto/AssetsDtoTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Dto;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\AssetsDto;
+use PHPUnit\Framework\TestCase;
+
+class AssetsDtoTest extends TestCase
+{
+    public function testRepriseAssetsDefaultsToEmptyArray(): void
+    {
+        $this->assertSame([], (new AssetsDto())->getRepriseAssets());
+    }
+
+    public function testAddRepriseAsset(): void
+    {
+        $assetsDto = new AssetsDto();
+        $assetsDto->addRepriseAsset(new AssetDto('admin'));
+
+        $this->assertArrayHasKey('admin', $assetsDto->getRepriseAssets());
+    }
+
+    public function testAddRepriseAssetThrowsOnDuplicate(): void
+    {
+        $assetsDto = new AssetsDto();
+        $assetsDto->addRepriseAsset(new AssetDto('admin'));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $assetsDto->addRepriseAsset(new AssetDto('admin'));
+    }
+
+    public function testLoadedOnFiltersRepriseAssetsByPage(): void
+    {
+        $assetsDto = new AssetsDto();
+        $indexOnly = new AssetDto('index-entry');
+        $indexOnly->setLoadedOn(KeyValueStore::new([Crud::PAGE_INDEX => Crud::PAGE_INDEX]));
+        $assetsDto->addRepriseAsset($indexOnly);
+
+        $detailOnly = new AssetDto('detail-entry');
+        $detailOnly->setLoadedOn(KeyValueStore::new([Crud::PAGE_DETAIL => Crud::PAGE_DETAIL]));
+        $assetsDto->addRepriseAsset($detailOnly);
+
+        $filtered = $assetsDto->loadedOn(Crud::PAGE_INDEX);
+
+        $this->assertArrayHasKey('index-entry', $filtered->getRepriseAssets());
+        $this->assertArrayNotHasKey('detail-entry', $filtered->getRepriseAssets());
+    }
+
+    public function testMergeWithMergesRepriseAssets(): void
+    {
+        $a = new AssetsDto();
+        $a->addRepriseAsset(new AssetDto('a-entry'));
+
+        $b = new AssetsDto();
+        $b->addRepriseAsset(new AssetDto('b-entry'));
+
+        $a->mergeWith($b);
+
+        $this->assertArrayHasKey('a-entry', $a->getRepriseAssets());
+        $this->assertArrayHasKey('b-entry', $a->getRepriseAssets());
+    }
+}

--- a/tests/Unit/Factory/AdminContextFactoryTest.php
+++ b/tests/Unit/Factory/AdminContextFactoryTest.php
@@ -328,6 +328,7 @@ class AdminContextFactoryTest extends KernelTestCase
         $this->assertIsArray($assets->getJsAssets());
         $this->assertIsArray($assets->getWebpackEncoreAssets());
         $this->assertIsArray($assets->getAssetMapperAssets());
+        $this->assertIsArray($assets->getRepriseAssets());
     }
 
     public function testCreateWithCrudControllerPreservesIconSetFromDashboard(): void

--- a/tests/Unit/Field/FieldTraitTest.php
+++ b/tests/Unit/Field/FieldTraitTest.php
@@ -27,4 +27,13 @@ class FieldTraitTest extends TestCase
         $this->assertSame('foo', $formTypeOptions['entry_options']['attr']['class']);
         $this->assertSame('bar', $formTypeOptions['entry_options']['attr']['id']);
     }
+
+    public function testAddRepriseEntriesThrowsWhenRepriseNotInstalled(): void
+    {
+        // Symfony Reprise is not a dependency of this package, so the guard must throw.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('composer require symfony/reprise');
+
+        TextField::new('test')->addRepriseEntries('admin');
+    }
 }


### PR DESCRIPTION
Mirror the existing Webpack Encore integration for [Symfony Reprise](https://github.com/symfony/reprise/), so Reprise entries can be registered the same way Encore entries are:

- `Assets::addRepriseEntry()` for dashboard and CRUD assets
- `FieldTrait::addRepriseEntries()` for field assets
- `Asset::reprisePackageName()` to set the Symfony Asset package of an entry

Entries are rendered through new `reprise_entry_script_tags` and `reprise_entry_link_tags` Twig functions.