### PR TITLE
Make `createEntity` return nullable entity type

### DIFF
--- a/src/Contracts/Controller/CrudControllerInterface.php
+++ b/src/Contracts/Controller/CrudControllerInterface.php
@@ -87,9 +87,9 @@ interface CrudControllerInterface
     /**
      * @param class-string<TEntity> $entityFqcn
      *
-     * @phpstan-return TEntity
+     * @phpstan-return ?TEntity
      */
-    public function createEntity(string $entityFqcn): object;
+    public function createEntity(string $entityFqcn): ?object;
 
     /**
      * @param TEntity $entityInstance

--- a/src/Controller/AbstractCrudController.php
+++ b/src/Controller/AbstractCrudController.php
@@ -626,9 +626,9 @@ abstract class AbstractCrudController extends AbstractController implements Crud
     /**
      * @param class-string<TEntity> $entityFqcn
      *
-     * @phpstan-return TEntity
+     * @phpstan-return ?TEntity
      */
-    public function createEntity(string $entityFqcn): object
+    public function createEntity(string $entityFqcn): ?object
     {
         return new $entityFqcn();
     }


### PR DESCRIPTION
Allow users to use [empty_data callable](https://symfony.com/doc/current/form/use_empty_data.html#option-2-provide-a-closure) for form types. [EntityDTO](https://github.com/EasyCorp/EasyAdminBundle/blob/5.x/src/Dto/EntityDto.php#L156) also allows `null` as a value for new instance. 

Before [this commit](https://github.com/EasyCorp/EasyAdminBundle/commit/e5bab01571dfa7f4b2f7fbf61531ba049232a8c7#diff-64a0084d3e12a7fc0b73dc074a001eb3970ed450883df5fa3f3b640a087f63d1R61-R74) we could return `null` from `createEntity`, and let Symfony handle the rest and have strict static analysis.

Full example shown in issue #6957 .