### PR TITLE
Fix NumericFilter with null values on money fields

### DIFF
--- a/src/Filter/NumericFilter.php
+++ b/src/Filter/NumericFilter.php
@@ -44,15 +44,21 @@ final class NumericFilter implements FilterInterface
         $value = $filterDataDto->getValue();
         $value2 = $filterDataDto->getValue2();
 
+        if (null === $value) {
+            $queryBuilder->andWhere(sprintf('%s.%s %s', $alias, $property, $comparison));
+
+            return;
+        }
+
         if (null !== $fieldDto && true === $fieldDto->getCustomOption(MoneyField::OPTION_STORED_AS_CENTS)) {
             $divisor = $fieldDto->getFormTypeOption('divisor') ?? MoneyConfigurator::DEFAULT_DIVISOR;
             $value *= $divisor;
-            $value2 *= $divisor;
+            if (null !== $value2) {
+                $value2 *= $divisor;
+            }
         }
 
-        if (null === $value) {
-            $queryBuilder->andWhere(sprintf('%s.%s %s', $alias, $property, $comparison));
-        } elseif (ComparisonType::BETWEEN === $comparison) {
+        if (ComparisonType::BETWEEN === $comparison) {
             $queryBuilder->andWhere(sprintf('%s.%s BETWEEN :%s and :%s', $alias, $property, $parameterName, $parameter2Name))
                 ->setParameter($parameterName, $value)
                 ->setParameter($parameter2Name, $value2);

--- a/tests/Unit/Filter/NumericFilterTest.php
+++ b/tests/Unit/Filter/NumericFilterTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Filter;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\QueryBuilder;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\FilterDataDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\MoneyField;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\NumericFilter;
+use PHPUnit\Framework\TestCase;
+
+class NumericFilterTest extends TestCase
+{
+    /**
+     * @dataProvider provideNullComparisons
+     */
+    public function testApplyNullComparisonWithMoneyFieldStoredAsCents(string $comparison): void
+    {
+        // when the value of a numeric filter is left empty, NumericFilterType
+        // transforms the comparison into 'IS NULL' / 'IS NOT NULL' and keeps the value as null;
+        // for money fields stored as cents, the value must not be multiplied by the divisor
+        // (null * divisor = 0), because that would generate an invalid DQL query
+        // such as 'entity.price IS NULL :price_0'
+        $queryBuilder = $this->createQueryBuilder();
+        $filterDataDto = $this->createFilterDataDto($comparison, null);
+        $fieldDto = MoneyField::new('price')->setCurrency('EUR')->getAsDto();
+
+        NumericFilter::new('price')->apply($queryBuilder, $filterDataDto, $fieldDto, $this->createEntityDto());
+
+        $this->assertSame(sprintf('entity.price %s', $comparison), (string) $queryBuilder->getDQLPart('where'));
+        $this->assertCount(0, $queryBuilder->getParameters());
+    }
+
+    public static function provideNullComparisons(): iterable
+    {
+        yield ['IS NULL'];
+        yield ['IS NOT NULL'];
+    }
+
+    public function testApplyWithMoneyFieldStoredAsCentsMultipliesValueByDivisor(): void
+    {
+        $queryBuilder = $this->createQueryBuilder();
+        $filterDataDto = $this->createFilterDataDto('=', 15.5);
+        $fieldDto = MoneyField::new('price')->setCurrency('EUR')->getAsDto();
+
+        NumericFilter::new('price')->apply($queryBuilder, $filterDataDto, $fieldDto, $this->createEntityDto());
+
+        $parameters = $queryBuilder->getParameters();
+        $this->assertCount(1, $parameters);
+        $this->assertSame(1550.0, $parameters->first()->getValue());
+    }
+
+    private function createQueryBuilder(): QueryBuilder
+    {
+        return new QueryBuilder($this->createMock(EntityManagerInterface::class));
+    }
+
+    private function createFilterDataDto(string $comparison, mixed $value): FilterDataDto
+    {
+        $filterDto = NumericFilter::new('price')->getAsDto();
+
+        return FilterDataDto::new(0, $filterDto, 'entity', [
+            'comparison' => $comparison,
+            'value' => $value,
+        ]);
+    }
+
+    private function createEntityDto(): EntityDto
+    {
+        return new EntityDto(\stdClass::class, new ClassMetadata(\stdClass::class));
+    }
+}


### PR DESCRIPTION
The list page crashes when a numeric filter is applied with an empty value to a `MoneyField` stored as cents.

**How to reproduce:**

1. Add a `NumericFilter` for a property displayed as `MoneyField` with `storedAsCents` enabled (the default)
2. Apply the filter with the "is equal to" comparison and leave the value empty

When the value is empty, `NumericFilterType` turns the comparison into `IS NULL` and keeps the value as `null`. But in `NumericFilter::apply()`, the divisor block runs before the null check, so `null * $divisor` turns the value into `0`. The null branch is then skipped and the generated DQL is invalid (an `IS NULL` condition with a bound parameter):

`entity.price IS NULL :price_0`

#7469 fixed the null handling for regular numeric properties, but for money fields stored as cents the divisor multiplication still happens before the null check, so the bug remains there.

This PR handles the `null` value before applying the divisor. It also avoids multiplying `$value2` when it's `null`, so it doesn't silently become `0`.

Tests included: filtering a money field with `IS NULL` / `IS NOT NULL` now produces the condition without bound parameters, and non-null values are still multiplied by the divisor.