### PR TITLE
[5.x] Fix param leak in AdminUrlGenerator::generateUrl

### DIFF
--- a/src/Router/AdminUrlGenerator.php
+++ b/src/Router/AdminUrlGenerator.php
@@ -156,6 +156,17 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
 
     public function generateUrl(): string
     {
+        try {
+            return $this->doGenerateUrl();
+        } finally {
+            // this is important to start the generation of each URL from the same initial state
+            // otherwise, some parameters used when generating some URL could leak to other URLs
+            $this->isInitialized = false;
+        }
+    }
+
+    private function doGenerateUrl(): string
+    {
         if (false === $this->isInitialized) {
             $this->initialize();
         }
@@ -239,13 +250,8 @@ final class AdminUrlGenerator implements \Stringable, AdminUrlGeneratorInterface
         }
 
         $url = $this->urlGenerator->generate($routeName, $canonicalRouteParameters, $urlType);
-        $url = '' === $url ? '?' : $url;
 
-        // this is important to start the generation of each URL from the same initial state
-        // otherwise, some parameters used when generating some URL could leak to other URLs
-        $this->isInitialized = false;
-
-        return $url;
+        return '' === $url ? '?' : $url;
     }
 
     private function setRouteParameter(string $parameterName, mixed $parameterValue): void

--- a/tests/Unit/Router/AdminUrlGeneratorTest.php
+++ b/tests/Unit/Router/AdminUrlGeneratorTest.php
@@ -112,6 +112,20 @@ class AdminUrlGeneratorTest extends KernelTestCase
         $this->assertNull($adminUrlGenerator->get('sort'));
     }
 
+    public function testRouteParametersDontLeakToNextUrl(): void
+    {
+        $adminUrlGenerator = $this->getAdminUrlGenerator();
+
+        // generating a URL for a custom route (the linkToRoute() code path) must reset the
+        // internal state so its parameters don't leak into the next URL generated in the
+        // same request; otherwise the following CRUD URLs lose their filters/page/sort
+        $adminUrlGenerator->setRoute('some_route', ['key' => 'value']);
+        $adminUrlGenerator->generateUrl();
+
+        $this->assertSame('http://localhost/admin?foo=bar', $adminUrlGenerator->generateUrl());
+        $this->assertNull($adminUrlGenerator->get(EA::ROUTE_NAME));
+    }
+
     public function testExplicitDashboardController(): void
     {
         $adminUrlGenerator = $this->getAdminUrlGenerator();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | Fix #7734
| License       | MIT

`AdminUrlGenerator::generateUrl()` ends with a state reset whose own comment
states it is *"important to start the generation of each URL from the same
initial state, otherwise some parameters used when generating some URL could
leak to other URLs"*. But three earlier `return` statements — the empty-route
dashboard link and both `EA::ROUTE_NAME` branches (the `linkToRoute()` path) —
returned **before** that reset ever ran.

As a result, once a URL was generated through the `linkToRoute()` path, the
generator stayed initialized with `routeName`/`routeParams` still set. The next
URL generated in the same request (e.g. a `linkToCrudAction()` global action)
re-entered the `ROUTE_NAME` branch and lost its `filters`/`page`/`sort`/`query`
parameters — even though every other link on the page kept them.

The fix moves the reset into a `finally` block so it runs on every return path
(and on exceptions), which is exactly the "same initial state" guarantee the
existing comment promised.

## Test verification (RED → GREEN)

New test `AdminUrlGeneratorTest::testRouteParametersDontLeakToNextUrl` generates
a custom-route URL and then asserts the following URL is clean.

RED — on `5.x` with only the test applied (before the fix):

```
1) EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\AdminUrlGeneratorTest::testRouteParametersDontLeakToNextUrl
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'http://localhost/admin?foo=bar'
+'http://localhost/admin?routeName=some_route&routeParams%5Bkey%5D=value'

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

GREEN — with the fix applied, whole test class:

```
Testing EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Router\AdminUrlGeneratorTest
..................                                                18 / 18 (100%)

OK (18 tests, 35 assertions)
```

`phpstan analyse src/Router/AdminUrlGenerator.php` and `php-cs-fixer` (dry-run)
both report no issues on the changed files.
