### PR TITLE
fix: 7787

### DIFF
--- a/src/Field/Configurator/ChoiceConfigurator.php
+++ b/src/Field/Configurator/ChoiceConfigurator.php
@@ -49,6 +49,13 @@ final class ChoiceConfigurator implements FieldConfiguratorInterface
         // if no choices are passed to the field, check if it's related to an Enum;
         // in that case, get all the possible values of the Enum (Doctrine supports only BackedEnum as enumType)
         $enumTypeClass = $field->getDoctrineMetadata()->get('enumType');
+        // only infer the enum class when choices are a plain list of cases; if the user
+        // passed explicit labels (e.g. ['Foo' => Bar::Foo]), those labels must be kept
+        // instead of enabling the enum-based labeling below
+        if (null === $enumTypeClass && $allChoicesAreEnums && \count($choices) >= 1 && array_is_list($choices)) {
+            $enumTypeClass = \get_class($choices[array_key_first($choices)]);
+        }
+
         if (0 === \count($choices) && null !== $enumTypeClass && enum_exists($enumTypeClass)) {
             $choices = $enumTypeClass::cases();
             $allChoicesAreEnums = true;

--- a/tests/Unit/Field/Configurator/ChoiceConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/ChoiceConfiguratorTest.php
@@ -83,6 +83,35 @@ class ChoiceConfiguratorTest extends AbstractFieldTest
         $this->assertTrue(array_is_list($formChoices));
     }
 
+    public function testTranslatableBackedEnumChoices(): void
+    {
+        $field = ChoiceField::new(self::PROPERTY_NAME);
+        $field->setCustomOptions(['choices' => TranslatableStatusBackedEnum::cases()]);
+
+        // enums implementing TranslatableInterface must be passed to the form as a plain
+        // list of cases (not an array keyed by case name) so Symfony's EnumType uses its
+        // own translatable labeling instead of the case names as labels (see issue #7242).
+        $formChoices = $this->configure($field)->getFormTypeOption('choices');
+
+        $this->assertSame(TranslatableStatusBackedEnum::cases(), $formChoices);
+        $this->assertTrue(array_is_list($formChoices));
+    }
+
+    public function testTranslatableBackedEnumChoicesLabeled(): void
+    {
+        // when the user passes explicit labels for translatable enum cases, those labels
+        // must be kept as-is instead of applying the enum's own translatable labeling
+        $choices = [
+            'Draft label' => TranslatableStatusBackedEnum::Draft,
+            'Published label' => TranslatableStatusBackedEnum::Published,
+        ];
+
+        $field = ChoiceField::new(self::PROPERTY_NAME);
+        $field->setCustomOptions(['choices' => $choices]);
+
+        $this->assertSame($choices, $this->configure($field)->getFormTypeOption('choices'));
+    }
+
     public function testUnitEnumTypeChoices(): void
     {
         $field = ChoiceField::new(self::PROPERTY_NAME);


### PR DESCRIPTION
if enum class could not be resolved but it's already established that all choices are Enums, just grab the first one and get its class

Edit: targeting 4.x since it's a bugfix imo

Fixes #7787
