### PR TITLE
Support sorting by nested association fields

### DIFF
--- a/doc/fields/AssociationField.rst
+++ b/doc/fields/AssociationField.rst
@@ -317,6 +317,35 @@ associated entity::
 
     yield AssociationField::new('user')->setSortProperty('name');
 
+Nested Associations
+-------------------
+
+This field can display a property of a *related* entity, following a chain of
+associations written as a dotted property path. For example, if an ``Order``
+entity is associated with a ``Customer`` and that ``Customer`` is associated
+with a ``Country``, you can show the order's country on the ``index`` and
+``detail`` pages like this::
+
+    yield AssociationField::new('customer.country');
+
+The value is rendered as a clickable link pointing to the ``detail`` page of
+the entity at the end of the path (the ``Country`` in this example). EasyAdmin
+finds the CRUD controller of that entity automatically; if you define more than
+one CRUD controller for it, use the ``setCrudController()`` method to choose
+which one to link to.
+
+Nested association columns are sortable by default, like single-level
+association fields, as long as every segment of the path is a *to-one*
+association (sorting by *to-many* associations is not supported for nested
+paths). By default, results are sorted by the ``id`` of the related entity;
+use ``setSortProperty()`` to sort by any other property of it::
+
+    // sorts by the id of the related country
+    yield AssociationField::new('customer.country');
+
+    // sorts by the name of the related country
+    yield AssociationField::new('customer.country')->setSortProperty('name');
+
 .. _`TomSelect`: https://tom-select.js.org/
 .. _`EntityType`: https://symfony.com/doc/current/reference/forms/types/entity.html
 .. _`query_builder option`: https://symfony.com/doc/current/reference/forms/types/entity.html#query-builder

--- a/src/Field/Configurator/CommonPreConfigurator.php
+++ b/src/Field/Configurator/CommonPreConfigurator.php
@@ -177,6 +177,16 @@ final readonly class CommonPreConfigurator implements FieldConfiguratorInterface
 
                 return true;
             } catch (\InvalidArgumentException) {
+            }
+
+            // nested paths ending at an association (e.g. 'customer.country') are sortable
+            // when the leaf is single-valued, mirroring single-level association fields;
+            // to-many leaves are not sortable (the COUNT-subquery sort is not supported here)
+            try {
+                $resolvedProperty = $this->associationResolver->resolveNestedAssociations(null, $entityDto, $field->getProperty(), true);
+
+                return $resolvedProperty->getEntityDto()->getClassMetadata()->isSingleValuedAssociation($resolvedProperty->getPropertyName());
+            } catch (\InvalidArgumentException) {
                 return false;
             }
         }

--- a/src/Orm/EntityRepository.php
+++ b/src/Orm/EntityRepository.php
@@ -183,7 +183,21 @@ final readonly class EntityRepository implements EntityRepositoryInterface, Nest
 
         if ($sortFieldIsDoctrineAssociation) {
             if (str_contains($sortProperty, '.')) {
-                $resolvedProperty = $this->resolveNestedAssociations($queryBuilder, $entityDto, $sortProperty);
+                $pathToResolve = $sortProperty;
+                $pathEndsInAssociation = $this->pathEndsInSingleValuedAssociation($entityDto, $sortProperty);
+
+                if ($pathEndsInAssociation) {
+                    // an AssociationField with a nested property (e.g. 'customer.country') sorts by the
+                    // property defined with setSortProperty() or, by default, by the foreign key of the
+                    // leaf association on its parent (mirroring the 'entity.assoc' single-level behavior)
+                    $associationSortProperty = $fields->getByProperty($sortProperty)?->getCustomOption(AssociationField::OPTION_SORT_PROPERTY);
+                    if (null !== $associationSortProperty) {
+                        $pathToResolve = $sortProperty.'.'.$associationSortProperty;
+                        $pathEndsInAssociation = false;
+                    }
+                }
+
+                $resolvedProperty = $this->resolveNestedAssociations($queryBuilder, $entityDto, $pathToResolve, $pathEndsInAssociation);
                 $queryBuilder->addOrderBy($resolvedProperty->getEntityAlias().'.'.$resolvedProperty->getPropertyName(), $sortOrder);
 
                 return;
@@ -460,6 +474,17 @@ final readonly class EntityRepository implements EntityRepositoryInterface, Nest
         return $entityDto->getClassMetadata()->hasAssociation($propertyNameParts[0]);
     }
 
+    private function pathEndsInSingleValuedAssociation(EntityDto $entityDto, string $propertyName): bool
+    {
+        try {
+            $resolvedProperty = $this->resolveNestedAssociations(null, $entityDto, $propertyName, true);
+        } catch (\InvalidArgumentException) {
+            return false;
+        }
+
+        return $resolvedProperty->getEntityDto()->getClassMetadata()->isSingleValuedAssociation($resolvedProperty->getPropertyName());
+    }
+
     private function isValidCustomSort(string $sortProperty, string $sortOrder, EntityDto $entityDto, FieldCollection $fields): bool
     {
         // the order direction reaches DQL via Expr\OrderBy as "$property $direction",
@@ -472,16 +497,19 @@ final readonly class EntityRepository implements EntityRepositoryInterface, Nest
         $classMetadata = $entityDto->getClassMetadata();
 
         // structural gate: the property must be a real Doctrine field or association,
-        // or a nested path (e.g. "author.publisher.name") whose every segment maps to
-        // one. This also rejects any key with characters (commas, spaces, quotes…) that
-        // could otherwise smuggle DQL fragments through identifier interpolation.
-        // Embeddable properties (e.g. "address.city") are real Doctrine fields with a
-        // dotted name (hasField() === true), so they don't need to be resolved
+        // or a nested path whose every segment maps to one, ending either in a field
+        // (e.g. "author.publisher.name") or in a single-valued association (e.g.
+        // "customer.country"). This also rejects any key with characters (commas, spaces,
+        // quotes…) that could otherwise smuggle DQL fragments through identifier
+        // interpolation. Embeddable properties (e.g. "address.city") are real Doctrine
+        // fields with a dotted name (hasField() === true), so they don't need to be resolved
         if (str_contains($sortProperty, '.') && !$classMetadata->hasField($sortProperty)) {
             try {
                 $this->resolveNestedAssociations(null, $entityDto, $sortProperty);
             } catch (\InvalidArgumentException) {
-                return false;
+                if (!$this->pathEndsInSingleValuedAssociation($entityDto, $sortProperty)) {
+                    return false;
+                }
             }
         } elseif (!$classMetadata->hasField($sortProperty) && !$classMetadata->hasAssociation($sortProperty)) {
             return false;

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/SortNestedAssociationByFkCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/SortNestedAssociationByFkCrudController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+
+/**
+ * CRUD controller for testing an AssociationField whose property is a nested
+ * association path ending at an association ('latestRelease.category') WITHOUT
+ * setSortProperty(): sorting must order by the foreign key of the leaf association
+ * (i.e. the category id), mirroring how single-level associations are sorted.
+ *
+ * @extends AbstractCrudController<Project>
+ */
+class SortNestedAssociationByFkCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Project::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setDefaultSort(['name' => 'ASC']);
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield TextField::new('name');
+        yield AssociationField::new('latestRelease.category');
+    }
+}

--- a/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/SortNestedAssociationCrudController.php
+++ b/tests/Functional/Apps/DefaultApp/src/Controller/Synthetic/SortNestedAssociationCrudController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic;
+
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Entity\ProjectDomain\Project;
+
+/**
+ * CRUD controller for testing an AssociationField whose property is a nested
+ * association path ending at an association ('latestRelease.category'). The field
+ * defines setSortProperty('name'), so sorting orders by the related category's name.
+ * It doesn't call setCrudController(): the cell must auto-link to the CRUD controller
+ * of the entity at the end of the path (ProjectReleaseCategory).
+ *
+ * @extends AbstractCrudController<Project>
+ */
+class SortNestedAssociationCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return Project::class;
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return parent::configureCrud($crud)
+            ->setDefaultSort(['name' => 'ASC']);
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        yield TextField::new('name');
+        yield AssociationField::new('latestRelease.category')
+            ->setSortProperty('name');
+    }
+}

--- a/tests/Functional/Default/Sort/SortByNestedAssociationFieldFkTest.php
+++ b/tests/Functional/Default/Sort/SortByNestedAssociationFieldFkTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Default\Sort;
+
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic\SortNestedAssociationByFkCrudController;
+
+/**
+ * Tests an AssociationField whose property is a nested association path ending at an
+ * association ('latestRelease.category') WITHOUT setSortProperty(): sorting via
+ * ?sort[latestRelease.category] orders by the foreign key of the leaf association
+ * (the category id), mirroring how single-level associations are sorted.
+ *
+ * From fixtures, categories are inserted in this order (so their ids are increasing):
+ * "Major" (used by Alpha Project), "Minor" (Beta Project), "Major" (Gamma Project);
+ * "Delta Project" has no release, so its category is NULL.
+ */
+class SortByNestedAssociationFieldFkTest extends AbstractCrudTestCase
+{
+    protected function getControllerFqcn(): string
+    {
+        return SortNestedAssociationByFkCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+    }
+
+    /**
+     * @dataProvider provideSortTests
+     *
+     * @param list<string> $expectedProjectNames
+     */
+    public function testSorting(array $query, array $expectedProjectNames): void
+    {
+        $this->client->request('GET', $this->generateIndexUrl().'?'.http_build_query($query));
+
+        $this->assertResponseIsSuccessful();
+        foreach ($expectedProjectNames as $index => $expectedProjectName) {
+            $row = $index + 1;
+            $this->assertSelectorTextSame(
+                sprintf('tbody tr:nth-child(%d) td[data-column="name"]', $row),
+                $expectedProjectName,
+                sprintf('Expected "%s" in row %d', $expectedProjectName, $row)
+            );
+        }
+    }
+
+    public static function provideSortTests(): iterable
+    {
+        // SQLite sorts NULL values first in ASC order and last in DESC order
+
+        yield 'sort by nested association ASC orders by category id' => [
+            ['sort' => ['latestRelease.category' => 'ASC']],
+            ['Delta Project', 'Alpha Project', 'Beta Project', 'Gamma Project'],
+        ];
+
+        yield 'sort by nested association DESC orders by category id' => [
+            ['sort' => ['latestRelease.category' => 'DESC']],
+            ['Gamma Project', 'Beta Project', 'Alpha Project', 'Delta Project'],
+        ];
+    }
+}

--- a/tests/Functional/Default/Sort/SortByNestedAssociationFieldTest.php
+++ b/tests/Functional/Default/Sort/SortByNestedAssociationFieldTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Default\Sort;
+
+use EasyCorp\Bundle\EasyAdminBundle\Test\AbstractCrudTestCase;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\DashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\ProjectDomain\ProjectReleaseCategoryCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Functional\Apps\DefaultApp\Controller\Synthetic\SortNestedAssociationCrudController;
+
+/**
+ * Tests an AssociationField whose property is a nested association path ending at an
+ * association ('latestRelease.category') with setSortProperty('name'), so sorting via
+ * ?sort[latestRelease.category] orders by the related category's name.
+ *
+ * From fixtures, the Project entities and their release categories:
+ * 1. "Alpha Project" → latestRelease=v1.0 → category.name="Major"
+ * 2. "Beta Project"  → latestRelease=v1.1 → category.name="Minor"
+ * 3. "Gamma Project" → latestRelease=v2.0 → category.name="Major"
+ * 4. "Delta Project" → latestRelease=null  (no release)
+ */
+class SortByNestedAssociationFieldTest extends AbstractCrudTestCase
+{
+    protected function getControllerFqcn(): string
+    {
+        return SortNestedAssociationCrudController::class;
+    }
+
+    protected function getDashboardFqcn(): string
+    {
+        return DashboardController::class;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->client->followRedirects();
+    }
+
+    public function testNestedAssociationColumnIsSortableByDefault(): void
+    {
+        // the controller never calls setSortable(): nested association paths ending at a
+        // single-valued association are sortable by default, like single-level associations
+        $this->client->request('GET', $this->generateIndexUrl());
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('th[data-column="latestRelease.category"] > a', 'The nested association column must render a sort link');
+    }
+
+    public function testNestedAssociationCellAutoLinksToLeafEntityCrudController(): void
+    {
+        // the field doesn't call setCrudController(): the cell must link to the CRUD
+        // controller of the entity at the end of the path (ProjectReleaseCategory)
+        $crawler = $this->client->request('GET', $this->generateIndexUrl());
+
+        $this->assertResponseIsSuccessful();
+
+        $hrefs = $crawler
+            ->filter('tbody td[data-column="latestRelease.category"] a')
+            ->each(static fn ($node): string => $node->attr('href'));
+
+        self::assertCount(3, $hrefs, 'The three projects with a release must link their category');
+
+        // depending on the URL format, the target controller appears as a query parameter
+        // (crudControllerFqcn=...) or as the URL path of its pretty route
+        foreach ($hrefs as $href) {
+            self::assertTrue(
+                str_contains($href, rawurlencode(ProjectReleaseCategoryCrudController::class)) || str_contains($href, 'project-release-category'),
+                sprintf('Expected href "%s" to target the ProjectReleaseCategory CRUD controller', $href)
+            );
+        }
+    }
+
+    /**
+     * @dataProvider provideSortTests
+     *
+     * @param list<string> $expectedProjectNames
+     */
+    public function testSorting(array $query, array $expectedProjectNames): void
+    {
+        $this->client->request('GET', $this->generateIndexUrl().'?'.http_build_query($query));
+
+        $this->assertResponseIsSuccessful();
+        foreach ($expectedProjectNames as $index => $expectedProjectName) {
+            $row = $index + 1;
+            $this->assertSelectorTextSame(
+                sprintf('tbody tr:nth-child(%d) td[data-column="name"]', $row),
+                $expectedProjectName,
+                sprintf('Expected "%s" in row %d', $expectedProjectName, $row)
+            );
+        }
+    }
+
+    public static function provideSortTests(): iterable
+    {
+        // SQLite sorts NULL values first in ASC order and last in DESC order;
+        // the secondary sort by project name makes the "Major" tie deterministic
+
+        yield 'sort by nested association ASC orders by category name' => [
+            ['sort' => ['latestRelease.category' => 'ASC', 'name' => 'ASC']],
+            ['Delta Project', 'Alpha Project', 'Gamma Project', 'Beta Project'],
+        ];
+
+        yield 'sort by nested association DESC orders by category name' => [
+            ['sort' => ['latestRelease.category' => 'DESC', 'name' => 'DESC']],
+            ['Beta Project', 'Gamma Project', 'Alpha Project', 'Delta Project'],
+        ];
+    }
+}

--- a/tests/Unit/Field/Configurator/CommonPreConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/CommonPreConfiguratorTest.php
@@ -2,8 +2,11 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Configurator;
 
+use Doctrine\ORM\Mapping\ClassMetadata;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Orm\NestedAssociationResolverInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\ResolvedPropertyDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\EntityFactory;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\CommonPreConfigurator;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
@@ -38,5 +41,58 @@ class CommonPreConfiguratorTest extends AbstractFieldTest
         $field = Field::new('foo')->setFormattedValue('bar');
 
         $this->assertSame('bar', $this->configure($field)->getFormattedValue());
+    }
+
+    public function testNestedPropertyEndingInSingleValuedAssociationIsSortableByDefault(): void
+    {
+        // e.g. AssociationField::new('customer.country') where 'country' is a to-one
+        // association: sortable by default, like single-level association fields
+        $this->configurator = $this->createConfiguratorForAssociationLeaf(isSingleValuedLeaf: true);
+
+        $field = Field::new('customer.country');
+
+        $this->assertTrue($this->configure($field)->isSortable());
+    }
+
+    public function testNestedPropertyEndingInToManyAssociationIsNotSortableByDefault(): void
+    {
+        $this->configurator = $this->createConfiguratorForAssociationLeaf(isSingleValuedLeaf: false);
+
+        $field = Field::new('customer.orders');
+
+        $this->assertFalse($this->configure($field)->isSortable());
+    }
+
+    /**
+     * Creates the configurator with a resolver stub that behaves like the real one does
+     * for a nested path ending at an association: the default resolve call (which requires
+     * the leaf to be a field) throws, and the resolve call allowing an association leaf
+     * returns the leaf's parent entity, whose metadata tells whether the leaf is single-valued.
+     */
+    private function createConfiguratorForAssociationLeaf(bool $isSingleValuedLeaf): CommonPreConfigurator
+    {
+        $associationResolver = $this->createMock(NestedAssociationResolverInterface::class);
+        $associationResolver->method('resolveNestedAssociations')->willReturnCallback(
+            function ($queryBuilder, EntityDto $entityDto, string $propertyName, bool $mustEndWithAssociation = false) use ($isSingleValuedLeaf): ResolvedPropertyDto {
+                if (!$mustEndWithAssociation) {
+                    throw new \InvalidArgumentException(sprintf('The "%s" property ends with an association.', $propertyName));
+                }
+
+                $leafName = substr($propertyName, strrpos($propertyName, '.') + 1);
+                $classMetadata = $this->createMock(ClassMetadata::class);
+                $classMetadata->method('isSingleValuedAssociation')->with($leafName)->willReturn($isSingleValuedLeaf);
+
+                return new ResolvedPropertyDto(new EntityDto('App\Entity\Customer', $classMetadata), null, $leafName);
+            }
+        );
+
+        $container = self::$kernel->getContainer()->get('test.service_container');
+
+        return new CommonPreConfigurator(
+            $container->get(PropertyAccessorInterface::class),
+            $container->get(EntityFactory::class),
+            $container->get(EntityTranslationIdGeneratorInterface::class),
+            $associationResolver,
+        );
     }
 }

--- a/tests/Unit/Orm/EntityRepositoryTest.php
+++ b/tests/Unit/Orm/EntityRepositoryTest.php
@@ -14,6 +14,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInter
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\SearchDto;
 use EasyCorp\Bundle\EasyAdminBundle\Factory\FormFactory;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Orm\EntityRepository;
 use PHPUnit\Framework\TestCase;
@@ -413,6 +414,134 @@ class EntityRepositoryTest extends TestCase
         self::assertSame([['entity.customer', 'ASC'], ['customer.name', 'DESC']], $orderClauses);
     }
 
+    public function testDefaultSortByNestedAssociationLeafOrdersByItsForeignKey(): void
+    {
+        // setDefaultSort(['customer.country' => 'ASC']) where 'country' is itself an
+        // association: with no setSortProperty(), the query orders by the leaf association
+        // on its already-joined parent (i.e. its foreign key), mirroring how single-level
+        // associations are ordered by 'entity.assoc'
+        $customerEntityDto = $this->createEntityDto([], ['country' => 'App\Entity\Country'], 'App\Entity\Customer');
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
+        $searchDto = $this->createSearchDtoForSort(defaultSort: ['customer.country' => 'ASC']);
+
+        $this->entityFactory->method('create')->willReturn($customerEntityDto);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->method('getRootAliases')->willReturn(['entity']);
+        $queryBuilder->expects($this->once())
+            ->method('leftJoin')
+            ->with('entity.customer', 'customer')
+            ->willReturnSelf();
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('customer.country', 'ASC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, new FieldCollection([]), new FilterCollection());
+    }
+
+    public function testDefaultSortByNestedAssociationLeafWithSortPropertyOrdersByThatProperty(): void
+    {
+        // AssociationField::new('customer.country')->setSortProperty('name') sorts by
+        // the 'name' property of the related Country entity: the leaf association is
+        // also joined and the ORDER BY targets its resolved alias
+        $countryEntityDto = $this->createEntityDto(['name' => ['type' => 'string']], [], 'App\Entity\Country');
+        $customerEntityDto = $this->createEntityDto([], ['country' => 'App\Entity\Country'], 'App\Entity\Customer');
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
+        $field = AssociationField::new('customer.country')->setSortProperty('name');
+        $searchDto = $this->createSearchDtoForSort(defaultSort: ['customer.country' => 'ASC']);
+
+        $this->entityFactory->method('create')->willReturnCallback(static fn (string $fqcn): EntityDto => match ($fqcn) {
+            'App\Entity\Customer' => $customerEntityDto,
+            'App\Entity\Country' => $countryEntityDto,
+        });
+
+        $joins = [];
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->method('getRootAliases')->willReturn(['entity']);
+        $queryBuilder->method('leftJoin')->willReturnCallback(static function (string $join, string $alias) use (&$joins, $queryBuilder) {
+            $joins[] = [$join, $alias];
+
+            return $queryBuilder;
+        });
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('country1.name', 'ASC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, new FieldCollection([$field]), new FilterCollection());
+
+        self::assertSame([['entity.customer', 'customer'], ['customer.country', 'country1']], $joins);
+    }
+
+    public function testCustomSortByExposedSortableNestedAssociationLeafIsApplied(): void
+    {
+        // ?sort[customer.country]=DESC is valid when every segment is a real Doctrine
+        // association, the leaf is single-valued and the property is exposed as a sortable field
+        $customerEntityDto = $this->createEntityDto([], ['country' => 'App\Entity\Country'], 'App\Entity\Customer');
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
+        $fields = new FieldCollection([$this->createField('customer.country', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['customer.country' => 'DESC']);
+
+        $this->entityFactory->method('create')->willReturn($customerEntityDto);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->method('getRootAliases')->willReturn(['entity']);
+        $queryBuilder->expects($this->once())
+            ->method('leftJoin')
+            ->with('entity.customer', 'customer')
+            ->willReturnSelf();
+        $queryBuilder->expects($this->once())
+            ->method('addOrderBy')
+            ->with('customer.country', 'DESC');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
+    public function testCustomSortByNestedAssociationLeafNotExposedAsFieldIsIgnored(): void
+    {
+        // URL sort remains opt-in: the nested association path maps to real Doctrine
+        // metadata, but the property is not exposed as a field of the INDEX page
+        $customerEntityDto = $this->createEntityDto([], ['country' => 'App\Entity\Country'], 'App\Entity\Customer');
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['customer.country' => 'ASC']);
+
+        $this->entityFactory->method('create')->willReturn($customerEntityDto);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->never())->method('addOrderBy');
+        $queryBuilder->expects($this->never())->method('leftJoin');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, new FieldCollection([]), new FilterCollection());
+    }
+
+    public function testCustomSortByNestedToManyAssociationLeafIsIgnored(): void
+    {
+        // ?sort[customer.orders]=ASC where 'orders' is a to-many association: sorting by
+        // a collection foreign key is undefined, so the key is rejected even though the
+        // field is exposed as sortable
+        $customerEntityDto = $this->createEntityDto([], ['orders' => 'App\Entity\Order'], 'App\Entity\Customer', ['orders']);
+        $entityDto = $this->createEntityDto([], ['customer' => 'App\Entity\Customer']);
+        $fields = new FieldCollection([$this->createField('customer.orders', true)]);
+        $searchDto = $this->createSearchDtoForSort(customSort: ['customer.orders' => 'ASC']);
+
+        $this->entityFactory->method('create')->willReturn($customerEntityDto);
+
+        $queryBuilder = $this->createSortingQueryBuilder();
+        $queryBuilder->expects($this->never())->method('addOrderBy');
+        $queryBuilder->expects($this->never())->method('leftJoin');
+
+        $this->stubEntityManager($queryBuilder);
+
+        $this->entityRepository->createQueryBuilder($searchDto, $entityDto, $fields, new FilterCollection());
+    }
+
     public function testCustomSortWithNonAscDescValueIsIgnored(): void
     {
         // ?sort[displayedField]=ASC,%20entity.hiddenField%20DESC — Expr\OrderBy
@@ -672,12 +801,13 @@ class EntityRepositoryTest extends TestCase
         return new SearchDto(new Request(), null, '', $defaultSort, $customSort, []);
     }
 
-    private function createEntityDto(array $mappedFields = [], array $mappedAssociations = [], string $fqcn = 'App\Entity\Product'): EntityDto
+    private function createEntityDto(array $mappedFields = [], array $mappedAssociations = [], string $fqcn = 'App\Entity\Product', array $collectionAssociations = []): EntityDto
     {
         $metadata = $this->createMock(ClassMetadata::class);
         $metadata->method('getSingleIdentifierFieldName')->willReturn('id');
         $metadata->method('hasField')->willReturnCallback(static fn (string $name): bool => isset($mappedFields[$name]));
         $metadata->method('hasAssociation')->willReturnCallback(static fn (string $name): bool => isset($mappedAssociations[$name]));
+        $metadata->method('isSingleValuedAssociation')->willReturnCallback(static fn (string $name): bool => isset($mappedAssociations[$name]) && !\in_array($name, $collectionAssociations, true));
         $metadata->method('getFieldNames')->willReturn(array_keys($mappedFields));
         $metadata->method('getFieldMapping')->willReturnCallback(
             static fn (string $name): array => $mappedFields[$name] ?? throw new \InvalidArgumentException()


### PR DESCRIPTION
`AssociationField` already supports displaying nested association paths ending at an association (e.g. `AssociationField::new('customer.country')`), auto-linking the value to the CRUD controller of the entity at the end of the path. However, these fields couldn't be sorted: they weren't sortable by default (unlike single-level association fields), `?sort[customer.country]` was rejected, and `setDefaultSort(['customer.country' => 'ASC'])` threw an exception.

This PR makes such fields sortable, reusing the existing `resolveNestedAssociations()` code:

* **Sortable by default** when every segment of the path is a *to-one* association, matching the behavior of single-level association fields (to-many leaves are not sortable).
* **Sorting behavior** also mirrors single-level associations: by default results are ordered by the foreign key of the leaf association; use `setSortProperty()` to order by any property of the related entity:

```php
// sorts by the id of the related country
yield AssociationField::new('customer.country');

// sorts by the name of the related country
yield AssociationField::new('customer.country')->setSortProperty('name');
```