### PR TITLE
Use modern way of loading the bundle's config by extending AbstractBu…

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -18,7 +18,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Contracts\Provider\AdminContextProviderInter
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Registry\AdminControllerRegistryInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Contracts\Translation\EntityTranslationIdGeneratorInterface;
 use EasyCorp\Bundle\EasyAdminBundle\DataCollector\EasyAdminDataCollector;
-use EasyCorp\Bundle\EasyAdminBundle\DependencyInjection\EasyAdminExtension;
+use EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\AdminRouterSubscriber;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\CrudResponseListener;
 use EasyCorp\Bundle\EasyAdminBundle\EventListener\ExceptionListener;
@@ -112,8 +112,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
 return static function (ContainerConfigurator $container) {
     $services = $container->services()
         ->defaults()->private()
-        ->instanceof(FieldConfiguratorInterface::class)->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR)
-        ->instanceof(FilterConfiguratorInterface::class)->tag(EasyAdminExtension::TAG_FILTER_CONFIGURATOR);
+        ->instanceof(FieldConfiguratorInterface::class)->tag(EasyAdminBundle::TAG_FIELD_CONFIGURATOR)
+        ->instanceof(FilterConfiguratorInterface::class)->tag(EasyAdminBundle::TAG_FILTER_CONFIGURATOR);
 
     $services
         ->set(MakeAdminDashboardCommand::class)->public()
@@ -235,10 +235,10 @@ return static function (ContainerConfigurator $container) {
             ->arg(0, service('cache.easyadmin'))
 
         ->set(AdminRouteGenerator::class)
-            ->arg(0, tagged_iterator(EasyAdminExtension::TAG_DASHBOARD_CONTROLLER))
-            ->arg(1, tagged_iterator(EasyAdminExtension::TAG_CRUD_CONTROLLER))
+            ->arg(0, tagged_iterator(EasyAdminBundle::TAG_DASHBOARD_CONTROLLER))
+            ->arg(1, tagged_iterator(EasyAdminBundle::TAG_CRUD_CONTROLLER))
             ->arg(2, service('cache.easyadmin'))
-            ->arg(3, tagged_iterator(EasyAdminExtension::TAG_ADMIN_ROUTE_CONTROLLER))
+            ->arg(3, tagged_iterator(EasyAdminBundle::TAG_ADMIN_ROUTE_CONTROLLER))
 
         ->set(AdminRouteLoader::class)
             ->arg(0, service(AdminRouteGenerator::class))
@@ -303,7 +303,7 @@ return static function (ContainerConfigurator $container) {
         ->set(FieldFactory::class)
             ->arg(0, service(AdminContextProvider::class))
             ->arg(1, service(AuthorizationChecker::class))
-            ->arg(2, tagged_iterator(EasyAdminExtension::TAG_FIELD_CONFIGURATOR))
+            ->arg(2, tagged_iterator(EasyAdminBundle::TAG_FIELD_CONFIGURATOR))
             ->arg(3, service(FormLayoutFactory::class))
 
         ->set(FieldProvider::class)
@@ -311,7 +311,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set(FilterFactory::class)
             ->arg(0, service(AdminContextProvider::class))
-            ->arg(1, tagged_iterator(EasyAdminExtension::TAG_FILTER_CONFIGURATOR))
+            ->arg(1, tagged_iterator(EasyAdminBundle::TAG_FILTER_CONFIGURATOR))
 
         ->set(FiltersFormType::class)
             ->tag('form.type', ['alias' => 'ea_filters'])
@@ -328,7 +328,7 @@ return static function (ContainerConfigurator $container) {
 
         ->set(CommonFilterConfigurator::class)
             ->arg(0, service(EntityTranslationIdGeneratorInterface::class))
-            ->tag(EasyAdminExtension::TAG_FILTER_CONFIGURATOR, ['priority' => 9999])
+            ->tag(EasyAdminBundle::TAG_FILTER_CONFIGURATOR, ['priority' => 9999])
 
         ->set(ComparisonFilterConfigurator::class)
 
@@ -359,7 +359,7 @@ return static function (ContainerConfigurator $container) {
             ->arg(1, new Reference(AuthorizationChecker::class))
             ->arg(2, new Reference(AdminUrlGenerator::class))
             ->arg(3, new Reference('security.csrf.token_manager', ContainerInterface::NULL_ON_INVALID_REFERENCE))
-            ->arg(4, tagged_iterator(EasyAdminExtension::TAG_ACTIONS_EXTENSION))
+            ->arg(4, tagged_iterator(EasyAdminBundle::TAG_ACTIONS_EXTENSION))
 
         ->set(SecurityVoter::class)
             ->arg(0, service(AuthorizationChecker::class))
@@ -397,14 +397,14 @@ return static function (ContainerConfigurator $container) {
         ->set(CommonPostConfigurator::class)
             ->arg(0, service(AdminContextProvider::class))
             ->arg(1, '%kernel.charset%')
-            ->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR, ['priority' => -9999])
+            ->tag(EasyAdminBundle::TAG_FIELD_CONFIGURATOR, ['priority' => -9999])
 
         ->set(CommonPreConfigurator::class)
             ->arg(0, new Reference('property_accessor'))
             ->arg(1, service(EntityFactory::class))
             ->arg(2, service(EntityTranslationIdGeneratorInterface::class))
             ->arg(3, service(EntityRepository::class))
-            ->tag(EasyAdminExtension::TAG_FIELD_CONFIGURATOR, ['priority' => 9999])
+            ->tag(EasyAdminBundle::TAG_FIELD_CONFIGURATOR, ['priority' => 9999])
 
         ->set(CountryConfigurator::class)
             ->arg(0, service('twig'))

--- a/src/DependencyInjection/EasyAdminExtension.php
+++ b/src/DependencyInjection/EasyAdminExtension.php
@@ -2,82 +2,19 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle\DependencyInjection;
 
-use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Action\ActionsExtensionInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
-use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\Extension\Extension;
-use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
-use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle;
 
 /**
  * @author Javier Eguiluz <javier.eguiluz@gmail.com>
+ *
+ * @deprecated since 5.5.1, use \EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle instead
  */
-class EasyAdminExtension extends Extension implements PrependExtensionInterface
+class EasyAdminExtension
 {
-    public const TAG_CRUD_CONTROLLER = 'ea.crud_controller';
-    public const TAG_DASHBOARD_CONTROLLER = 'ea.dashboard_controller';
-    public const TAG_ADMIN_ROUTE_CONTROLLER = 'ea.admin_route_controller';
-    public const TAG_FIELD_CONFIGURATOR = 'ea.field_configurator';
-    public const TAG_FILTER_CONFIGURATOR = 'ea.filter_configurator';
-    public const TAG_ACTIONS_EXTENSION = 'ea.actions_extension';
-
-    public function load(array $configs, ContainerBuilder $container): void
-    {
-        $container->registerAttributeForAutoconfiguration(AdminRoute::class,
-            // @phpstan-ignore-next-line argument.type The reflection subtypes specify where the attribute can be used
-            static function (Definition $definition, AdminRoute $attribute, \ReflectionClass|\ReflectionMethod $reflection): void {
-                $definition->addTag(self::TAG_ADMIN_ROUTE_CONTROLLER);
-            });
-
-        $container->registerForAutoconfiguration(DashboardControllerInterface::class)
-            ->addTag(self::TAG_DASHBOARD_CONTROLLER);
-
-        $container->registerForAutoconfiguration(CrudControllerInterface::class)
-            ->addTag(self::TAG_CRUD_CONTROLLER);
-
-        $container->registerForAutoconfiguration(FieldConfiguratorInterface::class)
-            ->addTag(self::TAG_FIELD_CONFIGURATOR);
-
-        $container->registerForAutoconfiguration(FilterConfiguratorInterface::class)
-            ->addTag(self::TAG_FILTER_CONFIGURATOR);
-
-        $container->registerForAutoconfiguration(ActionsExtensionInterface::class)
-            ->addTag(self::TAG_ACTIONS_EXTENSION);
-
-        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../config'));
-        $loader->load('services.php');
-    }
-
-    public function prepend(ContainerBuilder $builder): void
-    {
-        $builder->prependExtensionConfig('twig_component', [
-            'defaults' => [
-                'EasyCorp\\Bundle\\EasyAdminBundle\\Twig\\Component\\' => [
-                    'template_directory' => '@EasyAdmin/components/',
-                    'name_prefix' => 'ea',
-                ],
-            ],
-        ]);
-
-        /** @var string $projectDir */
-        $projectDir = $builder->getParameter('kernel.project_dir');
-
-        $bundleTemplatesOverrideDir = $projectDir.'/templates/bundles/EasyAdminBundle/';
-        $builder->prependExtensionConfig('twig', [
-            'paths' => is_dir($bundleTemplatesOverrideDir)
-                ? [
-                    'templates/bundles/EasyAdminBundle/' => 'ea',
-                    \dirname(__DIR__).'/../templates/' => 'ea',
-                ]
-                : [
-                    \dirname(__DIR__).'/../templates/' => 'ea',
-                ],
-        ]);
-    }
+    public const TAG_CRUD_CONTROLLER = EasyAdminBundle::TAG_CRUD_CONTROLLER;
+    public const TAG_DASHBOARD_CONTROLLER = EasyAdminBundle::TAG_DASHBOARD_CONTROLLER;
+    public const TAG_ADMIN_ROUTE_CONTROLLER = EasyAdminBundle::TAG_ADMIN_ROUTE_CONTROLLER;
+    public const TAG_FIELD_CONFIGURATOR = EasyAdminBundle::TAG_FIELD_CONFIGURATOR;
+    public const TAG_FILTER_CONFIGURATOR = EasyAdminBundle::TAG_FILTER_CONFIGURATOR;
+    public const TAG_ACTIONS_EXTENSION = EasyAdminBundle::TAG_ACTIONS_EXTENSION;
 }

--- a/src/EasyAdminBundle.php
+++ b/src/EasyAdminBundle.php
@@ -2,21 +2,83 @@
 
 namespace EasyCorp\Bundle\EasyAdminBundle;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Action\ActionsExtensionInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\CrudControllerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Controller\DashboardControllerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Field\FieldConfiguratorInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Contracts\Filter\FilterConfiguratorInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Bundle\AbstractBundle;
 
 /**
  * @author Maxime Steinhausser <maxime.steinhausser@gmail.com>
  */
-class EasyAdminBundle extends Bundle
+class EasyAdminBundle extends AbstractBundle
 {
     public const VERSION = '5.5.2-DEV';
+    public const TAG_CRUD_CONTROLLER = 'ea.crud_controller';
+    public const TAG_DASHBOARD_CONTROLLER = 'ea.dashboard_controller';
+    public const TAG_ADMIN_ROUTE_CONTROLLER = 'ea.admin_route_controller';
+    public const TAG_FIELD_CONFIGURATOR = 'ea.field_configurator';
+    public const TAG_FILTER_CONFIGURATOR = 'ea.filter_configurator';
+    public const TAG_ACTIONS_EXTENSION = 'ea.actions_extension';
 
-    public function getPath(): string
+    /**
+     * @phpstan-ignore missingType.iterableValue
+     */
+    public function loadExtension(array $config, ContainerConfigurator $configurator, ContainerBuilder $container): void
     {
-        $reflected = new \ReflectionObject($this);
-        /** @var non-empty-string $fileName */
-        $fileName = $reflected->getFileName();
+        $container->registerAttributeForAutoconfiguration(AdminRoute::class,
+            // @phpstan-ignore-next-line argument.type The reflection subtypes specify where the attribute can be used
+            static function (Definition $definition, AdminRoute $attribute, \ReflectionClass|\ReflectionMethod $reflection): void {
+                $definition->addTag(self::TAG_ADMIN_ROUTE_CONTROLLER);
+            });
 
-        return \dirname($fileName, 2);
+        $container->registerForAutoconfiguration(DashboardControllerInterface::class)
+            ->addTag(self::TAG_DASHBOARD_CONTROLLER);
+
+        $container->registerForAutoconfiguration(CrudControllerInterface::class)
+            ->addTag(self::TAG_CRUD_CONTROLLER);
+
+        $container->registerForAutoconfiguration(FieldConfiguratorInterface::class)
+            ->addTag(self::TAG_FIELD_CONFIGURATOR);
+
+        $container->registerForAutoconfiguration(FilterConfiguratorInterface::class)
+            ->addTag(self::TAG_FILTER_CONFIGURATOR);
+
+        $container->registerForAutoconfiguration(ActionsExtensionInterface::class)
+            ->addTag(self::TAG_ACTIONS_EXTENSION);
+
+        $configurator->import('../config/services.php');
+    }
+
+    public function prependExtension(ContainerConfigurator $configurator, ContainerBuilder $container): void
+    {
+        $container->prependExtensionConfig('twig_component', [
+            'defaults' => [
+                'EasyCorp\\Bundle\\EasyAdminBundle\\Twig\\Component\\' => [
+                    'template_directory' => '@EasyAdmin/components/',
+                    'name_prefix' => 'ea',
+                ],
+            ],
+        ]);
+
+        /** @var string $projectDir */
+        $projectDir = $container->getParameter('kernel.project_dir');
+
+        $bundleTemplatesOverrideDir = $projectDir.'/templates/bundles/EasyAdminBundle/';
+        $container->prependExtensionConfig('twig', [
+            'paths' => is_dir($bundleTemplatesOverrideDir)
+                ? [
+                    'templates/bundles/EasyAdminBundle/' => 'ea',
+                    \dirname(__DIR__).'/templates/' => 'ea',
+                ]
+                : [
+                    \dirname(__DIR__).'/templates/' => 'ea',
+                ],
+        ]);
     }
 }

--- a/src/Twig/Component/AGENTS.md
+++ b/src/Twig/Component/AGENTS.md
@@ -23,7 +23,7 @@ Complex components can be split into **sub-components in a subdirectory** of `te
 
 ## Conventions
 
-**Naming & usage.** All components use the `ea` prefix: a class/template named `Alert` is used as `<twig:ea:Alert>`. This is configured once in `EasyAdminExtension::prepend()` (`name_prefix: ea`, `template_directory: @EasyAdmin/components/`) — you don't annotate classes with `#[AsTwigComponent]`.
+**Naming & usage.** All components use the `ea` prefix: a class/template named `Alert` is used as `<twig:ea:Alert>`. This is configured once in `EasyAdminBundle::prependExtension()` (`name_prefix: ea`, `template_directory: @EasyAdmin/components/`) — you don't annotate classes with `#[AsTwigComponent]`.
 
 **Registration (class-backed).** Register the component explicitly in `config/services.php` with the `twig.component` tag. No autowiring — pass dependencies as explicit args, like every service in this bundle:
 ```php


### PR DESCRIPTION
…ndle instead of Bundle

See https://symfony.com/doc/current/bundles/configuration.html which states:

> 
> There are two different ways of creating friendly configuration for a bundle:
> 
> [Using the main bundle class](https://symfony.com/doc/current/bundles/configuration.html#bundle-friendly-config-bundle-class): this is recommended for new bundles and for bundles following the [recommended directory structure](https://symfony.com/doc/current/bundles.html#bundles-directory-structure);
> [Using the Bundle extension class](https://symfony.com/doc/current/bundles/configuration.html#bundle-friendly-config-extension): this was the traditional way of doing it, but nowadays it's only recommended for bundles following the [legacy directory structure](https://symfony.com/doc/current/bundles.html#bundles-legacy-directory-structure).

And see https://symfony.com/doc/current/bundles/best_practices.html which states:

> This directory structure is used by default when your bundle class extends the recommended [AbstractBundle](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/HttpKernel/Bundle/AbstractBundle.php). If your bundle extends the [Bundle](https://github.com/symfony/symfony/blob/8.1/src/Symfony/Component/HttpKernel/Bundle/Bundle.php) class, you have to override the getPath() method ...
