### PR TITLE
Add generic return type to AbstractCrudController::getContext()

### DIFF
--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -704,6 +704,9 @@ abstract class AbstractCrudController extends AbstractController implements Crud
         return $responseParameters;
     }
 
+    /**
+     * @return AdminContext<TEntity>|null
+     */
     protected function getContext(): ?AdminContext
     {
         return $this->container->get(AdminContextProviderInterface::class)->getContext();


### PR DESCRIPTION
EasyAdmin 5 made the CRUD stack generic: `AbstractCrudController` declares `@template TEntity of object`, all action methods are annotated with `@param AdminContext<TEntity> $context`, and the chain continues through `AdminContextInterface<TEntity>::getEntity(): EntityDto<TEntity>` down to `EntityDto::getInstance(): TEntity|null`.

One link is missing: `getContext()` has no `@return` annotation, so the generic type is lost right at the start of the chain:

```php
/** @extends AbstractCrudController<Product> */
final class ProductCrudController extends AbstractCrudController
{
    public function someAction(): void
    {
        $product = $this->getContext()?->getEntity()->getInstance();
        // PHPStan infers object|null, expected Product|null
    }
}
```

This forces consumers to keep manual `/** @var Product|null */` annotations, although the point of the 5.0 generics (see the "Static Analysis" section in UPGRADE.md) is to remove them.

This PR adds the missing `@return AdminContext<TEntity>|null` annotation, matching the existing `@param AdminContext<TEntity>` annotations of the action methods. With it, PHPStan infers `Product|null` in the example above.

Docblock-only change, no runtime impact.