### PR TITLE
[Router] Allow CRUD controllers to control which actions to generate admin routes for

### DIFF
--- a/src/Attribute/AdminRoute.php
+++ b/src/Attribute/AdminRoute.php
@@ -53,6 +53,20 @@ class AdminRoute
          *                                - [FooDashboard::class, BarDashboard::class, ...]: Deny specific dashboards
          */
         public array|false|null $deniedDashboards = false,
+
+        /**
+         * @var string[]|null $allowedActions If defined at the class level, admin routes will be available only for the specified actions. Possible values:
+         *                    - null (default): Not set - allow all actions
+         *                    - [Action::INDEX, Action::DELETE, 'customAction', ...]: Allow only specific actions
+         */
+        public ?array $allowedActions = null,
+
+        /**
+         * @var string[]|null $deniedActions If defined at the class level, admin routes won't be available for the specified actions. Possible values:
+         *                    - null (default): Not set - deny no actions
+         *                    - [Action::INDEX, Action::DELETE, 'customAction', ...]: Deny specific actions
+         */
+        public ?array $deniedActions = null,
     ) {
     }
 }

--- a/src/Router/AdminRouteGenerator.php
+++ b/src/Router/AdminRouteGenerator.php
@@ -214,6 +214,14 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
 
                 foreach (array_keys($actionsRouteConfig) as $actionName) {
                     $actionRouteConfig = $actionsRouteConfig[$actionName];
+
+                    if (null !== $crudControllerRouteConfig['allowedActions'] && !\in_array($actionRouteConfig['actionName'], $crudControllerRouteConfig['allowedActions'], true)) {
+                        continue;
+                    }
+                    if (null !== $crudControllerRouteConfig['deniedActions'] && \in_array($actionRouteConfig['actionName'], $crudControllerRouteConfig['deniedActions'], true)) {
+                        continue;
+                    }
+
                     $actionNameSnakeCase = strtolower(preg_replace('/[A-Z]/', '_$0', $actionRouteConfig['actionName']));
                     $actionNameSlug = strtolower(preg_replace('/[A-Z]/', '-$0', $actionRouteConfig['actionName']));
 
@@ -583,11 +591,11 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
     /**
      * @param class-string<CrudControllerInterface> $crudControllerFqcn
      *
-     * @return array{routeName: string, routePath: string}
+     * @return array{routeName: string, routePath: string, allowedActions: string[]|null, deniedActions: string[]|null}
      */
     private function getCrudControllerRouteConfig(string $crudControllerFqcn): array
     {
-        $crudControllerConfig = [];
+        $crudControllerConfig = ['allowedActions' => null, 'deniedActions' => null]; // Default to not set
 
         $reflectionClass = new \ReflectionClass($crudControllerFqcn);
 
@@ -608,6 +616,12 @@ final class AdminRouteGenerator implements AdminRouteGeneratorInterface
 
                 $crudControllerConfig['routeName'] = trim($adminRouteInstance->name, '_');
             }
+
+            if (null !== $adminRouteInstance->allowedActions && null !== $adminRouteInstance->deniedActions) {
+                throw new \RuntimeException(sprintf('In the #[AdminRoute] attribute of the "%s" CRUD controller, you cannot define both "allowedActions" and "deniedActions" at the same time because they are the exact opposite. Use only one of them.', $crudControllerFqcn));
+            }
+            $crudControllerConfig['allowedActions'] = $adminRouteInstance->allowedActions;
+            $crudControllerConfig['deniedActions'] = $adminRouteInstance->deniedActions;
         }
 
         // if the CRUD controller doesn't define any or all of the route configuration,


### PR DESCRIPTION
Lately I found myself creating a few "read-only" CRUD controllers with only the `index` and `detail` actions, and it works well as I can configure permissions on the actions to limit access to undesired ones.

However, I've realised that admin routes for all actions were still generated which results in 8 admin routes per CRUD controller where I actually need only 2 😄 

This feature allows CRUD controllers, using the `#[AdminRoute]` attribute at the class level to allow/deny actions which dictates which routes to generate.

Besides addressing the growing number of unused routes, I believe this could be good for security as well, if nobody is supposed to be able to delete an entity then do not expose the route to attempt at all 😄 