### PR TITLE
Fix search in deeply nested properties

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -401,6 +401,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, new Reference('property_accessor'))
             ->arg(1, service(EntityFactory::class))
             ->arg(2, service(EntityTranslationIdGeneratorInterface::class))
+            ->arg(3, service(EntityRepository::class))
             ->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR, ['priority' => 9999])
 
         ->set(CountryConfigurator::class)

--- a/doc/crud.rst
+++ b/doc/crud.rst
@@ -438,8 +438,9 @@ Search, Order, and Pagination Options
             // (user can later change this sorting by clicking on the table columns)
             ->setDefaultSort(['id' => 'DESC'])
             ->setDefaultSort(['id' => 'DESC', 'title' => 'ASC', 'startsAt' => 'DESC'])
-            // you can sort by Doctrine associations up to two levels
+            // you can sort by nested Doctrine associations of any depth
             ->setDefaultSort(['seller.name' => 'ASC'])
+            ->setDefaultSort(['seller.address.country' => 'ASC'])
         ;
     }
 

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -8,6 +8,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\NestedAssociationResolverInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\FieldDto;
@@ -30,6 +31,7 @@ final readonly class CommonPreConfigurator implements FieldConfiguratorInterface
         private PropertyAccessorInterface $propertyAccessor,
         private EntityFactory $entityFactory,
         private EntityTranslationIdGeneratorInterface $entityTranslationIdGenerator,
+        private NestedAssociationResolverInterface $associationResolver,
     ) {
     }
 
@@ -162,8 +164,24 @@ final readonly class CommonPreConfigurator implements FieldConfiguratorInterface
             return $isSortable;
         }
 
-        return isset($entityDto->getClassMetadata()->fieldMappings[$field->getProperty()])
-            || $entityDto->getClassMetadata()->hasAssociation($field->getProperty());
+        if (isset($entityDto->getClassMetadata()->fieldMappings[$field->getProperty()])
+            || $entityDto->getClassMetadata()->hasAssociation($field->getProperty())) {
+            return true;
+        }
+
+        // nested properties (e.g. 'author.publisher.name') are sortable when
+        // every segment of the path maps to a real Doctrine association or field
+        if (str_contains($field->getProperty(), '.')) {
+            try {
+                $this->associationResolver->resolveNestedAssociations(null, $entityDto, $field->getProperty());
+
+                return true;
+            } catch (\InvalidArgumentException) {
+                return false;
+            }
+        }
+
+        return false;
     }
 
     private function buildVirtualOption(FieldDto $field, EntityDto $entityDto): bool

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -179,52 +179,61 @@ final readonly class EntityRepository implements EntityRepositoryInterface, Nest
 
     private function applyOrderClause(QueryBuilder $queryBuilder, EntityDto $entityDto, FieldCollection $fields, string $sortProperty, string $sortOrder): void
     {
-        $aliases = $queryBuilder->getAllAliases();
         $sortFieldIsDoctrineAssociation = $this->isAssociation($entityDto, $sortProperty);
 
         if ($sortFieldIsDoctrineAssociation) {
-            $sortFieldParts = explode('.', $sortProperty, 2);
-            // check if join has been added once before.
-            if (!\in_array($sortFieldParts[0], $aliases, true)) {
-                $queryBuilder->leftJoin('entity.'.$sortFieldParts[0], $sortFieldParts[0]);
+            if (str_contains($sortProperty, '.')) {
+                $resolvedProperty = $this->resolveNestedAssociations($queryBuilder, $entityDto, $sortProperty);
+                $queryBuilder->addOrderBy($resolvedProperty->getEntityAlias().'.'.$resolvedProperty->getPropertyName(), $sortOrder);
+
+                return;
             }
 
-            if (1 === \count($sortFieldParts)) {
-                if ($entityDto->getClassMetadata()->isCollectionValuedAssociation($sortProperty)) {
-                    /** @var EntityManagerInterface $entityManager */
-                    $entityManager = $this->doctrine->getManagerForClass($entityDto->getFqcn());
-                    $countQueryBuilder = $entityManager->createQueryBuilder();
+            // check if join has been added once before.
+            if (!\in_array($sortProperty, $queryBuilder->getAllAliases(), true)) {
+                $queryBuilder->leftJoin('entity.'.$sortProperty, $sortProperty);
+            }
 
-                    if (ClassMetadata::MANY_TO_MANY === $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['type']) {
-                        // many-to-many relation
-                        $countQueryBuilder
-                            ->select($queryBuilder->expr()->count('subQueryEntity'))
-                            ->from($entityDto->getFqcn(), 'subQueryEntity')
-                            ->join(sprintf('subQueryEntity.%s', $sortProperty), 'relatedEntity')
-                            ->where('subQueryEntity = entity');
-                    } else {
-                        // one-to-many relation
-                        $countQueryBuilder
-                            ->select($queryBuilder->expr()->count('subQueryEntity'))
-                            ->from($entityDto->getClassMetadata()->getAssociationTargetClass($sortProperty), 'subQueryEntity')
-                            ->where(sprintf('subQueryEntity.%s = entity', $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['mappedBy']));
-                    }
+            // register the join in the shared cache so that resolveNestedAssociations() reuses it
+            // when another sort property (e.g. a nested defaultSort) traverses the same association
+            $joinedAssociations = $this->joinedAssociations[$queryBuilder] ?? [];
+            if (!isset($joinedAssociations[$sortProperty])) {
+                $joinedAssociations[$sortProperty] = $sortProperty;
+                $this->joinedAssociations[$queryBuilder] = $joinedAssociations;
+            }
 
-                    $queryBuilder->addSelect(sprintf('(%s) as HIDDEN sub_query_sort', $countQueryBuilder->getDQL()));
-                    $queryBuilder->addOrderBy('sub_query_sort', $sortOrder);
-                    $queryBuilder->addOrderBy('entity.'.$entityDto->getClassMetadata()->getSingleIdentifierFieldName(), $sortOrder);
+            if ($entityDto->getClassMetadata()->isCollectionValuedAssociation($sortProperty)) {
+                /** @var EntityManagerInterface $entityManager */
+                $entityManager = $this->doctrine->getManagerForClass($entityDto->getFqcn());
+                $countQueryBuilder = $entityManager->createQueryBuilder();
+
+                if (ClassMetadata::MANY_TO_MANY === $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['type']) {
+                    // many-to-many relation
+                    $countQueryBuilder
+                        ->select($queryBuilder->expr()->count('subQueryEntity'))
+                        ->from($entityDto->getFqcn(), 'subQueryEntity')
+                        ->join(sprintf('subQueryEntity.%s', $sortProperty), 'relatedEntity')
+                        ->where('subQueryEntity = entity');
                 } else {
-                    $field = $fields->getByProperty($sortProperty);
-                    $associationSortProperty = $field?->getCustomOption(AssociationField::OPTION_SORT_PROPERTY);
-
-                    if (null === $associationSortProperty) {
-                        $queryBuilder->addOrderBy('entity.'.$sortProperty, $sortOrder);
-                    } else {
-                        $queryBuilder->addOrderBy($sortProperty.'.'.$associationSortProperty, $sortOrder);
-                    }
+                    // one-to-many relation
+                    $countQueryBuilder
+                        ->select($queryBuilder->expr()->count('subQueryEntity'))
+                        ->from($entityDto->getClassMetadata()->getAssociationTargetClass($sortProperty), 'subQueryEntity')
+                        ->where(sprintf('subQueryEntity.%s = entity', $entityDto->getClassMetadata()->getAssociationMapping($sortProperty)['mappedBy']));
                 }
+
+                $queryBuilder->addSelect(sprintf('(%s) as HIDDEN sub_query_sort', $countQueryBuilder->getDQL()));
+                $queryBuilder->addOrderBy('sub_query_sort', $sortOrder);
+                $queryBuilder->addOrderBy('entity.'.$entityDto->getClassMetadata()->getSingleIdentifierFieldName(), $sortOrder);
             } else {
-                $queryBuilder->addOrderBy($sortProperty, $sortOrder);
+                $field = $fields->getByProperty($sortProperty);
+                $associationSortProperty = $field?->getCustomOption(AssociationField::OPTION_SORT_PROPERTY);
+
+                if (null === $associationSortProperty) {
+                    $queryBuilder->addOrderBy('entity.'.$sortProperty, $sortOrder);
+                } else {
+                    $queryBuilder->addOrderBy($sortProperty.'.'.$associationSortProperty, $sortOrder);
+                }
             }
         } else {
             $queryBuilder->addOrderBy('entity.'.$sortProperty, $sortOrder);
@@ -302,7 +311,12 @@ final readonly class EntityRepository implements EntityRepositoryInterface, Nest
         $searchableProperties = (null === $configuredSearchableProperties || 0 === \count($configuredSearchableProperties)) ? $entityDto->getClassMetadata()->getFieldNames() : $configuredSearchableProperties;
 
         foreach ($searchableProperties as $searchableProperty) {
-            $resolvedProperty = $this->resolveNestedAssociations($queryBuilder, $entityDto, $searchableProperty);
+            try {
+                $resolvedProperty = $this->resolveNestedAssociations($queryBuilder, $entityDto, $searchableProperty);
+            } catch (\InvalidArgumentException) {
+                // skip properties not mapped by Doctrine (e.g. virtual fields) instead of failing the whole search
+                continue;
+            }
 
             // In Doctrine ORM 3.x, FieldMapping implements \ArrayAccess; in 4.x it's an object with properties
             $fieldMapping = $resolvedProperty->getEntityDto()->getClassMetadata()->getFieldMapping($resolvedProperty->getPropertyName());
@@ -457,20 +471,19 @@ final readonly class EntityRepository implements EntityRepositoryInterface, Nest
 
         $classMetadata = $entityDto->getClassMetadata();
 
-        // multi-segment customSort (e.g. "customer.secretField") would otherwise
-        // reach the unfiltered multi-segment branch in applyOrderClause; URL-based
-        // association sort is supported via AssociationField::setSortProperty()
-        // with a single-segment key. Embeddable properties (e.g. "address.city")
-        // are real Doctrine fields with a dotted name (hasField() === true), so
-        // they are still allowed
+        // structural gate: the property must be a real Doctrine field or association,
+        // or a nested path (e.g. "author.publisher.name") whose every segment maps to
+        // one. This also rejects any key with characters (commas, spaces, quotes…) that
+        // could otherwise smuggle DQL fragments through identifier interpolation.
+        // Embeddable properties (e.g. "address.city") are real Doctrine fields with a
+        // dotted name (hasField() === true), so they don't need to be resolved
         if (str_contains($sortProperty, '.') && !$classMetadata->hasField($sortProperty)) {
-            return false;
-        }
-
-        // structural gate: the property must be a real Doctrine field or association
-        // on the entity. This also rejects any key with characters (commas, spaces,
-        // quotes…) that could otherwise smuggle DQL fragments through identifier interpolation
-        if (!$classMetadata->hasField($sortProperty) && !$classMetadata->hasAssociation($sortProperty)) {
+            try {
+                $this->resolveNestedAssociations(null, $entityDto, $sortProperty);
+            } catch (\InvalidArgumentException) {
+                return false;
+            }
+        } elseif (!$classMetadata->hasField($sortProperty) && !$classMetadata->hasAssociation($sortProperty)) {
             return false;
         }
 

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/SortMultiLevelAssocCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/SortMultiLevelAssocCrudController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+
+/**
+ * CRUD controller for testing sorting on multi-level association traversal.
+ * Sorts by latestRelease.category.name (2-level association chain).
+ *
+ * @extends AbstractCrudController<Project>
+ */
+class SortMultiLevelAssocCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Project::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setDefaultSort(['latestRelease.category.name' => 'DESC', 'name' => 'ASC']);
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield IdField::new('id')->hideOnForm();
+        yield TextField::new('name');
+        yield AssociationField::new('latestRelease');
+        yield TextField::new('latestRelease.category.name');
+    }
+}

--- a/tests/Functional/Default/Sort/SortByMultiLevelAssociationTest.php
+++ b/tests/Functional/Default/Sort/SortByMultiLevelAssociationTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Default\Sort;
+
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic\SortMultiLevelAssocCrudController;
+
+/**
+ * Tests sorting on multi-level association traversal.
+ * The controller sorts by latestRelease.category.name (2-level association chain).
+ *
+ * From fixtures, the Project entities and their release categories:
+ * 1. "Alpha Project" → latestRelease=v1.0 → category.name="Major"
+ * 2. "Beta Project"  → latestRelease=v1.1 → category.name="Minor"
+ * 3. "Gamma Project" → latestRelease=v2.0 → category.name="Major"
+ * 4. "Delta Project" → latestRelease=null  (no release)
+ */
+class SortByMultiLevelAssociationTest extends AbstractCrudTestCase
+{
+    protected function getControllerFqcn(): string
+    {
+        return SortMultiLevelAssocCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+    }
+
+    public function testCustomSortOnAssociationCombinedWithNestedDefaultSort(): void
+    {
+        // ?sort[latestRelease]=ASC replaces neither defaultSort entry, so this sort and the
+        // 'latestRelease.category.name' default sort traverse the same association; the
+        // 'latestRelease' JOIN must be added only once or Doctrine fails with
+        // "[Semantical Error] 'latestRelease' is already defined"
+        $this->client->request('GET', $this->generateIndexUrl().'?'.http_build_query(['sort' => ['latestRelease' => 'ASC']]));
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('tbody tr td[data-column="name"]');
+    }
+
+    public function testNestedColumnIsSortable(): void
+    {
+        $this->client->request('GET', $this->generateIndexUrl());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('th[data-column="latestRelease.category.name"] > a', 'The nested property column must render a sort link');
+    }
+
+    /**
+     * @dataProvider provideSortTests
+     *
+     * @param list<string> $expectedProjectNames
+     */
+    public function testSorting(array $query, array $expectedProjectNames): void
+    {
+        $url = $this->generateIndexUrl();
+        if ([] !== $query) {
+            $url .= '?'.http_build_query($query);
+        }
+        $this->client->request('GET', $url);
+
+        $this->assertResponseIsSuccessful();
+        foreach ($expectedProjectNames as $index => $expectedProjectName) {
+            $row = $index + 1;
+            $this->assertSelectorTextSame(
+                sprintf('tbody tr:nth-child(%d) td[data-column="name"]', $row),
+                $expectedProjectName,
+                sprintf('Expected "%s" in row %d', $expectedProjectName, $row)
+            );
+        }
+    }
+
+    public static function provideSortTests(): iterable
+    {
+        // SQLite sorts NULL values first in ASC order and last in DESC order;
+        // the secondary sort by project name makes ties deterministic
+
+        yield 'default sort (category name DESC, name ASC)' => [
+            [],
+            ['Beta Project', 'Alpha Project', 'Gamma Project', 'Delta Project'],
+        ];
+
+        yield 'URL sort by nested property ASC' => [
+            ['sort' => ['latestRelease.category.name' => 'ASC', 'name' => 'ASC']],
+            ['Delta Project', 'Alpha Project', 'Gamma Project', 'Beta Project'],
+        ];
+
+        yield 'URL sort by nested property DESC' => [
+            ['sort' => ['latestRelease.category.name' => 'DESC', 'name' => 'DESC']],
+            ['Beta Project', 'Gamma Project', 'Alpha Project', 'Delta Project'],
+        ];
+
+        yield 'invalid nested sort property falls back to default sort' => [
+            ['sort' => ['latestRelease.category.secretField' => 'ASC']],
+            ['Beta Project', 'Alpha Project', 'Gamma Project', 'Delta Project'],
+        ];
+    }
+}

--- a/tests/Unit/Field/Configurator/CommonPreConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/CommonPreConfiguratorTest.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Configurator;
 
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\NestedAssociationResolverInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CommonPreConfigurator;
@@ -21,7 +22,8 @@ class CommonPreConfiguratorTest extends AbstractFieldTest
         $propertyAccessor = $container->get(PropertyAccessorInterface::class);
         $entityFactory = $container->get(EntityFactory::class);
         $entityTranslationIdGenerator = $container->get(EntityTranslationIdGeneratorInterface::class);
-        $this->configurator = new CommonPreConfigurator($propertyAccessor, $entityFactory, $entityTranslationIdGenerator);
+        $associationResolver = $container->get(NestedAssociationResolverInterface::class);
+        $this->configurator = new CommonPreConfigurator($propertyAccessor, $entityFactory, $entityTranslationIdGenerator, $associationResolver);
     }
 
     public function testShouldKeepExistingValue(): void

--- a/tests/Unit/Orm/EntityRepositoryTest.php
+++ b/tests/Unit/Orm/EntityRepositoryTest.php
@@ -286,14 +286,17 @@ class EntityRepositoryTest extends TestCase
         $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
     }
 
-    public function testCustomSortKeyContainingDotIsIgnored(): void
+    public function testCustomSortByNestedPropertyNotExposedAsFieldIsIgnored(): void
     {
-        // ?sort[customer.secretField]=ASC — multi-segment keys reach the unfiltered
-        // multi-segment branch of applyOrderClause; URL-based association sort is
-        // supported via single-segment keys + AssociationField::setSortProperty()
+        // ?sort[customer.name]=ASC against a controller whose configureFields(INDEX)
+        // doesn't expose the `customer.name` property: the path maps to real Doctrine
+        // metadata, but only properties exposed as sortable fields can be sorted via the URL
+        $customerEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\Customer');
         $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
         $fields = new FieldCollection([$this->createField('customer', true)]);
-        $searchDto = $this->createSearchDtoForSort(customSort: ['customer.secretField' => 'ASC']);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['customer.name' => 'ASC']);
+
+        $this->entityFactory->method('create')->willReturn($customerEntityDto);
 
         $queryBuilder = $this->createSortingQueryBuilder();
         $queryBuilder->expects($this->never())->method('addOrderBy');
@@ -302,6 +305,112 @@ class EntityRepositoryTest extends TestCase
         $this->stubEntityManager($queryBuilder);
 
         $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testCustomSortByNestedPropertyNotMappedByDoctrineIsIgnored(): void
+    {
+        // ?sort[customer.secretField]=ASC — the last segment doesn't map to any
+        // Doctrine field of the associated entity, so the whole key is rejected
+        $customerEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\Customer');
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
+        $fields = new FieldCollection([$this->createField('customer.secretField', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['customer.secretField' => 'ASC']);
+
+        $this->entityFactory->method('create')->willReturn($customerEntityDto);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->never())->method('addOrderBy');
+        $queryBuilder->expects($this->never())->method('leftJoin');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testCustomSortByExposedSortableNestedPropertyIsApplied(): void
+    {
+        $customerEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\Customer');
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
+        $fields = new FieldCollection([$this->createField('customer.name', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['customer.name' => 'ASC']);
+
+        $this->entityFactory->method('create')->willReturn($customerEntityDto);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->method('getRootAliases')->willReturn(['entity']);
+        $queryBuilder->expects($this->once())
+            ->method('leftJoin')
+            ->with('entity.customer', 'customer');
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('customer.name', 'ASC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testDefaultSortByMultiLevelNestedPropertyAddsAllJoins(): void
+    {
+        $categoryEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\Category');
+        $releaseEntityDto = $this->createEntityDto([], ['category' => 'App\Entity\Category'], 'App\Entity\Release');
+        $entityDto = $this->createEntityDto([], ['latestRelease' => 'App\Entity\Release']);
+        $searchDto = $this->createSearchDtoForSort(defaultSort: ['latestRelease.category.name' => 'DESC']);
+
+        $this->entityFactory->method('create')->willReturnCallback(static fn (string $fqcn): EntityDto => match ($fqcn) {
+            'App\Entity\Release' => $releaseEntityDto,
+            'App\Entity\Category' => $categoryEntityDto,
+        });
+
+        $joins = [];
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->method('getRootAliases')->willReturn(['entity']);
+        $queryBuilder->method('leftJoin')->willReturnCallback(static function (string $join, string $alias) use (&$joins, $queryBuilder) {
+            $joins[] = [$join, $alias];
+
+            return $queryBuilder;
+        });
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('category1.name', 'DESC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, new FieldCollection([]), new FilterCollection());
+
+        self::assertSame([['entity.latestRelease', 'latestRelease'], ['latestRelease.category', 'category1']], $joins);
+    }
+
+    public function testCustomSortOnAssociationCombinedWithNestedDefaultSortJoinsOnlyOnce(): void
+    {
+        // ?sort[customer]=ASC on a CRUD with setDefaultSort(['customer.name' => 'DESC']):
+        // both sort properties traverse the 'customer' association, so its JOIN must be
+        // added only once or Doctrine fails with "[Semantical Error] 'customer' is already defined"
+        $customerEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\Customer');
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
+        $fields = new FieldCollection([$this->createField('customer', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['customer' => 'ASC'], defaultSort: ['customer.name' => 'DESC']);
+
+        $this->entityFactory->method('create')->willReturn($customerEntityDto);
+
+        $orderClauses = [];
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->method('getRootAliases')->willReturn(['entity']);
+        $queryBuilder->expects($this->once())
+            ->method('leftJoin')
+            ->with('entity.customer', 'customer')
+            ->willReturnSelf();
+        $queryBuilder->method('addOrderBy')->willReturnCallback(static function (string $sort, string $order) use (&$orderClauses, $queryBuilder) {
+            $orderClauses[] = [$sort, $order];
+
+            return $queryBuilder;
+        });
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+
+        self::assertSame([['entity.customer', 'ASC'], ['customer.name', 'DESC']], $orderClauses);
     }
 
     public function testCustomSortWithNonAscDescValueIsIgnored(): void
@@ -408,6 +517,33 @@ class EntityRepositoryTest extends TestCase
 
         self::assertSame($authorEntityDto, $resolved->getEntityDto());
         self::assertSame('author', $resolved->getEntityAlias());
+        self::assertSame('name', $resolved->getPropertyName());
+    }
+
+    public function testResolveNestedAssociationsWithMultiLevelNestedProperty(): void
+    {
+        $categoryEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\Category');
+        $releaseEntityDto = $this->createEntityDto([], ['category' => 'App\Entity\Category'], 'App\Entity\Release');
+        $rootEntityDto = $this->createEntityDto([], ['latestRelease' => 'App\Entity\Release'], 'App\Entity\Project');
+
+        $this->entityFactory->method('create')->willReturnCallback(static fn (string $fqcn): EntityDto => match ($fqcn) {
+            'App\Entity\Release' => $releaseEntityDto,
+            'App\Entity\Category' => $categoryEntityDto,
+        });
+
+        $joins = [];
+        $queryBuilder = $this->createResolveQueryBuilder();
+        $queryBuilder->method('leftJoin')->willReturnCallback(static function (string $join, string $alias) use (&$joins, $queryBuilder) {
+            $joins[] = [$join, $alias];
+
+            return $queryBuilder;
+        });
+
+        $resolved = $this->entityRepository->resolveNestedAssociations($queryBuilder, $rootEntityDto, 'latestRelease.category.name');
+
+        self::assertSame([['entity.latestRelease', 'latestRelease'], ['latestRelease.category', 'category1']], $joins);
+        self::assertSame($categoryEntityDto, $resolved->getEntityDto());
+        self::assertSame('category1', $resolved->getEntityAlias());
         self::assertSame('name', $resolved->getPropertyName());
     }
 


### PR DESCRIPTION
Found while reviewing issue #7737.

Nested properties (e.g. 'author.publisher.name') are sortable when every segment of the path maps to a real Doctrine association or field. Before, we only supported 2 nested levels.