### PR TITLE
Improve enum type class retrieval logic

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -47,9 +47,14 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         }, $choices));
         $allChoicesAreEnums = false === \in_array(false, $elementIsEnum, true);
 
+        // determine the enum type class from the form type option first,
+        // falling back to the Doctrine metadata when necessary (Doctrine supports only BackedEnum as enumType)
+        $enumTypeClass = enum_exists((string) $field->getFormTypeOption('class'))
+            ? $field->getFormTypeOption('class')
+            : $field->getDoctrineMetadata()->get('enumType');
+
         // if no choices are passed to the field, check if it's related to an Enum;
-        // in that case, get all the possible values of the Enum (Doctrine supports only BackedEnum as enumType)
-        $enumTypeClass = $field->getDoctrineMetadata()->get('enumType');
+        // in that case, get all the possible values of the Enum
         if (0 === \count($choices) && null !== $enumTypeClass && enum_exists($enumTypeClass)) {
             $choices = $enumTypeClass::cases();
             $allChoicesAreEnums = true;


### PR DESCRIPTION
I have a case where I am fetching a non mapped field returning enum.
Because the field is not mapped, enum type can't be retrieved from doctrine.
In that case I have explicitly specified the [`class` option](https://symfony.com/doc/current/reference/forms/types/enum.html#class) of the form type using `->setFormTypeOption('class', Role::class)`.

But unfortunately, this option is not supported at the moment. This PR fixes that issue.

I have a case where a non-mapped field returns an enum.

Because the field is not mapped, its enum type cannot be retrieved from Doctrine metadata. In this case, I explicitly specify the [class](https://symfony.com/doc/current/reference/forms/types/enum.html#class) option of the form type using:
```php
->setFormTypeOption('class', Role::class)
```
However, this option is currently not taken into account when determining the enum type.

This PR fixes the issue by also using the form type's class option to determine the enum type, falling back to Doctrine metadata when necessary.