### PR TITLE
Fix empty data for non-nullable text fields

### DIFF
--- a/src/Field/Configurator/TextConfigurator.php
+++ b/src/Field/Configurator/TextConfigurator.php
@@ -2,6 +2,7 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\Field\Configurator;
 
+use Doctrine\DBAL\Types\Types;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
@@ -23,6 +24,14 @@ final class TextConfigurator implements FieldConfiguratorInterface
 
     public function configure(FieldDto $field, EntityDto $entityDto, AdminContext $context): void
     {
+        $doctrineMetadata = $field->getDoctrineMetadata();
+        if (
+            false === $doctrineMetadata->get('nullable')
+            && \in_array($doctrineMetadata->get('type'), [Types::STRING, Types::TEXT], true)
+        ) {
+            $field->setFormTypeOptionIfNotSet('empty_data', '');
+        }
+
         if (TextareaField::class === $field->getFieldFqcn()) {
             $field->setFormTypeOptionIfNotSet('attr.rows', $field->getCustomOption(TextareaField::OPTION_NUM_OF_ROWS));
             $field->setFormTypeOptionIfNotSet('attr.data-ea-textarea-field', true);

--- a/tests/Unit/Field/Configurator/TextConfiguratorTest.php
+++ b/tests/Unit/Field/Configurator/TextConfiguratorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\Configurator;
+
+use Doctrine\DBAL\Types\Types;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Configurator\TextConfigurator;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Tests\Unit\Field\AbstractFieldTest;
+
+class TextConfiguratorTest extends AbstractFieldTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configurator = new TextConfigurator();
+    }
+
+    /**
+     * @dataProvider provideNonNullableDoctrineTextFields
+     */
+    public function testNonNullableDoctrineTextFieldsUseEmptyStringAsEmptyData(FieldInterface $field, string $doctrineType): void
+    {
+        $field->getAsDto()->setDoctrineMetadata(['type' => $doctrineType, 'nullable' => false]);
+
+        $fieldDto = $this->configure($field);
+
+        self::assertSame('', $fieldDto->getFormTypeOption('empty_data'));
+    }
+
+    public static function provideNonNullableDoctrineTextFields(): iterable
+    {
+        yield 'string TextField' => [TextField::new('name'), Types::STRING];
+        yield 'text TextareaField' => [TextareaField::new('description'), Types::TEXT];
+    }
+
+    public function testNullableDoctrineTextFieldKeepsDefaultEmptyData(): void
+    {
+        $field = TextField::new('name');
+        $field->getAsDto()->setDoctrineMetadata(['type' => Types::STRING, 'nullable' => true]);
+
+        $fieldDto = $this->configure($field);
+
+        self::assertNull($fieldDto->getFormTypeOption('empty_data'));
+    }
+
+    public function testExplicitEmptyDataOptionIsPreserved(): void
+    {
+        $emptyData = static fn (): null => null;
+        $field = TextField::new('name')->setFormTypeOption('empty_data', $emptyData);
+        $field->getAsDto()->setDoctrineMetadata(['type' => Types::STRING, 'nullable' => false]);
+
+        $fieldDto = $this->configure($field);
+
+        self::assertSame($emptyData, $fieldDto->getFormTypeOption('empty_data'));
+    }
+}


### PR DESCRIPTION
Fixes #7797.

## Summary

- set `empty_data` to an empty string for non-nullable Doctrine `string` and `text` fields configured as `TextField` or `TextareaField`
- preserve an explicitly configured `empty_data` option
- keep nullable text fields unchanged
- cover both field types and the configuration boundaries with unit tests

This prevents Symfony Forms from passing `null` to strictly typed string setters when an empty value is submitted. It also allows server-side constraints such as `NotBlank` to be rendered as regular form errors.

## Related observation

EasyAdmin's client-side form handler currently prevents submission and adds `.has-error` for invalid HTML5 fields, but it doesn't call `reportValidity()`. As a result, the browser's native required-field message may not be displayed. This is related to how the original problem was discovered, but it is intentionally not changed in this PR so the two fixes remain separate.

## Tests

- `make tests ARGS="tests/Unit/Field/"` — 658 tests, 1,209 assertions
- full PHPUnit suite — 3,094 tests, 7,954 assertions
- PHPStan — no errors
- PHP CS Fixer dry run — no changes required

---

Thanks for taking the time to review this! — Codex, an AI coding agent from OpenAI 🤖
